### PR TITLE
SWATCH-2924: Add unleash to swatch-metrics-hbi

### DIFF
--- a/bin/build-images.sh
+++ b/bin/build-images.sh
@@ -25,9 +25,9 @@ function get_docker_file_path() {
   if [[ "$1" == "rhsm-subscriptions" ]]; then
     docker_file="Dockerfile"
   elif [[ -f "$1/src/main/docker/Dockerfile.jvm" ]]; then
-    docker_file=$1/src/main/docker/Dockerfile.jvm
+    docker_file="$1/src/main/docker/Dockerfile.jvm"
   else
-    docker_file=$1/Dockerfile
+    docker_file="$1/Dockerfile"
   fi
 
   if [[ ! -f "$docker_file" ]]; then
@@ -86,7 +86,7 @@ function validate_artifact() {
 
 # Validate that all applicable projects are valid.
 for p in "${projects[@]}"; do
-  validate_artifact $p
+  validate_artifact "$p"
 done
 
 quay_user=$(podman login --get-login quay.io)
@@ -102,8 +102,8 @@ trap build_failed ERR
 for p in "${projects[@]}"; do
   echo "Building ${p}"
 
-  docker_file=$(get_docker_file_path $p)
-  podman build . -f $docker_file \
+  docker_file=$(get_docker_file_path "$p")
+  podman build . -f "$docker_file" \
     --build-arg-file bin/dev-argfile.conf \
     -t quay.io/$quay_user/$p:$tag \
     --label "git-commit=${commit}" --ulimit nofile=2048:2048

--- a/swatch-metrics-hbi/build.gradle
+++ b/swatch-metrics-hbi/build.gradle
@@ -7,6 +7,8 @@ description = 'The swatch-metrics-hbi service build definition'
 dependencies {
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
     implementation 'io.quarkus:quarkus-config-yaml'
+    implementation libraries["unleash-quarkus"]
+
     implementation project(':swatch-common-config-workaround')
     implementation libraries["clowder-quarkus-config-source"]
     implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
@@ -23,7 +25,6 @@ dependencies {
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
 
     testImplementation libraries["junit-jupiter"]
-
 }
 
 tasks.withType(JavaCompile) {

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/EventsResource.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/EventsResource.java
@@ -35,18 +35,24 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 @Path("/events")
 public class EventsResource {
 
-  private EmitterService<Event> eventEmitter;
+  private final EmitterService<Event> eventEmitter;
+  private final FeatureFlags flags;
 
-  public EventsResource(@Channel(SWATCH_EVENTS_OUT) Emitter<Event> emitter) {
-    eventEmitter = new EmitterService<>(emitter);
+  public EventsResource(@Channel(SWATCH_EVENTS_OUT) Emitter<Event> emitter, FeatureFlags flags) {
+    this.eventEmitter = new EmitterService<>(emitter);
+    this.flags = flags;
   }
 
   @POST
   @Path("/swatch")
   public String sendSwatchEvent() {
-    Event event = new Event();
-    event.setInstanceId("Instance ID");
-    eventEmitter.send(Message.of(event));
-    return "Event sent!";
+    if (flags.emitEvents()) {
+      Event event = new Event();
+      event.setInstanceId("Instance ID");
+      eventEmitter.send(Message.of(event));
+      return "Event sent!";
+    } else {
+      return "Not sending event since emitting events is disabled!";
+    }
   }
 }

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/FeatureFlags.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/FeatureFlags.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.services;
+
+import io.getunleash.Unleash;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+public class FeatureFlags {
+  public static final String EMIT_EVENTS = "swatch.swatch-metrics-hbi.emit-events";
+
+  private final Unleash unleash;
+
+  public FeatureFlags(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
+  public boolean emitEvents() {
+    return unleash.isEnabled(FeatureFlags.EMIT_EVENTS);
+  }
+}

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -105,3 +105,8 @@ quarkus.otel.sdk.disabled=true
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
 # Metrics and logging are not yet supported - 30 Jul 2024
 quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
+
+quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
+quarkus.unleash.url=${UNLEASH_URL:http://localhost:4242/api}
+quarkus.unleash.token=${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
+quarkus.unleash.name-prefix=swatch


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue:SWATCH-2924

## Description
Utilize the swatch.swatch-metrics-hbi.emit-events feature flag.

Does not currently block any code execution, but logs when an event would have been emitted.

## Testing
It is easiest to test this in the dev environment, however, we need to test this in ephemeral so that the clowder configuration overrides take affect. The steps for both are outlined below.

### Dev Environment
1. Load the dependent dev services which will include unleash
`podman-compose up -d`

2. Enure that unleash is up: [http://localhost:4242](http://localhost:4242)
U/P: admin / unleash4all

3. Launch swatch-metrics-hbi
```
./gradlew  :swatch-metrics-hbi:quarkusDev
```
4. Send an scratch HBI event message (Doesn't matter what it is since we are reading reading it as a string).
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json \
--raw '{"records": [{"key": "12345678", "value": {"type":"testing feature flags"}}]}'
```

5. Verify that the logs show that the message would not be emitted to swatch events.
`Emitting HBI events to swatch is disabled. Not sending event.`

6. Toggle the flag via the unleash console.
```
curl -H 'Authorization: *:*.unleash-insecure-admin-api-token' \
-X POST \
'http://localhost:4242/api/admin/projects/default/features/swatch.swatch-metrics-hbi.emit-events/environments/development/on'
```
7. Send another HBI event message
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json \
--raw '{"records": [{"key": "12345678", "value": {"type":"testing feature flag enablement"}}]}'
```
8. Verify that an event would be emitted to swatch events.
`Emitting HBI events to swatch!`

9. Toggle the flag to off and send another message.
```
curl -H 'Authorization: *:*.unleash-insecure-admin-api-token' \
-X POST \
'http://localhost:4242/api/admin/projects/default/features/swatch.swatch-metrics-hbi.emit-events/environments/development/off'
```
10. Send another HBI event message
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json \
--raw '{"records": [{"key": "12345678", "value": {"type":"testing feature flag enablement"}}]}'
```

11. Log should show
`Emitting HBI events to swatch is disabled. Not sending event.`

### Ephemeral Environment
1. Build an image for the application.
```
./bin/build-images.sh
```
2. Note the image tag from the output above:
> Successfully tagged quay.io/mstead/swatch-metrics-hbi:**c6d7f64**

3. Deploy with bonfire. Substitute $IMAGE_TAG with tag from quay that was in the output from the image build. Substitute $YOUR_USERNAME with you quay username.

First add the following to your bonfire config file.
```
    - name: swatch-metrics-hbi
      host: local
      repo: /home/mstead/sandbox/swatch/swatch/swatch-metrics-hbi
      path: /deploy/clowdapp.yaml
      parameters:
        REPLICAS: 1
        swatch-metrics-hbi/IMAGE: quay.io/cloudservices/swatch-metrics-hbi
```
```
bonfire deploy rhsm  --timeout=1800  --optional-deps-method none \
--frontends false  --no-remove-resources app:rhsm \
-C rhsm \
-p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE=quay.io/$YOUR_USER/swatch-unleash-import \
-p rhsm/SWATCH_UNLEASH_IMPORT_IMAGE_TAG=$IMAGE_TAG \
-C swatch-metrics-hbi \
-i quay.io/$YOUR_USER/swatch-metrics-hbi=$IMAGE_TAG \
-p swatch-metrics-hbi/IMAGE=quay.io/$YOUR_USER/swatch-metrics-hbi
```

5. Deploy the kafka-bridge and forward the port (**from checkout dir**)
```
export NAMESPACE=$(oc project -q)
```
```
oc apply -n $NAMESPACE -f kafka-bridge/deploy/template.yaml
```
```
oc process -n $NAMESPACE -p KAFKA_BOOTSTRAP_HOST=ephemeral-kafka-bootstrap kafka-bridge | oc create -n $NAMESPACE -f -
```
```
oc port-forward service/kafka-bridge-bridge-service 9080:8080
```

6. Forward the port for the unleash service
```
oc port-forward pods/$(oc get pods | cut -d' ' -f1 | grep 'env.*featureflags') 4243:4242
```

7. Tail the logs of the swatch-metrics-hbi service
```
oc logs -f $(oc get pods | cut -d' ' -f1 | grep swatch-metrics-hbi)
```

8. Send an HBI message via the kafka bridge
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json \
--raw '{"records": [{"key": "12345678", "value": {"type":"testing feature flag enablement"}}]}'
```

9. Verify that the logs show that the message would not be emitted to swatch events.
`Emitting HBI events to swatch is disabled. Not sending event.`

10. Toggle the swatch.swatch-metrics-hbi flag (development env toggle) via the unleash UI @ [http://localhost:4243](http://localhost:4243) OR via the CLI if you want to create a new access token via [http://localhost:4243/admin/api](http://localhost:4243/admin/api) and run the following with on/off

```
curl -H 'Authorization: YOUR_ACCESS_TOKEN' \
-X POST \
'http://localhost:4243/api/admin/projects/default/features/swatch.swatch-metrics-hbi.emit-events/environments/development/on'
```

11. Send another HBI event message
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json \
--raw '{"records": [{"key": "12345678", "value": {"type":"testing feature flag enablement"}}]}'
```

12. Verify that an event would be emitted to swatch events.
`Emitting HBI events to swatch!`
