### PR TITLE
SWATCH-2925: Prevent swatch contract service restarts on failures

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -318,12 +318,14 @@ mp.messaging.incoming.offering-sync-umb.connector=smallrye-amqp
 mp.messaging.incoming.offering-sync-umb.address=${OFFERING_UMB_QUEUE}
 mp.messaging.incoming.offering-sync-umb.client-options-name=umb
 mp.messaging.incoming.offering-sync-umb.enabled=${UMB_ENABLED}
+mp.messaging.incoming.offering-sync-umb.failure-strategy=ignore
 
 mp.messaging.incoming.subscription-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.subscription-sync-umb.connector=smallrye-in-memory
 mp.messaging.incoming.subscription-sync-umb.address=${SUBSCRIPTION_UMB_QUEUE}
 mp.messaging.incoming.subscription-sync-umb.client-options-name=umb
 mp.messaging.incoming.subscription-sync-umb.enabled=${UMB_ENABLED}
+mp.messaging.incoming.subscription-sync-umb.failure-strategy=ignore
 
 mp.messaging.incoming.offering-sync-task.connector=smallrye-kafka
 mp.messaging.incoming.offering-sync-task.topic=platform.rhsm-subscriptions.offering-sync

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -318,14 +318,14 @@ mp.messaging.incoming.offering-sync-umb.connector=smallrye-amqp
 mp.messaging.incoming.offering-sync-umb.address=${OFFERING_UMB_QUEUE}
 mp.messaging.incoming.offering-sync-umb.client-options-name=umb
 mp.messaging.incoming.offering-sync-umb.enabled=${UMB_ENABLED}
-mp.messaging.incoming.offering-sync-umb.failure-strategy=ignore
+mp.messaging.incoming.offering-sync-umb.failure-strategy=accept
 
 mp.messaging.incoming.subscription-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.subscription-sync-umb.connector=smallrye-in-memory
 mp.messaging.incoming.subscription-sync-umb.address=${SUBSCRIPTION_UMB_QUEUE}
 mp.messaging.incoming.subscription-sync-umb.client-options-name=umb
 mp.messaging.incoming.subscription-sync-umb.enabled=${UMB_ENABLED}
-mp.messaging.incoming.subscription-sync-umb.failure-strategy=ignore
+mp.messaging.incoming.subscription-sync-umb.failure-strategy=accept
 
 mp.messaging.incoming.offering-sync-task.connector=smallrye-kafka
 mp.messaging.incoming.offering-sync-task.topic=platform.rhsm-subscriptions.offering-sync


### PR DESCRIPTION
Jira issue: SWATCH-2925

## Description
Setting failure strategy to ignore when processing messages from UMB. This follows the same strategy as in offering-sync-task.

## Testing
Only regression testing.