### PR TITLE
SWATCH-2952: Support alternate schema for HBI tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ RHSM_RBAC_USE_STUB=true ./gradlew bootRun
 * `INVENTORY_DATABASE_DATABASE`: inventory DB database
 * `INVENTORY_DATABASE_USERNAME`: inventory DB user
 * `INVENTORY_DATABASE_PASSWORD`: inventory DB password
+* `INVENTORY_DATABASE_SCHEMA`: inventory DB schema
 * `PRODUCT_DENYLIST_RESOURCE_LOCATION`: location of the product denylist
 * `ACCOUNT_LIST_RESOURCE_LOCATION`: location of the account list (opt-in used otherwise)
 * `DATABASE_HOST`: DB host

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -17,7 +17,7 @@ rhsm-subscriptions:
   hourlyTallyEventBatchSize: ${HOURLY_TALLY_EVENT_BATCH_SIZE:16000}
   inventory-service:
     datasource:
-      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}?currentSchema${INVENTORY_DATABASE_SCHEMA:public}&ApplicationName=${clowder.metadata.name:rhsm-subscriptions}
+      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}?currentSchema=${INVENTORY_DATABASE_SCHEMA:public}&ApplicationName=${clowder.metadata.name:rhsm-subscriptions}
       username: ${INVENTORY_DATABASE_USERNAME:insights}
       password: ${INVENTORY_DATABASE_PASSWORD:insights}
       driver-class-name: org.postgresql.Driver

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -17,7 +17,7 @@ rhsm-subscriptions:
   hourlyTallyEventBatchSize: ${HOURLY_TALLY_EVENT_BATCH_SIZE:16000}
   inventory-service:
     datasource:
-      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}?ApplicationName=${clowder.metadata.name:rhsm-subscriptions}
+      url: jdbc:postgresql://${INVENTORY_DATABASE_HOST:localhost}/${INVENTORY_DATABASE_DATABASE:insights}?currentSchema${INVENTORY_DATABASE_SCHEMA:public}&ApplicationName=${clowder.metadata.name:rhsm-subscriptions}
       username: ${INVENTORY_DATABASE_USERNAME:insights}
       password: ${INVENTORY_DATABASE_PASSWORD:insights}
       driver-class-name: org.postgresql.Driver

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -109,6 +109,8 @@ parameters:
     value: 'host-inventory-db'
   - name: INVENTORY_SECRET_KEY_NAME_PREFIX
     value: ''
+  - name: INVENTORY_DATABASE_SCHEMA
+    value: public
   - name: KAFKA_SUBSCRIPTIONS_PRUNE_REPLICAS
     value: '3'
   - name: KAFKA_SUBSCRIPTIONS_PRUNE_PARTITIONS
@@ -317,6 +319,8 @@ objects:
                 secretKeyRef:
                   name: ${INVENTORY_SECRET_KEY_NAME}
                   key: ${INVENTORY_SECRET_KEY_NAME_PREFIX}password
+            - name: INVENTORY_DATABASE_SCHEMA
+              value: ${INVENTORY_DATABASE_SCHEMA}
             - name: PRODUCT_DENYLIST_RESOURCE_LOCATION
               value: file:/denylist/product-denylist.txt
             - name: PRODUCT_KEYSTORE

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -128,6 +128,8 @@ parameters:
     value: 'host-inventory-db'
   - name: INVENTORY_SECRET_KEY_NAME_PREFIX
     value: ''
+  - name: INVENTORY_DATABASE_SCHEMA
+    value: public
   - name: DEVTEST_EVENT_EDITING_ENABLED
     value: 'false'
 
@@ -395,6 +397,8 @@ objects:
               value: ${INVENTORY_DATABASE_CONNECTION_TIMEOUT_MS}
             - name: INVENTORY_DATABASE_MAX_POOL_SIZE
               value: ${INVENTORY_DATABASE_MAX_POOL_SIZE}
+            - name: INVENTORY_DATABASE_SCHEMA
+              value: ${INVENTORY_DATABASE_SCHEMA}
             - name: SWATCH_SELF_PSK
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2952

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

* Enable ClowdApp parameter for HBI host table schema location
* Add connection parameter to specify the schema to use during the connection
* HBI will be transitioning its host tables from the public schema to enable logical replication of data, in order to still perform tallies using this database subscription watch needs to be able to connect to an alternate schema.

See `currentSchema` connection parameter information here: https://jdbc.postgresql.org/documentation/use/
```
currentSchema (String) Default null
Specify the schema (or several schema separated by commas) to be set in the search-path. This schema will be used to resolve unqualified object names used in statements over this connection.
```

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Deploy to ephemeral environment
2. Populate HBI with several hosts
3. Create new schema in HBI postgres `CREATE SCHEMA hbi;`
4. Alter the HBI host tables to new schema
```
ALTER TABLE public.hosts SET SCHEMA hbi;
ALTER TABLE public.groups SET SCHEMA hbi;
ALTER TABLE public.hosts_groups SET SCHEMA hbi;
ALTER TABLE public.staleness SET SCHEMA hbi;
ALTER TABLE public.assignment_rules SET SCHEMA hbi;
```
5. Alter ClowdApp parameter `INVENTORY_DATABASE_SCHEMA` to be `hbi` and redeploy tally and sync

### Steps
<!-- Enter each step of the test below -->
1. Perform tally and sync tests

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Verify that connection can be made correctly
2. Verify that totals match expected values in being read from new schema location 
