### PR TITLE
SWATCH-3034: Fix the Quarkus AccessApi generated client interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,47 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 
 So, catch the ProcessingException exception as well as the ApiException one (for generated clients) to be sure, you catch all the errors.
 
+### **rest-client**: will remove the trailing slash in paths located at class level
+
+The Quarkus REST Client extension is magically removing the trailing slash when the `@Path` annotation is used at class level. For example, having the following REST interface:
+
+```java
+@RegisterRestClient
+@Path("/access/")
+public interface ClientApi {
+    @GET
+    String ping();
+}
+```
+
+Internally, the Quarkus REST Client extension will modify the path from "/access/" to "/access" which would make some servers to not found the endpoint. 
+The workaround is to move the `@Path` annotation at method level:
+```java
+@RegisterRestClient
+public interface ClientApi {
+    @GET
+    @Path("/access/")
+    String ping();
+}
+```
+
+Now, the URL will be correctly set by preserving the trailing slash. 
+
+Note that since we're using the OpenAPI generator to generate the REST Client interfaces, we can't easily change where to put the `@Path` annotation. The only workaround that I'm aware is to configure the API manifest to include different endpoints in the same client interface:
+```java
+@RegisterRestClient
+@Path("/common")
+public interface ClientApi {
+  @GET
+  @Path("/access/")
+  String ping();
+
+  @GET
+  @Path("/other")
+  String other();
+}
+```
+
 ### **fault-tolerance**: Quarkus does not have a configurable exponential backoff retry strategy
 
 In Spring Boot, we created a RetryTemplate bean where we could configure it using some properties:

--- a/clients/rbac-client/rbac-api-spec.yaml
+++ b/clients/rbac-client/rbac-api-spec.yaml
@@ -1958,7 +1958,7 @@
     "/permissions/": {
       "get": {
         "tags": [
-          "Permission"
+          "Access"
         ],
         "summary": "List the permissions for a tenant",
         "description": "By default, responses are sorted in ascending order by permission application.",
@@ -2076,7 +2076,7 @@
     "/permissions/options/": {
       "get": {
         "tags": [
-          "Permission"
+          "Access"
         ],
         "summary": "List the available options for fields of permissions for a tenant",
         "description": "By default, options of application is returned. And could be resource_type or verb on demand.",


### PR DESCRIPTION
Jira issue: SWATCH-3034

## Description
Changes:
- Join the PermissionsAPI to the AccessAPI (which is related). This way the AccessAPI gets fixed because the `@Path` annotation is now placed at method level
- Added a documentation item in the Quarkus migration section explaining this. 

This change has no effects because we're not using the PermissionsAPI.

## Testing
Regression testing. 
I applied this change in https://github.com/RedHatInsights/rhsm-subscriptions/pull/3864 and it fixed the CI. 