### PR TITLE
[HOTFIX] SWATCH-3036: Fix pagination to process remittances retries

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -86,9 +86,14 @@ public class BillableUsageRemittanceRepository
     return entityManager.createQuery(query).getResultList();
   }
 
-  public List<BillableUsageRemittanceEntity> findByRetryAfterLessThan(
-      OffsetDateTime asOf, int pageIndex, int pageSize) {
-    return find("retryAfter < ?1", asOf).page(pageIndex, pageSize).list();
+  @Transactional
+  public long countRemittancesByRetryAfterLessThan(OffsetDateTime asOf) {
+    return count("retryAfter < ?1", asOf);
+  }
+
+  public List<BillableUsageRemittanceEntity> findNextRemittancesByRetryAfterLessThan(
+      OffsetDateTime asOf, int pageSize) {
+    return find("retryAfter < ?1", asOf).page(0, pageSize).list();
   }
 
   public void deleteAllByOrgIdAndRemittancePendingDateBefore(

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
@@ -24,12 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.billable.usage.configuration.ApplicationConfiguration;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceEntity;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceFilter;
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceRepository;
@@ -54,15 +58,18 @@ import org.junit.jupiter.api.Test;
 class InternalBillableUsageControllerTest {
 
   private static final String PRODUCT_ID = "rosa";
+  private static final int REMITTANCES_BATCH_SIZE = 2;
 
   @Inject BillableUsageRemittanceRepository remittanceRepo;
   @Inject ApplicationClock clock;
   @InjectMock BillingProducer billingProducer;
   @Inject InternalBillableUsageController controller;
+  @InjectMock ApplicationConfiguration configuration;
 
   @Transactional
   @BeforeEach
   void setup() {
+    remittanceRepo.deleteAll();
     BillableUsageRemittanceEntity remittance1 =
         remittance(
             "111",
@@ -130,6 +137,7 @@ class InternalBillableUsageControllerTest {
             remittance6,
             remittance7));
     remittanceRepo.flush();
+    when(configuration.getRetryRemittancesBatchSize()).thenReturn(REMITTANCES_BATCH_SIZE);
   }
 
   @Transactional
@@ -297,12 +305,30 @@ class InternalBillableUsageControllerTest {
   }
 
   @Test
+  void testProcessRetriesInPages() {
+    String orgId = "testProcessRetriesInPages";
+    for (var i = 0; i < REMITTANCES_BATCH_SIZE * 2; i++) {
+      givenRemittanceWithOldRetryAfter(orgId + i);
+    }
+
+    controller.processRetries(OffsetDateTime.now());
+
+    // verify remittance has been sent
+    verify(billingProducer, times(REMITTANCES_BATCH_SIZE * 2)).produce(any());
+    // verify retry after is reset
+    var remittances =
+        remittanceRepo.listAll().stream().filter(b -> b.getOrgId().startsWith(orgId)).toList();
+    assertFalse(remittances.isEmpty());
+    assertTrue(remittances.stream().allMatch(u -> u.getRetryAfter() == null));
+  }
+
+  @Test
   void testProcessRetriesShouldRestoreStateIfSendFails() {
     String orgId = "testProcessRetriesOrg123";
     givenRemittanceWithOldRetryAfter(orgId);
     doThrow(RuntimeException.class).when(billingProducer).produce(any(BillableUsage.class));
 
-    controller.processRetries(OffsetDateTime.now());
+    assertThrows(RuntimeException.class, () -> controller.processRetries(OffsetDateTime.now()));
 
     // verify retry after is set
     var found =


### PR DESCRIPTION
When asking for next pages, since at the same time, we're also updating the remittances to clear the retry_after, we won't be consuming all the remittances. 

To address this issue, we'll always asking for the first page which eventually reach zero. Moreover, we will first count the number of remittances and won't process more than this count (this is to avoid edge conditions and process new usages that might lead in endless


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
