### PR TITLE
SWATCH-3006: Support back uom in the events ingestion

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
@@ -71,6 +71,16 @@ public class EventNormalizer {
         && event.getServiceType().equals(ANSIBLE_INFRASTRUCTURE_HOUR)) {
       event.setServiceType("Ansible Managed Node");
     }
+    // normalize UOM to metric_id
+    event
+        .getMeasurements()
+        .forEach(
+            measurement -> {
+              if (measurement.getUom() != null) {
+                measurement.setMetricId(measurement.getUom());
+                measurement.setUom(null);
+              }
+            });
     return event;
   }
 

--- a/swatch-model-events/schemas/event.yaml
+++ b/swatch-model-events/schemas/event.yaml
@@ -133,6 +133,12 @@ properties:
             - Managed-nodes
             - Transfer-gibibytes
             - Storage-gibibyte-months
+        uom:
+          description: Metric ID for the measurement. (e.g. Cores, Sockets)
+          type: string
+          required: false
+          deprecated: true
+          deprecationMessage: Use 'metric_id' instead.
     required: false
   cloud_provider:
     description: Identifier for the cloud provider of the subject.


### PR DESCRIPTION
Jira issue: SWATCH-3006

## Description
The uom property was fully removed as part of SWATCH-1233, but this was causing issues in production because the cost-management service was still emitting events using the removed uom property (reported by SWATCH-3006).

Therefore, the uom support was re-added only for ingesting the events and COST-5575 was reported for the cost-management to use the metric_id property.

## Testing
Create event as below (without product_tag) :

```
{
  "event_source": "cost-management",
  "event_type": "snapshot",
  "account_number": "6064760",
  "org_id": "11602918",
  "service_type": "RHEL System",
  "instance_id": "i-06aae2d3343f8b439",
  "timestamp": "2024-10-05T06:00:00Z",
  "expiration": "2024-10-05T07:00:00Z",
  "measurements": [
    {
      "value": "4",
      "uom": "vCPUs"
    }
  ],
  "cloud_provider": "AWS",
  "hardware_type": "Cloud",
  "product_ids": [
    "69",
    "204"
  ],
  "sla": "Premium",
  "usage": "Production",
  "billing_provider": "aws",
  "conversion": "false",
  "role": "Red Hat Enterprise Linux Server",
  "billing_account_id": "nikhil-test"
}
```
 

IQE helper:
```
app.rhsm_subscriptions.send_kafka_message("platform.rhsm-subscriptions.service-instance-ingress", message)
```