### PR TITLE
SWATCH-2935: Improve find guests DB query

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostRepository.java
@@ -527,7 +527,7 @@ public interface HostRepository
       "select distinct h1 from Host h1 where "
           + "h1.orgId = :orgId and "
           + "h1.hypervisorUuid in (select h2.subscriptionManagerId from Host h2 where "
-          + "h2.instanceId = :instanceId)")
+          + "h2.orgId=:orgId and h2.instanceId = :instanceId)")
   Page<Host> getGuestHostsByHypervisorInstanceId(
       @Param("orgId") String orgId, @Param("instanceId") String instanceId, Pageable pageable);
 


### PR DESCRIPTION

Jira issue: SWATCH-2935

Added Host.orgId to the sub query when looking up
guest Host's by the hypervisor's isntance_id.

This allows the DB to use indexes for the lookup
and improves performance quite a bit.

Testing
======
The org_id and instance_id to used to test the query can be found in the original issue. Be sure to sub in below.

**OLD QUERY**
```
gabi "explain analyse select distinct h1_0.id,h1_0.billing_account_id,h1_0.billing_provider,h1_0.cloud_provider,h1_0.display_name,h1_0.is_guest,h1_0.hardware_type,h1_0.hypervisor_uuid,h1_0.insights_id,h1_0.instance_id,h1_0.instance_type,h1_0.inventory_id,h1_0.is_hypervisor,h1_0.is_unmapped_guest,h1_0.last_applied_event_record_date,h1_0.last_seen,h1_0.num_of_guests,h1_0.org_id,h1_0.subscription_manager_id from hosts h1_0 where h1_0.org_id=$ORG_ID and h1_0.hypervisor_uuid in (select h2_0.subscription_manager_id from hosts h2_0 where h2_0.instance_id=$INSTANCE_ID)"

<SNIP>

"Planning Time: 0.581 ms"
"Execution Time: 19186.027 ms"
```

**UPDATED QUERY**

```
gabi "explain analyse select distinct h1_0.id,h1_0.billing_account_id,h1_0.billing_provider,h1_0.cloud_provider,h1_0.display_name,h1_0.is_guest,h1_0.hardware_type,h1_0.hypervisor_uuid,h1_0.insights_id,h1_0.instance_id,h1_0.instance_type,h1_0.inventory_id,h1_0.is_hypervisor,h1_0.is_unmapped_guest,h1_0.last_applied_event_record_date,h1_0.last_seen,h1_0.num_of_guests,h1_0.org_id,h1_0.subscription_manager_id from hosts h1_0 where h1_0.org_id=$ORG_ID and h1_0.hypervisor_uuid in (select h2_0.subscription_manager_id from hosts h2_0 where h2_0.org_id=$ORG_ID and h2_0.instance_id=$INSTANCE_ID)"

<SNIP>

"Planning Time: 0.617 ms"
"Execution Time: 0.456 ms"
```