### PR TITLE
SWATCH-2943: Improve performance of query for subscriptions table v2

### DIFF
--- a/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
+++ b/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <comment>
+      Update subscription_capacity_view to filter by org_id
+    </comment>
+    <dropView viewName="subscription_capacity_view" />
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[with active_subscriptions as
+                        (
+                          select org_id, subscription_id, MAX(start_date) as start_date
+                          from "subscription"
+                          where start_date <= now() and (end_date is null or end_date >= now())
+                          group by org_id, subscription_id
+                        )
+                 select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.description as product_name,
+                        coalesce(o.sla, '') as service_level,
+                        coalesce(o."usage", '') as "usage",
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from active_subscriptions a
+                 inner join "subscription" s on a.subscription_id=s.subscription_id and a.start_date=s.start_date and a.org_id=s.org_id
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        ]]>
+    </createView>
+    <rollback>
+      <createView
+              replaceIfExists="true"
+              viewName="subscription_capacity_view">
+        <![CDATA[with active_subscriptions as
+                        (
+                          select subscription_id, MAX(start_date) as start_date
+                          from "subscription"
+                          where start_date <= now() and (end_date is null or end_date >= now())
+                          group by subscription_id
+                        )
+                 select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.description as product_name,
+                        coalesce(o.sla, '') as service_level,
+                        coalesce(o."usage", '') as "usage",
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from active_subscriptions a
+                 inner join "subscription" s on a.subscription_id=s.subscription_id and a.start_date=s.start_date
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        ]]>
+      </createView>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -171,5 +171,6 @@
     <include file="/liquibase/202407160722-drop-subscription-product-ids-table.xml"/>
     <include file="/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml"/>
     <include file="/liquibase/202407231110-subscription-capacity-index.xml"/>
+    <include file="/liquibase/202409251400-update-subscription-capacity-view-org-id.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-2943

## Description
The poor performant query for the subscription table v2 is causing timeout issues in prodution. 

To address the issue, the only required change is to also group by org_id. By doing this, it drastically improves the execution plan of the query.

To verify the increase of performance, I loaded the stage data into my local and checked the execution plan. 
Before these changes, it was:

```
Subquery Scan on scv1_0  (cost=57678.75..57678.80 rows=1 width=265) (actual time=660.374..665.947 rows=0 loops=1)
  ->  GroupAggregate  (cost=57678.75..57678.79 rows=1 width=275) (actual time=660.373..665.945 rows=0 loops=1)
        Group Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, spt.product_tag, s.start_date
        ->  Sort  (cost=57678.75..57678.75 rows=1 width=1219) (actual time=660.371..665.943 rows=0 loops=1)
              Sort Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, s.start_date
              Sort Method: quicksort  Memory: 25kB
              ->  Nested Loop Left Join  (cost=40395.38..57678.74 rows=1 width=1219) (actual time=660.361..665.932 rows=0 loops=1)
                    ->  Nested Loop  (cost=40395.24..57670.57 rows=1 width=179) (actual time=660.360..665.931 rows=0 loops=1)
                          Join Filter: ((s.sku)::text = (spt.sku)::text)
                          ->  Nested Loop  (cost=40394.96..57667.21 rows=1 width=172) (actual time=660.359..665.930 rows=0 loops=1)
                                ->  Merge Join  (cost=40394.67..57658.90 rows=1 width=59) (actual time=660.358..665.929 rows=0 loops=1)
                                      Merge Cond: ((subscription.subscription_id)::text = (s.subscription_id)::text)
                                      Join Filter: (s.start_date = (max(subscription.start_date)))
                                      ->  Finalize GroupAggregate  (cost=40350.66..55958.13 rows=132539 width=16) (actual time=458.145..645.754 rows=128243 loops=1)
                                            Group Key: subscription.subscription_id
                                            ->  Gather Merge  (cost=40350.66..54079.92 rows=110564 width=16) (actual time=458.137..607.302 rows=128246 loops=1)
                                                  Workers Planned: 2
                                                  Workers Launched: 2
                                                  ->  Partial GroupAggregate  (cost=39350.63..40318.07 rows=55282 width=16) (actual time=432.749..466.779 rows=43502 loops=3)
                                                        Group Key: subscription.subscription_id
                                                        ->  Sort  (cost=39350.63..39488.84 rows=55282 width=16) (actual time=432.733..450.109 rows=43505 loops=3)
                                                              Sort Key: subscription.subscription_id
                                                              Sort Method: external merge  Disk: 1464kB
                                                              Worker 0:  Sort Method: external merge  Disk: 1416kB
                                                              Worker 1:  Sort Method: external merge  Disk: 1544kB
                                                              ->  Parallel Seq Scan on subscription  (cost=0.00..34995.93 rows=55282 width=16) (actual time=0.175..143.117 rows=44561 loops=3)
                                                                    Filter: ((start_date <= now()) AND ((end_date IS NULL) OR (end_date >= now())))
                                                                    Rows Removed by Filter: 496156
                                      ->  Sort  (cost=44.02..44.02 rows=1 width=59) (actual time=0.103..0.108 rows=22 loops=1)
                                            Sort Key: s.subscription_id
                                            Sort Method: quicksort  Memory: 28kB
                                            ->  Bitmap Heap Scan on subscription s  (cost=4.50..44.01 rows=1 width=59) (actual time=0.043..0.058 rows=22 loops=1)
                                                  Recheck Cond: ((org_id)::text = ''::text)
                                                  Filter: ((billing_provider_id IS NOT NULL) AND ((billing_provider_id)::text <> ''::text))
                                                  Heap Blocks: exact=6
```

Note the query cost is `57678.75` which is a lot. 

After these changes:

```
Subquery Scan on scv1_0  (cost=80.44..80.49 rows=1 width=265) (actual time=0.082..0.085 rows=0 loops=1)
  ->  GroupAggregate  (cost=80.44..80.48 rows=1 width=275) (actual time=0.082..0.084 rows=0 loops=1)
        Group Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, spt.product_tag, s.start_date
        ->  Sort  (cost=80.44..80.45 rows=1 width=1219) (actual time=0.080..0.082 rows=0 loops=1)
              Sort Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, s.start_date
              Sort Method: quicksort  Memory: 25kB
              ->  Nested Loop Left Join  (cost=45.23..80.43 rows=1 width=1219) (actual time=0.072..0.074 rows=0 loops=1)
                    ->  Nested Loop  (cost=45.09..72.27 rows=1 width=179) (actual time=0.071..0.073 rows=0 loops=1)
                          Join Filter: ((s.sku)::text = (spt.sku)::text)
                          ->  Nested Loop  (cost=44.81..68.91 rows=1 width=172) (actual time=0.071..0.073 rows=0 loops=1)
                                ->  Nested Loop  (cost=44.52..60.60 rows=1 width=59) (actual time=0.071..0.072 rows=0 loops=1)
                                      ->  GroupAggregate  (cost=44.09..44.11 rows=1 width=24) (actual time=0.071..0.072 rows=0 loops=1)
                                            Group Key: subscription.org_id, subscription.subscription_id
                                            ->  Sort  (cost=44.09..44.10 rows=1 width=24) (actual time=0.070..0.071 rows=0 loops=1)
                                                  Sort Key: subscription.subscription_id
                                                  Sort Method: quicksort  Memory: 25kB
                                                  ->  Bitmap Heap Scan on subscription  (cost=4.50..44.08 rows=1 width=24) (actual time=0.068..0.068 rows=0 loops=1)
                                                        Recheck Cond: ((org_id)::text = ''::text)
                                                        Filter: ((start_date <= now()) AND ((end_date IS NULL) OR (end_date >= now())))
                                                        Rows Removed by Filter: 22
                                                        Heap Blocks: exact=6
                                                        ->  Bitmap Index Scan on subscription_owner_id_idx  (cost=0.00..4.50 rows=10 width=0) (actual time=0.034..0.034 rows=22 loops=1)
                                                              Index Cond: ((org_id)::text = ''::text)
                                      ->  Index Scan using subscription_pkey on subscription s  (cost=0.43..8.45 rows=1 width=59) (never executed)
                                            Index Cond: (((subscription_id)::text = (subscription.subscription_id)::text) AND (start_date = (max(subscription.start_date))))
                                            Filter: ((billing_provider_id IS NOT NULL) AND ((billing_provider_id)::text <> ''::text) AND ((org_id)::text = ''::text))
                                ->  Index Scan using offering_pkey on offering o  (cost=0.29..8.30 rows=1 width=113) (never executed)
                                      Index Cond: ((sku)::text = (s.sku)::text)
                          ->  Index Scan using sku_product_tag_sku_idx on sku_product_tag spt  (cost=0.29..3.35 rows=1 width=25) (never executed)
                                Index Cond: ((sku)::text = (o.sku)::text)
                                Filter: ((product_tag)::text = ''::text)
                    ->  Index Scan using subscription_id_idx on subscription_measurements sm  (cost=0.14..8.16 rows=1 width=1556) (never executed)
                          Index Cond: ((subscription_id)::text = (s.subscription_id)::text)
```

Now, the cost is `80.44`.

## Testing
Regression testing only. 

