### PR TITLE
SWATCH-2864: Prune included products when syncing offerings

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingProductTagLookupService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingProductTagLookupService.java
@@ -70,6 +70,7 @@ public class OfferingProductTagLookupService {
             .build();
 
     SubscriptionDefinition.getAllProductTags(lookupParams).forEach(productTags::addDataItem);
+    SubscriptionDefinition.pruneIncludedProducts(productTags.getData());
   }
 
   public OfferingProductTags findPersistedProductTagsBySku(String sku) {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -376,7 +376,11 @@ public class SubscriptionDefinition {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions();
   }
 
-  public static void pruneIncludedProducts(Set<String> productTags) {
+  public static void pruneIncludedProducts(Collection<String> productTags) {
+    if (productTags == null) {
+      return;
+    }
+
     Set<String> exclusions =
         productTags.stream()
             .map(SubscriptionDefinition::lookupSubscriptionByTag)


### PR DESCRIPTION
Jira issue: SWATCH-2864

## Description
When syncing the sku "MCT3263" that uses the following eng IDs: [69, 645, 70, 290, 579, 872, 874, 588, 518, 519, 311, 240, 458, 603, 604, 317, 318, 608, 610, 180, 326, 686, 329, 473, 546, 185, 479, 408, 194, 197, 271, 201, 561, 491, 205, 857].
Then it results into mapping these three products: OpenShift Container Platform, rhel-for-x86-eus, RHEL for x86.

This is incorrect since the OpenShift Container Platform product is configured using the "includedSubscriptions" that should exclude the rhel-for-x86-eus, RHEL for x86 products.

After these changes, only the OpenShift Container Platform is used.

## Testing
Using iqe tooling:

```
app.rhsm_subscriptions.add_sku(sku="MCT3263", quantity=1, count=1, wait=True, product_id="OpenShift Container Platform")
```

Checking the "sku_product_tag" table should only contain one record with "MCT3263" -> "OpenShift Container Platform".