### PR TITLE
SWATCH-2907: Disable fault tolerance metrics for now

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -181,3 +181,7 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 # remittance retention policy configuration:
 # 70 days worth
 rhsm-subscriptions.remittance-retention-policy.duration=${REMITTANCE_RETENTION_DURATION:70d}
+
+# SWATCH-2907: fault tolerance metrics have high cardinality due to using a random UUID for method
+# labels, so disabling for now
+MP_Fault_Tolerance_Metrics_Enabled=false

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -382,3 +382,7 @@ rhsm-subscriptions.subscription-client.use-stub=${SUBSCRIPTION_CLIENT_USE_STUB:f
 %test.quarkus.micrometer.binder.http-server.enabled=false
 %test.quarkus.micrometer.binder.messaging.enabled=false
 %test.quarkus.micrometer.binder.mp-metrics.enabled=false
+
+# SWATCH-2907: fault tolerance metrics have high cardinality due to using a random UUID for method
+# labels, so disabling for now
+MP_Fault_Tolerance_Metrics_Enabled=false


### PR DESCRIPTION
Jira issue: SWATCH-2907

Currently, our usage causes high cardinality fault tolerance metrics, because smallrye fault tolerance is creating a unique `method` label with a random UUID, see https://github.com/smallrye/smallrye-fault-tolerance/blame/2393d05f2576c7c78c8a216503730a4022fe0577/implementation/core/src/main/java/io/smallrye/faulttolerance/core/apiimpl/FaultToleranceImpl.java#L158 ; I'll look for a more comprehensive fix later, but for now, disabling to reduce the impact on our prometheus instances.

I'll self-merge and hotfix since it is a config only change.
