### PR TITLE
SWATCH-2951: Allow to filter by metrics in the Instances Table API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -106,7 +106,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   public Stream<TallyInstanceView> fetchData(ExportServiceRequest request) {
     log.debug("Fetching data for {}", request.getOrgId());
     var reportCriteria = extractExportFilter(request);
-    boolean isPayg = ProductId.fromString(reportCriteria.getProductId()).isPayg();
+    boolean isPayg = reportCriteria.getProductId().isPayg();
     var repository = isPayg ? paygViewRepository : nonPaygViewRepository;
     return repository
         .findBy(buildSearchSpecification(reportCriteria), FluentQuery.FetchableFluentQuery::stream)
@@ -157,7 +157,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
     }
 
     // special handling of the month for non payg products
-    if (!ProductId.fromString(report.build().getProductId()).isPayg()) {
+    if (!report.build().getProductId().isPayg()) {
       report.month(null);
     }
 
@@ -166,7 +166,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
 
   private static void handleProductIdFilter(
       TallyInstancesDbReportCriteria.TallyInstancesDbReportCriteriaBuilder builder, String value) {
-    builder.productId(ProductId.fromString(value).toString());
+    builder.productId(ProductId.fromString(value));
   }
 
   private static void handleSlaFilter(

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/InstancesResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/InstancesResourceTest.java
@@ -108,8 +108,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(true),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -199,8 +201,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(false),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -283,8 +287,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(true),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -372,8 +378,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(false),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -406,8 +414,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(false),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -424,7 +434,6 @@ class InstancesResourceTest {
 
     verify(repository)
         .findAllBy(
-            eq(false),
             eq("owner123456"),
             any(),
             any(),
@@ -433,6 +442,9 @@ class InstancesResourceTest {
             any(),
             any(),
             eq(null),
+            any(),
+            any(),
+            any(),
             any(),
             any(),
             any(),
@@ -475,8 +487,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(false),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -509,7 +523,6 @@ class InstancesResourceTest {
 
     verify(repository)
         .findAllBy(
-            eq(false),
             eq("owner123456"),
             any(),
             any(),
@@ -518,6 +531,9 @@ class InstancesResourceTest {
             eq(0),
             eq(null),
             eq(null),
+            any(),
+            any(),
+            any(),
             any(),
             any(),
             any(),
@@ -542,8 +558,10 @@ class InstancesResourceTest {
 
     Mockito.when(
             repository.findAllBy(
-                eq(false),
                 eq("owner123456"),
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -576,7 +594,6 @@ class InstancesResourceTest {
 
     verify(repository)
         .findAllBy(
-            eq(false),
             eq("owner123456"),
             any(),
             any(),
@@ -585,6 +602,9 @@ class InstancesResourceTest {
             eq(null),
             eq(0),
             eq(null),
+            any(),
+            any(),
+            any(),
             any(),
             any(),
             any(),

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
@@ -24,8 +24,16 @@ import static java.util.Optional.ofNullable;
 
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Immutable;
@@ -36,6 +44,15 @@ import org.springframework.data.annotation.Immutable;
 @Immutable
 @Table(name = "tally_instance_non_payg_view")
 public class TallyInstanceNonPaygView extends TallyInstanceView {
+
+  /** This is only used when filtering/sorting instances. */
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "instance_measurements",
+      joinColumns = @JoinColumn(name = "host_id", referencedColumnName = "id"))
+  @MapKeyColumn(name = "metric_id")
+  @Column(name = "value")
+  private Map<String, Double> filteredMetrics = new HashMap<>();
 
   @Override
   public double getMetricValue(MetricId metricId) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygView.java
@@ -23,9 +23,16 @@ package org.candlepin.subscriptions.db.model;
 import static java.util.Optional.ofNullable;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Immutable;
@@ -39,6 +46,18 @@ public class TallyInstancePaygView extends TallyInstanceView {
 
   @Column(name = "month")
   private String month;
+
+  /** This is only used when filtering/sorting instances. */
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "instance_monthly_totals",
+      joinColumns = {
+        @JoinColumn(name = "host_id", referencedColumnName = "id"),
+        @JoinColumn(name = "month", referencedColumnName = "month")
+      })
+  @MapKeyColumn(name = "metric_id")
+  @Column(name = "value")
+  private Map<String, Double> filteredMetrics = new HashMap<>();
 
   @Override
   public double getMetricValue(MetricId metricId) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancesDbReportCriteria.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancesDbReportCriteria.java
@@ -21,16 +21,18 @@
 package org.candlepin.subscriptions.db.model;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
+import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 
 /** Common criteria that can be used to filter instances, subscriptions, and tally snapshots */
 @Data
 @Builder
 public class TallyInstancesDbReportCriteria {
   private String orgId;
-  private String productId;
+  private ProductId productId;
   private ServiceLevel sla;
   private Usage usage;
   private String displayNameSubstring;
@@ -41,5 +43,6 @@ public class TallyInstancesDbReportCriteria {
   private BillingProvider billingProvider;
   private String billingAccountId;
   private List<HardwareMeasurementType> hardwareMeasurementTypes;
-  private boolean isPayg;
+  private String sort;
+  private SortDirection sortDirection;
 }


### PR DESCRIPTION
Jira issue: SWATCH-2951

## Description
The payg and non payg views are aggregating all the metrics into a single row in jsonb format. And the problem is that we can't easily filter and order using these metrics because it is in jsonb.

So, instead of dealing with the metrics jsonb column, we're now adding a left join to the measurements table (for payg is "instance_monthly_totals" and for non payg is "instance_measurements") - note about performance: that these tables are indexed.

Therefore, we're now using this relationship to filter and also to order the result set. These relationships will not be used when mapping the query result set to the DTO.

Changes
- Removed the distinct in the query since it wasn't necessary (the distinct is done in the view).
- Implement the order using the Hibernate Criteria API because the Spring Specification API can only order by existing fields in the entity (and we now want to also order by programmatically added columns)
- Don't use the Spring Pageable API since the sort is not supported anylonger (if provided, then the programmatically order by is ignored)
- 
## Testing
Added a JUnit test to mimic the scenario. 