### PR TITLE
SWATCH-3049: Enable observation in Spring Boot services for Kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ config/*
 !config/rabbitmq
 !config/splunk
 !config/export-service
+!config/wiremock
 config/export-service/tmp
 
 #VS Code

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
 Some of these environment variables are our own (e.g. `SPLUNK_HEC_URL`) and are
 piped into the `quarkus.log.handler.splunk` namespace which is what ultimately
 controls the Splunk HEC configuration.  By default SSL/TLS certificate
-validation is disable in the `dev` profile for the `swatch-producer-aws`,
+validation is disabled in the `dev` profile for the `swatch-producer-aws`,
 `swatch-producer-azure`, and `swatch-contracts` projects.  If you are seeing
 SSL/TLS error (generally something like `unable to find valid certification path
 to requested target`), then setting `QUARKUS_LOG_HANDLER_SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true`
@@ -247,6 +247,20 @@ Furthermore, you can also check the export-service database (by default, it's: "
 ```
 f9288f52-59dc-4ad6-9307-8c67de75c09c	fb177ea7-a8ea-43e4-8c2e-cb4bd7170601	subscriptions	failed	subscriptions	{"product_id": "Wrong!"}	400	ProductId: Wrong! not found in configuration
 ```
+
+### Wiremock service
+
+Wiremock is a very helpful tool that helps us to mock other services like Prometheus. 
+At the moment, the wiremock service is configured to stub a prometheus instance which is necessary for swatch-metrics. 
+Let's see how we can start the swatch-metrics service to use the wiremock service as prometheus.
+We can start the Wiremock service via:
+```
+podman-compose -f config/wiremock/docker-compose.yml up -d
+```
+
+Next, we start the swatch metrics app using: `SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 EVENT_SOURCE=telemeter PROM_URL="http://localhost:8101/api/v1/" ./gradlew :swatch-metrics:quarkusDev`
+
+Finally, when syncing all the accounts by: `curl -v -H 'Origin: https://service.redhat.com' -X PUT http://localhost:8002/api/swatch-metrics/v1/internal/metering/sync`, we should see some events in the service logs and the Kafka topic.
 
 ### Build and Run rhsm-subscriptions
 

--- a/config/otel/docker-compose.yml
+++ b/config/otel/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.1'
 services:
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector:0.110.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/etc/otel-collector-config.yaml

--- a/config/wiremock/__files/prometheus_success.json
+++ b/config/wiremock/__files/prometheus_success.json
@@ -1,0 +1,21 @@
+{
+  "status" : "success",
+  "data" : {
+    "resultType" : "matrix",
+    "result" : [
+      {
+        "metric" : {
+          "_id" : "123456",
+          "support" : "Premium",
+          "usage" : "Production",
+          "product" : "moa-hostedcontrolplane",
+          "billing_marketplace" : "billing_marketplace",
+          "billing_marketplace_account" : "billing_marketplace_account",
+          "ebs_account" : "account",
+          "external_organization": "org123"
+        },
+        "values": [[ 1693476839, "1" ]]
+      }
+    ]
+  }
+}

--- a/config/wiremock/docker-compose.yml
+++ b/config/wiremock/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: '3.1'
+services:
+  wiremock:
+    image: wiremock/wiremock:2.32.0
+    ports:
+      - "8101:8080"
+    volumes:
+      - ./__files:/home/wiremock/__files
+      - ./mappings:/home/wiremock/mappings
+    entrypoint: [ "/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose" ]

--- a/config/wiremock/mappings/prometheus_query_success.json
+++ b/config/wiremock/mappings/prometheus_query_success.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/api/v1/query"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "prometheus_success.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/config/wiremock/mappings/prometheus_queryrange_success.json
+++ b/config/wiremock/mappings/prometheus_queryrange_success.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/api/v1/query_range"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "prometheus_success.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/docs/playbooks/observability.md
+++ b/docs/playbooks/observability.md
@@ -1,0 +1,124 @@
+# Observability playbook
+
+This guide will help us to set up the environment with Kafka, Database and Splunk into local with all our swatch services. 
+
+We'll exercise all the swatch integrations that are part of the diagram in [here](https://miro.com/app/board/uXjVLZZFmEc=/?share_link_id=967248979294).
+
+## Prerequisites
+
+Read more about the prerequisites in [here](../../CONTRIBUTING.md#build).
+
+## Set Up
+- Dependant services: instructions [here](../../README.md#dependent-services).
+- splunk: instructions [here](../../README.md#splunk).
+- Opentelemetry (OTEL) Exporter: instructions [here](../../README.md#opentelemetry-otel-exporter).
+- Wiremock (for prometheus): instructions [here](../../README.md#wiremock-service).
+- perform database migrations: `./gradlew liquibaseUpdate --no-daemon`
+- build all the swatch services: `./gradlew clean build -x test`
+
+## Run SWATCH Services
+
+- **swatch-metrics**: port 8002
+
+```
+SERVER_PORT=8002 \
+QUARKUS_MANAGEMENT_PORT=9002 \
+ENABLE_SPLUNK_HEC=true \
+SPLUNK_HEC_URL=https://localhost:8088 \
+SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+DISABLE_OTEL=false \
+EVENT_SOURCE=telemeter \
+PROM_URL="http://localhost:8101/api/v1/" \
+./gradlew :swatch-metrics:quarkusDev
+```
+
+- **swatch-tally**: port 8003
+
+```
+java -DENABLE_SPLUNK_HEC=true \
+-DSERVER_PORT=8003 \
+-DMANAGEMENT_PORT=9003 \
+-DSPLUNK_HEC_URL=https://localhost:8088 \
+-DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
+-DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true \
+-DSPLUNK_SOURCE_TYPE=springboot_server \
+-Dspring.profiles.active=worker,api,kafka-queue \
+-jar build/libs/rhsm-subscriptions-*.jar
+```
+
+- **swatch-billable-usage**: port 8004
+
+```
+SERVER_PORT=8004 \
+QUARKUS_MANAGEMENT_PORT=9004 \
+ENABLE_SPLUNK_HEC=true \
+SPLUNK_HEC_URL=https://localhost:8088 \
+SPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+DISABLE_OTEL=false \
+./gradlew :swatch-billable-usage:quarkusDev
+```
+
+## Scenarios
+
+### Events ingestion by API
+
+Services:
+- **swatch-metrics**
+- **swatch-tally**
+
+Triggered by:
+```
+curl -v -H 'Origin: https://service.redhat.com' -X PUT http://localhost:8002/api/swatch-metrics/v1/internal/metering/sync
+```
+
+The swatch metrics service produces events that are consumed by the swatch tally. Then, swatch tally will consume 
+these events in batches which will not correlate the incoming trace ID from the swatch metrics and will generate a 
+new trace ID instead.
+
+### <SnapshotSummaryProducer in Swatch tally> to <TallySummaryMessageConsumer in Swatch Billable Usage>
+
+Services:
+- **swatch-tally**
+- **swatch-billable-usage**
+
+Steps:
+
+1. Populate some data into the database:
+```
+INSERT INTO public.events (event_id, timestamp, data, event_type, event_source, instance_id, org_id, metering_batch_id, record_date) 
+VALUES ('8c57046a-7071-4fc9-a543-650b868edcc0', '2024-06-21 16:00:00.000000 +00:00', '{"sla": "Premium", "org_id": "12345678", "event_id": "8c57046a-7071-4fc9-a543-650b868edcc0", "timestamp": "2024-06-21T16:00:00Z", "conversion": false, "event_type": "snapshot_rhel-for-x86-els-payg_vcpus", "expiration": "2024-06-21T17:00:00Z", "instance_id": "efe37aa6-ac56-41df-8c8a-c260bd498f5b", "product_ids": ["204", "69"], "product_tag": ["rhel-for-x86-els-payg"], "record_date": "2024-07-24T18:40:04.224170097Z", "display_name": "ip-10-128-200-231.ec2.internal", "event_source": "rhelemeter", "measurements": [{"value": 5.0, "metric_id": "vCPUs"}], "service_type": "RHEL System", "billing_provider": "aws", "metering_batch_id": "6f4611df-8acf-48c8-9bf4-4a439ff59034", "billing_account_id": "customerAccount12345678"}', 'snapshot_rhel-for-x86-els-payg_vcpus', 'rhelemeter', 'efe37aa6-ac56-41df-8c8a-c260bd498f5b', '12345678', '6f4611df-8acf-48c8-9bf4-4a439ff59034', now());
+```
+
+2. Trigger the hourly tally
+```
+http POST ":8003/api/rhsm-subscriptions/v1/internal/tally/hourly?org=12345678" x-rh-swatch-psk:placeholder
+```
+
+Output:
+
+```
+HTTP/1.1 204 
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Connection: keep-alive
+Date: Thu, 24 Oct 2024 10:55:16 GMT
+Expires: 0
+Keep-Alive: timeout=60
+Pragma: no-cache
+Set-Cookie: JSESSIONID=DA87CC9E6BE6F1D96153444E125F7151; Path=/; HttpOnly
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-XSS-Protection: 0
+traceresponse: 00-314bf601e06b4c76d199a71b0abc119b-bd13c0fb161d55fd-00
+```
+
+Note that "314bf601e06b4c76d199a71b0abc119b" is the trace ID of the whole operation. 
+Running the splunk query `properties.traceId="314bf601e06b4c76d199a71b0abc119b"` will return all the logs within the spring boot and quarkus services.
+
+## Documentation
+
+- [Quarkus OTel Tracing docs](https://quarkus.io/guides/opentelemetry-tracing)
+- [Spring Boot Tracing docs](https://docs.spring.io/spring-boot/reference/actuator/tracing.html)
+- [OTel Spring Boot docs](https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/)
+- [Configure the Java agent for Splunk Observability Cloud](https://docs.splunk.com/observability/en/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.html)

--- a/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/capacity/CapacityIngressConfiguration.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.capacity;
 
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
+import org.candlepin.subscriptions.tracing.TracingConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
@@ -42,6 +43,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
+  TracingConfiguration.class
 })
 @ComponentScan(
     basePackages = {

--- a/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/ApiConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.resource;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
 import org.candlepin.subscriptions.tally.TallyWorkerConfiguration;
+import org.candlepin.subscriptions.tracing.TracingConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.context.annotation.ComponentScan;
@@ -50,6 +51,7 @@ import org.springframework.context.annotation.Profile;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  TallyWorkerConfiguration.class
+  TallyWorkerConfiguration.class,
+  TracingConfiguration.class
 })
 public class ApiConfiguration {}

--- a/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/subscription/SubscriptionServiceConfiguration.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.capacity.CapacityReconciliationConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.exception.UnretryableException;
 import org.candlepin.subscriptions.resteasy.ResteasyConfiguration;
+import org.candlepin.subscriptions.tracing.TracingConfiguration;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -44,7 +45,8 @@ import org.springframework.retry.support.RetryTemplateBuilder;
 @Import({
   ResteasyConfiguration.class,
   RhsmSubscriptionsDataSourceConfiguration.class,
-  CapacityReconciliationConfiguration.class
+  CapacityReconciliationConfiguration.class,
+  TracingConfiguration.class
 })
 @EnableJms
 @ComponentScan(

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -49,6 +49,7 @@ import org.candlepin.subscriptions.task.queue.TaskConsumerConfiguration;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskProcessor;
 import org.candlepin.subscriptions.task.queue.inmemory.ExecutorTaskQueueConsumerFactory;
 import org.candlepin.subscriptions.task.queue.kafka.KafkaTaskConsumerFactory;
+import org.candlepin.subscriptions.tracing.TracingConfiguration;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
@@ -97,7 +98,8 @@ import org.springframework.util.backoff.FixedBackOff;
   ContractsConfiguration.class,
   InventoryDataSourceConfiguration.class,
   ProductConfiguration.class,
-  ExportConfiguration.class
+  ExportConfiguration.class,
+  TracingConfiguration.class
 })
 @ComponentScan(
     basePackages = {
@@ -203,8 +205,12 @@ public class TallyWorkerConfiguration {
 
   @Bean
   public KafkaTemplate<String, TallySummary> tallySummaryKafkaTemplate(
-      ProducerFactory<String, TallySummary> tallySummaryProducerFactory) {
-    return new KafkaTemplate<>(tallySummaryProducerFactory);
+      ProducerFactory<String, TallySummary> tallySummaryProducerFactory,
+      KafkaProperties kafkaProperties) {
+    KafkaTemplate<String, TallySummary> kafkaTemplate =
+        new KafkaTemplate<>(tallySummaryProducerFactory);
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 
   @Bean

--- a/stub/mappings/README.md
+++ b/stub/mappings/README.md
@@ -3,8 +3,7 @@ Place your mapping JSON files in this directory.
 See the [WireMock documentation](https://wiremock.org/docs/stubbing/) for
 information about the format.
 
-The [WireMock admin
-API](https://wiremock.org/docs/standalone/admin-api-reference/) is very handy to
+The [WireMock admin API](https://wiremock.org/docs/standalone/admin-api-reference/) is very handy to
 reference as well.
 
 Starting a WireMock server using mappings in this directory is as easy as

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/TaskConsumerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/TaskConsumerConfiguration.java
@@ -46,7 +46,7 @@ public class TaskConsumerConfiguration {
   @Bean
   @Primary
   @Profile("kafka-queue")
-  KafkaTaskConsumerFactory kakfaTaskConsumerFactory(KafkaConsumerRegistry kafkaConsumerRegistry) {
+  KafkaTaskConsumerFactory kafkaTaskConsumerFactory(KafkaConsumerRegistry kafkaConsumerRegistry) {
     return new KafkaTaskConsumerFactory(kafkaConsumerRegistry);
   }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaConfigurator.java
@@ -72,8 +72,11 @@ public class KafkaConfigurator {
   }
 
   public KafkaTemplate<String, JsonTaskMessage> jsonTaskMessageKafkaTemplate(
-      ProducerFactory<String, JsonTaskMessage> factory) {
-    return new KafkaTemplate<>(factory);
+      ProducerFactory<String, JsonTaskMessage> factory, KafkaProperties kafkaProperties) {
+    KafkaTemplate<String, JsonTaskMessage> kafkaTemplate = new KafkaTemplate<>(factory);
+    // propagate observation properties
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 
   public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, JsonTaskMessage>>
@@ -95,6 +98,10 @@ public class KafkaConfigurator {
     }
     // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
     factory.getContainerProperties().setConsumerRebalanceListener(consumerRegistry);
+    // propagate observation properties
+    factory
+        .getContainerProperties()
+        .setObservationEnabled(kafkaProperties.getListener().isObservationEnabled());
     return factory;
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskConsumerFactory.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskConsumerFactory.java
@@ -20,19 +20,17 @@
  */
 package org.candlepin.subscriptions.task.queue.kafka;
 
+import lombok.AllArgsConstructor;
 import org.candlepin.subscriptions.task.TaskFactory;
 import org.candlepin.subscriptions.task.TaskQueueProperties;
 import org.candlepin.subscriptions.task.queue.TaskConsumerFactory;
 import org.candlepin.subscriptions.util.KafkaConsumerRegistry;
 
 /** Task consumer factory that creates consumers that read tasks from a kafka topic. */
+@AllArgsConstructor
 public class KafkaTaskConsumerFactory implements TaskConsumerFactory<KafkaTaskProcessor> {
 
   private final KafkaConsumerRegistry kafkaConsumerRegistry;
-
-  public KafkaTaskConsumerFactory(KafkaConsumerRegistry kafkaConsumerRegistry) {
-    this.kafkaConsumerRegistry = kafkaConsumerRegistry;
-  }
 
   @Override
   public KafkaTaskProcessor createTaskConsumer(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProcessor.java
@@ -48,7 +48,7 @@ public class KafkaTaskProcessor extends SeekableKafkaConsumer implements TaskCon
       TaskQueueProperties taskQueueProperties,
       KafkaConsumerRegistry kafkaConsumerRegistry) {
     super(taskQueueProperties, kafkaConsumerRegistry);
-    worker = new TaskWorker(taskFactory);
+    this.worker = new TaskWorker(taskFactory);
   }
 
   @KafkaListener(id = "#{__listener.groupId}", topics = "#{__listener.topic}")

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/task/queue/kafka/KafkaTaskProducerConfiguration.java
@@ -57,8 +57,9 @@ public class KafkaTaskProducerConfiguration {
   @Bean
   public KafkaTemplate<String, JsonTaskMessage> jsonKafkaProducerTemplate(
       ProducerFactory<String, JsonTaskMessage> jsonProducerFactory,
-      KafkaConfigurator kafkaConfigurator) {
-    return kafkaConfigurator.jsonTaskMessageKafkaTemplate(jsonProducerFactory);
+      KafkaConfigurator kafkaConfigurator,
+      KafkaProperties kafkaProperties) {
+    return kafkaConfigurator.jsonTaskMessageKafkaTemplate(jsonProducerFactory, kafkaProperties);
   }
 
   @NotNull

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/tracing/TracingConfiguration.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/tracing/TracingConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tracing;
+
+import io.micrometer.tracing.otel.bridge.OtelPropagator;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import(value = {TracingService.class})
+public class TracingConfiguration {
+
+  /**
+   * We don't want to import the "opentelemetry-exporter-otlp" dependency because we're exporting
+   * the traces via the java agent. Therefore, we need to configure the ContextPropagators by our
+   * own.
+   */
+  @Bean
+  ContextPropagators contextPropagators() {
+    return W3CTraceContextPropagator::getInstance;
+  }
+
+  @Bean
+  OtelPropagator otelPropagator(ContextPropagators contextPropagators, Tracer tracer) {
+    return new OtelPropagator(contextPropagators, tracer);
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/tracing/TracingService.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/tracing/TracingService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@AllArgsConstructor
+@Component
+public class TracingService {
+  private final Tracer tracer;
+
+  /**
+   * Create a new span programmatically. Documentation: <a
+   * href="https://docs.micrometer.io/tracing/reference/api.html"/>.
+   */
+  public void executeWithNewSpan(Runnable runnable) {
+    // Create a span. If there was a span present in this thread it will become
+    // the `newSpan`'s parent.
+    Span newSpan = this.tracer.nextSpan();
+    // Start a span and put it in scope. Putting in scope means putting the span
+    // in thread local
+    // and, if configured, adjust the MDC to contain tracing information
+    try (Tracer.SpanInScope ws = this.tracer.withSpan(newSpan.start())) {
+      runnable.run();
+    } finally {
+      // Once done remember to end the span. This will allow collecting
+      // the span to send it to a distributed tracing system e.g. Zipkin
+      newSpan.end();
+    }
+  }
+
+  public static String getCurrentTraceId() {
+    return io.opentelemetry.api.trace.Span.current().getSpanContext().getTraceId();
+  }
+}

--- a/swatch-core/src/main/resources/logback-spring.xml
+++ b/swatch-core/src/main/resources/logback-spring.xml
@@ -64,6 +64,7 @@
                 <connectTimeout>${SPLUNK_HEC_CONNECT_TIMEOUT:-5000}</connectTimeout>
                 <terminationTimeout>${SPLUNK_HEC_TERMINATION_TIMEOUT:-2000}</terminationTimeout>
                 <batch_size_count>${SPLUNK_HEC_BATCH_SIZE:-10}</batch_size_count>
+                <disableCertificateValidation>${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:-false}</disableCertificateValidation>
                 <eventHeaderSerializer>org.candlepin.subscriptions.logback.RhsmSplunkHecEventHeaderSerializer</eventHeaderSerializer>
                 <layout class="ch.qos.logback.classic.PatternLayout">
                     <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'} [thread=%t] [level=%p] [category=%c] %X{user} - %m%n%ex{full, SECURITY_STACKTRACE_EVAL}</pattern>

--- a/swatch-core/src/main/resources/swatch-core/application.yaml
+++ b/swatch-core/src/main/resources/swatch-core/application.yaml
@@ -123,6 +123,9 @@ spring:
       # the number of partitions on the queue)
       concurrency: ${KAFKA_MESSAGE_THREADS:1}
       idle-event-interval: ${KAFKA_IDLE_EVENT_INTERVAL:5s}
+      observation-enabled: true
+    template:
+      observation-enabled: true
     consumer:
       properties:
         # Required kafka defaults

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -21,6 +21,7 @@ DISABLE_OTEL: true
   SWATCH_SELF_PSK: placeholder
   ENABLE_SPLUNK_HEC: false
   SPLUNK_HEC_URL: https://splunk-hec.prod.utility-us-east-2.redhat.com:8088/
+  SPLUNK_DISABLE_CERTIFICATE_VALIDATION: true
   HOST_NAME: ${USER}@${HOSTNAME}
   SPLUNKMETA_namespace: local
   SPLUNK_HEC_INCLUDE_EX: true


### PR DESCRIPTION
Jira issue: SWATCH-3049
Depends on https://github.com/RedHatInsights/rhsm-subscriptions/pull/3883

## Description
- Started a playbook to deploy splunk and all the dependant services locally in order to see how the trace is propagated

For now, I've included two integrations:
(1) swatch-metrics <-> swatch-tally: this integration won't propagate the tracing context because we're consuming the events in batches. 
(2) swatch-tally <-> swatch-billable-usage: with these changes, the same trace ID will be used along all the tally hourly operation. 

I foresee that we'll be extending the playbook to verify other integrations in the future.

- Added new SPLUNK_DISABLE_CERTIFICATE_VALIDATION property to disable the certificate validation when posting logs into splunk. This is the same property as used in Quarkus services.
- Configure Spring Boot services to enable observation in Kafka. 

Note that this must be configured individually for each KafkaTemplate and KafkaListener. For now, I've enabled only the KafkaTemplate for tasks and tally-summary. 

## Testing
Follow the playbook observability.md guide. To be precise, the "<SnapshotSummaryProducer in Swatch tally> to <TallySummaryMessageConsumer in Swatch Billable Usage>" section. 