### PR TITLE
SWATCH-2970: Fix the contract API certificate configuration in azure svc

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -20,9 +20,6 @@ DATABASE_DATABASE=${clowder.database.name:rhsm-subscriptions}
 DATABASE_USERNAME=${clowder.database.username:rhsm-subscriptions}
 DATABASE_PASSWORD=${clowder.database.password:rhsm-subscriptions}
 
-CONTRACT_SERVICE_URL=${clowder.endpoints.swatch-contracts-service.url}
-%ephemeral.CONTRACT_SERVICE_URL=${WIREMOCK_ENDPOINT}/mock/contractsApi
-
 BILLABLE_USAGE_TOPIC=platform.rhsm-subscriptions.billable-usage
 BILLABLE_USAGE_HOURLY_AGGREGATE_TOPIC=platform.rhsm-subscriptions.billable-usage-hourly-aggregate
 KSTREAM_BILLABLE_USAGE_STORE=billable-usage-store

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -18,9 +18,14 @@ SPLUNK_HEC_RETRY_COUNT=3
 SPLUNK_HEC_INCLUDE_EX=false
 BILLABLE_USAGE_HOURLY_AGGREGATE_TOPIC=platform.rhsm-subscriptions.billable-usage-hourly-aggregate
 USAGE_AGGREGATE_FAIL_ON_DESER_FAILURE=true
+WIREMOCK_HOSTNAME=wiremock
+WIREMOCK_ENDPOINT=http://wiremock-service:8000
 CORS_ORIGINS=/.+\\\\.redhat\\\\.com/
 DISABLE_OTEL=true
 %ephemeral.DISABLE_OTEL=true
+
+# wiremock defaults
+%wiremock.SWATCH_CONTRACTS_ENDPOINT=http://${WIREMOCK_HOSTNAME}:8101/mock/internalSub
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -134,9 +134,9 @@ mp.messaging.outgoing.billable-usage-status-out.value.serializer=org.candlepin.s
 quarkus.rest-client-reactive.provider-autodiscovery=false
 
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".url=${SWATCH_CONTRACTS_ENDPOINT}
-quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-subscription-sync-service.trust-store-path}
-quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-password=${clowder.endpoints.swatch-subscription-sync-service.trust-store-password}
-quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-type=${clowder.endpoints.swatch-subscription-sync-service.trust-store-type}
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-contracts-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-password=${clowder.endpoints.swatch-contracts-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store-type=${clowder.endpoints.swatch-contracts-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".providers=com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter,com.redhat.swatch.azure.resource.DefaultApiExceptionMapper
 # Setting up the timeout to 2 minutes instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -43,8 +43,9 @@ AZURE_MARKETPLACE_BASE_URL=https://marketplaceapi.microsoft.com
 AZURE_MARKETPLACE_API_VERSION=2018-08-31
 AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 
+# wiremock defaults
 %wiremock.SWATCH_CONTRACTS_ENDPOINT=http://${WIREMOCK_HOSTNAME}:8101/mock/internalSub
-%ephemeral.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractsApi
+# %ephemeral.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractsApi
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -39,13 +39,11 @@ AZURE_OAUTH_TOKEN_URL=https://login.microsoftonline.com/[TenantIdPlaceholder]/oa
 AZURE_MARKETPLACE_CREDENTIALS={"credentials":{"azure":{"clients":[{"tenantId":"test","clientId":"test","clientSecret":"test","publisher":"test"}]}}}
 AZURE_MARKETPLACE_BASE_URL=https://marketplaceapi.microsoft.com
 %wiremock.AZURE_MARKETPLACE_BASE_URL=http://${WIREMOCK_HOSTNAME}:8101/mock/azureMarketplace
-%ephemeral.AZURE_MARKETPLACE_BASE_URL=${WIREMOCK_ENDPOINT}/mock/azure
 AZURE_MARKETPLACE_API_VERSION=2018-08-31
 AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 
 # wiremock defaults
 %wiremock.SWATCH_CONTRACTS_ENDPOINT=http://${WIREMOCK_HOSTNAME}:8101/mock/internalSub
-# %ephemeral.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractsApi
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
@@ -64,6 +62,10 @@ AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 %test.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}
 %test.HOST_NAME=unit_tests
 %test.SWATCH_CONTRACTS_ENDPOINT=${%dev.SWATCH_CONTRACTS_ENDPOINT}
+
+# ephemeral specifics:
+%ephemeral.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractApi
+%ephemeral.AZURE_MARKETPLACE_BASE_URL=${WIREMOCK_ENDPOINT}/mock/azure
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode


### PR DESCRIPTION
Jira issue: SWATCH-2970

## Description
- Fix the contract API certificate configuration in azure svc
- Not use the wiremock in swatch producer azure in EE
- Configure aws and azure services the same way to deal with the wiremock

## Testing
The test "test_verify_multi_cloud_provider_usage" should pass in CI.