### PR TITLE
SWATCH-2925: Handle NumberFormatException for cores/sockets

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -452,9 +452,9 @@ public class UpstreamProductData {
         Optional.ofNullable(attrs.get(Attr.IFL))
             .map(ifl -> Integer.parseInt(ifl) * CONVERSION_RATIO_IFL_TO_CORES)
             // ... but if IFL is not defined, then use the CORES attr.
-            .orElseGet(() -> nullOrInteger(attrs, Attr.CORES));
+            .orElseGet(() -> nullOrInteger(attrs, Attr.CORES, sku));
 
-    Integer sockets = nullOrInteger(attrs, Attr.SOCKET_LIMIT);
+    Integer sockets = nullOrInteger(attrs, Attr.SOCKET_LIMIT, sku);
 
     /*
     There are no SKUs today (2021-10-27) that provide both standard capacity and hypervisor capacity
@@ -485,7 +485,7 @@ public class UpstreamProductData {
     offering.setHasUnlimitedUsage(hasUnlimitedCores || hasUnlimitedSockets);
   }
 
-  private static Integer nullOrInteger(Map<Attr, String> attrs, Attr key) {
+  private static Integer nullOrInteger(Map<Attr, String> attrs, Attr key, String sku) {
     String capacity = attrs.get(key);
     if (capacity == null || hasUnlimitedUsage(capacity)) {
       return null;
@@ -493,7 +493,7 @@ public class UpstreamProductData {
       try {
         return Integer.valueOf(capacity);
       } catch (NumberFormatException e) {
-        log.warn("Invalid integer value {} for attr {}", capacity, key);
+        log.warn("Invalid integer value {} on sku {} for attr {}", capacity, sku, key);
         return null;
       }
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -452,9 +452,9 @@ public class UpstreamProductData {
         Optional.ofNullable(attrs.get(Attr.IFL))
             .map(ifl -> Integer.parseInt(ifl) * CONVERSION_RATIO_IFL_TO_CORES)
             // ... but if IFL is not defined, then use the CORES attr.
-            .orElseGet(() -> nullOrInteger(attrs.get(Attr.CORES)));
+            .orElseGet(() -> nullOrInteger(attrs, Attr.CORES));
 
-    Integer sockets = nullOrInteger(attrs.get(Attr.SOCKET_LIMIT));
+    Integer sockets = nullOrInteger(attrs, Attr.SOCKET_LIMIT);
 
     /*
     There are no SKUs today (2021-10-27) that provide both standard capacity and hypervisor capacity
@@ -485,11 +485,17 @@ public class UpstreamProductData {
     offering.setHasUnlimitedUsage(hasUnlimitedCores || hasUnlimitedSockets);
   }
 
-  private static Integer nullOrInteger(String capacity) {
+  private static Integer nullOrInteger(Map<Attr, String> attrs, Attr key) {
+    String capacity = attrs.get(key);
     if (capacity == null || hasUnlimitedUsage(capacity)) {
       return null;
     } else {
-      return Integer.valueOf(capacity);
+      try {
+        return Integer.valueOf(capacity);
+      } catch (NumberFormatException e) {
+        log.warn("Invalid integer value {} for attr {}", capacity, key);
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
Jira issue: SWATCH-2925

Description
===========

We started receiving messages having "None" as the value for SOCKET_LIMIT, and this caused a crashloop in swatch-contracts.

Instead, log a warning and interpret the value as null if it's not "Unlimited" or an integer.

Testing
=======

```shell
./gradlew -s swatch-contracts:test \
  --tests=UpstreamProductDataTest.testOfferingWithNoneSocketsProcessedSuccessfully
```

See logs like:

> Invalid integer value None for attr CORES
> Invalid integer value None for attr SOCKET_LIMIT