### PR TITLE
SWATCH-3026: Create RbacApi and RbacService into the Quarkus Rbac Client

### DIFF
--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApi.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApi.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import com.redhat.swatch.clients.rbac.api.model.Access;
+import java.util.List;
+
+/** Defines wrapper functions around all RBAC API calls that we want to make. */
+public interface RbacApi {
+
+  List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException;
+
+  List<Access> getCurrentIdentityAccess(String rbacAppName, String identity)
+      throws RbacApiException;
+}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiException.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+/** Thrown when an error occurs making an RBAC API call. */
+public class RbacApiException extends Exception {
+
+  public RbacApiException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiFactory.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import com.redhat.swatch.clients.rbac.api.resources.AccessApi;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@ApplicationScoped
+public class RbacApiFactory {
+
+  @RbacClient
+  @Produces
+  public RbacApi getApi(
+      @ConfigProperty(name = "rhsm-subscriptions.rbac-service.use-stub", defaultValue = "false")
+          boolean useStub,
+      @ConfigProperty(
+              name = "rhsm-subscriptions.rbac-service.stub-permissions",
+              defaultValue = "subscriptions:*:*")
+          String stubPermissions,
+      @RestClient AccessApi accessApi) {
+    if (useStub) {
+      return new StubRbacApi(stubPermissions.split(Pattern.quote(",")));
+    }
+
+    return new RbacApiImpl(accessApi);
+  }
+}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiImpl.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacApiImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import com.redhat.swatch.clients.rbac.api.model.Access;
+import com.redhat.swatch.clients.rbac.api.resources.AccessApi;
+import com.redhat.swatch.clients.rbac.api.resources.ApiException;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/** A wrapper around the RBAC API. */
+@AllArgsConstructor
+public class RbacApiImpl implements RbacApi {
+
+  private final AccessApi accessApi;
+
+  @Override
+  public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
+    try {
+      return accessApi.getPrincipalAccess(applicationName, null, null, null, null).getData();
+    } catch (ApiException apie) {
+      throw new RbacApiException("Unable to get current user access.", apie);
+    }
+  }
+
+  @Override
+  public List<Access> getCurrentIdentityAccess(String application, String identityCode)
+      throws RbacApiException {
+    try {
+      return accessApi.getPrincipalAccess(application, null, identityCode, null, null).getData();
+    } catch (ApiException apie) {
+      throw new RbacApiException("Unable to get current identity access.", apie);
+    }
+  }
+}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacClient.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to disambiguate the injection of the {@link com.redhat.swatch.clients.rbac.RbacApi}
+ * client. When used, the CDI context the real RbacApi or the stubRbacApi depending on the
+ * configuration property will use the RbacApi instance produced by {@link RbacApiFactory} that will
+ * resolve either "rhsm-subscriptions.rbac-service.use-stub".
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+public @interface RbacClient {}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacService.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/RbacService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import com.redhat.swatch.clients.rbac.api.model.Access;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+
+/** Provides RBAC functionality. */
+@AllArgsConstructor
+public class RbacService {
+
+  private final RbacApi api;
+
+  public List<String> getPermissions(String rbacAppName) throws RbacApiException {
+    // Get all permissions for the configured application name.
+    try (Stream<Access> accessStream = api.getCurrentUserAccess(rbacAppName).stream()) {
+      return accessStream
+          .filter(access -> access != null && hasText(access.getPermission()))
+          .map(Access::getPermission)
+          .toList();
+    }
+  }
+
+  public List<String> getPermissions(String rbacAppName, String identity) throws RbacApiException {
+    // Get all permissions for the configured application name.
+    try (Stream<Access> accessStream =
+        api.getCurrentIdentityAccess(rbacAppName, identity).stream()) {
+      return accessStream
+          .filter(access -> access != null && hasText(access.getPermission()))
+          .map(Access::getPermission)
+          .toList();
+    }
+  }
+
+  private boolean hasText(String str) {
+    if (str == null) {
+      return false;
+    }
+
+    for (int i = 0; i < str.length(); ++i) {
+      if (!Character.isWhitespace(str.charAt(i))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/StubRbacApi.java
+++ b/clients/quarkus/rbac-client/src/main/java/com/redhat/swatch/clients/rbac/StubRbacApi.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.clients.rbac;
+
+import com.redhat.swatch.clients.rbac.api.model.Access;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** Stub implementation of the RbacApi. */
+@Getter
+@AllArgsConstructor
+public class StubRbacApi implements RbacApi {
+
+  private final String[] stubPermissions;
+
+  @Override
+  public List<Access> getCurrentUserAccess(String applicationName) throws RbacApiException {
+    return Stream.of(stubPermissions).map(p -> new Access().permission(p)).toList();
+  }
+
+  @Override
+  public List<Access> getCurrentIdentityAccess(String rbacAppName, String identity) {
+    return Stream.of(stubPermissions).map(p -> new Access().permission(p)).toList();
+  }
+}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -209,6 +209,8 @@ RBAC_ENABLED=true
 RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
 %dev.RBAC_ENDPOINT=http://localhost:8080
 %test.RBAC_ENDPOINT=http://localhost:8080
+rhsm-subscriptions.rbac-service.use-stub=${RHSM_RBAC_USE_STUB:false}
+rhsm-subscriptions.rbac-service.stub-permissions=${RHSM_RBAC_STUB_PERMISSIONS:subscriptions:*:*}
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/rbac/RbacApiConfigurationUsingStubsTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/rbac/RbacApiConfigurationUsingStubsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.rbac;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.swatch.clients.rbac.RbacApi;
+import com.redhat.swatch.clients.rbac.RbacApiException;
+import com.redhat.swatch.clients.rbac.RbacClient;
+import com.redhat.swatch.clients.rbac.api.model.Access;
+import com.redhat.swatch.contract.test.resources.RbacUseStubService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(RbacUseStubService.class)
+class RbacApiConfigurationUsingStubsTest {
+
+  @RbacClient RbacApi rbacApi;
+
+  @Test
+  void testGetCurrentIdentityAccessShouldReturnStubAccesses() throws RbacApiException {
+    var actual = rbacApi.getCurrentIdentityAccess("any", "any");
+
+    assertNotNull(actual);
+    assertEquals(1, actual.size());
+    Access access = actual.get(0);
+    // this is configured in the application.properties file.
+    assertEquals("subscriptions:*:*", access.getPermission());
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/RbacUseStubService.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/RbacUseStubService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.test.resources;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class RbacUseStubService implements QuarkusTestProfile {
+
+  private static final String PRODUCT_USE_STUB = "rhsm-subscriptions.rbac-service.use-stub";
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of(PRODUCT_USE_STUB, Boolean.TRUE.toString());
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3026

## Description
At the moment, we have some rbac utilities implemented in swatch-core (see package org.candlepin.subscriptions.rbac).

These changes copy this logic into the Quarkus client rbac module.

Usage:

```java
@RbacClient RbacApi rbacApi;
``` 

If the property "rhsm-subscriptions.rbac-service.use-stub" is true, then the stub rbac api will be used. 
As in the monolith, the "rhsm-subscriptions.rbac-service.stub-permissions" can be used to stub the permissions (a comma separated list of permissions). Default value is "subscriptions:*:*".

## Testing
Added JUnit test in swatch-contracts to ensure the stub RbacApi works fine. 