### PR TITLE
SWATCH-3024 Usage doubled due to incorrect retry status

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
@@ -26,6 +26,7 @@ import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceEntity;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceFilter;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceRepository;
 import com.redhat.swatch.billable.usage.data.RemittanceErrorCode;
+import com.redhat.swatch.billable.usage.data.RemittanceStatus;
 import com.redhat.swatch.billable.usage.data.RemittanceSummaryProjection;
 import com.redhat.swatch.billable.usage.model.RemittanceMapper;
 import com.redhat.swatch.billable.usage.openapi.model.MonthlyRemittance;
@@ -98,6 +99,8 @@ public class InternalBillableUsageController {
       billingProducer.produce(toBillableUsage(remittance));
       // reset the retry after column
       remittance.setRetryAfter(null);
+      remittance.setErrorCode(null);
+      remittance.setStatus(RemittanceStatus.PENDING);
     }
 
     // to save the retry after column for all the entities

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceStatus.java
@@ -35,7 +35,8 @@ public enum RemittanceStatus {
   GRATIS("gratis"),
   FAILED("failed"),
   UNKNOWN("unknown"),
-  SUCCEEDED("succeeded");
+  SUCCEEDED("succeeded"),
+  RETRYABLE("retryable");
 
   private static final Map<String, RemittanceStatus> VALUE_ENUM_MAP =
       Arrays.stream(RemittanceStatus.values())

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
@@ -21,9 +21,7 @@
 package com.redhat.swatch.billable.usage.services;
 
 import static java.util.Optional.ofNullable;
-import static org.candlepin.subscriptions.billable.usage.BillableUsage.ErrorCode.MARKETPLACE_RATE_LIMIT;
-import static org.candlepin.subscriptions.billable.usage.BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND;
-import static org.candlepin.subscriptions.billable.usage.BillableUsage.Status.FAILED;
+import static org.candlepin.subscriptions.billable.usage.BillableUsage.Status.RETRYABLE;
 
 import com.redhat.swatch.billable.usage.configuration.Channels;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceRepository;
@@ -81,8 +79,6 @@ public class BillableUsageStatusConsumer {
   }
 
   private boolean needsRetry(BillableUsageAggregate billableUsageAggregate) {
-    return billableUsageAggregate.getStatus() == FAILED
-        && (billableUsageAggregate.getErrorCode() == SUBSCRIPTION_NOT_FOUND
-            || billableUsageAggregate.getErrorCode() == MARKETPLACE_RATE_LIMIT);
+    return billableUsageAggregate.getStatus() == RETRYABLE;
   }
 }

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -51,6 +51,7 @@ properties:
       - succeeded
       - failed
       - gratis
+      - retryable
   error_code:
     description: Intended to be used for reporting remittance error code in case of failure
     type: string

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -181,7 +181,7 @@ class AwsBillableUsageAggregateConsumerTest {
         .emitStatus(
             argThat(
                 usage ->
-                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                    BillableUsage.Status.RETRYABLE.equals(usage.getStatus())
                         && BillableUsage.ErrorCode.MARKETPLACE_RATE_LIMIT.equals(
                             usage.getErrorCode())));
   }
@@ -326,7 +326,7 @@ class AwsBillableUsageAggregateConsumerTest {
         .emitStatus(
             argThat(
                 usage ->
-                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                    BillableUsage.Status.RETRYABLE.equals(usage.getStatus())
                         && BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND.equals(
                             usage.getErrorCode())));
 

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -148,7 +148,7 @@ public class AzureBillableUsageAggregateConsumer {
             billableUsageAggregate.getAggregateKey().getOrgId(),
             billableUsageAggregate.getRemittanceUuids(),
             e);
-        emitErrorStatusOnUsage(
+        emitRetryableStatusOnUsage(
             billableUsageAggregate, BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND);
       }
       return;
@@ -312,6 +312,13 @@ public class AzureBillableUsageAggregateConsumer {
   private void emitErrorStatusOnUsage(
       BillableUsageAggregate usage, BillableUsage.ErrorCode errorCode) {
     usage.setStatus(BillableUsage.Status.FAILED);
+    usage.setErrorCode(errorCode);
+    billableUsageStatusProducer.emitStatus(usage);
+  }
+
+  private void emitRetryableStatusOnUsage(
+      BillableUsageAggregate usage, BillableUsage.ErrorCode errorCode) {
+    usage.setStatus(BillableUsage.Status.RETRYABLE);
     usage.setErrorCode(errorCode);
     billableUsageStatusProducer.emitStatus(usage);
   }

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -153,7 +153,7 @@ class BillableUsageConsumerTest {
         .emitStatus(
             argThat(
                 usage ->
-                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                    BillableUsage.Status.RETRYABLE.equals(usage.getStatus())
                         && BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND.equals(
                             usage.getErrorCode())));
   }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3024

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The scenario we need to test involves the following steps:
Step 1. Tally Summary -> Billable Usage -> Billable Usage Aggregate -> AWS -> Status: Failed with retry after timestamp due to subscription_not_found.
Step 2. Retry Mechanism API Request -> Billable Usage -> Aggregate -> AWS -> Status: Failed with retry after timestamp. The intermediate state transitions from pending to failed instead of failed with not retry after.
Step 3. Tally Summary -> Billable Usage -> Billable Usage Aggregate -> AWS -> Status: Failed with retry after timestamp  due to subscription_not_found (this should exclude usage from the first step).
Step 4. Add a subscription
Step 5. Tally Summary -> Billable Usage -> Billable Usage Aggregate -> AWS -> Status: Success
Step 6. Retry should also give success for previous usages
Occasionally, steps 2 and 3 are interchanged due to a race condition causing the issue to occur.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Run swatch-core, swatch-contracts, swatch-billable-usage, swatch-aws-producer
```
RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8882 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew clean :bootRun

SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev

SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev

 SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-producer-aws:quarkusDev
```

### Steps
<!-- Enter each step of the test below -->
1. Insert an event and then do hourly tally
INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) VALUES ('2c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-21 14:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "2c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-21T14:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-12T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-06-21T20:37:40.540859342Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 5.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', '2024-06-21 20:37:40.540000 +00:00');


3. g

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
