### PR TITLE
SWATCH-2916: Don't fail when facts are not integer in Swatch Conduit

### DIFF
--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -1021,6 +1021,16 @@ class InventoryControllerTest {
     assertNull(conduitFacts.getThreadsPerCore());
   }
 
+  @Test
+  void testThreadsPerCoreIsMappedUsingStringValueToConduitFacts() {
+    Consumer consumer = new Consumer();
+    consumer.getFacts().put("cpu.thread(s)_per_core", "confidential");
+
+    // verify when cpu.thread(s)_per_core is unset
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(new Consumer());
+    assertNull(conduitFacts.getThreadsPerCore());
+  }
+
   @ParameterizedTest
   @EnumSource(value = ProviderFact.class)
   void testProviderIdAndProviderTypeToConduitFacts(ProviderFact provider) {


### PR DESCRIPTION
Jira issue: SWATCH-2916

## Description
With these changes, we return an optional integer when parsing facts to integer to prevent failures.

## Testing
Added junit test to reproduce the issue.