### PR TITLE
SWATCH-2960: Increase timeout to get azure/aws context

### DIFF
--- a/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/api/RetryWithExponentialBackoff.java
+++ b/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/api/RetryWithExponentialBackoff.java
@@ -66,4 +66,8 @@ public @interface RetryWithExponentialBackoff {
    */
   @Nonbinding
   String maxDelay() default "";
+
+  /** Exceptions to be retried on. */
+  @Nonbinding
+  Class<? extends Throwable>[] retryOn() default Exception.class;
 }

--- a/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptor.java
+++ b/swatch-common-smallrye-fault-tolerance/src/main/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptor.java
@@ -71,6 +71,10 @@ public class RetryWithExponentialBackoffInterceptor {
       retry.delay(duration.get().toMillis(), ChronoUnit.MILLIS);
     }
 
+    if (binding.retryOn() != null) {
+      retry.retryOn(List.of(binding.retryOn()));
+    }
+
     var exponentialBackoff = retry.withExponentialBackoff();
     getOptionalValue(binding.factor(), Integer.class).ifPresent(exponentialBackoff::factor);
     getOptionalValue(binding.maxDelay(), Duration.class)

--- a/swatch-common-smallrye-fault-tolerance/src/test/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptorTest.java
+++ b/swatch-common-smallrye-fault-tolerance/src/test/java/com/redhat/swatch/faulttolerance/interceptors/RetryWithExponentialBackoffInterceptorTest.java
@@ -86,6 +86,18 @@ class RetryWithExponentialBackoffInterceptorTest {
     assertEquals(2, COUNTER.get());
   }
 
+  @Test
+  void testAnnotationUsingRetryOnPropertyShouldNotRetry() {
+    assertThrows(RuntimeException.class, () -> service.runUsingRetryOnShouldNotRetry());
+    assertEquals(1, COUNTER.get());
+  }
+
+  @Test
+  void testAnnotationUsingRetryOnPropertyShouldRetry() {
+    assertThrows(RuntimeException.class, () -> service.runUsingRetryOnShouldRetry());
+    assertEquals(4, COUNTER.get());
+  }
+
   @ApplicationScoped
   static class Service {
 
@@ -95,6 +107,18 @@ class RetryWithExponentialBackoffInterceptorTest {
 
     @RetryWithExponentialBackoff(maxRetries = "3")
     void runUsingDirectValue() {
+      run();
+    }
+
+    @RetryWithExponentialBackoff(maxRetries = "3", retryOn = NullPointerException.class)
+    void runUsingRetryOnShouldNotRetry() {
+      // run throws a RuntimeException, not a NullPointerException exception.
+      run();
+    }
+
+    @RetryWithExponentialBackoff(maxRetries = "3", retryOn = RuntimeException.class)
+    void runUsingRetryOnShouldRetry() {
+      // run throws a RuntimeException, so it should retry
       run();
     }
 

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(":swatch-common-kafka")
     implementation project(":swatch-common-resteasy-client")
     implementation project(':swatch-common-trace-response')
+    implementation project(':swatch-common-smallrye-fault-tolerance')
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -125,8 +125,8 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-password=${clowder.endpoints.swatch-contracts-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-type=${clowder.endpoints.swatch-contracts-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter, com.redhat.swatch.aws.resource.DefaultApiExceptionMapper, com.redhat.swatch.common.resteasy.OffsetDateTimeParamConverterProvider
-com.redhat.swatch.processors.BillableUsageProcessor/lookupAwsUsageContext/Retry/maxRetries=${AWS_USAGE_CONTEXT_LOOKUP_RETRIES}
-com.redhat.swatch.processors.BillableUsageProcessor/send/Retry/maxRetries=${AWS_SEND_RETRIES}
+# Setting up the timeout to 2 minutes instead of 30 seconds (default)
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(":clients:azure-marketplace-client")
     implementation project(':swatch-model-billable-usage')
     implementation project(':swatch-common-trace-response')
+    implementation project(':swatch-common-smallrye-fault-tolerance')
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'org.mockito:mockito-junit-jupiter'

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -36,6 +36,7 @@ import com.redhat.swatch.clients.contracts.api.resources.DefaultApi;
 import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.Variant;
+import com.redhat.swatch.faulttolerance.api.RetryWithExponentialBackoff;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.reactive.messaging.annotations.Blocking;
@@ -54,7 +55,6 @@ import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.MDC;
@@ -233,7 +233,7 @@ public class AzureBillableUsageAggregateConsumer {
     return usage;
   }
 
-  @Retry(retryOn = AzureUsageContextLookupException.class)
+  @RetryWithExponentialBackoff(retryOn = AzureUsageContextLookupException.class)
   public AzureUsageContext lookupAzureUsageContext(BillableUsageAggregate billableUsageAggregate)
       throws AzureUsageContextLookupException {
     try {

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -135,6 +135,8 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter,com.redhat.swatch.azure.resource.DefaultApiExceptionMapper
+# Setting up the timeout to 2 minutes instead of 30 seconds (default)
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}


### PR DESCRIPTION
Jira issue: SWATCH-2960

## Description
- Increase timeout to get azure/aws context
- Fix the retry policy in the aws producer service

## Testing
To be verified in stage.