### PR TITLE
Expose swagger ui for billable usage component

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -162,6 +162,14 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-
 # Metrics and logging are not yet supported - 30 Jul 2024
 quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
 
+# expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
+quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
+# By default, the openapi and swagger ui endpoints are exposed on the management port, so we need to disable it
+# to expose it on the server port 8000:
+quarkus.smallrye-openapi.management.enabled=false
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+
 # configuration properties for contracts client
 rhsm-subscriptions.contracts.use-stub=${CONTRACT_USE_STUB:false}
 


### PR DESCRIPTION
Expose swagger ui for billable usage component
http://localhost:8002/api/swatch-billable-usage/internal/swagger-ui/