### PR TITLE
SWATCH-2942: Identify product if any of the rule matches

### DIFF
--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -239,21 +239,15 @@ public class SubscriptionDefinition {
             .flatMap(subscription -> subscription.getVariants().stream())
             .collect(Collectors.toSet());
 
-    List<Predicate<Variant>> sequentialPredicates =
-        List.of(
-            createLevelPredicate(params),
-            createRolePredicate(params),
-            createEngIdPredicate(params),
-            createProductNamePredicate(params));
-
-    Set<Variant> filteredVariants = new HashSet<>();
-
-    for (Predicate<Variant> predicate : sequentialPredicates) {
-      filteredVariants = variants.stream().filter(predicate).collect(Collectors.toSet());
-      if (!filteredVariants.isEmpty()) {
-        break;
-      }
-    }
+    Set<Variant> filteredVariants =
+        variants.stream()
+            // order of predicates is important. When one applies, we stop checking the rest.
+            .filter(
+                createLevelPredicate(params)
+                    .or(createRolePredicate(params))
+                    .or(createEngIdPredicate(params))
+                    .or(createProductNamePredicate(params)))
+            .collect(Collectors.toSet());
 
     if (filteredVariants.isEmpty()) {
       log.info("No variants found to uniquely identify a product based on {}", params);

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -383,6 +383,22 @@ class SubscriptionDefinitionTest {
     assertEquals(expectedProductTags, actual);
   }
 
+  /** Test to reproduce <a href="https://issues.redhat.com/browse/SWATCH-2942">SWATCH-2942</a>. */
+  @Test
+  void testRhelSapProducts() {
+    ProductTagLookupParams params =
+        ProductTagLookupParams.builder()
+            .engIds(
+                Set.of(
+                    387, 388, // match rhel-for-sap-x86
+                    389, 479))
+            .role("Red Hat Enterprise Linux Server") // role will match the product "RHEL x86"
+            .build();
+    var actual = SubscriptionDefinition.getAllProductTags(params);
+    assertTrue(actual.contains("rhel-for-sap-x86"), "missing product 'rhel-for-sap-x86'");
+    assertTrue(actual.contains("RHEL for x86"), "missing product 'RHEL for x86'");
+  }
+
   private static Stream<Arguments> ansibleTestCases() {
 
     var lookupParams1 =
@@ -396,7 +412,7 @@ class SubscriptionDefinitionTest {
     var lookupParams2 =
         ProductTagLookupParams.builder()
             .metricIds(Set.of())
-            .engIds(Set.of("69", "204", "83", "408"))
+            .engIds(Set.of("69", "83", "408"))
             .role(null)
             .productName("NULL")
             .level1("Ansible")


### PR DESCRIPTION
Jira issue: SWATCH-2942

## Description
Before these changes, when identifying matching products, as long as one rule applies, we stop checking other products rules. 
After these changes, we will always loop among the products to see if any rule applies. 

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/884