### PR TITLE
Fix `gradlew tasks`

### DIFF
--- a/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
@@ -19,7 +19,6 @@ tasks.register("generateApiDocs", GenerateTask) {
     generateModelDocumentation = true
     generateModelTests = false
     generateApiTests = false
-    withXml = false
 }
 
 openApiGenerate {

--- a/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.spring-boot-rest-client-conventions.gradle
@@ -24,7 +24,6 @@ tasks.register("generateApiDocs", GenerateTask) {
     generateModelDocumentation = true
     generateModelTests = false
     generateApiTests = false
-    withXml = false
 }
 
 openApiGenerate {


### PR DESCRIPTION
Jira issue: None

## Description
The `withXml` argument was causing the task not to instantiate correctly and so
when you run `gradlew tasks`, you wouldn't get a task list.

## Testing

### Steps
1. Run `./gradlew tasks` on `main` and then on this branch.

### Verification
1. It works on this branch
