### PR TITLE
SWATCH-2910: Filter snapshots by supported metric in the product

### DIFF
--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -60,6 +60,7 @@ properties:
       - subscription_not_found
       - subscription_terminated
       - usage_context_lookup
+      - unsupported_metric
       - unknown
   billed_on:
     type: string

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -322,6 +322,19 @@ class AwsBillableUsageAggregateConsumerTest {
         .emitStatus(argThat(usage -> BillableUsage.Status.SUCCEEDED.equals(usage.getStatus())));
   }
 
+  @Test
+  void testShouldSendErrorWhenMetricIsUnsupported() {
+    var aggregate = createAggregate("BASILISK", "Cores", OffsetDateTime.now(), 10);
+    consumer.process(aggregate);
+    verify(billableUsageStatusProducer)
+        .emitStatus(
+            argThat(
+                usage ->
+                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                        && BillableUsage.ErrorCode.UNSUPPORTED_METRIC.equals(
+                            usage.getErrorCode())));
+  }
+
   static Stream<Arguments> usageWindowTestArgs() {
     OffsetDateTime now = OffsetDateTime.now(clock);
     OffsetDateTime startOfCurrentHour = now.minusMinutes(30);

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
@@ -21,7 +21,9 @@
 package com.redhat.swatch.azure.service;
 
 import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_STATUS;
 import static com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource.IN_MEMORY_CONNECTOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource;
@@ -32,6 +34,7 @@ import com.redhat.swatch.configuration.util.MetricIdUtils;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySink;
 import io.smallrye.reactive.messaging.memory.InMemorySource;
 import jakarta.inject.Inject;
 import java.time.OffsetDateTime;
@@ -71,6 +74,7 @@ class AzureBillableUsageAggregateConsumerTest {
   @InjectWireMock WireMockResource wireMockResource;
 
   InMemorySource<BillableUsageAggregate> source;
+  InMemorySink<BillableUsageAggregate> status;
   BillableUsageAggregate usage;
   AzureUsageContext contextForUsage;
 
@@ -85,6 +89,8 @@ class AzureBillableUsageAggregateConsumerTest {
   void setup() {
     LOGGER_CAPTOR.clearRecords();
     source = connector.source(BILLABLE_USAGE_HOURLY_AGGREGATE);
+    status = connector.sink(BILLABLE_USAGE_STATUS);
+    status.clear();
   }
 
   @Test
@@ -114,6 +120,21 @@ class AzureBillableUsageAggregateConsumerTest {
     thenWarningLogWithMessage("status: Error");
   }
 
+  @Test
+  void testShouldSendErrorWhenMetricIsUnsupported() {
+    givenUsageWithUnsupportedMetric();
+    whenSendUsage();
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              var received = status.received();
+              assertEquals(1, received.size());
+              var actual = received.get(0).getPayload();
+              assertEquals(BillableUsage.Status.FAILED, actual.getStatus());
+              assertEquals(BillableUsage.ErrorCode.UNSUPPORTED_METRIC, actual.getErrorCode());
+            });
+  }
+
   private void givenAzureMarketplaceReturnsForbidden() {
     wireMockResource.stubAzureMarketplaceSubmitUsageEventForReturnsStatus(
         contextForUsage, HttpStatus.SC_FORBIDDEN);
@@ -131,6 +152,14 @@ class AzureBillableUsageAggregateConsumerTest {
   private void givenAzureContextForUsage() {
     contextForUsage =
         wireMockResource.stubInternalSubscriptionAzureMarketPlaceContextForUsage(usage);
+  }
+
+  private void givenUsageWithUnsupportedMetric() {
+    givenValidUsage();
+    // this metric is not configured for rosa
+    usage
+        .getAggregateKey()
+        .setMetricId(MetricIdUtils.getStorageGibibyteMonths().toUpperCaseFormatted());
   }
 
   private void givenValidUsage() {


### PR DESCRIPTION
Jira issue: SWATCH-2910

## Description
When existing snapshots have metrics that are not supported by the project (for example: the product "rhel-for-x86-els-payg-addon" does not support the metrics "Sockets" or "Cores"),  Then we were creating invalid billable usage remittance entries that were kept indefinetely on pending state.

Also, we are updating the aws and azure producers to properly update these records with status failed.

## Testing
Added junit tests to cover these changes.
This addresses a production issue containing ol data in the tally_measurements table. 