### PR TITLE
SWATCH-3041: Populate traceresponse header in spring boot services

### DIFF
--- a/swatch-core/build.gradle
+++ b/swatch-core/build.gradle
@@ -19,6 +19,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-actuator-autoconfigure"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-security"
+    // to generate trace ID and span ID for tracing
+    implementation "io.micrometer:micrometer-tracing-bridge-otel"
+    implementation "io.opentelemetry:opentelemetry-api"
     implementation libraries["guava"] // for ip address class
     implementation libraries["jackson-annotations"] // for json generated models
     implementation "com.fasterxml.jackson.core:jackson-databind" // for use of objectmapper in EventRecord

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/resteasy/TraceResponseFilter.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/resteasy/TraceResponseFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resteasy;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * See <a href="https://w3c.github.io/trace-context/#traceresponse-header"></a> for reference and
+ * format.
+ */
+@Component
+@Provider
+@Slf4j
+public class TraceResponseFilter implements ContainerResponseFilter {
+
+  protected static final String TRACE_RESPONSE_HEADER = "traceresponse";
+
+  @Override
+  public void filter(
+      ContainerRequestContext containerRequestContext,
+      ContainerResponseContext containerResponseContext)
+      throws IOException {
+    SpanContext spanContext = Span.current().getSpanContext();
+    containerResponseContext
+        .getHeaders()
+        .putSingle(
+            TRACE_RESPONSE_HEADER,
+            String.format(
+                "00-%s-%s-%s  ",
+                spanContext.getTraceId(), spanContext.getSpanId(), spanContext.getTraceFlags()));
+  }
+}

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/resteasy/TraceResponseFilterTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/resteasy/TraceResponseFilterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resteasy;
+
+import static org.candlepin.subscriptions.resteasy.TraceResponseFilter.TRACE_RESPONSE_HEADER;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TraceResponseFilterTest {
+
+  @Mock ContainerRequestContext requestContext;
+  @Mock ContainerResponseContext responseContext;
+  MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+
+  private final TraceResponseFilter filter = new TraceResponseFilter();
+
+  @BeforeEach
+  void setup() {
+    headers.clear();
+    when(responseContext.getHeaders()).thenReturn(headers);
+  }
+
+  @Test
+  void testPopulateHeader() throws IOException {
+    filter.filter(requestContext, responseContext);
+    String traceResponse = (String) headers.getFirst(TRACE_RESPONSE_HEADER);
+    assertNotNull(traceResponse);
+    assertTrue(traceResponse.startsWith("00-"));
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3041

## Description
Added the "traceresponse" header as similarly as done in Quarkus services: https://github.com/RedHatInsights/rhsm-subscriptions/pull/3660

I also spotted that we were not populating the tracing context in spring boot, to fix this, I had to add the `micrometer-tracing-bridge-otel` and `opentelemetry-api`. 

With these two dependencies, we can now get access to the span context, and the trace ID/span ID will be populated when exporting the logs into splunk.

Note that jira SWATCH-3041 also asked for the "Server-Timing" header which is not supported by spring boot services. There are some extensions to enable it like https://github.com/sercasti/spring-httpserver-timings, but we need to carefully evaluate this change, that's why I prefer doing this as a separate task. fyi @ntkathole 

## Testing
1.- podman-compose up
2.- `DEV_MODE=true SPRING_PROFILES_ACTIVE=api ./gradlew :bootRun`
3.- perform any request like `curl -v -X 'PUT'   'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in'   -H 'accept: application/vnd.api+json'   -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIzMzQwODUxIn19fQ=='`

And you will see now something like:

```
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
* Connected to localhost (::1) port 8000
> PUT /api/rhsm-subscriptions/v1/opt-in HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.6.0
> accept: application/vnd.api+json
> x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIzMzQwODUxIn19fQ==
> 
< HTTP/1.1 200 
< Set-Cookie: JSESSIONID=63CF9DB759256DA274615F8E761A74B5; Path=/; HttpOnly
< traceresponse: 00-d3bc34178e8041d8c7a78943d53c60b5-accf266c175a8aa5-00  
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 0
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Content-Type: application/vnd.api+json
< Content-Length: 195
< Date: Wed, 23 Oct 2024 06:03:59 GMT
< 
* Connection #0 to host localhost left intact
{"meta":{"org_id":"3340851"},"data":{"opt_in_complete":true,"org":{"org_id":"3340851","opt_in_type":"API","created":"2024-10-23T05:35:12.634394Z","last_updated":"2024-10-23T06:03:58.82972216Z"}}}
```

Note the `traceresponse` header.

