### PR TITLE
SWATCH-2871: Handle azure contracts measurements in MeasurementMetricIdTransformer

### DIFF
--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-amqp'
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
     implementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
-    implementation project(':clients:swatch-internal-subscription-client')
     implementation project(':clients:quarkus:subscription-client')
     implementation project(':swatch-common-clock')
     implementation project(':swatch-common-config-workaround')

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -190,14 +190,6 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 # Setting up the timeout to 2 minutes instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".read-timeout=120000
 
-# configuration properties for subscriptions-sync
-# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".url=${SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT}/api/rhsm-subscriptions
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
-quarkus.rest-client."com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter
-
 # configuration properties for product client
 rhsm-subscriptions.product.use-stub=${PRODUCT_USE_STUB:false}
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
@@ -23,7 +23,6 @@ package com.redhat.swatch.contract.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
 import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
@@ -124,7 +123,7 @@ class MeasurementMetricIdTransformerTest {
   }
 
   @Test
-  void testUnsupportedDimensionsAreRemovedFromContracts() throws ApiException, RuntimeException {
+  void testUnsupportedDimensionsAreRemovedFromContracts() throws RuntimeException {
     var contract = new ContractEntity();
     contract.setBillingProvider(BillingProvider.AWS.getValue());
     var instanceHours = new ContractMetricEntity();

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
@@ -22,12 +22,8 @@ package com.redhat.swatch.contract.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
-import com.redhat.swatch.clients.swatch.internal.subscription.api.model.Metric;
 import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.ApiException;
-import com.redhat.swatch.clients.swatch.internal.subscription.api.resources.InternalSubscriptionsApi;
 import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
@@ -39,44 +35,43 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MeasurementMetricIdTransformerTest {
-  @Mock InternalSubscriptionsApi internalSubscriptionsApi;
   @InjectMocks MeasurementMetricIdTransformer transformer;
 
-  @Test
-  void testMapsAwsDimensionToMetricId() throws ApiException, RuntimeException {
+  @ParameterizedTest
+  @EnumSource(
+      value = BillingProvider.class,
+      names = {"AWS", "AZURE"})
+  void testMapsMarketplaceDimensionToMetricId(BillingProvider billingProvider)
+      throws RuntimeException {
     var subscription = new SubscriptionEntity();
-    subscription.setBillingProvider(BillingProvider.AWS);
+    subscription.setBillingProvider(billingProvider);
     var measurement1 = new SubscriptionMeasurementEntity();
-    measurement1.setMetricId("bar");
+    measurement1.setMetricId("control_plane");
     var measurement2 = new SubscriptionMeasurementEntity();
-    measurement2.setMetricId("foo");
+    measurement2.setMetricId("four_vcpu_hour");
     measurement2.setValue(100.0);
     subscription.addSubscriptionMeasurement(measurement1);
     subscription.addSubscriptionMeasurement(measurement2);
     subscription.setOffering(new OfferingEntity());
-    subscription.getOffering().setProductTags(Set.of("hello"));
+    subscription.getOffering().setProductTags(Set.of("rosa"));
 
-    when(internalSubscriptionsApi.getMetrics("hello"))
-        .thenReturn(
-            List.of(
-                new Metric().uom("foo1").awsDimension("foo").billingFactor(0.25),
-                new Metric().uom("bar2").awsDimension("bar").billingFactor(1.0)));
     transformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
     assertTrue(
         subscription.getSubscriptionMeasurements().stream()
             .map(SubscriptionMeasurementEntity::getMetricId)
-            .collect(Collectors.toList())
-            .containsAll(Set.of("bar2", "foo1")));
+            .toList()
+            .containsAll(Set.of("Instance-hours", "Cores")));
     assertEquals(
         400.0,
         subscription.getSubscriptionMeasurements().stream()
-            .filter(m -> m.getMetricId().startsWith("foo"))
+            .filter(m -> m.getMetricId().startsWith("Cores"))
             .findFirst()
             .orElseThrow()
             .getValue());
@@ -86,28 +81,27 @@ class MeasurementMetricIdTransformerTest {
   void testNoMappingAttemptedForMissingBillingProvider() throws RuntimeException {
     var subscription = new SubscriptionEntity();
     var measurement1 = new SubscriptionMeasurementEntity();
-    measurement1.setMetricId("bar");
+    measurement1.setMetricId("control_plane");
     var measurement2 = new SubscriptionMeasurementEntity();
-    measurement2.setMetricId("foo");
+    measurement2.setMetricId("four_vcpu_hour");
     subscription.addSubscriptionMeasurement(measurement1);
     subscription.addSubscriptionMeasurement(measurement2);
     subscription.setOffering(new OfferingEntity());
-    subscription.getOffering().setProductTags(Set.of("hello"));
+    subscription.getOffering().setProductTags(Set.of("rosa"));
 
     transformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
-    verifyNoInteractions(internalSubscriptionsApi);
   }
 
   @Test
-  void testUnsupportedMetricIdAreRemoved() throws ApiException, RuntimeException {
+  void testUnsupportedMetricIdAreRemoved() throws RuntimeException {
     var subscription = new SubscriptionEntity();
     subscription.setBillingProvider(BillingProvider.AWS);
     var instanceHours = new SubscriptionMeasurementEntity();
     instanceHours.setValue(100.0);
-    instanceHours.setMetricId("control_plane_0");
+    instanceHours.setMetricId("control_plane");
 
     var cores = new SubscriptionMeasurementEntity();
-    cores.setMetricId("four_vcpu_0");
+    cores.setMetricId("four_vcpu_hour");
     cores.setValue(100.0);
 
     var unknown = new SubscriptionMeasurementEntity();
@@ -121,11 +115,6 @@ class MeasurementMetricIdTransformerTest {
     subscription.setOffering(new OfferingEntity());
     subscription.getOffering().setProductTags(Set.of("rosa"));
 
-    when(internalSubscriptionsApi.getMetrics("rosa"))
-        .thenReturn(
-            List.of(
-                new Metric().uom("Instance-hours").awsDimension("control_plane_0"),
-                new Metric().uom("Cores").awsDimension("four_vcpu_0").billingFactor(0.25)));
     transformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
     assertEquals(
         List.of("Instance-hours", "Cores"),
@@ -140,10 +129,10 @@ class MeasurementMetricIdTransformerTest {
     contract.setBillingProvider(BillingProvider.AWS.getValue());
     var instanceHours = new ContractMetricEntity();
     instanceHours.setValue(100.0);
-    instanceHours.setMetricId("control_plane_0");
+    instanceHours.setMetricId("control_plane");
 
     var cores = new ContractMetricEntity();
-    cores.setMetricId("four_vcpu_0");
+    cores.setMetricId("four_vcpu_hour");
     cores.setValue(100.0);
 
     var unknown = new ContractMetricEntity();
@@ -162,14 +151,9 @@ class MeasurementMetricIdTransformerTest {
     contract.setOffering(new OfferingEntity());
     contract.getOffering().setProductTags(Set.of("rosa"));
 
-    when(internalSubscriptionsApi.getMetrics("rosa"))
-        .thenReturn(
-            List.of(
-                new Metric().uom("Instance-hours").awsDimension("control_plane_0"),
-                new Metric().uom("Cores").awsDimension("four_vcpu_0").billingFactor(0.25)));
     transformer.resolveConflictingMetrics(contract);
     assertEquals(
-        Set.of("control_plane_0", "four_vcpu_0"),
+        Set.of("control_plane", "four_vcpu_hour"),
         contract.getMetrics().stream()
             .map(ContractMetricEntity::getMetricId)
             .collect(Collectors.toSet()));

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/MeasurementMetricIdTransformerTest.java
@@ -80,15 +80,20 @@ class MeasurementMetricIdTransformerTest {
   void testNoMappingAttemptedForMissingBillingProvider() throws RuntimeException {
     var subscription = new SubscriptionEntity();
     var measurement1 = new SubscriptionMeasurementEntity();
-    measurement1.setMetricId("control_plane");
+    measurement1.setMetricId("test1");
     var measurement2 = new SubscriptionMeasurementEntity();
-    measurement2.setMetricId("four_vcpu_hour");
+    measurement2.setMetricId("test2");
     subscription.addSubscriptionMeasurement(measurement1);
     subscription.addSubscriptionMeasurement(measurement2);
     subscription.setOffering(new OfferingEntity());
     subscription.getOffering().setProductTags(Set.of("rosa"));
 
     transformer.translateContractMetricIdsToSubscriptionMetricIds(subscription);
+    assertEquals(
+        List.of("test1", "test2"),
+        subscription.getSubscriptionMeasurements().stream()
+            .map(SubscriptionMeasurementEntity::getMetricId)
+            .collect(Collectors.toList()));
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2871

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Azure contracts were not setting the correct metricId value on subscription measurements causing errors. This change also includes removing the dependency on internalSubscriptionApi.

## Testing
Should fix failing IQE tests