### PR TITLE
delete unused env vars

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 SERVER_PORT=${clowder.endpoints.swatch-contracts.port:8000}
-SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=${clowder.endpoints.swatch-subscription-sync-service.url}
 WIREMOCK_ENDPOINT=http://wiremock-service:8000
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
@@ -35,7 +34,6 @@ SPLUNK_HEC_INCLUDE_EX=false
 %dev.SPLUNK_HEC_INCLUDE_EX=true
 %dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
-%dev.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8101
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
@@ -72,9 +70,6 @@ SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=60d
 
 # Product Service configuration
 %prod.PRODUCT_URL=https://product.api.redhat.com/svcrest/product/v3
-
-# Swatch Subscription Internal configuration
-%wiremock.SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://wiremock:8101/mock/internalSubs
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode


### PR DESCRIPTION
Delete unused env vars in swatch-contracts