### PR TITLE
SWATCH-2903 Marketplace throws vague error when handling Default api exception

### DIFF
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -130,9 +130,16 @@ public class AwsBillableUsageAggregateConsumer {
             billableUsageAggregate.getAggregateKey().getOrgId(),
             billableUsageAggregate.getRemittanceUuids(),
             billableUsageAggregate.getWindowTimestamp(),
-            awsUsageWindow);
+            awsUsageWindow,
+            e);
         emitErrorStatusOnUsage(billableUsageAggregate, BillableUsage.ErrorCode.INACTIVE);
       } else {
+        log.warn(
+            "Subscription not found for for aggregateId={} orgId={} remittanceUUIDs={}",
+            billableUsageAggregate.getAggregateId(),
+            billableUsageAggregate.getAggregateKey().getOrgId(),
+            billableUsageAggregate.getRemittanceUuids(),
+            e);
         emitErrorStatusOnUsage(
             billableUsageAggregate, BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND);
       }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -137,9 +137,16 @@ public class AzureBillableUsageAggregateConsumer {
             billableUsageAggregate.getAggregateKey().getOrgId(),
             billableUsageAggregate.getRemittanceUuids(),
             billableUsageAggregate.getWindowTimestamp(),
-            azureUsageWindow);
+            azureUsageWindow,
+            e);
         emitErrorStatusOnUsage(billableUsageAggregate, BillableUsage.ErrorCode.INACTIVE);
       } else {
+        log.warn(
+            "Subscription not found for for aggregateId={} orgId={} remittanceUUIDs={}",
+            billableUsageAggregate.getAggregateId(),
+            billableUsageAggregate.getAggregateKey().getOrgId(),
+            billableUsageAggregate.getRemittanceUuids(),
+            e);
         emitErrorStatusOnUsage(
             billableUsageAggregate, BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND);
       }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2903

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Run azure app
```
SERVER_PORT=8004 WIREMOCK_HOSTNAME=localhost ENABLE_AZURE_DRY_RUN=false SWATCH_INTERNAL_SUBSCRIPTION_ENDPOINT=http://localhost:8000 QUARKUS_PROFILE=dev,wiremock ./gradlew :swatch-producer-azure:quarkusDev

```

### Steps
<!-- Enter each step of the test below -->
1. Send kafka message using producer ` billable-usage-hourly-aggregate`
```
{"windowTimestamp":"2023-12-21T01:10:28Z","aggregateId": "e81bc918-6434-4a58-9192-8a8dd73ec8fb","aggregateKey": {"orgId": "org123","billingProvider": "azure","metricId": "CORES","productId": "rosa"}, "remittanceUuids": ["d125f119-0c98-43f2-a5de-ccf2e8e1ab55"]}
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Logs
```
2024-09-23 23:48:10,154 WARN  [com.red.swa.azu.ser.AzureBillableUsageAggregateConsumer] (vert.x-worker-thread-1) Subscription not found for for aggregateId=e81bc918-6434-4a58-9192-8a8dd73ec8fb orgId=org123 remittanceUUIDs=[d125f119-0c98-43f2-a5de-ccf2e8e1ab55]: com.redhat.swatch.azure.exception.SubscriptionCanNotBeDeterminedException: SUBSCRIPTION_CANNOT_BE_DETERMINED
        at com.redhat.swatch.azure.service.AzureBillableUsageAggregateConsumer.lookupAzureUsageContext(AzureBillableUsageAggregateConsumer.java:263)
        at com.redhat.swatch.azure.service.AzureBillableUsageAggregateConsumer_Subclass.lookupAzureUsageContext$$superforward(Unknown Source)
        at com.redhat.swatch.azure.service.AzureBillableUsageAggregateConsumer_Subclass$$function$$1.apply(Unknown Source)
        at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:73)
        at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:62)
        at io.smallrye.faulttolerance.FaultToleranceInterceptor.lambda$syncFlow$3(FaultToleranceInterceptor.java:267)
```
