### PR TITLE
SWATCH-2915 Specify BYOS aws product code

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/ConduitFacts.java
@@ -38,6 +38,11 @@ public class ConduitFacts extends ConsumerInventory {
   private List<HbiNetworkInterface> networkInterfaces;
   private Map<String, String> originalFacts = new HashMap<>();
 
+  public ConduitFacts() {
+    // Force non-null boolean value since ConsumerInventory generated as Boolean data type
+    this.isMarketplace(false);
+  }
+
   // Reusing systemprofile for network interfaces in Inventory Service
   public void setNetworkInterfaces(List<HbiNetworkInterface> networkInterfaces) {
     this.networkInterfaces = networkInterfaces;

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -66,6 +66,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -453,35 +454,14 @@ class InventoryControllerTest {
     consumer.getFacts().put(azureOfferFact, azzureOffer);
 
     conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertNull(conduitFacts.getIsMarketplace());
+    assertFalse(conduitFacts.getIsMarketplace());
 
     azureOfferFact = "azure_offer";
     azzureOffer = "rhel-byos";
     consumer.getFacts().put(azureOfferFact, azzureOffer);
 
     conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertNull(conduitFacts.getIsMarketplace());
-  }
-
-  @Test
-  void testIsMarketplaceFacts_WhenAwsBillingProductsPresent() {
-    String awsBillingProductsFact = "aws_billing_products";
-    String awsBillingProducts = "bi-6fa54";
-    String uuid = UUID.randomUUID().toString();
-    Consumer consumer = new Consumer();
-    consumer.setUuid(uuid);
-
-    consumer.getFacts().put(awsBillingProductsFact, awsBillingProducts);
-
-    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertEquals(true, conduitFacts.getIsMarketplace());
-
-    awsBillingProductsFact = "aws_billing_products";
-    awsBillingProducts = " ";
-    consumer.getFacts().put(awsBillingProductsFact, awsBillingProducts);
-
-    conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertNull(conduitFacts.getIsMarketplace());
+    assertFalse(conduitFacts.getIsMarketplace());
   }
 
   @Test
@@ -491,7 +471,7 @@ class InventoryControllerTest {
     consumer.setUuid(uuid);
 
     ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertNull(conduitFacts.getIsMarketplace());
+    assertFalse(conduitFacts.getIsMarketplace());
   }
 
   @Test
@@ -517,7 +497,26 @@ class InventoryControllerTest {
     consumer.getFacts().put(InventoryController.GCP_LICENSE_CODES, "non-rhel-placeholder");
 
     ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
-    assertNull(conduitFacts.getIsMarketplace());
+    assertFalse(conduitFacts.getIsMarketplace());
+  }
+
+  @ParameterizedTest(name = "[{index}] billingCode={0}, isMarketplace={1}")
+  @CsvSource({
+    "'', false",
+    ", false",
+    "'bp-63a5400a', false",
+    "'bananas', true",
+    "'bp-6fa54006', true",
+  })
+  void testIsMarketplaceFactsForAwsBillingCodes(String billingCode, boolean expected) {
+    String uuid = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+    consumer.getFacts().put(InventoryController.AWS_BILLING_PRODUCTS, billingCode);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+
+    assertEquals(expected, conduitFacts.getIsMarketplace());
   }
 
   @Test


### PR DESCRIPTION

<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2915

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Our previous implementation was based off the incorrect assumption that the presence of an aws billing code on a system fact indicated that system was tied to a marketplace subscription.  We've since learned that any system provisioned in aws, regardless of if they're paying for the subscription through aws, gets an aws billing code associated with it.

Systems that were provisioned with a red hat gold image get specifically *bp-63a5400a* as a billing product code.  PM identified this product code as indicating BYOS.  If a billing product code is absent, that also indicates BYOS.  A meeting with PM was had, and it was decided that we would maintain a list of product codes to consider BYOS instead of the opposite.  If a billing product code is present and it doesn't appear in the list of BYOS product codes, then consider it a Marketplace system.  Similar updates will need to happen with other system reporters since HBI doesn't centralize any normalization.


## Testing

### Setup

[swatch-2915-wiremock.zip](https://github.com/user-attachments/files/17248664/swatch-2915-wiremock.zip)

Run wiremock with stubs.  For convenience here is a zip file with a compose file and the wiremock mappings and payloads.  The format of the responses came from a real response from https://api.rhsm.redhat.com/v1/candlepin/consumers/feeds, and then I modified sensitive values.  Account numbers and ip addresses are randomly generated.

If you don't use podman-compose, here's the cli equivalent:

```
podman run -d \
  --name wiremock \
  -p 8101:8080 \
  -v ./wiremock/mappings:/home/wiremock/mappings:z \
  -v ./wiremock/__files:/home/wiremock/__files:z \
  wiremock/wiremock:2.32.0 \
  --verbose --global-response-templating
```

Confirm that wiremock is serving responses properly for both account ids `9999999` and `1111111`.

We're expecting
```
http http://localhost:8101/v1/candlepin/consumers/feeds X-RhsmApi-AccountID:9999999 | jq '.body[0] | {name, aws_instance_id: .facts.aws_instance_id,  aws_billing_products: .facts.aws_billing_products}'
```
```json
{
  "name": "bananas.lab.eng.brq2.redhat.com",
  "aws_instance_id": "i-0c892607c9a3820c6",
  "aws_billing_products": "weeee_not_byos_billing_product_code"
}
```

```
http http://localhost:8101/v1/candlepin/consumers/feeds X-RhsmApi-AccountID:1111111 | jq '.body[0] | {name, aws_instance_id: .facts.aws_instance_id,  aws_billing_products: .facts.aws_billing_products}'
```
```json
{
  "name": "oranges.lab.eng.brq2.redhat.com",
  "aws_instance_id": "i-d4e435fa4dc3f9189",
  "aws_billing_products": "bp-63a5400a"
}
```

### Steps

Start conduit
```
RHSM_URL=http://localhost:8101/v1 DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun
```
Hit the conduit API described as "Initiate viewing conduit representation of an org's systems from RHSM" with each of the org ids that we mocked with wiremock

http ':8000/api/rhsm-subscriptions/v1/internal/organizations/9999999/inventory?limit=10' x-rh-swatch-psk:placeholder Origin:console.redhat.com 

http ':8000/api/rhsm-subscriptions/v1/internal/organizations/1111111/inventory?limit=10' x-rh-swatch-psk:placeholder Origin:console.redhat.com

### Verification
We're expecting `is_marketplace: true` for 9999999, and `is_marketplace: false` for 1111111

```
http ':8000/api/rhsm-subscriptions/v1/internal/organizations/9999999/inventory?limit=10' x-rh-swatch-psk:placeholder Origin:console.redhat.com | jq '.consumer_inventories[0] | {org_id, provider_id, is_marketplace, cloud_provider, provider_type}'
```
```json
{
  "org_id": "9999999",
  "provider_id": "i-0c892607c9a3820c6",
  "is_marketplace": true,
  "cloud_provider": "aws",
  "provider_type": "aws"
}
```

```
http ':8000/api/rhsm-subscriptions/v1/internal/organizations/1111111/inventory?limit=10' x-rh-swatch-psk:placeholder Origin:console.redhat.com | jq '.consumer_inventories[0] | {org_id, provider_id, is_marketplace, cloud_provider, provider_type}'
```
```json
{
  "org_id": "1111111",
  "provider_id": "i-d4e435fa4dc3f9189",
  "is_marketplace": false,
  "cloud_provider": "aws",
  "provider_type": "aws"
}
```