### PR TITLE
SWATCH-3036: Fix pagination to process remittances retries

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
@@ -93,24 +93,25 @@ public class InternalBillableUsageController {
   }
 
   public long processRetries(OffsetDateTime asOf) {
-    int pageIndex = 0;
-    int total = 0;
-
-    List<BillableUsageRemittanceEntity> remittances = findByRetryAfterLessThan(asOf, pageIndex);
-    while (!remittances.isEmpty()) {
-      remittances.forEach(this::processRetryForUsage);
-      total += remittances.size();
-      pageIndex++;
-      remittances = findByRetryAfterLessThan(asOf, pageIndex);
+    long total = remittanceRepository.countRemittancesByRetryAfterLessThan(asOf);
+    if (total > 0) {
+      long current = 0;
+      List<BillableUsageRemittanceEntity> remittances =
+          findNextRemittancesByRetryAfterLessThan(asOf);
+      while (current < total && !remittances.isEmpty()) {
+        remittances.forEach(this::processRetryForUsage);
+        current += remittances.size();
+        remittances = findNextRemittancesByRetryAfterLessThan(asOf);
+      }
     }
 
     return total;
   }
 
   @Transactional
-  List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(OffsetDateTime asOf, int pageIndex) {
-    return remittanceRepository.findByRetryAfterLessThan(
-        asOf, pageIndex, applicationConfiguration.getRetryRemittancesBatchSize());
+  List<BillableUsageRemittanceEntity> findNextRemittancesByRetryAfterLessThan(OffsetDateTime asOf) {
+    return remittanceRepository.findNextRemittancesByRetryAfterLessThan(
+        asOf, applicationConfiguration.getRetryRemittancesBatchSize());
   }
 
   @Transactional
@@ -140,6 +141,7 @@ public class InternalBillableUsageController {
       log.warn("Remittance {} failed to be sent over kafka. Restoring.", remittance);
       // restoring previous state of the remittance because it fails to be sent
       updateRemittance(remittance, previousStatus, previousRetryAfter, previousErrorCode);
+      throw ex;
     }
   }
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -86,9 +86,14 @@ public class BillableUsageRemittanceRepository
     return entityManager.createQuery(query).getResultList();
   }
 
-  public List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(
-      OffsetDateTime asOf, int pageIndex, int pageSize) {
-    return find("retryAfter < ?1", asOf).page(pageIndex, pageSize).list();
+  @Transactional
+  public long countRemittancesByRetryAfterLessThan(OffsetDateTime asOf) {
+    return count("retryAfter < ?1", asOf);
+  }
+
+  public List<BillableUsageRemittanceEntity> findNextRemittancesByRetryAfterLessThan(
+      OffsetDateTime asOf, int pageSize) {
+    return find("retryAfter < ?1", asOf).page(0, pageSize).list();
   }
 
   public void deleteAllByOrgIdAndRemittancePendingDateBefore(


### PR DESCRIPTION
Jira issue: SWATCH-3036

## Description
When asking for next pages, since at the same time, we're also updating the remittances to clear the retry_after, we won't be consuming all the remittances. 

To address this issue, we'll always asking for the first page which eventually reach zero. Moreover, we will first count the number of remittances and won't process more than this count (this is to avoid edge conditions and process new usages that might lead in endless

## Testing
Added a test to reproduce the pagination issue.