### PR TITLE
SWATCH-2145: Merge duplicate hosts from different sources in tally

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyDataController.java
@@ -57,6 +57,8 @@ public class InternalTallyDataController {
   private final BillableUsageController billableUsageController;
   private final TallySnapshotController snapshotController;
   private final EventNormalizer eventNormalizer;
+  private final DataMigrationRunner dataMigrationRunner;
+  private final MergeHostsMigration mergeHostsMigration;
 
   public void deleteDataAssociatedWithOrg(String orgId) {
     // we first delete the contracts and if it works, we continue with the rest of the data.
@@ -129,6 +131,11 @@ public class InternalTallyDataController {
 
   public void tallyAllOrgsByHourly() throws IllegalArgumentException {
     tasks.updateHourlySnapshotsForAllOrgs();
+  }
+
+  public void mergeHostsFromMultipleSources(String orgId) {
+    mergeHostsMigration.setOrgId(orgId);
+    dataMigrationRunner.migrate(mergeHostsMigration, null, 10);
   }
 
   public String createOrUpdateOptInConfig(String orgId, OptInType api) {

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -311,6 +311,21 @@ public class InternalTallyResource implements InternalTallyApi {
     return response;
   }
 
+  /**
+   * Update hosts to eliminate duplicate systems that arrived from different inputs
+   *
+   * @return
+   */
+  @Override
+  public DefaultResponse mergeHostsFromMultipleSources(String orgId) {
+    var response = new DefaultResponse();
+    Object principal = ResourceUtils.getPrincipal();
+    log.info(
+        "Merge hosts org {} triggered via API by {}", orgId == null ? "all" : orgId, principal);
+    internalTallyDataController.mergeHostsFromMultipleSources(orgId);
+    return response;
+  }
+
   private boolean isFeatureEnabled() {
     if (!properties.isDevMode() && !properties.isManualEventEditingEnabled()) {
       log.error(FEATURE_NOT_ENABLED_MESSSAGE);

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/MergeHostsMigration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/MergeHostsMigration.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.SqlRowSetResultSetExtractor;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Slf4j
+public class MergeHostsMigration extends DataMigration {
+
+  public static final SqlRowSetResultSetExtractor SQL_ROW_SET_RESULT_SET_EXTRACTOR =
+      new SqlRowSetResultSetExtractor();
+
+  private static final String INSTANCE_DUPLICATE_QUERY_WITH_ORG =
+      """
+        select instance_id, org_id from hosts where instance_id in (
+        select instance_id from hosts group by instance_id having count(instance_id) > 1)
+                                and (?::varchar is null or instance_id > ?::varchar)
+                                and org_id = ?
+                                and instance_id <> ''
+                                and hardware_type <> ''
+                                order by instance_id asc
+                                limit ?;
+      """;
+
+  private static final String INSTANCE_DUPLICATE_QUERY_NO_ORG =
+      """
+        select instance_id, org_id from hosts where instance_id in (
+        select instance_id from hosts group by instance_id having count(instance_id) > 1)
+                                and (?::varchar is null or instance_id > ?::varchar)
+                                and instance_id <> ''
+                                and hardware_type <> ''
+                                order by instance_id asc
+                                limit ?;
+      """;
+
+  private HostRepository hostRepository;
+  private final Counter counter;
+  private String orgId;
+
+  public MergeHostsMigration(
+      JdbcTemplate jdbcTemplate, MeterRegistry meterRegistry, HostRepository hostRepository) {
+    super(jdbcTemplate, meterRegistry);
+    counter = meterRegistry.counter("swatch_mergeHosts_migration");
+    this.hostRepository = hostRepository;
+  }
+
+  @Override
+  public SqlRowSet extract(String recordOffset, int batchSize) {
+    if (orgId == null) {
+      return jdbcTemplate.query(
+          INSTANCE_DUPLICATE_QUERY_NO_ORG,
+          new Object[] {recordOffset, recordOffset, batchSize},
+          new int[] {Types.VARCHAR, Types.VARCHAR, Types.NUMERIC},
+          SQL_ROW_SET_RESULT_SET_EXTRACTOR);
+    } else {
+      return jdbcTemplate.query(
+          INSTANCE_DUPLICATE_QUERY_WITH_ORG,
+          new Object[] {recordOffset, recordOffset, orgId, batchSize},
+          new int[] {Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.NUMERIC},
+          SQL_ROW_SET_RESULT_SET_EXTRACTOR);
+    }
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  @Transactional
+  @Override
+  public String transformAndLoad(SqlRowSet data) {
+    String lastInstanceId = null;
+    int hostCount = 0;
+
+    while (data.next()) {
+      List<Host> deleteList = new ArrayList<>();
+      String instanceId = data.getString("instance_id");
+      String organizationId = data.getString("org_id");
+      // get the hosts that share the id.
+      List<Host> hosts =
+          hostRepository
+              .findAllByOrgIdAndInstanceIdIn(organizationId, Set.of(instanceId))
+              .collect(Collectors.toCollection(ArrayList::new));
+      Collections.sort(hosts, Comparator.comparing(Host::getLastSeen).reversed());
+      Host primaryHost = hosts.get(0);
+      for (Host host : hosts) {
+        if (primaryHost.getId().equals(host.getId())) {
+          continue;
+        }
+        deleteList.add(host);
+        mergeDataFields(primaryHost, host);
+        mergeTallyBuckets(primaryHost, host);
+        mergeMeasurements(primaryHost, host);
+        mergeMonthlyTotals(primaryHost, host);
+      }
+
+      lastInstanceId = instanceId;
+      hostCount++;
+      try {
+        hostRepository.save(primaryHost);
+      } catch (Exception e) {
+        log.error("Unable to update host on host merge: [instanceId: {}]", e.getMessage());
+        throw e;
+      }
+      hostRepository.deleteAll(deleteList);
+    }
+
+    counter.increment(hostCount);
+    return lastInstanceId;
+  }
+
+  /**
+   * Merge the identifier values into the primary (latest seen wins)
+   *
+   * @param primaryHost
+   * @param host
+   */
+  private void mergeDataFields(Host primaryHost, Host host) {
+    if (primaryHost.getInventoryId() == null) primaryHost.setInventoryId(host.getInventoryId());
+    if (primaryHost.getInsightsId() == null) primaryHost.setInsightsId(host.getInsightsId());
+    if (primaryHost.getSubscriptionManagerId() == null)
+      primaryHost.setSubscriptionManagerId(host.getSubscriptionManagerId());
+    if (primaryHost.getHypervisorUuid() == null)
+      primaryHost.setHypervisorUuid(host.getHypervisorUuid());
+    if (primaryHost.getBillingProvider() == null)
+      primaryHost.setBillingProvider(host.getBillingProvider());
+    if (primaryHost.getBillingAccountId() == null)
+      primaryHost.setBillingAccountId(host.getBillingAccountId());
+    // keep the latest applied event record date
+    if (primaryHost.getLastAppliedEventRecordDate() == null
+        || host.getLastAppliedEventRecordDate() != null
+            && primaryHost
+                    .getLastAppliedEventRecordDate()
+                    .compareTo(host.getLastAppliedEventRecordDate())
+                < 0) {
+      primaryHost.setLastAppliedEventRecordDate(host.getLastAppliedEventRecordDate());
+    }
+    // HBI_HOST will always win if there are different values
+    if (primaryHost.getInstanceType() == null
+        || !primaryHost.getInstanceType().equals("HBI_HOST") && host.getInstanceType() != null) {
+      primaryHost.setInstanceType(host.getInstanceType());
+    }
+  }
+
+  /**
+   * Compile all buckets from all hosts
+   *
+   * @param primaryHost
+   * @param host
+   */
+  private void mergeTallyBuckets(Host primaryHost, Host host) {
+    for (HostTallyBucket hostTallyBucket : host.getBuckets()) {
+      primaryHost.addBucket(
+          hostTallyBucket.getKey().getProductId(),
+          hostTallyBucket.getKey().getSla(),
+          hostTallyBucket.getKey().getUsage(),
+          hostTallyBucket.getKey().getBillingProvider(),
+          hostTallyBucket.getKey().getBillingAccountId(),
+          hostTallyBucket.getKey().getAsHypervisor(),
+          hostTallyBucket.getSockets(),
+          hostTallyBucket.getCores(),
+          hostTallyBucket.getMeasurementType());
+    }
+  }
+
+  /**
+   * Add measurements to primary only if it does not exist yet
+   *
+   * @param primaryHost
+   * @param host
+   */
+  private void mergeMeasurements(Host primaryHost, Host host) {
+    for (String measurementName : host.getMeasurements().keySet()) {
+      if (primaryHost.getMeasurements().get(measurementName) == null) {
+        primaryHost
+            .getMeasurements()
+            .put(measurementName, host.getMeasurements().get(measurementName));
+      }
+    }
+  }
+
+  /**
+   * Add monthly totals to primary; duplicates will be handled in the Host object
+   *
+   * @param primaryHost
+   * @param host
+   */
+  private void mergeMonthlyTotals(Host primaryHost, Host host) {
+    // add monthly totals to primary. duplicates will be handled in the Host object
+    for (InstanceMonthlyTotalKey monthlyKey : host.getMonthlyTotals().keySet()) {
+      primaryHost.addToMonthlyTotal(
+          monthlyKey.getMonth(),
+          MetricId.fromString(monthlyKey.getMetricId()),
+          host.getMonthlyTotal(
+              monthlyKey.getMonth(), MetricId.fromString(monthlyKey.getMetricId())));
+    }
+  }
+
+  @Override
+  public void recordCompleted() {
+    // intentionally left blank
+  }
+}

--- a/src/main/spec/internal-tally-api-spec.yaml
+++ b/src/main/spec/internal-tally-api-spec.yaml
@@ -340,6 +340,32 @@ paths:
         '500':
           $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
       tags: [ internalTally ]
+  /v1/internal/rpc/tally/hosts/merge:
+    description: 'Merge existing host entries that arrived from different sources.'
+    post:
+      operationId: mergeHostsFromMultipleSources
+      parameters:
+        - in: query
+          name: org_id
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: 'The request for merging hosts was successful.'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultResponse"
+        '400':
+          $ref: "../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '401':
+          $ref: "../../../spec/error-responses.yaml#/$defs/Unauthorized"
+        '404':
+          $ref: "../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+        '500':
+          $ref: "../../../spec/error-responses.yaml#/$defs/InternalServerError"
+      tags: [internalTally]
 components:
   requestBodies:
     UuidListBody:

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/MergeHostsMigrationTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/MergeHostsMigrationTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.db.HostRepository;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+@ExtendWith(MockitoExtension.class)
+class MergeHostsMigrationTest {
+
+  @Mock HostRepository hostRepository;
+  @Mock JdbcTemplate jdbcTemplate;
+  @Mock MeterRegistry meterRegistry;
+
+  @Test
+  void transformAndLoadTwoHostsOneInstanceId() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1", "instance-1", "org-1", OffsetDateTime.now(), null, null, null, null, null);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2));
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    verify(hostRepository).save(host1);
+    verify(hostRepository).deleteAll(List.of(host2));
+  }
+
+  @Test
+  void transformAndLoadFourHostsTwoInstanceIds() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1", "instance-2");
+    when(data.getString("org_id")).thenReturn("org-1", "org-2");
+
+    Host host1 =
+        makeHost(
+            "Host-1", "instance-1", "org-1", OffsetDateTime.now(), null, null, null, null, null);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+    Host host3 =
+        makeHost(
+            "Host-3", "instance-2", "org-2", OffsetDateTime.now(), null, null, null, null, null);
+    Host host4 =
+        makeHost(
+            "Host-4",
+            "instance-2",
+            "org-2",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2));
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-2", Set.of("instance-2")))
+        .thenReturn(Stream.of(host3, host4));
+    assertEquals("instance-2", mergeHostsMigration.transformAndLoad(data));
+    verify(hostRepository).save(host3);
+    verify(hostRepository).deleteAll(List.of(host4));
+  }
+
+  @Test
+  void transformAndLoadFieldUpdates() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now(),
+            "insight-1",
+            null,
+            null,
+            null,
+            null);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            "insight-2",
+            "subscription-manager-2",
+            null,
+            "hypervisor-2",
+            null);
+    Host host3 =
+        makeHost(
+            "Host-3",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(3),
+            "insight-3",
+            "subscription-manager-3",
+            "inventory-3",
+            null,
+            null);
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2, host3));
+
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    verify(hostRepository).save(host1);
+    verify(hostRepository).deleteAll(List.of(host2, host3));
+    assertEquals("insight-1", host1.getInsightsId());
+    assertEquals("subscription-manager-2", host1.getSubscriptionManagerId());
+    assertEquals("inventory-3", host1.getInventoryId());
+    assertEquals("hypervisor-2", host1.getHypervisorUuid());
+  }
+
+  @Test
+  void transformAndLoadInstanceTypeUpdates() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now(),
+            null,
+            null,
+            null,
+            null,
+            "RHEL System");
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            "HBI_HOST");
+    Host host3 =
+        makeHost(
+            "Host-3",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(3),
+            null,
+            null,
+            null,
+            null,
+            null);
+    Host host4 =
+        makeHost(
+            "Host-4",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(4),
+            null,
+            null,
+            null,
+            null,
+            "RHEL System");
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2, host3, host4));
+
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    verify(hostRepository).save(host1);
+    verify(hostRepository).deleteAll(List.of(host2, host3, host4));
+    assertEquals("HBI_HOST", host1.getInstanceType());
+  }
+
+  @Test
+  void transformAndLoadDiffentTallyBucketUpdates() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1", "instance-1", "org-1", OffsetDateTime.now(), null, null, null, null, null);
+    HostTallyBucket bucket1 =
+        makeTallyBucket(
+            "product-1",
+            ServiceLevel.SELF_SUPPORT,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "billing_account-1",
+            false,
+            1,
+            2);
+    host1.addBucket(bucket1);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+    HostTallyBucket bucket2 =
+        makeTallyBucket(
+            "product-2",
+            ServiceLevel.SELF_SUPPORT,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "billing_account-1",
+            false,
+            1,
+            2);
+    host1.addBucket(bucket2);
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2));
+
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    assertEquals(2, host1.getBuckets().size());
+    assertTrue(host1.getBuckets().containsAll(Set.of(bucket1, bucket2)));
+  }
+
+  @Test
+  void transformAndLoadMeasurementUpdate() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1", "instance-1", "org-1", OffsetDateTime.now(), null, null, null, null, null);
+    host1.setMeasurement("SOCKETS", 7.0);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+    host2.setMeasurement("SOCKETS", 8.0);
+    host2.setMeasurement("CORES", 3.0);
+
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2));
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    assertEquals(2, host1.getMeasurements().size());
+    assertEquals(7.0, host1.getMeasurements().get("SOCKETS"));
+    assertEquals(3.0, host1.getMeasurements().get("CORES"));
+  }
+
+  @Test
+  void transformAndLoadMonthlyTotalUpdate() {
+    when(meterRegistry.counter(any(String.class))).thenReturn(mock(Counter.class));
+    MergeHostsMigration mergeHostsMigration =
+        new MergeHostsMigration(jdbcTemplate, meterRegistry, hostRepository);
+    SqlRowSet data = mock(SqlRowSet.class);
+    when(data.next()).thenReturn(true, false);
+    when(data.getString("instance_id")).thenReturn("instance-1");
+    when(data.getString("org_id")).thenReturn("org-1");
+
+    Host host1 =
+        makeHost(
+            "Host-1", "instance-1", "org-1", OffsetDateTime.now(), null, null, null, null, null);
+    host1.addToMonthlyTotal("2023-11", MetricId.fromString("CORES"), 80.0);
+    host1.addToMonthlyTotal("2023-10", MetricId.fromString("CORES"), 100.0);
+    host1.addToMonthlyTotal("2023-10", MetricId.fromString("VCPUS"), 50.0);
+    Host host2 =
+        makeHost(
+            "Host-2",
+            "instance-1",
+            "org-1",
+            OffsetDateTime.now().minusHours(2),
+            null,
+            null,
+            null,
+            null,
+            null);
+    host2.addToMonthlyTotal("2023-11", MetricId.fromString("CORES"), 10.0);
+    host2.addToMonthlyTotal("2023-10", MetricId.fromString("CORES"), 5.0);
+    host2.addToMonthlyTotal("2023-10", MetricId.fromString("SOCKETS"), 25.0);
+
+    when(hostRepository.findAllByOrgIdAndInstanceIdIn("org-1", Set.of("instance-1")))
+        .thenReturn(Stream.of(host1, host2));
+    assertEquals("instance-1", mergeHostsMigration.transformAndLoad(data));
+    assertEquals(4, host1.getMonthlyTotals().size());
+    assertEquals(90.0, host1.getMonthlyTotal("2023-11", MetricId.fromString("CORES")));
+    assertEquals(105.0, host1.getMonthlyTotal("2023-10", MetricId.fromString("CORES")));
+    assertEquals(25.0, host1.getMonthlyTotal("2023-10", MetricId.fromString("SOCKETS")));
+    assertEquals(50.0, host1.getMonthlyTotal("2023-10", MetricId.fromString("VCPUS")));
+  }
+
+  private Host makeHost(
+      String displayName,
+      String instanceId,
+      String orgId,
+      OffsetDateTime lastSeen,
+      String insightsId,
+      String subscriptionManagerId,
+      String inventoryId,
+      String hypervisorUuid,
+      String instanceType) {
+    Host host = new Host();
+    host.setId(UUID.randomUUID());
+    host.setDisplayName(displayName);
+    host.setInstanceId(instanceId);
+    host.setOrgId(orgId);
+    host.setLastSeen(lastSeen);
+    host.setInsightsId(insightsId);
+    host.setSubscriptionManagerId(subscriptionManagerId);
+    host.setInventoryId(inventoryId);
+    host.setHypervisorUuid(hypervisorUuid);
+    host.setInstanceType(instanceType);
+    return host;
+  }
+
+  private HostTallyBucket makeTallyBucket(
+      String productTag,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      boolean asHypervisor,
+      int cores,
+      int sockets) {
+    HostTallyBucket bucket = new HostTallyBucket();
+    HostBucketKey key = new HostBucketKey();
+    key.setProductId(productTag);
+    key.setSla(sla);
+    key.setUsage(usage);
+    key.setBillingProvider(billingProvider);
+    key.setBillingAccountId(billingAccountId);
+    key.setAsHypervisor(asHypervisor);
+    bucket.setCores(cores);
+    bucket.setSockets(sockets);
+    bucket.setKey(key);
+    return bucket;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -197,8 +197,8 @@ public class Host implements Serializable {
       BillingProvider billingProvider,
       String billingAccountId,
       Boolean asHypervisor,
-      int sockets,
-      int cores,
+      Integer sockets,
+      Integer cores,
       HardwareMeasurementType measurementType) {
 
     HostTallyBucket bucket =


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2145

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
We have hosts in the rhsm-subscription table 'hosts' that have duplicate instance ID's. This migration will merge those entries into a single host entry. This will be followed by a new constraint put on the table as well as new logic to determine if a host already exists in this table.

## Testing

### Setup
<!-- Add any steps required to set up the test case -->
1. import from production:
```
./import-from-gabi.py --host --org-id='5345257'
```

### Steps
<!-- Enter each step of the test below -->
1. Find an instance id that is repeated:
```
select id,instance_id, org_id from hosts where instance_id in (
    select instance_id from hosts group by instance_id having count(instance_id) > 1)
  and org_id = '5345257'
order by instance_id asc
```
2. Look at the host entries [keep track of the host ids]:
```
select * from hosts where instance_id = 'i-0002481e85a633e0c' order by last_seen desc
```
3. Look at the monthly totals:
```
select * from instance_monthly_totals where host_id in ('bff818fb-ab19-47a9-bf30-bc59f175491c','1d2d9476-b757-4b0b-895e-752397a48d8f');
```
4. Look at the instance measurements:
```
select * from instance_measurements where host_id in ('bff818fb-ab19-47a9-bf30-bc59f175491c','1d2d9476-b757-4b0b-895e-752397a48d8f')
```
5. Look at the tally buckets
```
select * from host_tally_buckets where host_id in ('bff818fb-ab19-47a9-bf30-bc59f175491c','1d2d9476-b757-4b0b-895e-752397a48d8f');
```

6. Call the migration endpoint:
```
http  POST :8000/api/rhsm-subscriptions/v1/internal/rpc/tally/hosts/merge?org_id=5345257 x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"5345257"}}}' | base64 -w0)
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. There should only be one host entry for an instance id. The initial query for hosts should return no values.
2. The instance type should be HBI_HOST if either had that value before
3. the last_seen and last_applied_event_record_date should be the most recent
4. the monthly totals should be summed across the hosts per metric_id
5. the measurements should be a single entry per metric id with the value belonging to the most recent last_seen [they really should be the same anyway]
6. The list of tally buckets should include all associated with both.
7. The initial query for hosts should return no values
