### PR TITLE
SWATCH-2755 Enable wiremock for internal swatch contract url

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
@@ -121,13 +121,15 @@ public class ContractsController {
   /**
    * Check whether contract start date applies the condition for a gratis usage: contract starts on
    * the current month. See more in <a
-   * href="https://issues.redhat.com/browse/SWATCH-2571">SWATCH-2571</a>.
+   * href="https://issues.redhat.com/browse/SWATCH-2571">SWATCH-2571</a>. contract starting in Jan
+   * First part billable usage in Jan -> gratis 'jan 2' != null && 'jan 2'.isAfter(startOfMonth('jan
+   * 4')) -> true && 'jan 2'.isAfter('jan 1') = true. Second part billable usage in Feb -> not 'jan
+   * 2' != null && 'jan 2'.isAfter(startOfMonth('feb 4')) -> true && 'jan 2'.isAfter('feb 1') =
+   * false
    */
   private boolean isContractCompatibleWithGratis(Contract contract, BillableUsage usage) {
     OffsetDateTime startDate = contract.getStartDate();
-    return startDate != null
-        && startDate.isAfter(clock.startOfCurrentMonth())
-        && usage.getSnapshotDate().isBefore(clock.endOfCurrentMonth());
+    return startDate != null && startDate.isAfter(clock.startOfMonth(usage.getSnapshotDate()));
   }
 
   private boolean isValidContract(Contract contract, BillableUsage usage) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
@@ -105,7 +105,7 @@ public class ContractsController {
                 .filter(metric -> metric.getMetricId().equals(contractMetricId))
                 .map(Metric::getValue)
                 .reduce(0, Integer::sum);
-        isGratisContract &= isContractCompatibleWithGratis(contract);
+        isGratisContract &= isContractCompatibleWithGratis(contract, usage);
         total += value;
       }
     }
@@ -123,9 +123,11 @@ public class ContractsController {
    * the current month. See more in <a
    * href="https://issues.redhat.com/browse/SWATCH-2571">SWATCH-2571</a>.
    */
-  private boolean isContractCompatibleWithGratis(Contract contract) {
+  private boolean isContractCompatibleWithGratis(Contract contract, BillableUsage usage) {
     OffsetDateTime startDate = contract.getStartDate();
-    return startDate != null && startDate.isAfter(clock.startOfCurrentMonth());
+    return startDate != null
+        && startDate.isAfter(clock.startOfCurrentMonth())
+        && usage.getSnapshotDate().isBefore(clock.endOfCurrentMonth());
   }
 
   private boolean isValidContract(Contract contract, BillableUsage usage) {

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -170,7 +170,7 @@ rhsm-subscriptions.contracts.use-stub=${CONTRACT_USE_STUB:false}
 
 SWATCH_CONTRACT_SERVICE_URL=${clowder.endpoints.swatch-contracts-service.url:http://localhost:8001}
 %dev.SWATCH_CONTRACT_SERVICE_URL=http://localhost:8001
-%ephemeral.SWATCH_CONTRACT_SERVICE_URL=${WIREMOCK_ENDPOINT}
+%ephemeral.SWATCH_CONTRACT_SERVICE_URL=${WIREMOCK_ENDPOINT}/mock/contractApi
 %wiremock.SWATCH_CONTRACT_SERVICE_URL=http://wiremock:8080
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".uri=${SWATCH_CONTRACT_SERVICE_URL}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-contracts-service.trust-store-path}

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 SERVER_PORT=${clowder.endpoints.swatch-billable-usage.port:8000}
+WIREMOCK_ENDPOINT=http://wiremock-service:8000
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
 ENABLE_SPLUNK_HEC=true
@@ -166,7 +167,12 @@ quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
 
 # configuration properties for contracts client
 rhsm-subscriptions.contracts.use-stub=${CONTRACT_USE_STUB:false}
-quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".uri=${clowder.endpoints.swatch-contracts-service.url:http://localhost:8001}
+
+SWATCH_CONTRACT_SERVICE_URL=${clowder.endpoints.swatch-contracts-service.url:http://localhost:8001}
+%dev.SWATCH_CONTRACT_SERVICE_URL=http://localhost:8001
+%ephemeral.SWATCH_CONTRACT_SERVICE_URL=${WIREMOCK_ENDPOINT}
+%wiremock.SWATCH_CONTRACT_SERVICE_URL=http://wiremock:8080
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".uri=${SWATCH_CONTRACT_SERVICE_URL}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-contracts-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-password=${clowder.endpoints.swatch-contracts-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-type=${clowder.endpoints.swatch-contracts-service.trust-store-type}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2755

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Enable wiremock proxy for swatch_contract from swatch_billable_usage
Also change the logic to make gratis identification a bit easier.
```
contract starting in Jan
billable usage in Jan -> gratis

'jan 2' != null && 'jan 2'.isAfter(startOfMonth('jan 4'))
-> true && 'jan 2'.isAfter('jan 1')
-> true && true

billable usage in Feb -> not
'jan 2' != null && 'jan 2'.isAfter(startOfMonth('feb 4'))
-> true && 'jan 2'.isAfter('feb 1')
-> true && false
-> false
```

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/843
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/850
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/117912
https://github.com/RedHatInsights/wiremock-consoledot/pull/1

No test steps since the IQE covers a lot of it.

### Wiremock setup
The below will download the wiremock and will run on 8080 port
```
mkdir Programming
mkdir stub
podman run -it --rm  -p 8080:8080   --name wiremock  -v /home/karshah/Programming/stub:/home/wiremock:z wiremock/wiremock:3.9.1
%dev.SWATCH_CONTRACT_SERVICE_URL=http://localhost:8080
SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev
```

### Without wiremock
```
SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev
%dev.SWATCH_CONTRACT_SERVICE_URL=http://localhost:8001
SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev
```
