### PR TITLE
SWATCH-2843: Implement logic for subscription table endpoints to swatch-contracts

### DIFF
--- a/swatch-common-panache/src/main/java/com/redhat/swatch/panache/Specification.java
+++ b/swatch-common-panache/src/main/java/com/redhat/swatch/panache/Specification.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.panache;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
@@ -31,6 +32,11 @@ import jakarta.persistence.criteria.Root;
  * @param <T> Entity type of the specification
  */
 public interface Specification<T> {
+
+  static <T> Specification<T> where(@Nullable Specification<T> spec) {
+    return spec == null ? (root, query, builder) -> null : spec;
+  }
+
   static <T> Specification<T> where() {
     return (root, query, builder) -> null;
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ErrorCode.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
   OFFERING_MISSING_ERROR(3003, "Sku not present in Offering"),
   BAD_UPDATE(4000, "Bad update request"),
   UNHANDLED_EXCEPTION(5000, "Unhandled exception"),
+  VALIDATION_FAILED_ERROR(1002, "Client request failed validation."),
   /**
    * An exception was thrown by RestEasy while processing a request to the rhsm-conduit API. This
    * typically means that an HTTP client error has occurred (HTTP 4XX).

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/SubscriptionsException.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/SubscriptionsException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.exception;
+
+import jakarta.ws.rs.core.Response.Status;
+import java.util.Optional;
+import lombok.Getter;
+
+/**
+ * Application's base exception class. Provides a means to create an Error object that should be
+ * typically return as part of an error response.
+ */
+public class SubscriptionsException extends RuntimeException {
+
+  @Getter private final Status status;
+  @Getter private final String detail;
+  @Getter private final ErrorCode code;
+
+  public SubscriptionsException(ErrorCode code, Status status, String message, String detail) {
+    this(code, status, message, detail, null);
+  }
+
+  public SubscriptionsException(ErrorCode code, Status status, String message, Throwable e) {
+    this(code, status, message, Optional.ofNullable(e).map(Throwable::getMessage).orElse(null), e);
+  }
+
+  public SubscriptionsException(
+      ErrorCode code, Status status, String message, String detail, Throwable e) {
+    super(message, e);
+    this.code = code;
+    this.status = status;
+    this.detail = detail;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/SubscriptionCapacityViewMetricConverter.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/SubscriptionCapacityViewMetricConverter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityViewMetric;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.AttributeConverter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+
+@ApplicationScoped
+@AllArgsConstructor
+public class SubscriptionCapacityViewMetricConverter
+    implements AttributeConverter<Set<SubscriptionCapacityViewMetric>, String> {
+
+  private static final String METRIC_ID = "metric_id";
+  private static final String VALUE = "value";
+  private static final String MEASUREMENT_TYPE = "measurement_type";
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public String convertToDatabaseColumn(Set<SubscriptionCapacityViewMetric> collection) {
+    throw new UnsupportedOperationException(
+        "This converter should only be used in the SubscriptionCapacityView view which is only read-only mode.");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Set<SubscriptionCapacityViewMetric> convertToEntityAttribute(String s) {
+    if (s == null || s.isEmpty()) {
+      return Set.of();
+    }
+
+    try {
+      Set<SubscriptionCapacityViewMetric> metrics = new HashSet<>();
+      objectMapper
+          .readValue(s, List.class)
+          .forEach(
+              e -> {
+                Map<String, Object> m = (Map<String, Object>) e;
+                metrics.add(
+                    SubscriptionCapacityViewMetric.builder()
+                        .metricId(
+                            Optional.ofNullable(m.get(METRIC_ID))
+                                .map(String.class::cast)
+                                .orElse(null))
+                        .capacity(Optional.ofNullable(m.get(VALUE)).map(this::toDouble).orElse(0.0))
+                        .measurementType(
+                            Optional.ofNullable(m.get(MEASUREMENT_TYPE))
+                                .map(String.class::cast)
+                                .orElse(null))
+                        .build());
+              });
+      return metrics;
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error parsing metrics", e);
+    }
+  }
+
+  private double toDouble(Object o) {
+    if (o instanceof Integer i) {
+      return i;
+    } else if (o instanceof Double d) {
+      return d;
+    } else if (o instanceof Long l) {
+      return l;
+    } else if (o instanceof Float f) {
+      return f;
+    }
+
+    return 0.0;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/HardwareMeasurementType.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/HardwareMeasurementType.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Enum to capture the various types of measurements in the hardware_measurements table */
+public enum HardwareMeasurementType {
+  PHYSICAL,
+  HYPERVISOR,
+  VIRTUAL,
+  TOTAL,
+  AWS, // AWS measured by HBI data
+  // NOTE: AWS_CLOUDIGRADE kept to avoid a bug when accessing old data created with now-retired
+  // integration
+  @Deprecated
+  AWS_CLOUDIGRADE,
+  GOOGLE("GCP"),
+  ALIBABA,
+  AZURE,
+  EMPTY;
+
+  private final String[] aliases;
+
+  HardwareMeasurementType() {
+    this.aliases = new String[0];
+  }
+
+  HardwareMeasurementType(String... aliases) {
+    this.aliases = aliases;
+  }
+
+  public static boolean isSupportedCloudProvider(String name) {
+    if (name == null || name.isEmpty()) {
+      return false;
+    }
+
+    return getCloudProviderTypes().contains(fromString(name));
+  }
+
+  public static List<HardwareMeasurementType> getCloudProviderTypes() {
+    return Arrays.asList(AWS, GOOGLE, AZURE, ALIBABA);
+  }
+
+  public static HardwareMeasurementType fromString(String name) {
+    for (HardwareMeasurementType measurementType : HardwareMeasurementType.values()) {
+      if (measurementType.name().equalsIgnoreCase(name)) {
+        return measurementType;
+      }
+
+      for (String alias : measurementType.aliases) {
+        if (alias.equalsIgnoreCase(name)) {
+          return measurementType;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import com.redhat.swatch.contract.model.SubscriptionCapacityViewMetricConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@IdClass(SubscriptionEntity.SubscriptionCompoundId.class)
+@Table(name = "subscription_capacity_view")
+public class SubscriptionCapacityView implements Serializable {
+
+  @Id
+  @Column(name = "subscription_id")
+  private String subscriptionId;
+
+  @Column(name = "subscription_number")
+  private String subscriptionNumber;
+
+  @Column(name = "start_date")
+  private OffsetDateTime startDate;
+
+  @Column(name = "end_date")
+  private OffsetDateTime endDate;
+
+  @Column(name = "sku")
+  private String sku;
+
+  @Column(name = "has_unlimited_usage")
+  private Boolean hasUnlimitedUsage;
+
+  @Column(name = "product_name")
+  private String productName;
+
+  @Column(name = "service_level")
+  private ServiceLevel serviceLevel;
+
+  @Column(name = "usage")
+  private Usage usage;
+
+  @Column(name = "org_id")
+  private String orgId;
+
+  @Column(name = "billing_provider")
+  private BillingProvider billingProvider;
+
+  @Column(name = "billing_provider_id")
+  private BillingProvider billingProviderId;
+
+  @Column(name = "billing_account_id")
+  private String billingAccountId;
+
+  @Column(name = "product_tag")
+  private String productTag;
+
+  @Column(name = "quantity")
+  private long quantity;
+
+  @Column(name = "metrics", insertable = false, updatable = false)
+  @Convert(converter = SubscriptionCapacityViewMetricConverter.class)
+  private Set<SubscriptionCapacityViewMetric> metrics = new HashSet<>();
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewMetric.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewMetric.java
@@ -20,27 +20,18 @@
  */
 package com.redhat.swatch.contract.repository;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-/** Map key for subscription measurements */
-@Getter
-@Setter
+@Builder
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
-@Embeddable
-public class SubscriptionMeasurementKey implements Serializable {
-
-  @Column(name = "metric_id")
+public class SubscriptionCapacityViewMetric implements Serializable {
   private String metricId;
-
-  @Column(name = "measurement_type")
   private String measurementType;
+  private Double capacity;
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.repository;
+
+import static com.redhat.swatch.contract.resource.ResourceUtils.ANY;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeBillingAccountId;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeBillingProvider;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeServiceLevel;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeUsage;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.panache.PanacheSpecificationSupport;
+import com.redhat.swatch.panache.Specification;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class SubscriptionCapacityViewRepository
+    implements PanacheSpecificationSupport<SubscriptionCapacityView, String> {
+
+  static final String PHYSICAL = "PHYSICAL";
+  static final String HYPERVISOR = "HYPERVISOR";
+
+  public Stream<SubscriptionCapacityView> streamBy(
+      Specification<SubscriptionCapacityView> criteria) {
+    return find(SubscriptionCapacityView.class, criteria).stream();
+  }
+
+  static Specification<SubscriptionCapacityView> buildSearchSpecification(String orgId) {
+    return buildSearchSpecification(orgId, null, null, null, null, null, null, null);
+  }
+
+  public static Specification<SubscriptionCapacityView> buildSearchSpecification( // NOSONAR
+      String orgId,
+      ProductId productId,
+      ReportCategory category,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      String metricId) {
+    ServiceLevel sanitizedServiceLevel = sanitizeServiceLevel(serviceLevel);
+    Usage sanitizedUsage = sanitizeUsage(usage);
+    BillingProvider sanitizedBillingProvider = sanitizeBillingProvider(billingProvider);
+    String sanitizedBillingAccountId = sanitizeBillingAccountId(billingAccountId);
+
+    /* The where call allows us to build a Specification object to operate on even if the first
+     * specification method we call returns null (which it won't in this case, but it's good
+     * practice to handle it). */
+    Specification<SubscriptionCapacityView> searchCriteria =
+        Specification.where(orgIdEquals(orgId));
+    if (productId != null) {
+      searchCriteria = searchCriteria.and(productIdEquals(productId));
+      if (productId.isPayg() || productId.isPrometheusEnabled()) {
+        searchCriteria = searchCriteria.and(hasBillingProviderId());
+      }
+    }
+    if (Objects.nonNull(sanitizedServiceLevel)
+        && !sanitizedServiceLevel.equals(ServiceLevel._ANY)) {
+      searchCriteria = searchCriteria.and(slaEquals(sanitizedServiceLevel));
+    }
+    if (Objects.nonNull(sanitizedUsage) && !sanitizedUsage.equals(Usage._ANY)) {
+      searchCriteria = searchCriteria.and(usageEquals(sanitizedUsage));
+    }
+    if (Objects.nonNull(sanitizedBillingProvider)
+        && !sanitizedBillingProvider.equals(BillingProvider._ANY)) {
+      searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
+    }
+    if (Objects.nonNull(metricId)) {
+      searchCriteria = searchCriteria.and(hasMetricId(metricId));
+    }
+    if (Objects.nonNull(category)) {
+      searchCriteria = searchCriteria.and(hasCategory(category));
+    }
+    if (Objects.nonNull(sanitizedBillingAccountId)
+        && !ANY.equalsIgnoreCase(sanitizedBillingAccountId)
+        && productId != null
+        && productId.isPrometheusEnabled()) {
+      searchCriteria = searchCriteria.and(billingAccountIdStartsWith(sanitizedBillingAccountId));
+    }
+
+    return searchCriteria;
+  }
+
+  static Specification<SubscriptionCapacityView> productIdEquals(ProductId productId) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.productTag), productId.getValue());
+  }
+
+  static Specification<SubscriptionCapacityView> hasBillingProviderId() {
+    return (root, query, builder) ->
+        builder.and(
+            builder.isNotNull(root.get(SubscriptionCapacityView_.billingProviderId)),
+            builder.notEqual(root.get(SubscriptionCapacityView_.billingProviderId), ""));
+  }
+
+  static Specification<SubscriptionCapacityView> billingAccountIdStartsWith(String value) {
+    return (root, query, builder) ->
+        builder.like(root.get(SubscriptionCapacityView_.billingAccountId), value + "%");
+  }
+
+  static Specification<SubscriptionCapacityView> slaEquals(ServiceLevel sla) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.serviceLevel), sla);
+  }
+
+  static Specification<SubscriptionCapacityView> usageEquals(Usage usage) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.usage), usage);
+  }
+
+  static Specification<SubscriptionCapacityView> billingProviderEquals(
+      BillingProvider billingProvider) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.billingProvider), billingProvider);
+  }
+
+  static Specification<SubscriptionCapacityView> hasCategory(ReportCategory value) {
+    String measurementType = getMeasurementTypeFromCategory(value);
+    if (measurementType != null) {
+      return handleMetricsFilter("measurement_type", measurementType);
+    }
+
+    return null;
+  }
+
+  static Specification<SubscriptionCapacityView> hasMetricId(String value) {
+    return handleMetricsFilter("metric_id", MetricId.fromString(value).toString());
+  }
+
+  static String getMeasurementTypeFromCategory(ReportCategory value) {
+    var category = HypervisorReportCategory.mapCategory(value);
+    if (category != null) {
+      return switch (category) {
+        case NON_HYPERVISOR -> PHYSICAL;
+        case HYPERVISOR -> HYPERVISOR;
+      };
+    }
+    return null;
+  }
+
+  static Specification<SubscriptionCapacityView> orgIdEquals(String orgId) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.orgId), orgId);
+  }
+
+  private static Specification<SubscriptionCapacityView> handleMetricsFilter(
+      String key, String value) {
+    return (root, query, builder) ->
+        builder.isTrue(
+            builder.function(
+                "jsonb_path_exists",
+                Boolean.class,
+                root.get("metrics"),
+                builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionRepository.java
@@ -75,7 +75,7 @@ public class SubscriptionRepository
         .list();
   }
 
-  List<SubscriptionEntity> findUnlimited(DbReportCriteria dbReportCriteria) {
+  public List<SubscriptionEntity> findUnlimited(DbReportCriteria dbReportCriteria) {
     var searchCriteria = SubscriptionEntity.buildSearchSpecification(dbReportCriteria);
     searchCriteria = searchCriteria.and(SubscriptionEntity.hasUnlimitedUsage());
     return find(SubscriptionEntity.class, searchCriteria);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/InMemoryPager.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/InMemoryPager.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource;
+
+import com.redhat.swatch.contract.exception.ErrorCode;
+import com.redhat.swatch.contract.exception.SubscriptionsException;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+public class InMemoryPager {
+  private static final Integer DEFAULT_LIMIT = 50;
+
+  private InMemoryPager() {
+    /* intentionally empty */
+  }
+
+  public static <T> List<T> paginate(List<T> items, Integer offset, Integer limit) {
+    if (limit == null) {
+      limit = DEFAULT_LIMIT;
+    }
+
+    if (offset == null) {
+      offset = 0;
+    }
+
+    if (offset % limit != 0) {
+      throw new SubscriptionsException(
+          ErrorCode.VALIDATION_FAILED_ERROR,
+          Response.Status.BAD_REQUEST,
+          "Offset must be divisible by limit",
+          "Arbitrary offsets are not currently supported by this API");
+    }
+
+    if (offset > items.size()) {
+      return List.of();
+    }
+    int lastIndex = Math.min(items.size(), offset + limit);
+    return items.subList(offset, lastIndex);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/JsonNonNull.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/JsonNonNull.java
@@ -18,29 +18,17 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.contract.repository;
+package com.redhat.swatch.contract.resource;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.enterprise.context.ApplicationScoped;
 
-/** Map key for subscription measurements */
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@EqualsAndHashCode
-@Embeddable
-public class SubscriptionMeasurementKey implements Serializable {
-
-  @Column(name = "metric_id")
-  private String metricId;
-
-  @Column(name = "measurement_type")
-  private String measurementType;
+@ApplicationScoped
+public class JsonNonNull implements ObjectMapperCustomizer {
+  @Override
+  public void customize(ObjectMapper objectMapper) {
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ResourceUtils.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ResourceUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource;
+
+import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.ServiceLevel;
+import com.redhat.swatch.contract.repository.Usage;
+import java.util.Objects;
+
+/** Functionality common to both capacity and tally resources. */
+public class ResourceUtils {
+
+  public static final String ANY = "_ANY";
+
+  private ResourceUtils() {
+    throw new IllegalStateException("Utility class; should never be instantiated!");
+  }
+
+  /**
+   * Uses Usage.ANY for a null value
+   *
+   * @param usageType nullable Usage value
+   * @return Usage enum
+   */
+  public static Usage sanitizeUsage(Usage usageType) {
+    return Objects.isNull(usageType) ? Usage._ANY : usageType;
+  }
+
+  /**
+   * Uses ServiceLevel.ANY for a null value
+   *
+   * @param sla nullable ServiceLevel
+   * @return ServiceLevel enum
+   */
+  public static ServiceLevel sanitizeServiceLevel(ServiceLevel sla) {
+    return Objects.isNull(sla) ? ServiceLevel._ANY : sla;
+  }
+
+  /**
+   * Uses BillingProvider.ANY for a null value
+   *
+   * @param billingProvider nullable billingProvider
+   * @return BilligProvider enum
+   */
+  public static BillingProvider sanitizeBillingProvider(BillingProvider billingProvider) {
+    return Objects.isNull(billingProvider) ? BillingProvider._ANY : billingProvider;
+  }
+
+  public static String sanitizeBillingAccountId(String billingAccountId) {
+
+    return Objects.isNull(billingAccountId) || billingAccountId.isBlank() ? ANY : billingAccountId;
+  }
+
+  /**
+   * Simple method to get around sonar complaint: java:S5411 - Boxed "Boolean" should be avoided in
+   * boolean expressions
+   */
+  public static boolean sanitizeBoolean(Boolean value, boolean defaultValue) {
+    if (Objects.isNull(value)) {
+      return defaultValue;
+    }
+    return value;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/ApiModelMapperV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/ApiModelMapperV1.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v1;
+
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.repository.HardwareMeasurementType;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "cdi")
+public interface ApiModelMapperV1 {
+  com.redhat.swatch.contract.repository.ReportCategory map(
+      com.redhat.swatch.contract.openapi.model.ReportCategory reportCategory);
+
+  com.redhat.swatch.contract.repository.ServiceLevel map(
+      com.redhat.swatch.contract.openapi.model.ServiceLevelType serviceLevelType);
+
+  com.redhat.swatch.contract.openapi.model.ServiceLevelType map(
+      com.redhat.swatch.contract.repository.ServiceLevel sanitizedServiceLevel);
+
+  com.redhat.swatch.contract.repository.Usage map(
+      com.redhat.swatch.contract.openapi.model.UsageType usage);
+
+  com.redhat.swatch.contract.openapi.model.UsageType map(
+      com.redhat.swatch.contract.repository.Usage sanitizedUsage);
+
+  com.redhat.swatch.contract.repository.BillingProvider map(
+      com.redhat.swatch.contract.openapi.model.BillingProviderType billingProviderType);
+
+  com.redhat.swatch.contract.openapi.model.BillingProviderType map(
+      com.redhat.swatch.contract.repository.BillingProvider sanitizeProviderLevel);
+
+  @SuppressWarnings("Duplicates")
+  default ReportCategory measurementTypeToReportCategory(HardwareMeasurementType measurementType) {
+    if (HardwareMeasurementType.isSupportedCloudProvider(measurementType.name())) {
+      return ReportCategory.CLOUD;
+    }
+    return switch (measurementType) {
+      case VIRTUAL -> ReportCategory.VIRTUAL;
+      case PHYSICAL -> ReportCategory.PHYSICAL;
+      case HYPERVISOR -> ReportCategory.HYPERVISOR;
+      default -> null;
+    };
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionResourceV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionResourceV1.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v1;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.contract.openapi.model.BillingProviderType;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV1;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV1;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.openapi.resource.SubscriptionsV1Api;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.validation.constraints.Min;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+
+/** Subscriptions Table API implementation. */
+@ApplicationScoped
+@AllArgsConstructor
+public class SubscriptionResourceV1 implements SubscriptionsV1Api {
+
+  private SubscriptionTableControllerV1 subscriptionTableController;
+
+  @RolesAllowed({"customer"})
+  @Override
+  public SkuCapacityReportV1 getSkuCapacityReportV1(
+      ProductId productId,
+      @Min(0) Integer offset,
+      @Min(1) Integer limit,
+      ReportCategory category,
+      ServiceLevelType sla,
+      UsageType usage,
+      BillingProviderType billingProvider,
+      String billingAccountId,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      String metricId,
+      SkuCapacityReportSortV1 sort,
+      SortDirection dir) {
+    return subscriptionTableController.capacityReportBySkuV1(
+        productId,
+        offset,
+        limit,
+        category,
+        sla,
+        usage,
+        billingProvider,
+        billingAccountId,
+        beginning,
+        ending,
+        metricId,
+        sort,
+        dir);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v1;
+
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeBillingAccountId;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeBillingProvider;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeServiceLevel;
+import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeUsage;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.contract.openapi.model.BillingProviderType;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV1;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV1;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV1Meta;
+import com.redhat.swatch.contract.openapi.model.SkuCapacitySubscription;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityV1;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.SubscriptionEventType;
+import com.redhat.swatch.contract.openapi.model.SubscriptionType;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.DbReportCriteria;
+import com.redhat.swatch.contract.repository.HardwareMeasurementType;
+import com.redhat.swatch.contract.repository.HypervisorReportCategory;
+import com.redhat.swatch.contract.repository.ServiceLevel;
+import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import com.redhat.swatch.contract.repository.SubscriptionMeasurementKey;
+import com.redhat.swatch.contract.repository.SubscriptionRepository;
+import com.redhat.swatch.contract.repository.Usage;
+import com.redhat.swatch.contract.resource.InMemoryPager;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.clock.ApplicationClock;
+
+@ApplicationScoped
+@Slf4j
+public class SubscriptionTableControllerV1 {
+
+  private static final String NO_METRIC_ID = null;
+  private final ApiModelMapperV1 mapper;
+  private final SubscriptionRepository subscriptionRepository;
+  private final ApplicationClock clock;
+
+  public static final String PHYSICAL = HardwareMeasurementType.PHYSICAL.toString().toUpperCase();
+  public static final String HYPERVISOR =
+      HardwareMeasurementType.HYPERVISOR.toString().toUpperCase();
+
+  @Context SecurityContext securityContext;
+
+  @Inject
+  SubscriptionTableControllerV1(
+      ApiModelMapperV1 mapper,
+      SubscriptionRepository subscriptionRepository,
+      ApplicationClock clock) {
+    this.mapper = mapper;
+    this.subscriptionRepository = subscriptionRepository;
+    this.clock = clock;
+  }
+
+  // Transactional annotation necessary to access lazy loaded ElementCollections for Subscription
+  @Transactional
+  public SkuCapacityReportV1 capacityReportBySkuV1( // NOSONAR
+      ProductId productId,
+      @Min(0) Integer offset,
+      @Min(1) Integer limit,
+      ReportCategory category,
+      ServiceLevelType serviceLevel,
+      UsageType usage,
+      BillingProviderType billingProviderType,
+      String billingAccountId,
+      OffsetDateTime begining,
+      OffsetDateTime ending,
+      String metricId,
+      SkuCapacityReportSortV1 sort,
+      SortDirection dir) {
+    /*
+    Notes:
+    - Ignoring beginning and ending query params, as the table should (currently, anyway) only
+      report on the latest subscription status information.
+    - The implementation will report "subscription end" events for Next Event ONLY. That is,
+      future-dated subs are not taken into account when reporting the Next Event; only currently
+      active subs are used for calculating Next Event.
+    */
+
+    OffsetDateTime reportEnd = clock.now();
+    OffsetDateTime reportStart = clock.now();
+    ServiceLevel sanitizedServiceLevel = sanitizeServiceLevel(mapper.map(serviceLevel));
+    Usage sanitizedUsage = sanitizeUsage(mapper.map(usage));
+    BillingProvider sanitizedBillingProvider =
+        sanitizeBillingProvider(mapper.map(billingProviderType));
+    String sanitizedBillingAccountId = sanitizeBillingAccountId(billingAccountId);
+    HypervisorReportCategory hypervisorReportCategory =
+        HypervisorReportCategory.mapCategory(mapper.map(category));
+
+    var orgId = getOrgId();
+    log.info(
+        "Finding all subscription capacities for "
+            + "orgId={}, "
+            + "productId={}, "
+            + "categories={}, "
+            + "Service Level={}, "
+            + "Usage={}, "
+            + "between={} and {}, "
+            + "MetricId={}, "
+            + "Billing Provider={}",
+        orgId,
+        productId,
+        hypervisorReportCategory,
+        sanitizedServiceLevel,
+        sanitizedUsage,
+        reportStart,
+        reportEnd,
+        metricId,
+        sanitizedBillingProvider);
+
+    var reportCriteria =
+        DbReportCriteria.builder()
+            .orgId(orgId)
+            .productTag(productId.toString())
+            .serviceLevel(sanitizedServiceLevel)
+            .usage(sanitizedUsage)
+            .beginning(reportStart)
+            .ending(reportEnd)
+            .metricId(metricId)
+            .hypervisorReportCategory(hypervisorReportCategory)
+            .billingProvider(sanitizedBillingProvider)
+            .build();
+    var subscriptions = subscriptionRepository.findByCriteria(reportCriteria);
+    List<SubscriptionEntity> unlimitedSubs = subscriptionRepository.findUnlimited(reportCriteria);
+    Map<String, SkuCapacityV1> reportItemsBySku = new HashMap<>();
+
+    for (SubscriptionEntity subscription : subscriptions) {
+      SkuCapacityV1 inventory =
+          reportItemsBySku.computeIfAbsent(
+              subscription.getOffering().getSku(),
+              s -> initializeSkuCapacity(subscription, metricId));
+      calculateNextEvent(subscription, inventory, reportEnd);
+      addSubscriptionInformation(subscription, inventory);
+      var measurements = subscription.getSubscriptionMeasurements().entrySet().stream();
+      if (metricId != null) {
+        measurements =
+            measurements.filter(entry -> Objects.equals(entry.getKey().getMetricId(), metricId));
+      }
+      if (hypervisorReportCategory == HypervisorReportCategory.HYPERVISOR) {
+        measurements =
+            measurements.filter(
+                entry ->
+                    ReportCategory.HYPERVISOR
+                        .toString()
+                        .equalsIgnoreCase(entry.getKey().getMeasurementType()));
+      } else if (hypervisorReportCategory == HypervisorReportCategory.NON_HYPERVISOR) {
+        measurements =
+            measurements.filter(
+                entry ->
+                    !ReportCategory.HYPERVISOR
+                        .toString()
+                        .equalsIgnoreCase(entry.getKey().getMeasurementType()));
+      }
+      measurements.forEach(
+          entry -> {
+            var measurementKey = entry.getKey();
+            var value = entry.getValue();
+            addTotalCapacity(subscription, measurementKey, value, inventory);
+          });
+    }
+
+    for (SubscriptionEntity subscription : unlimitedSubs) {
+      if (subscription.getOffering() != null) {
+        SkuCapacityV1 inventory =
+            reportItemsBySku.computeIfAbsent(
+                subscription.getOffering().getSku(),
+                s -> initializeSkuCapacity(subscription, metricId));
+
+        inventory.setHasInfiniteQuantity(true);
+        calculateNextEvent(subscription, inventory, reportCriteria.getEnding());
+        addSubscriptionInformation(subscription, inventory);
+      }
+    }
+
+    boolean isOnDemand = SubscriptionDefinition.isPrometheusEnabled(productId.toString());
+
+    SubscriptionType subscriptionType =
+        isOnDemand ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;
+
+    List<SkuCapacityV1> reportItems = new ArrayList<>(reportItemsBySku.values());
+    if (isOnDemand && reportItems.isEmpty()) {
+      reportItems.addAll(
+          getOnDemandSkuCapacities(
+              productId,
+              sanitizedServiceLevel,
+              sanitizedUsage,
+              sanitizedBillingProvider,
+              sanitizedBillingAccountId,
+              reportStart,
+              reportEnd));
+    }
+
+    int reportItemCount = reportItems.size();
+    // The pagination and sorting of capacities is done in memory and can cause performance
+    // issues
+    // As an improvement this should be pushed lower into the Repository layer
+    sortCapacities(reportItems, sort, dir);
+    var page = InMemoryPager.paginate(reportItems, offset, limit);
+
+    return new SkuCapacityReportV1()
+        .data(page)
+        .meta(
+            new SkuCapacityReportV1Meta()
+                .subscriptionType(subscriptionType)
+                .count(reportItemCount)
+                .serviceLevel(serviceLevel)
+                .usage(usage)
+                .reportCategory(category)
+                .product(productId.toString()));
+  }
+
+  @SuppressWarnings("java:S107")
+  private Collection<SkuCapacityV1> getOnDemandSkuCapacities(
+      ProductId productId,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      OffsetDateTime reportStart,
+      OffsetDateTime reportEnd) {
+
+    Map<String, SkuCapacityV1> inventories = new HashMap<>();
+
+    var subscriptions =
+        subscriptionRepository.findByCriteria(
+            DbReportCriteria.builder()
+                .orgId(getOrgId())
+                .productTag(productId.getValue())
+                .serviceLevel(serviceLevel)
+                .usage(usage)
+                .billingProvider(billingProvider)
+                .billingAccountId(billingAccountId)
+                .beginning(reportStart)
+                .ending(reportEnd)
+                .payg(true)
+                .build(),
+            Sort.empty());
+
+    subscriptions.forEach(
+        sub -> {
+          var sku = sub.getOffering().getSku();
+          final SkuCapacityV1 inventory =
+              inventories.computeIfAbsent(
+                  String.format("%s:%s", sku, sub.getBillingProvider()),
+                  key -> initializeSkuCapacity(sub, NO_METRIC_ID));
+          addOnDemandSubscriptionInformation(sub, inventory);
+        });
+    return inventories.values();
+  }
+
+  public SkuCapacityV1 initializeSkuCapacity(
+      @Nonnull SubscriptionEntity sub, @Nullable String metricId) {
+    var offering = sub.getOffering();
+    var inventory = new SkuCapacityV1();
+    inventory.setSubscriptions(new ArrayList<>());
+    inventory.setSku(offering.getSku());
+    inventory.setProductName(offering.getDescription());
+    inventory.setServiceLevel(
+        mapper.map(Optional.ofNullable(offering.getServiceLevel()).orElse(ServiceLevel.EMPTY)));
+    inventory.setUsage(mapper.map(Optional.ofNullable(offering.getUsage()).orElse(Usage.EMPTY)));
+    inventory.setHasInfiniteQuantity(offering.isHasUnlimitedUsage());
+    inventory.setBillingProvider(
+        mapper.map(Optional.ofNullable(sub.getBillingProvider()).orElse(BillingProvider.EMPTY)));
+    inventory.setQuantity(0);
+    inventory.setCapacity(0);
+    inventory.setHypervisorCapacity(0);
+    inventory.setTotalCapacity(0);
+    inventory.setMetricId(metricId);
+    return inventory;
+  }
+
+  public void calculateNextEvent(
+      SubscriptionEntity subscription, SkuCapacityV1 skuCapacity, OffsetDateTime now) {
+
+    OffsetDateTime nearestEventDate = skuCapacity.getNextEventDate();
+    OffsetDateTime subEnd = subscription.getEndDate();
+    if (subEnd != null
+        && now.isBefore(subEnd)
+        && (nearestEventDate == null || subEnd.isBefore(nearestEventDate))) {
+      nearestEventDate = subEnd;
+      skuCapacity.setNextEventDate(nearestEventDate);
+      skuCapacity.setNextEventType(SubscriptionEventType.END);
+    }
+  }
+
+  public void addOnDemandSubscriptionInformation(
+      SubscriptionEntity subscription, SkuCapacityV1 skuCapacity) {
+    var invSub = new SkuCapacitySubscription();
+    invSub.setId(subscription.getSubscriptionId());
+    Optional.ofNullable(subscription.getSubscriptionNumber()).ifPresent(invSub::setNumber);
+    skuCapacity.addSubscriptionsItem(invSub);
+    skuCapacity.setQuantity(skuCapacity.getQuantity() + (int) subscription.getQuantity());
+    OffsetDateTime subEnd = subscription.getEndDate();
+    OffsetDateTime nearestEventDate = skuCapacity.getNextEventDate();
+    if (subEnd != null && (nearestEventDate == null || subEnd.isBefore(nearestEventDate))) {
+      nearestEventDate = subEnd;
+      skuCapacity.setNextEventDate(nearestEventDate);
+      skuCapacity.setNextEventType(SubscriptionEventType.END);
+    }
+  }
+
+  public void addSubscriptionInformation(
+      SubscriptionEntity subscription, SkuCapacityV1 skuCapacity) {
+    var invSub = new SkuCapacitySubscription();
+    invSub.setId(subscription.getSubscriptionId());
+    Optional.ofNullable(subscription.getSubscriptionNumber()).ifPresent(invSub::setNumber);
+    // Different measurements can have the same subscription.  I'm not crazy about this
+    // implementation but refining it is for another day.
+
+    if (!skuCapacity.getSubscriptions().contains(invSub)) {
+      skuCapacity.addSubscriptionsItem(invSub);
+      skuCapacity.setQuantity(skuCapacity.getQuantity() + (int) subscription.getQuantity());
+    }
+  }
+
+  @SuppressWarnings("java:S3776")
+  public static void addTotalCapacity(
+      SubscriptionEntity subscription,
+      SubscriptionMeasurementKey key,
+      Double value,
+      SkuCapacityV1 skuCapacity) {
+    log.debug(
+        "Calculating total capacity using sku capacity {} and subscription capacity view {}, value: {}",
+        skuCapacity,
+        key,
+        value);
+
+    var metric = key.getMetricId();
+    var type = key.getMeasurementType();
+    // we only initialize the metric for measurements with a value higher than zero.
+    if (value > 0 && skuCapacity.getMetricId() == null) {
+      // initialize metric ID using the current metric if it's not set
+      skuCapacity.setMetricId(metric);
+    }
+
+    // accumulate the value
+    if (metric.equals(skuCapacity.getMetricId())) {
+      if (PHYSICAL.equals(type)) {
+        skuCapacity.setCapacity(skuCapacity.getCapacity() + value.intValue());
+      } else if (HYPERVISOR.equals(type)) {
+        skuCapacity.setHypervisorCapacity(skuCapacity.getHypervisorCapacity() + value.intValue());
+      }
+    }
+
+    if (subscription.getOffering().isHasUnlimitedUsage()) {
+      log.warn(
+          "Subscription for SKU {} has both capacity and unlimited quantity", skuCapacity.getSku());
+    }
+
+    skuCapacity.setTotalCapacity(skuCapacity.getCapacity() + skuCapacity.getHypervisorCapacity());
+    skuCapacity.setHasInfiniteQuantity(subscription.getOffering().isHasUnlimitedUsage());
+  }
+
+  private static void sortCapacities(
+      List<SkuCapacityV1> items, SkuCapacityReportSortV1 sort, SortDirection dir) {
+    items.sort(
+        (left, right) -> {
+          var sortField = Optional.ofNullable(sort).orElse(SkuCapacityReportSortV1.SKU);
+          int sortDir = 1;
+          if (dir == SortDirection.DESC) {
+            sortDir = -1;
+          }
+          int diff =
+              switch (sortField) {
+                case SKU -> left.getSku().compareTo(right.getSku());
+                case SERVICE_LEVEL -> left.getServiceLevel().compareTo(right.getServiceLevel());
+                case USAGE -> left.getUsage().compareTo(right.getUsage());
+                case QUANTITY -> left.getQuantity().compareTo(right.getQuantity());
+                case NEXT_EVENT_DATE -> left.getNextEventDate().compareTo(right.getNextEventDate());
+                case NEXT_EVENT_TYPE -> left.getNextEventType().compareTo(right.getNextEventType());
+                case TOTAL_CAPACITY -> compareTotalCapacity(left, right);
+                case PRODUCT_NAME -> left.getProductName().compareTo(right.getProductName());
+              };
+          // If the two items are sorted by some other field than SKU and are equal, then break the
+          // tie by sorting by SKU. No two SKUs in the list are equal.
+          if (diff == 0 && sortField != SkuCapacityReportSortV1.SKU) {
+            diff = left.getSku().compareTo(right.getSku());
+          }
+
+          return diff * sortDir;
+        });
+  }
+
+  private static int compareTotalCapacity(SkuCapacityV1 left, SkuCapacityV1 right) {
+    // unlimited capacity subscriptions are greater than non-unlimited
+    if (!Objects.equals(left.getHasInfiniteQuantity(), right.getHasInfiniteQuantity())) {
+      if (Boolean.TRUE.equals(left.getHasInfiniteQuantity())) {
+        return 1;
+      }
+      if (Boolean.TRUE.equals(right.getHasInfiniteQuantity())) {
+        return -1;
+      }
+    }
+    return left.getTotalCapacity().compareTo(right.getTotalCapacity());
+  }
+
+  private String getOrgId() {
+    return securityContext.getUserPrincipal().getName();
+  }
+
+  // for unit testing since we have no REST request
+  protected void setTestSecurityContext(SecurityContext securityContext) {
+    this.securityContext = securityContext;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/ApiModelMapperV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/ApiModelMapperV2.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.repository.HardwareMeasurementType;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "cdi")
+public interface ApiModelMapperV2 {
+  com.redhat.swatch.contract.repository.ReportCategory map(
+      com.redhat.swatch.contract.openapi.model.ReportCategory reportCategory);
+
+  com.redhat.swatch.contract.repository.ServiceLevel map(
+      com.redhat.swatch.contract.openapi.model.ServiceLevelType serviceLevelType);
+
+  com.redhat.swatch.contract.openapi.model.ServiceLevelType map(
+      com.redhat.swatch.contract.repository.ServiceLevel sanitizedServiceLevel);
+
+  com.redhat.swatch.contract.repository.Usage map(
+      com.redhat.swatch.contract.openapi.model.UsageType usage);
+
+  com.redhat.swatch.contract.openapi.model.UsageType map(
+      com.redhat.swatch.contract.repository.Usage sanitizedUsage);
+
+  com.redhat.swatch.contract.repository.BillingProvider map(
+      com.redhat.swatch.contract.openapi.model.BillingProviderType billingProviderType);
+
+  com.redhat.swatch.contract.openapi.model.BillingProviderType map(
+      com.redhat.swatch.contract.repository.BillingProvider sanitizeProviderLevel);
+
+  @SuppressWarnings("Duplicates")
+  default ReportCategory measurementTypeToReportCategory(HardwareMeasurementType measurementType) {
+    if (HardwareMeasurementType.isSupportedCloudProvider(measurementType.name())) {
+      return ReportCategory.CLOUD;
+    }
+    return switch (measurementType) {
+      case VIRTUAL -> ReportCategory.VIRTUAL;
+      case PHYSICAL -> ReportCategory.PHYSICAL;
+      case HYPERVISOR -> ReportCategory.HYPERVISOR;
+      default -> null;
+    };
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionResourceV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionResourceV2.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.contract.openapi.model.BillingProviderType;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV2;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV2;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.openapi.resource.SubscriptionsV2Api;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.validation.constraints.Min;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+
+/** Subscriptions Table API implementation. */
+@ApplicationScoped
+@AllArgsConstructor
+public class SubscriptionResourceV2 implements SubscriptionsV2Api {
+
+  private SubscriptionTableControllerV2 subscriptionTableController;
+
+  @RolesAllowed({"customer"})
+  @Override
+  public SkuCapacityReportV2 getSkuCapacityReportV2(
+      ProductId productId,
+      @Min(0) Integer offset,
+      @Min(1) Integer limit,
+      ReportCategory category,
+      ServiceLevelType sla,
+      UsageType usage,
+      BillingProviderType billingProvider,
+      String billingAccountId,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      String metricId,
+      SkuCapacityReportSortV2 sort,
+      SortDirection dir) {
+
+    return subscriptionTableController.capacityReportBySkuV2(
+        productId,
+        offset,
+        limit,
+        category,
+        sla,
+        usage,
+        billingProvider,
+        billingAccountId,
+        metricId,
+        sort,
+        dir);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import com.redhat.swatch.contract.openapi.model.BillingProviderType;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV2;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV1Meta;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV2;
+import com.redhat.swatch.contract.openapi.model.SkuCapacitySubscription;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityV2;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.SubscriptionEventType;
+import com.redhat.swatch.contract.openapi.model.SubscriptionType;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.HardwareMeasurementType;
+import com.redhat.swatch.contract.repository.ServiceLevel;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityView;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityViewMetric;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository;
+import com.redhat.swatch.contract.repository.Usage;
+import com.redhat.swatch.contract.resource.InMemoryPager;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.clock.ApplicationClock;
+
+@ApplicationScoped
+@Slf4j
+public class SubscriptionTableControllerV2 {
+
+  private final ApiModelMapperV2 mapper;
+  private final SubscriptionCapacityViewRepository repository;
+  private final ApplicationClock clock;
+
+  @Context SecurityContext securityContext;
+
+  @Inject
+  SubscriptionTableControllerV2(
+      ApiModelMapperV2 mapper,
+      SubscriptionCapacityViewRepository repository,
+      ApplicationClock clock) {
+    this.mapper = mapper;
+    this.repository = repository;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public SkuCapacityReportV2 capacityReportBySkuV2( // NOSONAR
+      ProductId productId,
+      @Min(0) Integer offset,
+      @Min(1) Integer limit,
+      ReportCategory category,
+      ServiceLevelType serviceLevel,
+      UsageType usage,
+      BillingProviderType billingProviderType,
+      String billingAccountId,
+      String metricId,
+      SkuCapacityReportSortV2 sort,
+      SortDirection dir) {
+
+    var subscriptionSpec =
+        SubscriptionCapacityViewRepository.buildSearchSpecification(
+            getOrgId(),
+            productId,
+            mapper.map(category),
+            mapper.map(serviceLevel),
+            mapper.map(usage),
+            mapper.map(billingProviderType),
+            billingAccountId,
+            metricId);
+    MetricsMeta metrics = new MetricsMeta(metricId, productId);
+    Map<InventoryKey, SkuCapacityV2> reportItemsBySku = new HashMap<>();
+    repository
+        .streamBy(subscriptionSpec)
+        .forEach(
+            subscription -> {
+              InventoryKey inventoryKey = new InventoryKey(productId, subscription);
+
+              SkuCapacityV2 inventory =
+                  reportItemsBySku.computeIfAbsent(
+                      inventoryKey, s -> initializeSkuCapacity(subscription, metrics, category));
+              calculateNextEvent(subscription, inventory);
+              if (productId.isPrometheusEnabled()) {
+                addOnDemandSubscriptionInformation(subscription, inventory);
+              } else {
+                addSubscriptionInformation(subscription, inventory);
+              }
+
+              subscription.getMetrics().stream()
+                  .filter(m -> m.getCapacity() != null)
+                  .filter(m -> m.getMetricId() != null)
+                  .filter(metrics::isSupported)
+                  .filter(filterByCategory(inventory))
+                  .forEach(
+                      entry -> {
+                        int position =
+                            metrics.getPosition(MetricId.fromString(entry.getMetricId()));
+                        inventory
+                            .getMeasurements()
+                            .set(
+                                position,
+                                inventory.getMeasurements().get(position) + entry.getCapacity());
+                      });
+            });
+
+    List<SkuCapacityV2> reportItems = new ArrayList<>(reportItemsBySku.values());
+    int reportItemCount = reportItems.size();
+    // The pagination and sorting of capacities is done in memory and can cause performance
+    // issues
+    // As an improvement this should be pushed lower into the Repository layer
+    sortCapacities(reportItems, sort, dir);
+    var page = InMemoryPager.paginate(reportItems, offset, limit);
+
+    return new SkuCapacityReportV2()
+        .data(page)
+        .meta(
+            new SkuCapacityReportV1Meta()
+                .subscriptionType(
+                    productId.isPrometheusEnabled()
+                        ? SubscriptionType.ON_DEMAND
+                        : SubscriptionType.ANNUAL)
+                .count(reportItemCount)
+                .serviceLevel(serviceLevel)
+                .usage(usage)
+                .measurements(metrics.stream().map(MetricId::toString).toList())
+                .reportCategory(category)
+                .product(productId.toString()));
+  }
+
+  private void addOnDemandSubscriptionInformation(
+      SubscriptionCapacityView subscription, SkuCapacityV2 skuCapacity) {
+    var invSub = new SkuCapacitySubscription();
+    invSub.setId(subscription.getSubscriptionId());
+    Optional.ofNullable(subscription.getSubscriptionNumber()).ifPresent(invSub::setNumber);
+    skuCapacity.addSubscriptionsItem(invSub);
+    skuCapacity.setQuantity(skuCapacity.getQuantity() + (int) subscription.getQuantity());
+    OffsetDateTime subEnd = subscription.getEndDate();
+    OffsetDateTime nearestEventDate = skuCapacity.getNextEventDate();
+    if (subEnd != null && (nearestEventDate == null || subEnd.isBefore(nearestEventDate))) {
+      nearestEventDate = subEnd;
+      skuCapacity.setNextEventDate(nearestEventDate);
+      skuCapacity.setNextEventType(SubscriptionEventType.END);
+    }
+  }
+
+  private void addSubscriptionInformation(
+      SubscriptionCapacityView subscription, SkuCapacityV2 skuCapacity) {
+    var invSub = new SkuCapacitySubscription();
+    invSub.setId(subscription.getSubscriptionId());
+    Optional.ofNullable(subscription.getSubscriptionNumber()).ifPresent(invSub::setNumber);
+    // Different measurements can have the same subscription.  I'm not crazy about this
+    // implementation but refining it is for another day.
+
+    if (!skuCapacity.getSubscriptions().contains(invSub)) {
+      skuCapacity.addSubscriptionsItem(invSub);
+      skuCapacity.setQuantity(skuCapacity.getQuantity() + (int) subscription.getQuantity());
+    }
+  }
+
+  private void calculateNextEvent(
+      SubscriptionCapacityView subscription, SkuCapacityV2 skuCapacity) {
+
+    OffsetDateTime nearestEventDate = skuCapacity.getNextEventDate();
+    OffsetDateTime subEnd = subscription.getEndDate();
+    if (subEnd != null
+        && clock.now().isBefore(subEnd)
+        && (nearestEventDate == null || subEnd.isBefore(nearestEventDate))) {
+      nearestEventDate = subEnd;
+      skuCapacity.setNextEventDate(nearestEventDate);
+      skuCapacity.setNextEventType(SubscriptionEventType.END);
+    }
+  }
+
+  private static void sortCapacities(
+      List<SkuCapacityV2> items, SkuCapacityReportSortV2 sort, SortDirection dir) {
+    items.sort(
+        (left, right) -> {
+          var sortField = Optional.ofNullable(sort).orElse(SkuCapacityReportSortV2.SKU);
+          int sortDir = 1;
+          if (dir == SortDirection.DESC) {
+            sortDir = -1;
+          }
+          int diff =
+              switch (sortField) {
+                case SKU -> left.getSku().compareTo(right.getSku());
+                case SERVICE_LEVEL -> left.getServiceLevel().compareTo(right.getServiceLevel());
+                case USAGE -> left.getUsage().compareTo(right.getUsage());
+                case QUANTITY -> left.getQuantity().compareTo(right.getQuantity());
+                case NEXT_EVENT_DATE -> left.getNextEventDate().compareTo(right.getNextEventDate());
+                case NEXT_EVENT_TYPE -> left.getNextEventType().compareTo(right.getNextEventType());
+                case PRODUCT_NAME -> left.getProductName().compareTo(right.getProductName());
+              };
+          // If the two items are sorted by some other field than SKU and are equal, then break the
+          // tie by sorting by SKU. No two SKUs in the list are equal.
+          if (diff == 0 && sortField != SkuCapacityReportSortV2.SKU) {
+            diff = left.getSku().compareTo(right.getSku());
+          }
+
+          return diff * sortDir;
+        });
+  }
+
+  private Predicate<SubscriptionCapacityViewMetric> filterByCategory(SkuCapacityV2 inventory) {
+    return m -> {
+      if (inventory.getCategory() != null) {
+        HardwareMeasurementType type = HardwareMeasurementType.fromString(m.getMeasurementType());
+        return type != null
+            && inventory.getCategory().equals(mapper.measurementTypeToReportCategory(type));
+      }
+
+      return true;
+    };
+  }
+
+  private SkuCapacityV2 initializeSkuCapacity(
+      @Nonnull SubscriptionCapacityView sub,
+      @Nonnull MetricsMeta metrics,
+      ReportCategory category) {
+    var inventory = new SkuCapacityV2();
+    inventory.setSubscriptions(new ArrayList<>());
+    inventory.setSku(sub.getSku());
+    inventory.setProductName(sub.getProductName());
+    inventory.setServiceLevel(
+        mapper.map(Optional.ofNullable(sub.getServiceLevel()).orElse(ServiceLevel.EMPTY)));
+    inventory.setUsage(mapper.map(Optional.ofNullable(sub.getUsage()).orElse(Usage.EMPTY)));
+    inventory.setHasInfiniteQuantity(sub.getHasUnlimitedUsage());
+    inventory.setBillingProvider(
+        mapper.map(Optional.ofNullable(sub.getBillingProvider()).orElse(BillingProvider.EMPTY)));
+    inventory.setQuantity(0);
+    inventory.setMeasurements(new ArrayList<>(Collections.nCopies(metrics.size(), 0.0)));
+    if (category != null) {
+      inventory.setCategory(category);
+    } else {
+      // inspect the subscription measurements
+      inventory.setCategory(
+          sub.getMetrics().stream()
+              .map(m -> HardwareMeasurementType.fromString(m.getMeasurementType()))
+              .filter(Objects::nonNull)
+              .findFirst()
+              .map(mapper::measurementTypeToReportCategory)
+              .orElse(null));
+    }
+
+    return inventory;
+  }
+
+  @EqualsAndHashCode
+  private static class InventoryKey {
+    private final String sku;
+    private BillingProvider billingProvider;
+
+    public InventoryKey(ProductId productId, SubscriptionCapacityView subscription) {
+      sku = subscription.getSku();
+      if (productId.isPrometheusEnabled()) {
+        billingProvider = subscription.getBillingProvider();
+      }
+    }
+  }
+
+  private static class MetricsMeta {
+
+    private final List<MetricId> metrics;
+    private final Map<MetricId, Integer> positionOfMetrics;
+
+    MetricsMeta(String metricIdFromRequest, ProductId productId) {
+      metrics =
+          Optional.ofNullable(metricIdFromRequest)
+              .map(MetricId::fromString)
+              .map(List::of)
+              .orElseGet(() -> getMetricsFromProduct(productId));
+      positionOfMetrics = new HashMap<>();
+      for (int index = 0; index < metrics.size(); index++) {
+        positionOfMetrics.put(metrics.get(index), index);
+      }
+    }
+
+    private static List<MetricId> getMetricsFromProduct(ProductId productId) {
+      return MetricIdUtils.getMetricIdsFromConfigForTag(productId.toString())
+          .sorted(Comparator.comparing(MetricId::getValue))
+          .toList();
+    }
+
+    public Stream<MetricId> stream() {
+      return metrics.stream();
+    }
+
+    public int size() {
+      return metrics.size();
+    }
+
+    public boolean isSupported(SubscriptionCapacityViewMetric metric) {
+      return positionOfMetrics.containsKey(MetricId.fromString(metric.getMetricId()));
+    }
+
+    public int getPosition(MetricId metricId) {
+      return positionOfMetrics.get(metricId);
+    }
+  }
+
+  private String getOrgId() {
+    return securityContext.getUserPrincipal().getName();
+  }
+
+  // for unit testing since we have no REST request
+  protected void setSecurityContext(SecurityContext securityContext) {
+    this.securityContext = securityContext;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/Identity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/Identity.java
@@ -34,6 +34,10 @@ import lombok.NoArgsConstructor;
 public class Identity {
   private String type;
 
+  public String getType() {
+    return type != null ? type : "User";
+  }
+
   @JsonProperty("org_id")
   private String orgId;
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/RbacRolesAugmentor.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/RbacRolesAugmentor.java
@@ -47,7 +47,7 @@ public class RbacRolesAugmentor implements SecurityIdentityAugmentor {
   private static final String RBAC_APP_NAME = "subscriptions";
   private static final String RBAC_ADMIN_ROLE = String.format("%s:*:*", RBAC_APP_NAME);
   private static final String RBAC_READER_ROLE = String.format("%s:reports:read", RBAC_APP_NAME);
-  private static final List<String> ALL_ROLES = List.of("test", "support", "service");
+  private static final List<String> ALL_ROLES = List.of("test", "support", "service", "customer");
 
   @ConfigProperty(name = "RBAC_ENABLED")
   boolean rbacEnabled;

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -822,6 +822,322 @@ paths:
         - test: [ ]
         - service: [ ]
 
+  /api/rhsm-subscriptions/v1/subscriptions/products/{product_id}:
+    description: "Operations for total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+    parameters:
+      - name: product_id
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ProductId"
+        description: "The ID for the product we wish to query"
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        description: "The numbers of items to return"
+    get:
+      summary: "Returns the total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+      operationId: getSkuCapacityReportV1
+      deprecated: true
+      parameters:
+        - name: category
+          in: query
+          schema:
+            $ref: '#/components/schemas/ReportCategory'
+          description: 'The category to fetch data for'
+        - name: sla
+          in: query
+          schema:
+            $ref: '#/components/schemas/ServiceLevelType'
+          description: "Include only capacity for the specified service level."
+        - name: usage
+          in: query
+          schema:
+            $ref: '#/components/schemas/UsageType'
+          description: "Include only capacity for the specified usage level."
+        - name: billing_provider
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingProviderType'
+          description: "Include only report data matching the specified billing provider"
+        - name: billing_account_id
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingAccountId'
+          description: "Include only report data matching the specified billing account"
+        - name: beginning
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+             format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
+        - name: ending
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period.  Defaults to the current time. Dates should
+             be provided in UTC."
+        - name: metric_id
+          in: query
+          schema:
+            type: string
+          description: "Filter subscriptions to those that contribute to a specific unit of measure"
+        - name: sort
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkuCapacityReportSort_V1"
+          description: "What property to sort by (optional)"
+        - name: dir
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+          description: "Which direction to sort by (default: asc)"
+      responses:
+        '200':
+          description: "The request for the account's subscription capacities was successful."
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/SkuCapacityReport_V1"
+              example:
+                data:
+                  - sku: RH00011
+                    product_name: "Red Hat Enterprise Linux Server, Premium (Physical and 4 Virtual Nodes)(L3 Only)"
+                    service_level: Premium
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567890"
+                        number: "1234567891"
+                      - id: "1234567892"
+                        number: "1234567893"
+                      - id: "1234567894"
+                        number: "1234567895"
+                    next_event_date: "2020-04-01T00:00:00Z"
+                    next_event_type: Subscription Begin
+                    quantity: 3
+                    capacity: 3
+                    hypervisor_capacity: 3
+                    total_capacity: 6
+                    metricId: Sockets
+                  - sku: RH00010
+                    product_name: "Red Hat Enterprise Linux Server"
+                    service_level: Self-Support
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567896"
+                        number: "1234567897"
+                      - id: "1234567898"
+                        number: "1234567899"
+                      - id: "1234567900"
+                        number: "1234567901"
+                    next_event_date: "2020-04-02T00:00:00Z"
+                    next_event_type: Subscription Begin
+                    quantity: 3
+                    capacity: 3
+                    hypervisor_capacity: 3
+                    total_capacity": 6
+                    metricId: Sockets
+                  - sku: RH00009
+                    product_name: "Red Hat Enterprise Linux Server, Premium"
+                    service_level: Premium
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567902"
+                        number: "1234567903"
+                      - id: "1234567904"
+                        number: "1234567905"
+                      - id: "1234567906"
+                        number: "1234567907"
+                    next_event_date: "2020-04-01T00:00:00Z"
+                    next_event_type: Subscription End
+                    quantity: 3
+                    capacity: 6
+                    hypervisor_capacity: 6
+                    total_capacity: 12
+                    metricId: Cores
+                meta:
+                  count: 3
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '403':
+          $ref: "#/components/responses/Forbidden"
+        '404':
+          $ref: "#/components/responses/ResourceNotFound"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+      tags:
+        - subscriptions_v1
+      security:
+        - customer: [ ]
+
+  /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}:
+    description: "Operations for total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+    parameters:
+      - name: product_id
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ProductId"
+        description: "The ID for the product we wish to query"
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        description: "The numbers of items to return"
+    get:
+      summary: "Returns the total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+      operationId: getSkuCapacityReportV2
+      deprecated: true
+      parameters:
+        - name: category
+          in: query
+          schema:
+            $ref: '#/components/schemas/ReportCategory'
+          description: 'The category to fetch data for'
+        - name: sla
+          in: query
+          schema:
+            $ref: '#/components/schemas/ServiceLevelType'
+          description: "Include only capacity for the specified service level."
+        - name: usage
+          in: query
+          schema:
+            $ref: '#/components/schemas/UsageType'
+          description: "Include only capacity for the specified usage level."
+        - name: billing_provider
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingProviderType'
+          description: "Include only report data matching the specified billing provider"
+        - name: billing_account_id
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingAccountId'
+          description: "Include only report data matching the specified billing account"
+        - name: beginning
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+             format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
+        - name: ending
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period.  Defaults to the current time. Dates should
+             be provided in UTC."
+        - name: metric_id
+          in: query
+          schema:
+            type: string
+          description: "Filter subscriptions to those that contribute to a specific unit of measure"
+        - name: sort
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkuCapacityReportSort_V2"
+          description: "What property to sort by (optional)"
+        - name: dir
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+          description: "Which direction to sort by (default: asc)"
+      responses:
+        '200':
+          description: "The request for the account's subscription capacities was successful."
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/SkuCapacityReport_V2"
+              example:
+                data:
+                  - sku: RH00011
+                    product_name: "Red Hat Enterprise Linux Server, Premium (Physical and 4 Virtual Nodes)(L3 Only)"
+                    service_level: Premium
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567890"
+                        number: "1234567891"
+                      - id: "1234567892"
+                        number: "1234567893"
+                      - id: "1234567894"
+                        number: "1234567895"
+                    next_event_date: "2020-04-01T00:00:00Z"
+                    next_event_type: Subscription Begin
+                    quantity: 3
+                    capacity: 3
+                    hypervisor_capacity: 3
+                    total_capacity: 6
+                    metricId: Sockets
+                  - sku: RH00010
+                    product_name: "Red Hat Enterprise Linux Server"
+                    service_level: Self-Support
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567896"
+                        number: "1234567897"
+                      - id: "1234567898"
+                        number: "1234567899"
+                      - id: "1234567900"
+                        number: "1234567901"
+                    next_event_date: "2020-04-02T00:00:00Z"
+                    next_event_type: Subscription Begin
+                    quantity: 3
+                    capacity: 3
+                    hypervisor_capacity: 3
+                    total_capacity": 6
+                    metricId: Sockets
+                  - sku: RH00009
+                    product_name: "Red Hat Enterprise Linux Server, Premium"
+                    service_level: Premium
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567902"
+                        number: "1234567903"
+                      - id: "1234567904"
+                        number: "1234567905"
+                      - id: "1234567906"
+                        number: "1234567907"
+                    next_event_date: "2020-04-01T00:00:00Z"
+                    next_event_type: Subscription End
+                    quantity: 3
+                    capacity: 6
+                    hypervisor_capacity: 6
+                    total_capacity: 12
+                    metricId: Cores
+                meta:
+                  count: 3
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '403':
+          $ref: "#/components/responses/Forbidden"
+        '404':
+          $ref: "#/components/responses/ResourceNotFound"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+      tags:
+        - subscriptions_v2
+      security:
+        - customer: [ ]
+
 components:
   schemas:
     Errors:
@@ -1093,6 +1409,248 @@ components:
       properties:
         detail:
           type: string
+    # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
+    ServiceLevelType:
+      description: "Describes the service level that the report was made against. Not set if it
+          wasn't specified as a query parameter."
+      type: string
+      enum: [ "", Premium, Standard, Self-Support, _ANY ]
+    UsageType:
+      description: "Describes the usage that the report was made against. Not set if it wasn't
+          specified as a query parameter."
+      type: string
+      enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
+    BillingProviderType:
+      type: string
+      enum: [ "", red hat, aws, gcp, azure, oracle, _ANY ]
+    ReportCategory:
+      type: string
+      enum:
+        - physical
+        - virtual
+        - cloud
+        - hypervisor
+    BillingAccountId:
+      type: string
+    SortDirection:
+      type: string
+      enum:
+        - asc
+        - desc
+    PageLinks:
+      properties:
+        first:
+          type: string
+        last:
+          type: string
+        previous:
+          type: string
+        next:
+          type: string
+      required:
+        - first
+        - last
+
+    SubscriptionType:
+      type: string
+      enum:
+        - On-demand
+        - Annual
+
+    SubscriptionEventType:
+      description: "The most immediate subscription event, such as a subscription beginning or ending."
+      type: string
+      enum:
+        - Subscription Start
+        - Subscription End
+
+    SkuCapacitySubscription:
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+
+    SkuCapacity_V1:
+      properties:
+        sku:
+          description: "The identifier for the offering."
+          type: string
+        product_name:
+          description: "The offering name."
+          type: string
+        service_level:
+          $ref: "#/components/schemas/ServiceLevelType"
+        usage:
+          $ref: "#/components/schemas/UsageType"
+        subscriptions:
+          description: "List of active subscriptions that contribute to the quantity and capacity totals."
+          type: array
+          items:
+            $ref: "#/components/schemas/SkuCapacitySubscription"
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
+        next_event_date:
+          description: "The most immediate date for a subscription event."
+          type: string
+          format: date-time
+        next_event_type:
+          $ref: "#/components/schemas/SubscriptionEventType"
+        quantity:
+          description: "The summed subscription quantities across the active subscriptions for the offering."
+          type: integer
+          format: int32
+        capacity:
+          description: "The summed standard capacity of the unit-of-measure of the active subscriptions for the offering."
+          type: integer
+          format: int32
+        hypervisor_capacity:
+          description: "The summed hypervisor capacity of the unit-of-measure of the active subscriptions for the offering."
+          type: integer
+          format: int32
+        total_capacity:
+          description: "The combined (standard and hypervisor) capacity for the offering."
+          type: integer
+          format: int32
+        has_infinite_quantity:
+          description: "Denotes unlimited capacity for the offering when true."
+          type: boolean
+        metric_id:
+          type: string
+
+    SkuCapacity_V2:
+      properties:
+        sku:
+          description: "The identifier for the offering."
+          type: string
+        product_name:
+          description: "The offering name."
+          type: string
+        service_level:
+          $ref: "#/components/schemas/ServiceLevelType"
+        usage:
+          $ref: "#/components/schemas/UsageType"
+        subscriptions:
+          description: "List of active subscriptions that contribute to the quantity and capacity totals."
+          type: array
+          items:
+            $ref: "#/components/schemas/SkuCapacitySubscription"
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
+        next_event_date:
+          description: "The most immediate date for a subscription event."
+          type: string
+          format: date-time
+        next_event_type:
+          $ref: "#/components/schemas/SubscriptionEventType"
+        quantity:
+          description: "The summed subscription quantities across the active subscriptions for the offering."
+          type: integer
+          format: int32
+        measurements:
+          description: >-
+            The summed standard capacity of the unit-of-measure of the active subscriptions for the offering. 
+            Must be in the same order as "measurements" in the meta.
+          type: array
+          items:
+            format: double
+            type: number
+        category:
+          $ref: '#/components/schemas/ReportCategory'
+        has_infinite_quantity:
+          description: "Denotes unlimited capacity for the offering when true."
+          type: boolean
+
+    SkuCapacityReportSort_V1:
+      type: string
+      enum:
+        - sku
+        - service_level
+        - usage
+        - next_event_date
+        - next_event_type
+        - quantity
+        - total_capacity
+        - product_name
+
+    SkuCapacityReportSort_V2:
+      type: string
+      enum:
+        - sku
+        - service_level
+        - usage
+        - next_event_date
+        - next_event_type
+        - quantity
+        - product_name
+
+    SkuCapacityReport_V1:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkuCapacity_V1'
+        links:
+          $ref: "#/components/schemas/PageLinks"
+        meta:
+          type: object
+          properties:
+            count:
+              type: integer
+            product:
+              type: string
+            measurements:
+              type: array
+              items:
+                type: string
+            service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
+            usage:
+              $ref: '#/components/schemas/UsageType'
+            subscription_type:
+              $ref: '#/components/schemas/SubscriptionType'
+            report_category:
+              $ref: '#/components/schemas/ReportCategory'
+          required:
+            - count
+            - product
+            - subscription_type
+
+    SkuCapacityReport_V2:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkuCapacity_V2'
+        links:
+          $ref: "#/components/schemas/PageLinks"
+        meta:
+          type: object
+          properties:
+            count:
+              type: integer
+            product:
+              type: string
+            measurements:
+              type: array
+              items:
+                type: string
+            service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
+            usage:
+              $ref: '#/components/schemas/UsageType'
+            subscription_type:
+              $ref: '#/components/schemas/SubscriptionType'
+            report_category:
+              $ref: '#/components/schemas/ReportCategory'
+          required:
+            - count
+            - product
+            - subscription_type
+    ProductId:
+      type: string
+      format: ProductId
+
   responses:
     ErrorResponse:
       description: "Error handling request"
@@ -1100,6 +1658,31 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Errors'
+    BadRequest:
+      description: "The server could could not process the current request."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    Forbidden:
+      description: "The request was valid, but the request was refused by the server."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    ResourceNotFound:
+      description: "The requested resource was not found."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    InternalServerError:
+      description: "An internal server error has occurred and is not recoverable."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+
   securitySchemes:
     customer:
       type: apiKey

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionResourceV1Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionResourceV1Test.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v1;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV1;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SubscriptionResourceV1Test {
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
+  private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
+  private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
+
+  @Inject SubscriptionResourceV1 subscriptionResource;
+  @InjectMock SubscriptionTableControllerV1 controller;
+
+  @Test
+  @TestSecurity(
+      user = "123456",
+      roles = {"test"})
+  void testAccessDeniedWhenUserIsNotACustomer() {
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            subscriptionResource.getSkuCapacityReportV1(
+                RHEL_FOR_X86,
+                0,
+                10,
+                null,
+                null,
+                UsageType.PRODUCTION,
+                null,
+                null,
+                min,
+                max,
+                null,
+                SkuCapacityReportSortV1.SKU,
+                null));
+  }
+
+  @Test
+  @TestSecurity(
+      user = "123456",
+      roles = {"customer"})
+  void testAccessAllowed() {
+    assertDoesNotThrow(
+        () ->
+            subscriptionResource.getSkuCapacityReportV1(
+                RHEL_FOR_X86,
+                0,
+                10,
+                null,
+                null,
+                UsageType.PRODUCTION,
+                null,
+                null,
+                min,
+                max,
+                null,
+                SkuCapacityReportSortV1.SKU,
+                null));
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1Test.java
@@ -1,0 +1,1156 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v1;
+
+import static com.redhat.swatch.contract.repository.ReportCategory.HYPERVISOR;
+import static com.redhat.swatch.contract.repository.ReportCategory.PHYSICAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import com.redhat.swatch.contract.exception.SubscriptionsException;
+import com.redhat.swatch.contract.openapi.model.BillingProviderType;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV1;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportV1;
+import com.redhat.swatch.contract.openapi.model.SkuCapacitySubscription;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityV1;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.SubscriptionEventType;
+import com.redhat.swatch.contract.openapi.model.SubscriptionType;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.DbReportCriteria;
+import com.redhat.swatch.contract.repository.HypervisorReportCategory;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.ServiceLevel;
+import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import com.redhat.swatch.contract.repository.SubscriptionMeasurementKey;
+import com.redhat.swatch.contract.repository.SubscriptionRepository;
+import com.redhat.swatch.contract.repository.Usage;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.candlepin.clock.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+class SubscriptionTableControllerV1Test {
+
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
+  private static final String OFFERING_DESCRIPTION_SUFFIX = " test description";
+
+  @InjectMock SubscriptionRepository subscriptionRepository;
+  @Inject ApplicationClock clock;
+  @Inject SubscriptionTableControllerV1 subscriptionTableControllerV1;
+
+  private static final MeasurementSpec RH0180191 =
+      MeasurementSpec.offering(
+          "RH0180191", "RHEL Server", 2, 0, 0, 0, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH00604F5 =
+      MeasurementSpec.offering(
+          "RH00604F5", "RHEL Server", 2, 0, 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180192_SOCKETS =
+      MeasurementSpec.offering(
+          "RH0180192",
+          "RHEL Server",
+          2,
+          null,
+          2,
+          null,
+          ServiceLevel.STANDARD,
+          Usage.PRODUCTION,
+          false);
+  private static final MeasurementSpec RH0180193_CORES =
+      MeasurementSpec.offering(
+          "RH0180193",
+          "RHEL Server",
+          null,
+          2,
+          null,
+          2,
+          ServiceLevel.STANDARD,
+          Usage.PRODUCTION,
+          false);
+  private static final MeasurementSpec RH0180193_INSTANCE_HOURS =
+      MeasurementSpec.offering(
+              "RH0180193",
+              "RHEL Server",
+              null,
+              null,
+              null,
+              null,
+              ServiceLevel.STANDARD,
+              Usage.PRODUCTION,
+              false)
+          .withMetric(MetricIdUtils.getInstanceHours().toString(), 5);
+  private static final MeasurementSpec RH0180194_SOCKETS_AND_CORES =
+      MeasurementSpec.offering(
+          "RH0180194", "RHEL Server", 2, 2, 2, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180195_UNLIMITED_USAGE =
+      MeasurementSpec.offering(
+          "RH0180192",
+          "RHEL Server",
+          null,
+          null,
+          null,
+          null,
+          ServiceLevel.STANDARD,
+          Usage.PRODUCTION,
+          true);
+  private static final MeasurementSpec RH0180196_HYPERVISOR_SOCKETS =
+      MeasurementSpec.offering(
+          "RH0180196", "RHEL Server", 0, 0, 2, 0, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180197_HYPERVISOR_CORES =
+      MeasurementSpec.offering(
+          "RH0180197", "RHEL Server", 0, 0, 0, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+
+  private enum Org {
+    STANDARD("711497");
+
+    private final String orgId;
+
+    Org(String orgId) {
+      this.orgId = orgId;
+    }
+  }
+
+  /**
+   * Creates a list of SubscriptionMeasurements that can be returned by a mock
+   * SubscriptionMeasurementRepository.
+   *
+   * @param org The organization that owns the capacities
+   * @param specs specifies what sub capacities to return
+   * @return a list of subscription capacity views
+   */
+  private Map<SubscriptionMeasurementKey, Double> givenCapacities(
+      Org org, ProductId productId, MeasurementSpec... specs) {
+
+    Map<SubscriptionMeasurementKey, Double> flattened = new HashMap<>();
+    Arrays.stream(specs)
+        .map(
+            s -> {
+              var measurements = s.createMeasurements(org, productId);
+              s.subscription.setSubscriptionMeasurements(measurements);
+              return measurements;
+            })
+        .forEach(flattened::putAll);
+
+    return flattened;
+  }
+
+  @BeforeEach
+  public void updateSecurityContext() {
+    SecurityContext mockSecurityContext = Mockito.mock(SecurityContext.class);
+    Principal mockPrincipal = Mockito.mock(Principal.class);
+    subscriptionTableControllerV1.setTestSecurityContext(mockSecurityContext);
+    when(mockSecurityContext.getUserPrincipal()).thenReturn(mockPrincipal);
+    when(mockPrincipal.getName()).thenReturn("123456");
+  }
+
+  @Test
+  void testGetSkuCapacityReportSingleSub() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a socket
+    // capacity of 2,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec = RH0180191.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, spec);
+    givenSubscriptionsInRepository(expectedSub);
+    givenOfferings(spec);
+    expectedSub.setOffering(spec.createOffering());
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(4, actualItem.getQuantity(), "Incorrect quantity");
+    assertCapacities(8, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
+    assertSubscription(expectedSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+  }
+
+  @Test
+  void testGetSkuCapacityReportMultipleSubsSameSku() {
+    // Given an org with two active subs with different quantities for the same SKU,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1, spec2);
+    givenSubscriptionsInRepository(expectedOlderSub, expectedNewerSub);
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the subs and appropriate
+    // quantity and capacities.
+    assertEquals(
+        1,
+        actual.getData().size(),
+        "Both subs are for same SKU so should collect into one capacity item.");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(
+        9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
+    assertCapacities(18, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedOlderSub.getEndDate(),
+        actualItem.getNextEventDate(),
+        "Wrong upcoming event date. Given two or more subs, the even take should be the subscription enddate closest to now.");
+
+    SkuCapacitySubscription actualSub = actualItem.getSubscriptions().get(0);
+    assertSubscription(expectedOlderSub, actualSub);
+
+    actualSub = actualItem.getSubscriptions().get(1);
+    assertSubscription(expectedNewerSub, actualSub);
+  }
+
+  @Test
+  void testGetSkuCapacityReportDifferentSkus() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var spec2 = RH00604F5.withSub(expectedOlderSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1, spec2);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    givenOfferings(spec1, spec2);
+
+    // When requesting a SKU capacity report for the eng product, sorted by SKU
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH00604F5 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(RH00604F5.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        5,
+        actualItem.getQuantity(),
+        "Sub quantity should come from only sub(s) providing the SKU.");
+    assertCapacities(10, 10, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
+    assertSubscription(expectedOlderSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedOlderSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+
+    actualItem = actual.getData().get(1);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        4,
+        actualItem.getQuantity(),
+        "Sub quantity should come from only sub(s) providing the SKU.");
+    assertCapacities(8, 0, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
+    assertSubscription(expectedNewerSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedNewerSub.getEndDate(),
+        actualItem.getNextEventDate(),
+        "Wrong upcoming event " + "date");
+  }
+
+  @Test
+  void testGetSkuCapacityReportNoSub() {
+    // Given an org with no active subs,
+
+    givenSubscriptionsInRepository();
+
+    // When requesting a SKU capacity report for an eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            RHEL_FOR_X86, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains no inventory items.
+    assertEquals(0, actual.getData().size(), "An empty inventory list should be returned.");
+  }
+
+  @Test
+  void testShouldUseQueryBasedOnHeaderAndParameters() {
+
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+
+    givenCapacities(Org.STANDARD, RHEL_FOR_X86, spec1, spec2);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    SkuCapacityReportV1 report =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            RHEL_FOR_X86,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(1, report.getData().size());
+  }
+
+  @Test
+  void testFiltersBasedOnRequest() {
+    // By default, our mock will return empty collections for findAll and findUnlimited which is
+    // what we want in this case.
+    subscriptionTableControllerV1.capacityReportBySkuV1(
+        RHEL_FOR_X86,
+        null,
+        null,
+        ReportCategory.PHYSICAL,
+        ServiceLevelType.PREMIUM,
+        UsageType.PRODUCTION,
+        BillingProviderType.AWS,
+        null,
+        null,
+        null,
+        "Cores",
+        SkuCapacityReportSortV1.SKU,
+        null);
+
+    var criteria =
+        DbReportCriteria.builder()
+            .orgId("123456")
+            .productTag(RHEL_FOR_X86.toString())
+            .serviceLevel(ServiceLevel.PREMIUM)
+            .usage(Usage.PRODUCTION)
+            .metricId("Cores")
+            .hypervisorReportCategory(HypervisorReportCategory.NON_HYPERVISOR)
+            .billingProvider(BillingProvider.AWS)
+            .build();
+
+    // NB: Ideally we would thoroughly verify the findAll method as well, but that method takes a
+    // Spring Data Specification object which is substantially more difficult to introspect.
+    verify(subscriptionRepository).findByCriteria(any(DbReportCriteria.class));
+
+    // This verification is rather tedious since SubscriptionTableController populates its
+    // DbReportCriteria object with Clock.now() which we can't just match on with a call to
+    // DbReportCriteria.equals()
+    verify(subscriptionRepository)
+        .findUnlimited(
+            argThat(
+                x ->
+                    x.getOrgId().equals(criteria.getOrgId())
+                        && x.getProductTag().equals(criteria.getProductTag())
+                        && x.getServiceLevel().equals(criteria.getServiceLevel())
+                        && x.getUsage().equals(criteria.getUsage())
+                        && x.getMetricId().equals(criteria.getMetricId())
+                        && x.getHypervisorReportCategory()
+                            .equals(criteria.getHypervisorReportCategory())
+                        && x.getBillingProvider().equals(criteria.getBillingProvider())));
+  }
+
+  @Test
+  void testShouldUseSlaQueryParam() {
+    ProductId productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+    givenCapacities(Org.STANDARD, productId, spec1, spec2);
+
+    givenSubscriptionsInRepository();
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    SkuCapacityReportV1 reportForUnmatchedSLA =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.PREMIUM,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(0, reportForUnmatchedSLA.getData().size());
+
+    givenSubscriptionsInRepository(expectedNewerSub);
+    SkuCapacityReportV1 reportForMatchingSLA =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(1, reportForMatchingSLA.getData().size());
+  }
+
+  @Test
+  void testShouldUseUsageQueryParam() {
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    SubscriptionEntity expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+    givenCapacities(Org.STANDARD, productId, spec1, spec2);
+
+    givenSubscriptionsInRepository();
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    SkuCapacityReportV1 reportForUnmatchedUsage =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            UsageType.DEVELOPMENT_TEST,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(0, reportForUnmatchedUsage.getData().size());
+
+    givenSubscriptionsInRepository(expectedNewerSub);
+    SkuCapacityReportV1 reportForMatchingUsage =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            UsageType.PRODUCTION,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(1, reportForMatchingUsage.getData().size());
+  }
+
+  @Test
+  void testCountReturnedInMetaIgnoresOffsetAndLimit() {
+    var productId = RHEL_FOR_X86;
+    var spec1 = RH0180191.withSub(stubSubscription("1236", "1237", 5, 6, 6));
+    var spec2 = RH00604F5.withSub(stubSubscription("1234", "1235", 4, 5, 7));
+    var rh0060192 =
+        MeasurementSpec.offering(
+                "RH0060192",
+                "RHEL Server",
+                2,
+                0,
+                2,
+                0,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                false)
+            .withSub(stubSubscription("1239", "1235", 4, 5, 7));
+    var rh00604f7 =
+        MeasurementSpec.offering(
+                "RH00604F7",
+                "RHEL Server",
+                2,
+                0,
+                2,
+                0,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                false)
+            .withSub(stubSubscription("1238", "1235", 4, 5, 7));
+    var rh00604f6 =
+        MeasurementSpec.offering(
+                "RH00604F6",
+                "RHEL Server",
+                2,
+                0,
+                2,
+                0,
+                ServiceLevel.PREMIUM,
+                Usage.PRODUCTION,
+                false)
+            .withSub(stubSubscription("1237", "1235", 4, 5, 7));
+
+    givenCapacities(Org.STANDARD, productId, spec1, spec2, rh00604f6, rh00604f7, rh0060192);
+
+    givenSubscriptionsInRepository(
+        spec1.subscription,
+        spec2.subscription,
+        rh00604f6.subscription,
+        rh00604f7.subscription,
+        rh0060192.subscription);
+
+    givenOfferings(spec1, spec2, rh00604f6, rh00604f7, rh0060192);
+
+    SkuCapacityReportV1 reportWithOffsetAndLimit =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            0,
+            2,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(2, reportWithOffsetAndLimit.getData().size());
+    assertEquals(5, reportWithOffsetAndLimit.getMeta().getCount());
+  }
+
+  @Test
+  void testShouldUseMetricIdQueryParam() {
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var expectedMuchOlderSub = stubSubscription("1238", "1237", 5, 24, 6);
+
+    var coresSpec1 = RH0180193_CORES.withSub(expectedNewerSub);
+    var coresSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
+    givenOfferings(coresSpec1, coresSpec2);
+
+    var socketsSpec1 = RH0180192_SOCKETS.withSub(expectedOlderSub);
+    var socketsSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
+    givenOfferings(socketsSpec1, socketsSpec2);
+
+    givenCapacities(Org.STANDARD, productId, coresSpec1, coresSpec2);
+    givenCapacities(Org.STANDARD, productId, socketsSpec1, socketsSpec2);
+    givenSubscriptionsInRepository(coresSpec1.subscription, coresSpec2.subscription);
+    givenSubscriptionsInRepository(socketsSpec1.subscription, socketsSpec2.subscription);
+
+    SkuCapacityReportV1 reportForMatchingCores =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(2, reportForMatchingCores.getData().size());
+
+    SkuCapacityReportV1 reportForMatchingSockets =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getSockets().toString(),
+            SkuCapacityReportSortV1.SKU,
+            null);
+    assertEquals(2, reportForMatchingSockets.getData().size());
+  }
+
+  @Test
+  void testShouldThrowExceptionOnBadOffset() {
+    SubscriptionsException e =
+        assertThrows(
+            SubscriptionsException.class,
+            () ->
+                subscriptionTableControllerV1.capacityReportBySkuV1(
+                    RHEL_FOR_X86,
+                    11,
+                    10,
+                    null,
+                    null,
+                    UsageType.PRODUCTION,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    SkuCapacityReportSortV1.SKU,
+                    null));
+    assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
+  }
+
+  @Test
+  void testShouldPopulateAnnualSubscriptionType() {
+
+    givenSubscriptionsInRepository();
+
+    SkuCapacityReportV1 report =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            RHEL_FOR_X86,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV1.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ANNUAL, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
+  void testShouldPopulateOnDemandSubscriptionType() {
+
+    givenSubscriptionsInRepository();
+
+    SkuCapacityReportV1 report =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            ProductId.fromString("OpenShift-metrics"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV1.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
+  void testGetSkuCapacityReportUnlimitedQuantity() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
+    // usage.
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedSub);
+
+    when(subscriptionRepository.findUnlimited(any()))
+        .thenReturn(List.of(unlimitedSpec.subscription));
+    givenOfferings(unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and HasInfiniteQuantity
+    // should be true.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertTrue(actualItem.getHasInfiniteQuantity(), "HasInfiniteQuantity should be true");
+  }
+
+  @Test
+  void testShouldSortUnlimitedLastAscending() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedOlderSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    when(subscriptionRepository.findUnlimited(any()))
+        .thenReturn(List.of(unlimitedSpec.subscription));
+    givenOfferings(spec1, unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product, sorted by quantity
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.TOTAL_CAPACITY,
+            null);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH00604F5 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+
+    actualItem = actual.getData().get(1);
+    assertEquals(
+        unlimitedSpec.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+  }
+
+  @Test
+  void testShouldSortUnlimitedFirstDescending() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedOlderSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    when(subscriptionRepository.findUnlimited(any()))
+        .thenReturn(List.of(unlimitedSpec.subscription));
+    givenOfferings(spec1, unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product, sorted by quantity
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV1.TOTAL_CAPACITY,
+            SortDirection.DESC);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH0180195 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(
+        unlimitedSpec.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+
+    actualItem = actual.getData().get(1);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+  }
+
+  @Test
+  void testGetSkuCapacityReportHypervisorSocketsOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // hypervisor socket capacity of 2,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec1 = RH0180196_HYPERVISOR_SOCKETS.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1);
+    givenSubscriptionsInRepository(expectedSub);
+
+    givenOfferings(spec1);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(0, 8, MetricIdUtils.getSockets().toUpperCaseFormatted(), actualItem);
+  }
+
+  @Test
+  void testGetSkuCapacityReportHypervisorCoresOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // hypervisor socket capacity of 2,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec1 = RH0180197_HYPERVISOR_CORES.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1);
+    givenSubscriptionsInRepository(expectedSub);
+
+    givenOfferings(spec1);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(0, 8, MetricIdUtils.getCores().toUpperCaseFormatted(), actualItem);
+  }
+
+  @Test
+  void testGetSkuCapacityReportInstanceHours() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // physical instance hours of 5,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec1 = RH0180193_INSTANCE_HOURS.withSub(expectedSub);
+
+    givenCapacities(Org.STANDARD, productId, spec1);
+    givenSubscriptionsInRepository(expectedSub);
+
+    givenOfferings(spec1);
+
+    // When requesting a SKU capacity report for the eng product,
+    SkuCapacityReportV1 actual =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            productId, null, null, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    SkuCapacityV1 actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
+    assertCapacities(20, 0, MetricIdUtils.getInstanceHours().toUpperCaseFormatted(), actualItem);
+  }
+
+  private void givenOfferings(MeasurementSpec... specs) {
+    Stream.of(specs).forEach(spec -> spec.subscription.setOffering(spec.createOffering()));
+  }
+
+  private void givenSubscriptionsInRepository(SubscriptionEntity... subs) {
+    when(subscriptionRepository.findByCriteria(Mockito.any())).thenReturn(List.of(subs));
+  }
+
+  private static void assertCapacities(
+      int expectedCap, int expectedHypCap, String expectedMetricId, SkuCapacityV1 actual) {
+    if (MetricIdUtils.getCores().toString().equalsIgnoreCase(expectedMetricId)) {
+      assertEquals("CORES", actual.getMetricId(), "Correct metric id");
+    } else if (MetricIdUtils.getSockets().toString().equalsIgnoreCase(expectedMetricId)) {
+      assertEquals("SOCKETS", actual.getMetricId(), "Correct metric id");
+    } else {
+      assertNotNull(actual.getMetricId());
+    }
+
+    assertEquals(expectedMetricId, actual.getMetricId(), "Wrong Metric ID");
+    assertEquals(expectedCap, actual.getCapacity(), "Wrong Standard Capacity");
+    assertEquals(expectedHypCap, actual.getHypervisorCapacity(), "Wrong Hypervisor Capacity");
+    assertEquals(expectedCap + expectedHypCap, actual.getTotalCapacity(), "Wrong Total Capacity");
+    assertEquals(actual.getSku() + OFFERING_DESCRIPTION_SUFFIX, actual.getProductName());
+  }
+
+  private static void assertSubscription(
+      SubscriptionEntity expectedSub, SkuCapacitySubscription actual) {
+    assertEquals(expectedSub.getSubscriptionId(), actual.getId(), "Wrong Subscription ID");
+    assertEquals(
+        expectedSub.getSubscriptionNumber(), actual.getNumber(), "Wrong Subscription Number");
+  }
+
+  private static SubscriptionEntity stubSubscription(String id, String number, Integer quantity) {
+    return stubSubscription(id, number, quantity, 6, 6);
+  }
+
+  /* Also specifies the sub active timeframe, relative to now. */
+  private static SubscriptionEntity stubSubscription(
+      String id, String number, Integer quantity, int startMonthsAgo, int endMonthsAway) {
+    OffsetDateTime subStart = OffsetDateTime.now().minusMonths(startMonthsAgo);
+    OffsetDateTime subEnd = subStart.plusMonths(startMonthsAgo + endMonthsAway);
+
+    return SubscriptionEntity.builder()
+        .subscriptionId(id)
+        .subscriptionNumber(number)
+        .quantity(quantity)
+        .startDate(subStart)
+        .endDate(subEnd)
+        .build();
+  }
+
+  /** Class to generate SubscriptionMeasurements as tests need them. */
+  private static class MeasurementSpec {
+    private SubscriptionEntity subscription;
+
+    // Fields in this section specify the Offering used in the SubscriptionCapacity.
+    final String sku;
+    final String productName;
+    final Integer sockets;
+    final Integer cores;
+    final Integer hypervisorSockets;
+    final Integer hypervisorCores;
+    final Map<String, Integer> otherMetrics;
+    final ServiceLevel serviceLevel;
+    final Usage usage;
+    final boolean hasUnlimitedUsage;
+
+    private MeasurementSpec(
+        String sku,
+        String productName,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
+        Map<String, Integer> otherMetrics,
+        ServiceLevel serviceLevel,
+        Usage usage,
+        boolean hasUnlimitedUsage,
+        SubscriptionEntity subscription) {
+      this.sku = sku;
+      this.productName = productName;
+      this.sockets = sockets;
+      this.cores = cores;
+      this.hypervisorSockets = hypervisorSockets;
+      this.hypervisorCores = hypervisorCores;
+      this.otherMetrics = otherMetrics;
+      this.serviceLevel = serviceLevel;
+      this.usage = usage;
+      this.hasUnlimitedUsage = hasUnlimitedUsage;
+      this.subscription = subscription;
+    }
+
+    public MeasurementSpec withMetric(String metric, Integer value) {
+      otherMetrics.put(metric, value);
+      return this;
+    }
+
+    /*
+    Creates a new Subscription Capacity Specification, specifying only the Offering details. The
+    Swatch ProductId, subscription quantity, and org info still need supplied in order to create
+    a full SubscriptionCapacityView.
+    */
+    public static MeasurementSpec offering(
+        String sku,
+        String productName,
+        Integer sockets,
+        Integer cores,
+        Integer hypervisorSockets,
+        Integer hypervisorCores,
+        ServiceLevel serviceLevel,
+        Usage usage,
+        Boolean hasUnlimitedUsage) {
+      return new MeasurementSpec(
+          sku,
+          productName,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
+          new HashMap<>(),
+          serviceLevel,
+          usage,
+          hasUnlimitedUsage,
+          null);
+    }
+
+    /**
+     * Returns a new Subscription Capacity Specification but with the subscription information
+     * added. We want to return a new one, so we don't mutate the objects created from .offering as
+     * test fixtures.
+     */
+    public MeasurementSpec withSub(SubscriptionEntity sub) {
+      return new MeasurementSpec(
+          sku,
+          productName,
+          sockets,
+          cores,
+          hypervisorSockets,
+          hypervisorCores,
+          otherMetrics,
+          serviceLevel,
+          usage,
+          hasUnlimitedUsage,
+          sub);
+    }
+
+    public Map<SubscriptionMeasurementKey, Double> buildMeasurement(
+        String type, MetricId metric, Double value) {
+      if (value == null) {
+        return Map.of();
+      }
+
+      SubscriptionMeasurementKey key = new SubscriptionMeasurementKey();
+      key.setMeasurementType(type);
+      key.setMetricId(metric.toUpperCaseFormatted());
+
+      return Map.of(key, value);
+    }
+
+    public Map<SubscriptionMeasurementKey, Double> createMeasurements(
+        Org org, ProductId productId) {
+
+      if (subscription == null) {
+        subscription = stubSubscription("sub123", "number123", 1);
+      }
+
+      var offering =
+          OfferingEntity.builder()
+              .sku(sku)
+              .hasUnlimitedUsage(hasUnlimitedUsage)
+              .productTags(Set.of(productId.toString()))
+              .build();
+
+      subscription.setOffering(offering);
+      subscription.setOrgId(org.orgId);
+
+      var quantity = subscription.getQuantity();
+
+      var coresMetric = MetricId.fromString("Cores");
+      var socketsMetric = MetricId.fromString("Sockets");
+
+      var measurements = new HashMap<SubscriptionMeasurementKey, Double>();
+      measurements.putAll(
+          buildMeasurement(String.valueOf(PHYSICAL), coresMetric, totalCapacity(cores, quantity)));
+      measurements.putAll(
+          buildMeasurement(
+              String.valueOf(PHYSICAL), socketsMetric, totalCapacity(sockets, quantity)));
+      measurements.putAll(
+          buildMeasurement(
+              String.valueOf(HYPERVISOR), coresMetric, totalCapacity(hypervisorCores, quantity)));
+      measurements.putAll(
+          buildMeasurement(
+              String.valueOf(HYPERVISOR),
+              socketsMetric,
+              totalCapacity(hypervisorSockets, quantity)));
+      for (Map.Entry<String, Integer> otherMetric : otherMetrics.entrySet()) {
+        measurements.putAll(
+            buildMeasurement(
+                String.valueOf(PHYSICAL),
+                MetricId.fromString(otherMetric.getKey()),
+                totalCapacity(otherMetric.getValue(), quantity)));
+      }
+      subscription.setSubscriptionMeasurements(measurements);
+
+      return measurements;
+    }
+
+    public OfferingEntity createOffering() {
+      return OfferingEntity.builder()
+          .sku(sku)
+          .hasUnlimitedUsage(hasUnlimitedUsage)
+          .serviceLevel(serviceLevel)
+          .usage(usage)
+          .productName(productName)
+          .description(sku + OFFERING_DESCRIPTION_SUFFIX)
+          .build();
+    }
+
+    private static Double totalCapacity(Integer capacity, long quantity) {
+      return capacity == null ? null : (double) (capacity * quantity);
+    }
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionResourceV2Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionResourceV2Test.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV2;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SubscriptionResourceV2Test {
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
+  private final OffsetDateTime min = OffsetDateTime.now().minusDays(4);
+  private final OffsetDateTime max = OffsetDateTime.now().plusDays(4);
+
+  @Inject SubscriptionResourceV2 subscriptionResource;
+  @InjectMock SubscriptionTableControllerV2 controller;
+
+  @TestSecurity(
+      user = "123456",
+      roles = {"test"})
+  @Test
+  void testAccessDeniedWhenUserIsNotACustomer() {
+    assertThrows(
+        ForbiddenException.class,
+        () ->
+            subscriptionResource.getSkuCapacityReportV2(
+                RHEL_FOR_X86,
+                0,
+                10,
+                null,
+                null,
+                UsageType.PRODUCTION,
+                null,
+                null,
+                min,
+                max,
+                null,
+                SkuCapacityReportSortV2.SKU,
+                null));
+  }
+
+  @TestSecurity(
+      user = "123456",
+      roles = {"customer"})
+  @Test
+  void testAccessAlowed() {
+    assertDoesNotThrow(
+        () ->
+            subscriptionResource.getSkuCapacityReportV2(
+                RHEL_FOR_X86,
+                0,
+                10,
+                null,
+                null,
+                UsageType.PRODUCTION,
+                null,
+                null,
+                min,
+                max,
+                null,
+                SkuCapacityReportSortV2.SKU,
+                null));
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
@@ -1,0 +1,932 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import static com.redhat.swatch.contract.repository.ReportCategory.HYPERVISOR;
+import static com.redhat.swatch.contract.repository.ReportCategory.PHYSICAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import com.redhat.swatch.contract.exception.SubscriptionsException;
+import com.redhat.swatch.contract.openapi.model.ReportCategory;
+import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
+import com.redhat.swatch.contract.openapi.model.SkuCapacityReportSortV2;
+import com.redhat.swatch.contract.openapi.model.SkuCapacitySubscription;
+import com.redhat.swatch.contract.openapi.model.SortDirection;
+import com.redhat.swatch.contract.openapi.model.SubscriptionEventType;
+import com.redhat.swatch.contract.openapi.model.SubscriptionType;
+import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.ServiceLevel;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityView;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityViewMetric;
+import com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository;
+import com.redhat.swatch.contract.repository.Usage;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.candlepin.clock.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+class SubscriptionTableControllerV2Test {
+
+  private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
+  private static final String OFFERING_DESCRIPTION_SUFFIX = " test description";
+
+  @InjectMock SubscriptionCapacityViewRepository repository;
+  @Inject ApplicationClock clock;
+  @Inject SubscriptionTableControllerV2 subscriptionTableControllerV2;
+
+  private static final MeasurementSpec RH0180191 =
+      MeasurementSpec.offering(
+          "RH0180191", "RHEL Server", 2, 0, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH00604F5 =
+      MeasurementSpec.offering(
+          "RH00604F5", "RHEL Server", 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180192_SOCKETS =
+      MeasurementSpec.offering(
+          "RH0180192", "RHEL Server", 2, null, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180193_CORES =
+      MeasurementSpec.offering(
+          "RH0180193", "RHEL Server", null, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180194_SOCKETS_AND_CORES =
+      MeasurementSpec.offering(
+          "RH0180194", "RHEL Server", 2, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
+  private static final MeasurementSpec RH0180195_UNLIMITED_USAGE =
+      MeasurementSpec.offering(
+          "RH0180192", "RHEL Server", null, null, ServiceLevel.STANDARD, Usage.PRODUCTION, true);
+  private static final MeasurementSpec RH0180196_HYPERVISOR_SOCKETS =
+      MeasurementSpec.offering(
+          "RH0180196",
+          "RHEL Server",
+          2,
+          0,
+          String.valueOf(HYPERVISOR),
+          ServiceLevel.STANDARD,
+          Usage.PRODUCTION,
+          false);
+
+  private enum Org {
+    STANDARD("711497");
+
+    private final String orgId;
+
+    Org(String orgId) {
+      this.orgId = orgId;
+    }
+  }
+
+  /**
+   * Creates a list of SubscriptionMeasurements that can be returned by a mock
+   * SubscriptionMeasurementRepository.
+   *
+   * @param specs specifies what sub capacities to return
+   */
+  private void givenCapacities(ProductId productId, MeasurementSpec... specs) {
+
+    Arrays.stream(specs)
+        .forEach(
+            s -> {
+              var measurements = s.createMeasurements(productId);
+              s.subscription.setMetrics(measurements);
+            });
+  }
+
+  @BeforeEach
+  public void updateSecurityContext() {
+    SecurityContext mockSecurityContext = Mockito.mock(SecurityContext.class);
+    Principal mockPrincipal = Mockito.mock(Principal.class);
+    subscriptionTableControllerV2.setSecurityContext(mockSecurityContext);
+    when(mockSecurityContext.getUserPrincipal()).thenReturn(mockPrincipal);
+    when(mockPrincipal.getName()).thenReturn("123456");
+  }
+
+  @Test
+  void testGetSkuCapacityReportSingleSub() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a socket
+    // capacity of 2,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec = RH0180191.withSub(expectedSub);
+
+    givenCapacities(productId, spec);
+    givenSubscriptionsInRepository(expectedSub);
+    givenOfferings(spec);
+    // When requesting a SKU capacity report for the eng product,
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    var actualItem = actual.getData().get(0);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(4, actualItem.getQuantity(), "Incorrect quantity");
+    assertEquals(MetricIdUtils.getSockets().toString(), actual.getMeta().getMeasurements().get(0));
+    assertEquals(8, actualItem.getMeasurements().get(0));
+    assertSubscription(expectedSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+  }
+
+  @Test
+  void testGetSkuCapacityReportMultipleSubsSameSku() {
+    // Given an org with two active subs with different quantities for the same SKU,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+
+    givenCapacities(productId, spec1, spec2);
+    givenSubscriptionsInRepository(expectedOlderSub, expectedNewerSub);
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    // When requesting a SKU capacity report for the eng product,
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the subs and appropriate
+    // quantity and capacities.
+    assertEquals(
+        1,
+        actual.getData().size(),
+        "Both subs are for same SKU so should collect into one capacity item.");
+    var actualItem = actual.getData().get(0);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(
+        9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
+    assertEquals(18, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
+    assertEquals(actualItem.getProductName(), actualItem.getProductName());
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedOlderSub.getEndDate(),
+        actualItem.getNextEventDate(),
+        "Wrong upcoming event date. Given two or more subs, the even take should be the subscription enddate closest to now.");
+
+    SkuCapacitySubscription actualSub = actualItem.getSubscriptions().get(0);
+    assertSubscription(expectedOlderSub, actualSub);
+
+    actualSub = actualItem.getSubscriptions().get(1);
+    assertSubscription(expectedNewerSub, actualSub);
+  }
+
+  @Test
+  void testGetSkuCapacityReportDifferentSkus() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var spec2 = RH00604F5.withSub(expectedOlderSub);
+
+    givenCapacities(productId, spec1, spec2);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    givenOfferings(spec1, spec2);
+
+    // When requesting a SKU capacity report for the eng product, sorted by SKU
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH00604F5 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    var actualItem = actual.getData().get(0);
+    assertEquals(RH00604F5.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        5,
+        actualItem.getQuantity(),
+        "Sub quantity should come from only sub(s) providing the SKU.");
+    assertEquals(10, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
+    assertEquals(MetricIdUtils.getSockets().toString(), actual.getMeta().getMeasurements().get(0));
+    assertSubscription(expectedOlderSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedOlderSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+
+    actualItem = actual.getData().get(1);
+    assertEquals(RH0180191.sku, actualItem.getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        4,
+        actualItem.getQuantity(),
+        "Sub quantity should come from only sub(s) providing the SKU.");
+    assertEquals(8, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
+    assertEquals(MetricIdUtils.getSockets().toString(), actual.getMeta().getMeasurements().get(0));
+    assertSubscription(expectedNewerSub, actualItem.getSubscriptions().get(0));
+    assertEquals(
+        SubscriptionEventType.END, actualItem.getNextEventType(), "Wrong upcoming event type");
+    assertEquals(
+        expectedNewerSub.getEndDate(),
+        actualItem.getNextEventDate(),
+        "Wrong upcoming event " + "date");
+  }
+
+  @Test
+  void testGetSkuCapacityReportNoSub() {
+    // Given an org with no active subs,
+
+    givenSubscriptionsInRepository();
+
+    // When requesting a SKU capacity report for an eng product,
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            RHEL_FOR_X86, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains no inventory items.
+    assertEquals(0, actual.getData().size(), "An empty inventory list should be returned.");
+  }
+
+  @Test
+  void testShouldUseQueryBasedOnHeaderAndParameters() {
+
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+
+    givenCapacities(RHEL_FOR_X86, spec1, spec2);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub);
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    var report =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            RHEL_FOR_X86,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(1, report.getData().size());
+  }
+
+  @Test
+  void testShouldUseSlaQueryParam() {
+    ProductId productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+    givenCapacities(productId, spec1, spec2);
+
+    givenSubscriptionsInRepository();
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    var reportForUnmatchedSLA =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.PREMIUM,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(0, reportForUnmatchedSLA.getData().size());
+
+    givenSubscriptionsInRepository(expectedNewerSub);
+    var reportForMatchingSLA =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(1, reportForMatchingSLA.getData().size());
+  }
+
+  @Test
+  void testShouldUseUsageQueryParam() {
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedOlderSub);
+    var spec2 = RH0180191.withSub(expectedNewerSub);
+    givenCapacities(productId, spec1, spec2);
+
+    givenSubscriptionsInRepository();
+
+    givenOfferings(spec1); // spec2 is the same offering
+
+    var reportForUnmatchedUsage =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            UsageType.DEVELOPMENT_TEST,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(0, reportForUnmatchedUsage.getData().size());
+
+    givenSubscriptionsInRepository(expectedNewerSub);
+    var reportForMatchingUsage =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            UsageType.PRODUCTION,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(1, reportForMatchingUsage.getData().size());
+  }
+
+  @Test
+  void testCountReturnedInMetaIgnoresOffsetAndLimit() {
+    var productId = RHEL_FOR_X86;
+    var spec1 = RH0180191.withSub(stubSubscription("1236", "1237", 5, 6, 6));
+    var spec2 = RH00604F5.withSub(stubSubscription("1234", "1235", 4, 5, 7));
+    var rh0060192 =
+        MeasurementSpec.offering(
+                "RH0060192", "RHEL Server", 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION, false)
+            .withSub(stubSubscription("1239", "1235", 4, 5, 7));
+    var rh00604f7 =
+        MeasurementSpec.offering(
+                "RH00604F7", "RHEL Server", 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION, false)
+            .withSub(stubSubscription("1238", "1235", 4, 5, 7));
+    var rh00604f6 =
+        MeasurementSpec.offering(
+                "RH00604F6", "RHEL Server", 2, 0, ServiceLevel.PREMIUM, Usage.PRODUCTION, false)
+            .withSub(stubSubscription("1237", "1235", 4, 5, 7));
+
+    givenCapacities(productId, spec1, spec2, rh00604f6, rh00604f7, rh0060192);
+
+    givenSubscriptionsInRepository(
+        spec1.subscription,
+        spec2.subscription,
+        rh00604f6.subscription,
+        rh00604f7.subscription,
+        rh0060192.subscription);
+
+    givenOfferings(spec1, spec2, rh00604f6, rh00604f7, rh0060192);
+
+    var reportWithOffsetAndLimit =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId, 0, 2, null, null, null, null, null, null, SkuCapacityReportSortV2.SKU, null);
+    assertEquals(2, reportWithOffsetAndLimit.getData().size());
+    assertEquals(5, reportWithOffsetAndLimit.getMeta().getCount());
+  }
+
+  @Test
+  void testShouldUseMetricIdQueryParam() {
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var expectedMuchOlderSub = stubSubscription("1238", "1237", 5, 24, 6);
+
+    var coresSpec1 = RH0180193_CORES.withSub(expectedNewerSub);
+    var coresSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
+    givenOfferings(coresSpec1, coresSpec2);
+
+    var socketsSpec1 = RH0180192_SOCKETS.withSub(expectedOlderSub);
+    var socketsSpec2 = RH0180194_SOCKETS_AND_CORES.withSub(expectedMuchOlderSub);
+    givenOfferings(socketsSpec1, socketsSpec2);
+
+    givenCapacities(productId, coresSpec1, coresSpec2);
+    givenCapacities(productId, socketsSpec1, socketsSpec2);
+    givenSubscriptionsInRepository(coresSpec1.subscription, coresSpec2.subscription);
+    givenSubscriptionsInRepository(socketsSpec1.subscription, socketsSpec2.subscription);
+
+    var reportForMatchingCores =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(2, reportForMatchingCores.getData().size());
+
+    var reportForMatchingSockets =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            ServiceLevelType.STANDARD,
+            null,
+            null,
+            null,
+            MetricIdUtils.getSockets().toString(),
+            SkuCapacityReportSortV2.SKU,
+            null);
+    assertEquals(2, reportForMatchingSockets.getData().size());
+  }
+
+  @Test
+  void testShouldThrowExceptionOnBadOffset() {
+    SubscriptionsException e =
+        assertThrows(
+            SubscriptionsException.class,
+            () ->
+                subscriptionTableControllerV2.capacityReportBySkuV2(
+                    RHEL_FOR_X86,
+                    11,
+                    10,
+                    null,
+                    null,
+                    UsageType.PRODUCTION,
+                    null,
+                    null,
+                    null,
+                    SkuCapacityReportSortV2.SKU,
+                    null));
+    assertEquals(Response.Status.BAD_REQUEST, e.getStatus());
+  }
+
+  @Test
+  void testShouldPopulateAnnualSubscriptionType() {
+
+    givenSubscriptionsInRepository();
+
+    var report =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            RHEL_FOR_X86,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV2.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ANNUAL, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
+  void testShouldPopulateOnDemandSubscriptionType() {
+
+    givenSubscriptionsInRepository();
+
+    var report =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            ProductId.fromString("OpenShift-metrics"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getCores().toString(),
+            SkuCapacityReportSortV2.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
+  void testGetSkuCapacityReportUnlimitedQuantity() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
+    // usage.
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedSub);
+
+    givenCapacities(productId, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedSub);
+
+    when(repository.streamBy(any())).thenReturn(Stream.of(unlimitedSpec.subscription));
+    givenOfferings(unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product,
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId, null, null, null, null, null, null, null, null, null, null);
+
+    // Then the report contains a single inventory item containing the sub and HasInfiniteQuantity
+    // should be true.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    var actualItem = actual.getData().get(0);
+    assertTrue(actualItem.getHasInfiniteQuantity(), "HasInfiniteQuantity should be true");
+  }
+
+  @Test
+  void testShouldSortUnlimitedLastAscending() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedOlderSub);
+
+    givenCapacities(productId, spec1, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub, unlimitedSpec.subscription);
+    givenOfferings(spec1, unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product, sorted by quantity
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.QUANTITY,
+            null);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH00604F5 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    assertEquals(
+        spec1.sku, actual.getData().get(0).getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        unlimitedSpec.sku,
+        actual.getData().get(1).getSku(),
+        "Wrong SKU. (Incorrect ordering of SKUs?)");
+  }
+
+  @Test
+  void testShouldSortUnlimitedFirstDescending() {
+    // Given an org with two active subs with different quantities for different SKUs,
+    // and the subs have an eng product with a socket capacity of 2,
+    // and the subs have different ending dates,
+    var productId = RHEL_FOR_X86;
+    var expectedNewerSub = stubSubscription("1234", "1235", 4, 5, 7);
+    var expectedOlderSub = stubSubscription("1236", "1237", 5, 6, 6);
+    var spec1 = RH0180191.withSub(expectedNewerSub);
+    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedOlderSub);
+
+    givenCapacities(productId, spec1, unlimitedSpec);
+    givenSubscriptionsInRepository(expectedNewerSub, expectedOlderSub, unlimitedSpec.subscription);
+    givenOfferings(spec1, unlimitedSpec);
+
+    // When requesting a SKU capacity report for the eng product, sorted by quantity
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SkuCapacityReportSortV2.QUANTITY,
+            SortDirection.DESC);
+
+    // Then the report contains two inventory items containing a sub with appropriate
+    // quantity and capacities, and RH0180195 is listed first.
+    assertEquals(
+        2,
+        actual.getData().size(),
+        "Both subs are for different SKUs so should collect into two capacity items.");
+
+    assertEquals(
+        unlimitedSpec.sku,
+        actual.getData().get(0).getSku(),
+        "Wrong SKU. (Incorrect ordering of SKUs?)");
+    assertEquals(
+        spec1.sku, actual.getData().get(1).getSku(), "Wrong SKU. (Incorrect ordering of SKUs?)");
+  }
+
+  @Test
+  void testGetSkuCapacityReportHypervisorSocketsOnly() {
+    // Given an org with one active sub with a quantity of 4 and has an eng product with a
+    // hypervisor socket capacity of 2,
+    var productId = RHEL_FOR_X86;
+    var expectedSub = stubSubscription("1234", "1235", 4);
+    var spec1 = RH0180196_HYPERVISOR_SOCKETS.withSub(expectedSub);
+
+    givenCapacities(productId, spec1);
+    givenSubscriptionsInRepository(expectedSub);
+
+    givenOfferings(spec1);
+
+    // When requesting a SKU capacity report for the eng product,
+    var actual =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            productId,
+            null,
+            null,
+            ReportCategory.HYPERVISOR,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    // Then the report contains a single inventory item containing the sub and appropriate
+    // quantity and capacities.
+    assertEquals(1, actual.getData().size(), "Wrong number of items returned");
+    var actualItem = actual.getData().get(0);
+    assertEquals(spec1.sku, actualItem.getSku(), "Wrong SKU");
+    assertEquals(8, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
+    assertEquals(ReportCategory.HYPERVISOR, actualItem.getCategory());
+    assertEquals(MetricIdUtils.getSockets().toString(), actual.getMeta().getMeasurements().get(0));
+  }
+
+  private void givenOfferings(MeasurementSpec... specs) {
+    Stream.of(specs)
+        .forEach(
+            spec -> {
+              OfferingEntity offering = spec.createOffering();
+              spec.subscription.setSku(offering.getSku());
+              spec.subscription.setHasUnlimitedUsage(offering.isHasUnlimitedUsage());
+              spec.subscription.setUsage(offering.getUsage());
+              spec.subscription.setServiceLevel(offering.getServiceLevel());
+              spec.subscription.setProductName(offering.getProductName());
+            });
+  }
+
+  private void givenSubscriptionsInRepository(SubscriptionCapacityView... subs) {
+    Mockito.doAnswer(c -> Stream.of(subs)).when(repository).streamBy(any());
+  }
+
+  private static void assertSubscription(
+      SubscriptionCapacityView expectedSub, SkuCapacitySubscription actual) {
+    assertEquals(expectedSub.getSubscriptionId(), actual.getId(), "Wrong Subscription ID");
+    assertEquals(
+        expectedSub.getSubscriptionNumber(), actual.getNumber(), "Wrong Subscription Number");
+  }
+
+  private static SubscriptionCapacityView stubSubscription(
+      String id, String number, Integer quantity) {
+    return stubSubscription(id, number, quantity, 6, 6);
+  }
+
+  /* Also specifies the sub active timeframe, relative to now. */
+  private static SubscriptionCapacityView stubSubscription(
+      String id, String number, Integer quantity, int startMonthsAgo, int endMonthsAway) {
+    OffsetDateTime subStart = OffsetDateTime.now().minusMonths(startMonthsAgo);
+    OffsetDateTime subEnd = subStart.plusMonths(startMonthsAgo + endMonthsAway);
+
+    SubscriptionCapacityView subscription = new SubscriptionCapacityView();
+    subscription.setSubscriptionId(id);
+    subscription.setSubscriptionNumber(number);
+    subscription.setQuantity(quantity);
+    subscription.setStartDate(subStart);
+    subscription.setEndDate(subEnd);
+    return subscription;
+  }
+
+  /** Class to generate SubscriptionMeasurements as tests need them. */
+  private static class MeasurementSpec {
+    private SubscriptionCapacityView subscription;
+
+    // Fields in this section specify the Offering used in the SubscriptionCapacity.
+    final String sku;
+    final String productName;
+    final Integer sockets;
+    final Integer cores;
+    final String category;
+    final Map<String, Integer> otherMetrics;
+    final ServiceLevel serviceLevel;
+    final Usage usage;
+    final boolean hasUnlimitedUsage;
+
+    private MeasurementSpec(
+        String sku,
+        String productName,
+        Integer sockets,
+        Integer cores,
+        String category,
+        Map<String, Integer> otherMetrics,
+        ServiceLevel serviceLevel,
+        Usage usage,
+        boolean hasUnlimitedUsage,
+        SubscriptionCapacityView subscription) {
+      this.sku = sku;
+      this.productName = productName;
+      this.sockets = sockets;
+      this.cores = cores;
+      this.category = category;
+      this.otherMetrics = otherMetrics;
+      this.serviceLevel = serviceLevel;
+      this.usage = usage;
+      this.hasUnlimitedUsage = hasUnlimitedUsage;
+      this.subscription = subscription;
+    }
+
+    public MeasurementSpec withMetric(String metric, Integer value) {
+      otherMetrics.put(metric, value);
+      return this;
+    }
+
+    public static MeasurementSpec offering(
+        String sku,
+        String productName,
+        Integer sockets,
+        Integer cores,
+        ServiceLevel serviceLevel,
+        Usage usage,
+        Boolean hasUnlimitedUsage) {
+      return offering(
+          sku,
+          productName,
+          sockets,
+          cores,
+          String.valueOf(PHYSICAL),
+          serviceLevel,
+          usage,
+          hasUnlimitedUsage);
+    }
+
+    public static MeasurementSpec offering(
+        String sku,
+        String productName,
+        Integer sockets,
+        Integer cores,
+        String category,
+        ServiceLevel serviceLevel,
+        Usage usage,
+        Boolean hasUnlimitedUsage) {
+      return new MeasurementSpec(
+          sku,
+          productName,
+          sockets,
+          cores,
+          category,
+          new HashMap<>(),
+          serviceLevel,
+          usage,
+          hasUnlimitedUsage,
+          null);
+    }
+
+    /**
+     * Returns a new Subscription Capacity Specification but with the subscription information
+     * added. We want to return a new one, so we don't mutate the objects created from .offering as
+     * test fixtures.
+     */
+    public MeasurementSpec withSub(SubscriptionCapacityView sub) {
+      return new MeasurementSpec(
+          sku,
+          productName,
+          sockets,
+          cores,
+          category,
+          otherMetrics,
+          serviceLevel,
+          usage,
+          hasUnlimitedUsage,
+          sub);
+    }
+
+    public SubscriptionCapacityViewMetric buildMeasurement(
+        String type, MetricId metricId, Double value) {
+      SubscriptionCapacityViewMetric metric = new SubscriptionCapacityViewMetric();
+      metric.setMeasurementType(type);
+      metric.setMetricId(metricId.toUpperCaseFormatted());
+      metric.setCapacity(value);
+      return metric;
+    }
+
+    public Set<SubscriptionCapacityViewMetric> createMeasurements(ProductId productId) {
+
+      if (subscription == null) {
+        subscription = stubSubscription("sub123", "number123", 1);
+      }
+
+      subscription.setProductTag(productId.toString());
+      subscription.setSku(sku);
+      subscription.setHasUnlimitedUsage(hasUnlimitedUsage);
+      subscription.setOrgId(Org.STANDARD.orgId);
+
+      var quantity = subscription.getQuantity();
+
+      var coresMetric = MetricId.fromString("Cores");
+      var socketsMetric = MetricId.fromString("Sockets");
+
+      var measurements = new HashSet<SubscriptionCapacityViewMetric>();
+      measurements.add(buildMeasurement(category, coresMetric, totalCapacity(cores, quantity)));
+      measurements.add(buildMeasurement(category, socketsMetric, totalCapacity(sockets, quantity)));
+      for (Map.Entry<String, Integer> otherMetric : otherMetrics.entrySet()) {
+        measurements.add(
+            buildMeasurement(
+                category,
+                MetricId.fromString(otherMetric.getKey()),
+                totalCapacity(otherMetric.getValue(), quantity)));
+      }
+
+      subscription.setProductTag(productId.getValue());
+      subscription.setMetrics(measurements);
+
+      return measurements;
+    }
+
+    public OfferingEntity createOffering() {
+      return OfferingEntity.builder()
+          .sku(sku)
+          .hasUnlimitedUsage(hasUnlimitedUsage)
+          .serviceLevel(serviceLevel)
+          .usage(usage)
+          .productName(productName)
+          .description(sku + OFFERING_DESCRIPTION_SUFFIX)
+          .build();
+    }
+
+    private static Double totalCapacity(Integer capacity, long quantity) {
+      return capacity == null ? null : (double) (capacity * quantity);
+    }
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/security/RbacRolesAugmentorTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/security/RbacRolesAugmentorTest.java
@@ -141,6 +141,6 @@ class RbacRolesAugmentorTest {
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create());
     verifyNoInteractions(rbacApi);
-    subscriber.assertCompleted().assertItem(Set.of("test", "service", "support"));
+    subscriber.assertCompleted().assertItem(Set.of("test", "service", "support", "customer"));
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2843

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Moving this endpoint to swatch-contracts while allowing it to still work in the monolith

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: 
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/900

### Setup
To check locally from this branch with the iqe pr
1. Modify iqe_rhsm_subscriptions/conf/rhsm_subscriptions.default.yaml lines 273, 498, and 502 to match your port of choice for swatch-contracts [8003 for this example]
2. Start swatch-contracts
`SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-contracts:quarkusDev`
3. Start the monolith (for opt in call)
` DEV_MODE=true SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew clean :bootRun`
4. Create an entry in the org_config table for an org
`insert into org_config (org_id, opt_in_type,created, updated) values ('5345257','API','2024-06-21T12:50:39.496954Z','2024-06-21T12:50:39.496954Z')`
5. Run the opt-in
`http :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"5345257"}}}' | base64 -w0)
`

### Steps
<!-- Enter each step of the test below -->
1. Run from command line to exercise endpoint [either v1 or v2 will work]
`http GET ':8003/api/rhsm-subscriptions/v2/subscriptions/products/RHEL for x86' x-rh-identity:$(echo '{"identity":{"type":"User","org_id":"5345257"}}' | base64 -w0)`
2. Run test command from iqe
`iqe tests plugin rhsm_subscriptions  -k test_subscription_table_api_subscription_type_contracts`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. for the command line, you will see the expected json that you would get using the same command against port 8000
`http GET ':8000/api/rhsm-subscriptions/v2/subscriptions/products/RHEL for x86' x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"5345257"}}}' | base64 -w0)`
2. The 2 iqe tests will succeed.

