### PR TITLE
SWATCH-2611: Update existing billable_usage_remittance status to unknown

### DIFF
--- a/src/main/resources/liquibase/202410021300-update_usages_to_unknown.xml
+++ b/src/main/resources/liquibase/202410021300-update_usages_to_unknown.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202410021300-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <comment>
+      All existing billable_usage_remittance older than October 1 where status='pending'
+      or status is null are updated to have status='unknown'.
+    </comment>
+    <sql dbms="postgresql">
+      <![CDATA[
+        update billable_usage_remittance set status = 'unknown'
+        where (status is null or status = 'pending')
+        and remittance_pending_date < TO_TIMESTAMP('2024-10-01 0:00:00','YYYY-MM-DD HH24:MI:SS')
+      ]]>
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -172,5 +172,6 @@
     <include file="/liquibase/202407161214-clean-up-non-payg-measurements-on-rhel-systems.xml"/>
     <include file="/liquibase/202407231110-subscription-capacity-index.xml"/>
     <include file="/liquibase/202409251400-update-subscription-capacity-view-org-id.xml"/>
+    <include file="/liquibase/202410021300-update_usages_to_unknown.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
@@ -34,6 +34,7 @@ public enum RemittanceStatus {
   PENDING("pending"),
   GRATIS("gratis"),
   FAILED("failed"),
+  UNKNOWN("unknown"),
   SUCCEEDED("succeeded");
 
   private static final Map<String, RemittanceStatus> VALUE_ENUM_MAP =


### PR DESCRIPTION
Jira issue: SWATCH-2611

## Description
All existing billable_usage_remittance older than the release where we started populating the statuses ( Prior to October 1) where status='pending' or status is null records updated to have status='unknown'

## Testing
0. start database
1. checkout the main branch (to not use the migration script from this PR)
2. start api service to migrate the schema: `SPRING_PROFILES_ACTIVE=api DEV_MODE=true ./gradlew :bootRun`
3. stop the api service
4. create the following usages:

```
-- old usage without status: needs to be updated with unknown
INSERT INTO billable_usage_remittance(uuid, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, remitted_pending_value)
VALUES ('c2d29867-3d0b-d497-9191-18a9d8ee7830', 'org123', 'rosa', 'CORES', '2024-02', 'Premium', 'Production', 'azure', '123456', '2023-02-11T04:00:09.620406Z', '4.0');

-- recent usage without status: no updates here because remittance_pending_date is more recent than 1 oct
INSERT INTO billable_usage_remittance(uuid, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, remitted_pending_value)
VALUES ('c2d29867-3d0b-d497-9191-18a9d8ee7831', 'org124', 'rosa', 'CORES', '2024-02', 'Premium', 'Production', 'azure', '123456', '2024-10-01T04:00:09.620406Z', '4.0');

-- old usage with status 'pending': needs to be updated with unknown
INSERT INTO billable_usage_remittance(uuid, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, remitted_pending_value, status)
VALUES ('c2d29867-3d0b-d497-9191-18a9d8ee7832', 'org125', 'rosa', 'CORES', '2024-02', 'Premium', 'Production', 'azure', '123456', '2023-02-11T04:00:09.620406Z', '4.0', 'pending');

-- old usage with status 'failed': no updates because status was not pending
INSERT INTO billable_usage_remittance(uuid, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remittance_pending_date, remitted_pending_value, status)
VALUES ('c2d29867-3d0b-d497-9191-18a9d8ee7833', 'org126', 'rosa', 'CORES', '2024-02', 'Premium', 'Production', 'azure', '123456', '2023-02-11T04:00:09.620406Z', '4.0', 'failed');
```

5. checkout the `jcarvaja/SWATCH-2611` branch
6. start api service to migrate the schema: `SPRING_PROFILES_ACTIVE=api DEV_MODE=true ./gradlew :bootRun`
7. check the billable_usage_remittance table where

- The entry with org_id `org123` and `org125` should have been updated to status 'unknown' because the usage was before 1 Oct

The rest of entries are expected not to be updated. 