### PR TITLE
SWATCH-2960: Increase usage hourly consumer timeout and context retries

### DIFF
--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -5,7 +5,7 @@ SWATCH_CONTRACTS_ENDPOINT=${clowder.endpoints.swatch-contracts-service.url}
 AWS_REGION=us-east-1
 AWS_MANUAL_SUBMISSION_ENABLED=false
 AWS_SEND_RETRIES=0
-AWS_USAGE_CONTEXT_LOOKUP_RETRIES=0
+AWS_USAGE_CONTEXT_LOOKUP_RETRIES=3
 AWS_MARKETPLACE_ENDPOINT_OVERRIDE=false
 AWS_MARKETPLACE_USAGE_WINDOW=6h
 ENABLE_SPLUNK_HEC=true
@@ -105,6 +105,9 @@ mp.messaging.incoming.billable-usage-hourly-aggregate-in.topic=${BILLABLE_USAGE_
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.group.id=swatch-producer-aws-usage-aggregate-consumer
 # Start at end of topic to prevent duplicate billing
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.auto.offset.reset=latest
+# This value needs to be synced with the retry configuration of the contracts API which will retry up to
+# 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
+mp.messaging.incoming.billable-usage-hourly-aggregate-in.throttled.unprocessed-record-max-age.ms=360000
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.value.deserializer=org.candlepin.subscriptions.billable.usage.BillableUsageAggregateDeserializer
 
 # Producer settings

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -233,7 +233,9 @@ public class AzureBillableUsageAggregateConsumer {
     return usage;
   }
 
-  @RetryWithExponentialBackoff(retryOn = AzureUsageContextLookupException.class)
+  @RetryWithExponentialBackoff(
+      maxRetries = "${AZURE_USAGE_CONTEXT_LOOKUP_RETRIES}",
+      retryOn = AzureUsageContextLookupException.class)
   public AzureUsageContext lookupAzureUsageContext(BillableUsageAggregate billableUsageAggregate)
       throws AzureUsageContextLookupException {
     try {

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -26,7 +26,7 @@ AZURE_MANUAL_SUBMISSION_ENABLED=false
 %stage.AZURE_MANUAL_SUBMISSION_ENABLED=true
 
 AZURE_SEND_RETRIES=0
-AZURE_USAGE_CONTEXT_LOOKUP_RETRIES=0
+AZURE_USAGE_CONTEXT_LOOKUP_RETRIES=3
 
 ENABLE_AZURE_DRY_RUN=true
 %ephemeral.ENABLE_AZURE_DRY_RUN=false
@@ -117,6 +117,9 @@ mp.messaging.incoming.billable-usage-hourly-aggregate-in.topic=platform.rhsm-sub
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.group.id=swatch-producer-azure-usage-aggregate-consumer
 # Start at end of topic to prevent duplicate billing
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.auto.offset.reset=earliest
+# This value needs to be synced with the retry configuration of the contracts API which will retry up to
+# 3 times with a max duration of 120 seconds, so the correct value would be 3 x 120 =
+mp.messaging.incoming.billable-usage-hourly-aggregate-in.throttled.unprocessed-record-max-age.ms=360000
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.value.deserializer=org.candlepin.subscriptions.billable.usage.BillableUsageAggregateDeserializer
 
 # Producer settings


### PR DESCRIPTION
Jira issue: SWATCH-2960

## Description
We increased the contracts API timeout to 2 minutes, but we missed to also increase the consumer topic timeout, so we're seeing errors like the following in stage:

```
SRMSG18231: The record 20723 from topic-partition 'platform.rhsm-subscriptions.billable-usage-hourly-aggregate-10' has waited for 62 seconds to be acknowledged. This waiting time is greater than the configured threshold (60000 ms). At the moment 1 messages from this partition are awaiting acknowledgement. The last committed offset for this partition was 20722. This error is due to a potential issue in the application which does not acknowledged the records in a timely fashion. The connector cannot commit as a record processing has not completed.
```

Moreover, I still see some errors getting the context (for aws and azure), I will keep investigate these failures, though I will also increase the retry to 3 (before, we were not retrying).

## Testing
Regression testing and to be verified in stage.