### PR TITLE
SWATCH-2736: Resize resource requests on curl containers.

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -56,13 +56,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
   - name: AGGREGATE_FLUSH_SCHEDULE
     value: '@hourly'
   - name: PURGE_REMITTANCE_SCHEDULE

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -93,13 +93,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -26,13 +26,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
   - name: MEMORY_REQUEST
     value: 1000Mi
   - name: MEMORY_LIMIT

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -122,13 +122,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
   - name: OTEL_SERVICE_NAME
     value: swatch-subscription-sync
   - name: OTEL_JAVAAGENT_ENABLED

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -83,13 +83,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
   - name: KAFKA_CONDUIT_TASKS_REPLICAS
     value: '3'
   - name: KAFKA_CONDUIT_TASKS_PARTITIONS

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -201,13 +201,13 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 500Mi
+    value: 10Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 800Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
-    value: 350m
+    value: 100m
   - name: CURL_CRON_CPU_LIMIT
-    value: 500m
+    value: 100m
   - name: OTEL_SERVICE_NAME
     value: swatch-tally
   - name: OTEL_JAVAAGENT_ENABLED


### PR DESCRIPTION
Jira issue: SWATCH-2736

# Description
The curl containers do not need nearly as much memory and CPU as we were allocating them.

We can get a better idea of the memory requirements by using the following PromQL:

```
1.5 * (
  avg(
    quantile_over_time(.99, container_memory_working_set_bytes{namespace='rhsm-prod', container!="POD",container!="", container=~'swatch-billable-usage-purge-remittances|swatch-billable-usage-retry-remittances|swatch-billable-usage-sync|swatch-contracts-offering-sync|swatch-contracts-subscription-sync|swatch-metrics-rhel-sync|swatch-metrics-sync|swatch-system-conduit-sync|swatch-tally-hourly|swatch-tally-purge|swatch-tally-purge-events|swatch-tally-tally'}[60d])
  ) by (container) > 0) / 1000000
```

This query calculates the memory use of the 99th percentile of a job run and then adds 50% for breathing room.  For most of our jobs, 2Mb was ample but I've made it an even 10Mb for the request just to be extra cautious.

The CPU determination is more of an educated guess.  As outlined in https://blog.kubecost.com/blog/requests-and-limits/, the best way to get empirical data is to create a recording rule:

```
avg(irate(container_cpu_usage_seconds_total{namespace="rhsm-prod", container!="POD", container!=""}[5m])) by (container)
```

And then use the series gather by that rule like so

```
1.5 * quantile_over_time(.99,container_cpu_usage_irate[7d])
```

We don't have that rule in place, however, so I'm making a conservative guess of 100 millicores.  The speed of the job container's completion is not highly critical.  The vast majority of the run time is going to be curl waiting on the HTTP response.  We mostly just need the curl call to pass or fail in anything vaguely resembling a reasonable time.

## Testing

### Setup
1.  Do an EE deployment.  Here's how I do it:
    ```
    % bin/build-images.sh
    % VER=$(git rev-parse --short=7 HEAD) ;  bonfire deploy rhsm \
    --source=appsre \
    --ref-env insights-production \
    --optional-deps-method none \
    --frontends false \
    --no-remove-resources app:rhsm \
    --timeout 900 \
    -i quay.io/awood/swatch-metrics=$VER \
    -i quay.io/awood/rhsm-subscriptions=$VER \
    -i quay.io/awood/swatch-contracts=$VER \
    -i quay.io/awood/swatch-producer-aws=$VER \
    -i quay.io/awood/swatch-producer-azure=$VER \
    -i quay.io/awood/swatch-system-conduit=$VER \
    -p swatch-metrics/IMAGE=quay.io/awood/swatch-metrics \
    -p swatch-tally/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-api/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-contracts/IMAGE=quay.io/awood/swatch-contracts \
    -p swatch-producer-aws/IMAGE=quay.io/awood/swatch-producer-aws \
    -p swatch-producer-azure/IMAGE=quay.io/awood/swatch-producer-azure \
    -p swatch-system-conduit/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-system-conduit/CONDUIT_IMAGE=quay.io/awood/swatch-system-conduit \
    -p swatch-producer-red-hat-marketplace/IMAGE=quay.io/awood/rhsm-subscriptions \
    -p swatch-subscription-sync/IMAGE=quay.io/awood/rhsm-subscriptions
    ```   

### Steps
1.  Trigger some jobs.  E.g.
    ```bash
    oc create job --from=cronjob/swatch-billable-usage-purge-remittances curl-resource-test
    ```

### Verification
1.  Check the logs.
    ```
    oc logs job.batch/curl-resource-test
    ```
    Curl should complete its run.  You can try triggering other jobs.  But even if they fail, as long as curl is receiving a response and correctly returning a status code, we should be good to go.