### PR TITLE
SWATCH-2907: Populate description in RetryWithExponentialBackoff

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -181,7 +181,3 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 # remittance retention policy configuration:
 # 70 days worth
 rhsm-subscriptions.remittance-retention-policy.duration=${REMITTANCE_RETENTION_DURATION:70d}
-
-# SWATCH-2907: fault tolerance metrics have high cardinality due to using a random UUID for method
-# labels, so disabling for now
-MP_Fault_Tolerance_Metrics_Enabled=false

--- a/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptor.java
+++ b/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptor.java
@@ -77,7 +77,12 @@ public class RetryWithExponentialBackoffInterceptor {
         .ifPresent(maxDelay -> exponentialBackoff.maxDelay(maxDelay.toMillis(), ChronoUnit.MILLIS));
     retry = exponentialBackoff.done();
 
-    return retry.done().build().call(context::proceed);
+    return retry.done().withDescription(getMethod(context)).build().call(context::proceed);
+  }
+
+  private String getMethod(InvocationContext context) {
+    return String.format(
+        "%s.%s", context.getMethod().getDeclaringClass().getName(), context.getMethod().getName());
   }
 
   @SuppressWarnings("unchecked")

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -382,7 +382,3 @@ rhsm-subscriptions.subscription-client.use-stub=${SUBSCRIPTION_CLIENT_USE_STUB:f
 %test.quarkus.micrometer.binder.http-server.enabled=false
 %test.quarkus.micrometer.binder.messaging.enabled=false
 %test.quarkus.micrometer.binder.mp-metrics.enabled=false
-
-# SWATCH-2907: fault tolerance metrics have high cardinality due to using a random UUID for method
-# labels, so disabling for now
-MP_Fault_Tolerance_Metrics_Enabled=false


### PR DESCRIPTION
Jira issue: SWATCH-2907

This pull request will also revert the changes in https://github.com/RedHatInsights/rhsm-subscriptions/commit/e1893b4a489e16acfcf9bddbd06c123b18c48460. 

## Description
The description in RetryWithExponentialBackoffInterceptor is used to properly populate the metrics.
Before these changes, the metric was:

```
ft_retry_retries_total{method="ce6f4e2e-9d9a-4a8f-97b9-46be9b5d4d3b"} 4.0 # {span_id="041b30a82716b919",trace_id="7dd99bae960ff2fcf893f37205788b5e"} 1.0 1726464250.243
```

After these changes:

```
ft_retry_retries_total{method="com.redhat.swatch.billable.usage.services.TallySummaryMessageConsumer.consume"} 4.0 # {span_id="0b5dfec6270bc635",trace_id="8d361b716a7e357c08aeb7c3ded22f7c"} 1.0 1726464785.796
```

## Testing
Setup
-----

1. Temporarily add to `TallySummaryMessageConsumer.consume`:

```java
if (true) {
  throw new RuntimeException("foobar");
}
```

2. Start swatch-billable-usage with the max retries overridden:

```shell
BILLING_PRODUCER_MAX_ATTEMPTS=4 \
./gradlew swatch-billable-usage:quarkusDev
```

Steps
-----

1. Using a kafka producer (IntelliJ kafka producer works well for this), produce a message to `platform.rhsm-subscriptions.tally` with the contents `{"org_id":"foo","tally_snapshots":[]}`.
2. Wait about 15 seconds to allow all retries to finish.
3. Fetch metrics via `http :9000/metrics | grep ft_retry_retries_total`

Verification
------------

1. Notice that the count (the first number in the returned line) is 4.0, corresponding to the retry setting.
2. Notice that the method is specified appropriately.

If you try these steps prior to this change, you should notice that the `method` value is a random UUID.