### PR TITLE
Increase swatch-billable-usage memory to 1024mi

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -12,9 +12,9 @@ parameters:
   - name: IMAGE_PULL_SECRET
     value: quay-cloudservices-pull
   - name: MEMORY_REQUEST
-    value: 512Mi
+    value: 1024Mi
   - name: MEMORY_LIMIT
-    value: 512Mi
+    value: 1024Mi
   - name: CPU_REQUEST
     value: 200m
   - name: CPU_LIMIT


### PR DESCRIPTION
Pods are crashing on occasion due to memory usage.