### PR TITLE
Remove logic to force sync an org during UsageContext lookup

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
@@ -41,7 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class UsageContextSubscriptionProvider {
 
-  private final SubscriptionSyncService subscriptionSyncService;
   private final SubscriptionRepository subscriptionRepository;
   private final MeterRegistry meterRegistry;
 
@@ -55,10 +54,6 @@ public class UsageContextSubscriptionProvider {
     List<SubscriptionEntity> subscriptions =
         subscriptionRepository.findByCriteria(
             criteria, Sort.descending(SubscriptionEntity_.START_DATE));
-    if (subscriptions.isEmpty()) {
-      subscriptionSyncService.forceSyncSubscriptionsForOrg(criteria.getOrgId(), true);
-      subscriptions = subscriptionRepository.findByCriteria(criteria);
-    }
 
     var existsRecentlyTerminatedSubscription =
         subscriptions.stream()

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProviderTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProviderTest.java
@@ -58,7 +58,6 @@ class UsageContextSubscriptionProviderTest {
   private static final OffsetDateTime DEFAULT_END_DATE =
       OffsetDateTime.of(2022, 7, 22, 8, 0, 0, 0, ZoneOffset.UTC);
 
-  @Mock private SubscriptionSyncService syncService;
   @Mock private SubscriptionRepository repo;
   private MeterRegistry meterRegistry;
   private UsageContextSubscriptionProvider provider;
@@ -68,7 +67,7 @@ class UsageContextSubscriptionProviderTest {
   void setupTest() {
     givenDefaultCriteria();
     meterRegistry = new SimpleMeterRegistry();
-    provider = new UsageContextSubscriptionProvider(syncService, repo, meterRegistry);
+    provider = new UsageContextSubscriptionProvider(repo, meterRegistry);
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2971

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Force syncing subscriptions is slowing down the GET azureUsageContext and awsUsageContext calls which in turn is causing lag in our swatch-producer-azure and swatch-producer-aws components. We no longer need to perform this sync because we have retries in place so we are removing the forceSync logic.

## Testing
Regression
