### PR TITLE
SWATCH-3036: Use separated transactions when processing retry remittance

### DIFF
--- a/src/main/resources/liquibase/202410211200-retry-after-billable-usage-index.xml
+++ b/src/main/resources/liquibase/202410211200-retry-after-billable-usage-index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202410211200-01" author="jcarvaja">
+    <createIndex tableName="billable_usage_remittance" indexName="billable_usage_retry_after_idx">
+      <column name="retry_after"/>
+    </createIndex>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -173,5 +173,6 @@
     <include file="/liquibase/202407231110-subscription-capacity-index.xml"/>
     <include file="/liquibase/202409251400-update-subscription-capacity-view-org-id.xml"/>
     <include file="/liquibase/202410021300-update_usages_to_unknown.xml"/>
+    <include file="/liquibase/202410211200-retry-after-billable-usage-index.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/configuration/ApplicationConfiguration.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/configuration/ApplicationConfiguration.java
@@ -30,4 +30,9 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 public class ApplicationConfiguration {
   @ConfigProperty(name = "rhsm-subscriptions.remittance-retention-policy.duration")
   Duration remittanceRetentionPolicyDuration;
+
+  @ConfigProperty(
+      name = "rhsm-subscriptions.billable-usage.retry-remittances-batch-size",
+      defaultValue = "1024")
+  int retryRemittancesBatchSize;
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -86,8 +86,9 @@ public class BillableUsageRemittanceRepository
     return entityManager.createQuery(query).getResultList();
   }
 
-  public List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(OffsetDateTime asOf) {
-    return find("retryAfter < ?1", asOf).list();
+  public List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(
+      OffsetDateTime asOf, int pageIndex, int pageSize) {
+    return find("retryAfter < ?1", asOf).page(pageIndex, pageSize).list();
   }
 
   public void deleteAllByOrgIdAndRemittancePendingDateBefore(

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -185,3 +185,4 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 # remittance retention policy configuration:
 # 70 days worth
 rhsm-subscriptions.remittance-retention-policy.duration=${REMITTANCE_RETENTION_DURATION:70d}
+rhsm-subscriptions.billable-usage.retry-remittances-batch-size=${RETRY_REMITTANCES_BATCH_SIZE:1024}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
@@ -77,6 +77,7 @@ class InternalBillableUsageResourceTest {
     enabledOrgsSink.clear();
     billableUsageSink = connector.sink(BILLABLE_USAGE_OUT);
     billableUsageSink.clear();
+    when(configuration.getRetryRemittancesBatchSize()).thenReturn(10);
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-3036

## Description
Changes:
- Add an index for billable_usage_remittance.retry_after column
- Query the remittances to be retried in batches and single transactions
- Perform update operations in single transactions (after sending the remittance to kafka)
- If the send operation fails, we need to rollback the remittance to its previous state. 

## Testing
Added unit test to reproduce the issue.