### PR TITLE
SWATCH-2887: Delete host tally buckets after processing event batches

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -73,8 +73,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MetricUsageCollectorTest {
 
-  public static final String RHEL_ENG_ID = "69";
-  public static final String RHEL_ELS_PAYG_ENG_ID = "204";
+  private static final String RHEL_ENG_ID = "69";
+  private static final String RHEL_ELS_PAYG_ENG_ID = "204";
+  private static final String ORG_ID = "orgId";
+  private static final String SERVICE_TYPE = "OpenShift Cluster";
+  private static final String RHEL_FOR_X86 = "RHEL for x86";
+  private static final String RHEL_FOR_X86_ELS_PAYG = "rhel-for-x86-els-payg";
+
+  private static final String RHEL_WORKSTATION_SWATCH_PRODUCT_ID = "RHEL Workstation";
+  private static final String RHEL_COMPUTE_NODE_SWATCH_PRODUCT_ID = "RHEL Compute Node";
+  private static final String OSD_PRODUCT_TAG = "OpenShift-dedicated-metrics";
+  private static final String OCP_PRODUCT_TAG = "OpenShift-metrics";
+
+  private static final String OSD_METRIC_ID = "redhat.com:openshift_dedicated:4cpu_hour";
+
   MetricUsageCollector metricUsageCollector;
 
   @Mock AccountServiceInventoryRepository accountRepo;
@@ -85,18 +97,6 @@ class MetricUsageCollectorTest {
 
   ApplicationClock clock = new TestClockConfiguration().adjustableClock();
 
-  static final String ORG_ID = "orgId";
-  static final String SERVICE_TYPE = "OpenShift Cluster";
-  static final String RHEL_FOR_X86 = "RHEL for x86";
-  static final String RHEL_FOR_X86_ELS_PAYG = "rhel-for-x86-els-payg";
-
-  static final String RHEL_WORKSTATION_SWATCH_PRODUCT_ID = "RHEL Workstation";
-  static final String RHEL_COMPUTE_NODE_SWATCH_PRODUCT_ID = "RHEL Compute Node";
-  static final String OSD_PRODUCT_TAG = "OpenShift-dedicated-metrics";
-  static final String OCP_PRODUCT_TAG = "OpenShift-metrics";
-
-  static final String OSD_METRIC_ID = "redhat.com:openshift_dedicated:4cpu_hour";
-
   @BeforeEach
   void setup() {
     metricUsageCollector =
@@ -104,7 +104,7 @@ class MetricUsageCollectorTest {
   }
 
   @Test
-  void updateHosts_noIteractionsWhenNoEventsFound() {
+  void updateHosts_noIterationsWhenNoEventsFound() {
     metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of());
     verifyNoInteractions(accountRepo, hostRepository, tallySnapshotRepository);
   }
@@ -785,7 +785,7 @@ class MetricUsageCollectorTest {
         List.of(coresEvent1, instanceHoursEvent1, coresEvent2, instanceHoursEvent2));
 
     ArgumentCaptor<Host> saveHostCaptor = ArgumentCaptor.forClass(Host.class);
-    verify(hostRepository, times(4)).save(saveHostCaptor.capture());
+    verify(hostRepository).save(saveHostCaptor.capture());
 
     Set<Host> savedHosts = new HashSet<>(saveHostCaptor.getAllValues());
     assertEquals(1, savedHosts.size());
@@ -904,8 +904,6 @@ class MetricUsageCollectorTest {
   @Test
   void testEventWithNullFieldsProcessedDuringUpdateHosts() {
     // NOTE: null in the JSON gets represented as Optional.empty()
-    Measurement measurement =
-        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
     Event event =
         createEvent()
             .withEventId(UUID.randomUUID())
@@ -1087,7 +1085,7 @@ class MetricUsageCollectorTest {
               .withSla(Event.Sla.PREMIUM)
               .withBillingProvider(Event.BillingProvider.RED_HAT)
               .withBillingAccountId(Optional.of(billingAccountId));
-      metricUsageCollector.updateHosts("org123", "serviceType", List.of(event));
+      metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event));
       var expectedBillingAccountIds = Set.of(billingAccountId, "_ANY");
       // This shows that the instance has only a single billing account id in its buckets
       var hostBucketBillingAccountIds =

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -63,18 +63,23 @@ import org.candlepin.subscriptions.utilization.api.v1.model.GranularityType;
 import org.candlepin.subscriptions.utilization.api.v1.model.TallyReportData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(properties = "CONTRACT_USE_STUB=true")
+@SpringBootTest(properties = {"CONTRACT_USE_STUB=true", "HOURLY_TALLY_EVENT_BATCH_SIZE=2"})
 @ActiveProfiles(value = {"worker", "kafka-queue", "api", "test-inventory", "capacity-ingress"})
+@ExtendWith(OutputCaptureExtension.class)
 class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithEmbeddedKafka {
-  static final String PROMETHEUS = "prometheus";
+  static final String INSTANCE_ID = "i-123456";
   static final String METRIC = "Cores";
   static final String USER_ID = "123";
   static final String ORG_ID = "owner" + USER_ID;
@@ -100,10 +105,40 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   List<Event> events = new ArrayList<>();
   ExpectedReport expectedReport = new ExpectedReport();
 
+  @Transactional
   @BeforeEach
   public void setup() {
     expectedReport.clear();
     events.clear();
+  }
+
+  /**
+   * Test to reproduce the issue <a
+   * href="https://issues.redhat.com/browse/SWATCH-2887">SWATCH-2887</a>
+   */
+  @WithMockRedHatPrincipal(value = USER_ID)
+  @Test
+  void testProduceHourlySnapshotsForOrgFromEventsUpdatingTheSameBucket(CapturedOutput output) {
+    givenOrgAndAccountInConfig();
+    givenFiveDaysOfRangeForReport();
+    // prevent retally
+    givenExistingHostInformation();
+    // first tx
+    // host_tally_buckets created with STANDARD
+    givenEventAtDay(1, 2, Event.Sla.STANDARD);
+    // do nothing
+    givenEventAtDay(2, 2, Event.Sla.STANDARD);
+
+    // second tx
+    // host_tally_buckets deleted with STANDARD
+    // host_tally_buckets created with PREMIUM
+    givenEventAtDay(3, 2, Event.Sla.PREMIUM);
+    // host_tally_buckets deleted with PREMIUM
+    // host_tally_buckets created with STANDARD
+    givenEventAtDay(4, 2, Event.Sla.STANDARD);
+
+    whenProduceHourlySnapshotsForOrg();
+    assertFalse(output.getAll().contains("Could not collect"));
   }
 
   @WithMockRedHatPrincipal(value = USER_ID)
@@ -197,15 +232,19 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
   }
 
   private void givenEventAtDay(int dayAt, double value) {
+    givenEventAtDay(dayAt, value, Event.Sla.PREMIUM);
+  }
+
+  private void givenEventAtDay(int dayAt, double value, Event.Sla sla) {
     Event event = new Event();
     event.setEventId(UUID.randomUUID());
     event.setTimestamp(start.plusDays(dayAt));
-    event.setSla(Event.Sla.PREMIUM);
+    event.setSla(sla);
     event.setRole(Event.Role.MOA_HOSTEDCONTROLPLANE);
     event.setProductTag(Set.of(PRODUCT_TAG));
     event.setOrgId(ORG_ID);
     event.setEventType("snapshot_" + METRIC.toLowerCase() + "_" + PRODUCT_TAG.toLowerCase());
-    event.setInstanceId(PROMETHEUS);
+    event.setInstanceId(INSTANCE_ID);
     event.setEventSource("any");
     event.setExpiration(Optional.of(event.getTimestamp().plusHours(5)));
     event.setMeasurements(List.of(measurement(value)));

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -229,6 +229,7 @@ public class Host implements Serializable {
       HostTallyBucket b = existingBucket.get();
       b.setSockets(bucket.getSockets());
       b.setCores(bucket.getCores());
+      b.setStale(false);
     } else {
       bucket.setHost(this);
       getBuckets().add(bucket);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -29,6 +29,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
 import java.io.Serializable;
 import java.util.Objects;
@@ -60,6 +61,8 @@ public class HostTallyBucket implements Serializable {
   @ManyToOne(fetch = FetchType.LAZY)
   private Host host;
 
+  @Transient private boolean stale;
+
   // Version to enable optimistic locking
   @Version @Column private Integer version;
 
@@ -82,6 +85,7 @@ public class HostTallyBucket implements Serializable {
     this.cores = cores;
     this.sockets = sockets;
     this.measurementType = type;
+    this.stale = false;
   }
 
   public void setHost(Host host) {


### PR DESCRIPTION
Jira issue: SWATCH-2887

## Description
After the refactor of the event ingestion, we are handling events in batches ordered only by record date. 

Then, when we handle the events for the same host and the buckets need to be either updated/added/deleted in different transactions, hibernate throws an exception because the bucket version to update or delete does not match with the expected (the bucket version has been updated in other transaction).

Therefore, we are adding a transient "stale" field in the host tally buckets, so we can delete them after processing the batch of events. This way when an event is handled, a previously deleted tally bucket can be "restored" preserving the version.

## Testing
Added test to reproduce the issue. 