### PR TITLE
SWATCH-718: Ensure SnakeYAML does not deserialize arbitrary classes

### DIFF
--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistry.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistry.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.inspector.UnTrustedTagInspector;
 
 /**
  * Loads yaml files from src/main/resource/subscription_configs into List<Subscription>. Provides
@@ -59,8 +60,11 @@ public class SubscriptionDefinitionRegistry {
 
   SubscriptionDefinitionRegistry() {
     subscriptions = new ArrayList<>();
+
     var options = new LoaderOptions();
+    options.setTagInspector(new UnTrustedTagInspector());
     options.setEnumCaseSensitive(false);
+
     Constructor constructor = new Constructor(SubscriptionDefinition.class, options);
     constructor.getPropertyUtils().setSkipMissingProperties(true);
 

--- a/swatch-product-configuration/src/test/resources/cve_2022_1471_product.yaml
+++ b/swatch-product-configuration/src/test/resources/cve_2022_1471_product.yaml
@@ -1,0 +1,2 @@
+# From https://snyk.io/blog/unsafe-deserialization-snakeyaml-java-cve-2022-1471/
+!!javax.script.ScriptEngineManager [!!java.net.URLClassLoader [[!!java.net.URL ["http://localhost:8080/"]]]]

--- a/swatch-product-configuration/src/test/resources/cve_2022_1471_swatch_config_index.txt
+++ b/swatch-product-configuration/src/test/resources/cve_2022_1471_swatch_config_index.txt
@@ -1,0 +1,1 @@
+cve_2022_1471_product.yaml


### PR DESCRIPTION
Jira issue: SWATCH-718

## Description
[CVE-2022-1471][1] describes an issue where versions of SnakeYAML prior to
2.0 would deserialize a YAML document and instantiate a class based on
the document contents.  This behavior can lead to issues like

```
!!javax.script.ScriptEngineManager [!!java.net.URLClassLoader [[!!java.net.URL ["http://localhost:8080/"]]]]
```

where untrusted code can be loaded over the internet into the
ClassLoader.

This issue is addressed in version 2.0 where SnakeYAML was altered to no
longer allow so-called "global tags" which are the mechanism used for
this arbitrary deserialization.  There is also the `SafeConstructor`
class which does not do any deserialization beyond primitive Java types
and basic collections.

We, however, need to deserialize to an object of our choice,
SubscriptionRegistry, so this patch explicitly disables global tags
(even though that is the default with SnakeYAML >2.0 anyway) and adds a
test to ensure global tags are disabled.

[1]: https://www.cve.org/CVERecord?id=CVE-2022-1471

## Testing
Unit test only
