### PR TITLE
SWATCH-2899: Subscription type is On-demand for Paygo products

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableController.java
@@ -25,7 +25,6 @@ import static org.candlepin.subscriptions.resource.api.v1.CapacityResource.HYPER
 import static org.candlepin.subscriptions.resource.api.v1.CapacityResource.PHYSICAL;
 
 import com.redhat.swatch.configuration.registry.ProductId;
-import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Min;
 import java.time.OffsetDateTime;
@@ -195,13 +194,11 @@ public class SubscriptionTableController {
       }
     }
 
-    boolean isOnDemand = SubscriptionDefinition.isPrometheusEnabled(productId.toString());
-
     SubscriptionType subscriptionType =
-        isOnDemand ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;
+        productId.isOnDemand() ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;
 
     List<SkuCapacity> reportItems = new ArrayList<>(reportItemsBySku.values());
-    if (isOnDemand && reportItems.isEmpty()) {
+    if (productId.isOnDemand() && reportItems.isEmpty()) {
       reportItems.addAll(
           getOnDemandSkuCapacities(
               productId,

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
@@ -112,7 +112,7 @@ public class SubscriptionTableController {
                   reportItemsBySku.computeIfAbsent(
                       inventoryKey, s -> initializeSkuCapacity(subscription, metrics, category));
               calculateNextEvent(subscription, inventory);
-              if (productId.isPrometheusEnabled()) {
+              if (productId.isOnDemand()) {
                 addOnDemandSubscriptionInformation(subscription, inventory);
               } else {
                 addSubscriptionInformation(subscription, inventory);
@@ -149,9 +149,7 @@ public class SubscriptionTableController {
         .meta(
             new SkuCapacityReportMeta()
                 .subscriptionType(
-                    productId.isPrometheusEnabled()
-                        ? SubscriptionType.ON_DEMAND
-                        : SubscriptionType.ANNUAL)
+                    productId.isOnDemand() ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL)
                 .count(reportItemCount)
                 .serviceLevel(serviceLevel)
                 .usage(usage)
@@ -283,7 +281,7 @@ public class SubscriptionTableController {
 
     public InventoryKey(ProductId productId, SubscriptionCapacityView subscription) {
       sku = subscription.getSku();
-      if (productId.isPrometheusEnabled()) {
+      if (productId.isOnDemand()) {
         billingProvider = subscription.getBillingProvider();
       }
     }

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/SubscriptionTableControllerTest.java
@@ -685,6 +685,28 @@ class SubscriptionTableControllerTest {
   }
 
   @Test
+  void testShouldPopulateOnDemandSubscriptionTypeNonPrometheus() {
+
+    givenSubscriptionsInRepository();
+
+    SkuCapacityReport report =
+        subscriptionTableController.capacityReportBySku(
+            ProductId.fromString("ansible-aap-managed"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getInstanceHours().toString(),
+            SkuCapacityReportSort.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
   void testGetSkuCapacityReportUnlimitedQuantity() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
     // usage.

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableControllerTest.java
@@ -564,6 +564,28 @@ class SubscriptionTableControllerTest {
   }
 
   @Test
+  void testShouldPopulateOnDemandSubscriptionTypeNonPrometheus() {
+
+    givenSubscriptionsInRepository();
+
+    var report =
+        subscriptionTableController.capacityReportBySku(
+            ProductId.fromString("ansible-aap-managed"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getInstanceHours().toString(),
+            SkuCapacityReportSort.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
   void testGetSkuCapacityReportUnlimitedQuantity() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
     // usage.

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -71,7 +71,7 @@ public class SubscriptionCapacityViewRepository
         Specification.where(orgIdEquals(orgId));
     if (productId != null) {
       searchCriteria = searchCriteria.and(productIdEquals(productId));
-      if (productId.isPayg() || productId.isPrometheusEnabled()) {
+      if (productId.isOnDemand()) {
         searchCriteria = searchCriteria.and(hasBillingProviderId());
       }
     }
@@ -95,7 +95,7 @@ public class SubscriptionCapacityViewRepository
     if (Objects.nonNull(sanitizedBillingAccountId)
         && !ANY.equalsIgnoreCase(sanitizedBillingAccountId)
         && productId != null
-        && productId.isPrometheusEnabled()) {
+        && productId.isOnDemand()) {
       searchCriteria = searchCriteria.and(billingAccountIdStartsWith(sanitizedBillingAccountId));
     }
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1.java
@@ -26,7 +26,6 @@ import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeServiceL
 import static com.redhat.swatch.contract.resource.ResourceUtils.sanitizeUsage;
 
 import com.redhat.swatch.configuration.registry.ProductId;
-import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.contract.openapi.model.BillingProviderType;
 import com.redhat.swatch.contract.openapi.model.ReportCategory;
 import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
@@ -214,13 +213,11 @@ public class SubscriptionTableControllerV1 {
       }
     }
 
-    boolean isOnDemand = SubscriptionDefinition.isPrometheusEnabled(productId.toString());
-
     SubscriptionType subscriptionType =
-        isOnDemand ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;
+        productId.isOnDemand() ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL;
 
     List<SkuCapacityV1> reportItems = new ArrayList<>(reportItemsBySku.values());
-    if (isOnDemand && reportItems.isEmpty()) {
+    if (productId.isOnDemand() && reportItems.isEmpty()) {
       reportItems.addAll(
           getOnDemandSkuCapacities(
               productId,

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
@@ -121,7 +121,7 @@ public class SubscriptionTableControllerV2 {
                   reportItemsBySku.computeIfAbsent(
                       inventoryKey, s -> initializeSkuCapacity(subscription, metrics, category));
               calculateNextEvent(subscription, inventory);
-              if (productId.isPrometheusEnabled()) {
+              if (productId.isOnDemand()) {
                 addOnDemandSubscriptionInformation(subscription, inventory);
               } else {
                 addSubscriptionInformation(subscription, inventory);
@@ -157,9 +157,7 @@ public class SubscriptionTableControllerV2 {
         .meta(
             new SkuCapacityReportV1Meta()
                 .subscriptionType(
-                    productId.isPrometheusEnabled()
-                        ? SubscriptionType.ON_DEMAND
-                        : SubscriptionType.ANNUAL)
+                    productId.isOnDemand() ? SubscriptionType.ON_DEMAND : SubscriptionType.ANNUAL)
                 .count(reportItemCount)
                 .serviceLevel(serviceLevel)
                 .usage(usage)
@@ -292,7 +290,7 @@ public class SubscriptionTableControllerV2 {
 
     public InventoryKey(ProductId productId, SubscriptionCapacityView subscription) {
       sku = subscription.getSku();
-      if (productId.isPrometheusEnabled()) {
+      if (productId.isOnDemand()) {
         billingProvider = subscription.getBillingProvider();
       }
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/SubscriptionTableControllerV1Test.java
@@ -727,6 +727,30 @@ class SubscriptionTableControllerV1Test {
   }
 
   @Test
+  void testShouldPopulateOnDemandSubscriptionTypeNonPrometheus() {
+
+    givenSubscriptionsInRepository();
+
+    SkuCapacityReportV1 report =
+        subscriptionTableControllerV1.capacityReportBySkuV1(
+            ProductId.fromString("ansible-aap-managed"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getInstanceHours().toString(),
+            SkuCapacityReportSortV1.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
   void testGetSkuCapacityReportUnlimitedQuantity() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
     // usage.

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
@@ -572,6 +572,28 @@ class SubscriptionTableControllerV2Test {
   }
 
   @Test
+  void testShouldPopulateOnDemandSubscriptionTypeNonPrometheus() {
+
+    givenSubscriptionsInRepository();
+
+    var report =
+        subscriptionTableControllerV2.capacityReportBySkuV2(
+            ProductId.fromString("ansible-aap-managed"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            MetricIdUtils.getInstanceHours().toString(),
+            SkuCapacityReportSortV2.SKU,
+            null);
+
+    assertEquals(SubscriptionType.ON_DEMAND, report.getMeta().getSubscriptionType());
+  }
+
+  @Test
   void testGetSkuCapacityReportUnlimitedQuantity() {
     // Given an org with one active sub with a quantity of 4 and has an eng product with unlimited
     // usage.

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -78,7 +78,7 @@ public interface SubscriptionCapacityViewRepository
         Specification.where(orgIdEquals(orgId));
     if (productId != null) {
       searchCriteria = searchCriteria.and(productIdEquals(productId));
-      if (productId.isPayg() || productId.isPrometheusEnabled()) {
+      if (productId.isOnDemand()) {
         searchCriteria = searchCriteria.and(hasBillingProviderId());
       }
     }
@@ -102,7 +102,7 @@ public interface SubscriptionCapacityViewRepository
     if (Objects.nonNull(sanitizedBillingAccountId)
         && !ANY.equalsIgnoreCase(sanitizedBillingAccountId)
         && productId != null
-        && productId.isPrometheusEnabled()) {
+        && productId.isOnDemand()) {
       searchCriteria = searchCriteria.and(billingAccountIdStartsWith(sanitizedBillingAccountId));
     }
 

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/ProductId.java
@@ -63,6 +63,10 @@ public class ProductId {
                     String.format("ProductId: %s not found in configuration", value)));
   }
 
+  public boolean isOnDemand() {
+    return this.isPrometheusEnabled || this.isPayg;
+  }
+
   // NOTE: intentionally overriding the toString() from @Data, so users can use getValue() and
   // toString() interchangeably without introducing errors
   public String toString() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2899

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
The criteria for the On-Demand subscription type needs to be Prometheus enabled or Pay As You Go

## Testing

### Setup
<!-- Add any steps required to set up the test case -->
1. Start swatch-contracts
`SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-contracts:quarkusDev`
2. Start the monolith
` DEV_MODE=true SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew :bootRun`
3. Create an entry in the org_config table for an org
`insert into org_config (org_id, opt_in_type,created, updated) values ('5345257','API','2024-06-21T12:50:39.496954Z','2024-06-21T12:50:39.496954Z')`
4. Run the opt-in
`http :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"5345257"}}}' | base64 -w0)
`

### Steps
<!-- Enter each step of the test below -->
1. Run from command line to exercise endpoint [either v1 or v2 will work]
`http GET ':8003/api/rhsm-subscriptions/v2/subscriptions/products/ansible-aap-managed' x-rh-identity:$(echo '{"identity":{"type":"User","org_id":"5345257"}}' | base64 -w0)`
`http GET ':8000/api/rhsm-subscriptions/v1/subscriptions/products/ansible-aap-managed' x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"5345257"}}}' | base64 -w0)`


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. The subscription type will be shown as "On-demand" in all cases.
