### PR TITLE
SWATCH-2990: Build swatch-metrics-hbi in Konflux on hotfix branch

### DIFF
--- a/.tekton/swatch-metrics-hbi-pull-request.yaml
+++ b/.tekton/swatch-metrics-hbi-pull-request.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions

--- a/.tekton/swatch-metrics-hbi-push.yaml
+++ b/.tekton/swatch-metrics-hbi-push.yaml
@@ -6,8 +6,8 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions


### PR DESCRIPTION
Jira issue: SWATCH-2990

## Description
This PR modifies the Tekton files for `swatch-metrics-hbi` so that Konflux
builds occur when PRs are opened against the `hotfix` branch.

## Testing
Testing was performed in #3849.  `swatch-metrics-hbi` isn't actually present in
the `hotfix` branch so I made the same modifications this PR has to
`swatch-contracts`.  I confirmed that builds occurred with the modified
`on-cel-expression` and did not occur when the commit was reverted.
