### PR TITLE
SWATCH-2995 Retry billable usage when it gets marketplace retry error

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
@@ -36,7 +36,8 @@ public enum RemittanceErrorCode {
   SUBSCRIPTION_NOT_FOUND("subscription_not_found"),
   SUBSCRIPTION_TERMINATED("subscription_terminated"),
   USAGE_CONTEXT_LOOKUP("usage_context_lookup"),
-  UNKNOWN("unknown");
+  UNKNOWN("unknown"),
+  MARKETPLACE_RATE_LIMIT("marketplace_rate_limit");
 
   private static final Map<String, RemittanceErrorCode> VALUE_ENUM_MAP =
       Arrays.stream(RemittanceErrorCode.values())

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.billable.usage.services;
 
 import static java.util.Optional.ofNullable;
+import static org.candlepin.subscriptions.billable.usage.BillableUsage.ErrorCode.MARKETPLACE_RATE_LIMIT;
 import static org.candlepin.subscriptions.billable.usage.BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND;
 import static org.candlepin.subscriptions.billable.usage.BillableUsage.Status.FAILED;
 
@@ -81,6 +82,7 @@ public class BillableUsageStatusConsumer {
 
   private boolean needsRetry(BillableUsageAggregate billableUsageAggregate) {
     return billableUsageAggregate.getStatus() == FAILED
-        && billableUsageAggregate.getErrorCode() == SUBSCRIPTION_NOT_FOUND;
+        && (billableUsageAggregate.getErrorCode() == SUBSCRIPTION_NOT_FOUND
+            || billableUsageAggregate.getErrorCode() == MARKETPLACE_RATE_LIMIT);
   }
 }

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -62,6 +62,7 @@ properties:
       - usage_context_lookup
       - unsupported_metric
       - unknown
+      - marketplace_rate_limit
   billed_on:
     type: string
     format: date-time

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsThrottlingException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsThrottlingException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AwsThrottlingException extends AwsProducerException {
+
+  private final int count;
+
+  public AwsThrottlingException(int count) {
+    super(ErrorCode.AWS_THROTTLING_ERROR, String.format("count=%d", count));
+    this.count = count;
+  }
+
+  public AwsThrottlingException(int count, Exception e) {
+    super(ErrorCode.AWS_THROTTLING_ERROR, String.format("count=%d", count), e);
+    this.count = count;
+  }
+}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
   USAGE_TIMESTAMP_OUT_OF_RANGE(1007, "Usage timestamp will not be accepted by AWS"),
   SUBSCRIPTION_CANNOT_BE_DETERMINED(
       1010,
-      "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId.");
+      "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId."),
+  AWS_THROTTLING_ERROR(1011, "AWS throttling error");
 
   private static final String CODE_PREFIX = "SWATCHAWS";
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2995

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
When AwsThrottlingException is thrown we shouldn't hard fail the tuple. We should try resending it next hour.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert Event
`INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('6c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-12 16:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "6c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-12T16:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-12T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-21T18:37:40.540859342Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 2.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', '2024-06-21 18:37:40.540859 +00:00');
`
2. Insert subscription
`INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02781MO', '12345678', '14991902', 1, '2024-05-31 12:36:06.963022 +00:00', '2025-06-30 03:59:59.000000 +00:00', 'dummy;dummy;dummy', '14992059', 'aws', 'customerAccount12345678');
`

3. .aws/config
[profile dummy]
aws_access_key_id = dummy
aws_secret_access_key = dummy

4. Change the code to below
```
@RetryWithExponentialBackoff(maxRetries = "${AWS_SEND_RETRIES}")
  public BatchMeterUsageResponse send(
      MarketplaceMeteringClient client, BatchMeterUsageRequest request) {
    throw ThrottlingException.builder().message("Rate limit exceeded").build();
    //return client.batchMeterUsage(request);
  }

```
### Steps
<!-- Enter each step of the test below -->
1. `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`
2. `SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev`
3. `SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev`
4. `SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-producer-aws:quarkusDev`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Billable usage remittance 
`INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '12345678', 'rhel-for-x86-els-payg', 'vCPUs', '2024-06', 'Premium', 'Production', 'aws', 'customerAccount12345678', 2, '2024-10-03 19:29:29.659542 +00:00', '2024-10-03 20:32:16.529010 +00:00', '360f0367-3797-4f4e-9346-850a7abd6ef9', 'PHYSICAL', '361670c4-a043-456a-838d-1af832035047', null, 'marketplace_rate_limit', 'failed');`

Logs in AWS:
```
2024-10-03 15:32:16,508 ERROR [com.red.swa.aws.ser.AwsBillableUsageAggregateConsumer] (vert.x-worker-thread-1) Error sending aws usage due to rate limit for rhSubscriptionId=14991902 aggregateId=77c5b4ec-092e-4fd8-a256-3bfc809e6218 awsCustomerId=dummy awsProductCode=dummy orgId=12345678 remittanceUUIDs=[361670c4-a043-456a-838d-1af832035047]: com.redhat.swatch.aws.exception.AwsThrottlingException: SWATCHAWS1011: AWS throttling error: count=1
        at com.redhat.swatch.aws.service.AwsBillableUsageAggregateConsumer.transformAndSend(AwsBillableUsageAggregateConsumer.java:309)
        at com.redhat.swatch.aws.service.AwsBillableUsageAggregateConsumer.process(AwsBillableUsageAggregateConsumer.java:170)
```

