### PR TITLE
Set existing retryable remittances to failed

### DIFF
--- a/src/main/resources/liquibase/202410241408-clear-retryable.xml
+++ b/src/main/resources/liquibase/202410241408-clear-retryable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202410241408-01" author="khowell">
+    <update tableName="billable_usage_remittance">
+      <column name="status" value="failed"/>
+      <!-- NOTE: omitting value sets to null -->
+      <column name="retry_after"/>
+      <where>status='retryable'</where>
+      <!-- NOTE: the error code is still accurate -->
+    </update>
+    <!-- no rollback -->
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -174,5 +174,6 @@
     <include file="/liquibase/202409251400-update-subscription-capacity-view-org-id.xml"/>
     <include file="/liquibase/202410021300-update_usages_to_unknown.xml"/>
     <include file="/liquibase/202410211200-retry-after-billable-usage-index.xml"/>
+    <include file="/liquibase/202410241408-clear-retryable.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Description
===========

Clear existing retryable remittances via update statement

Testing
=======

You can run `./gradlew :liquibaseUpdateSql` to see the statement generated:

```sql
UPDATE public.billable_usage_remittance SET retry_after = NULL, status = 'failed' WHERE status='retryable';
```

or you can just run `./gradlew :liquibaseUpdate` and see the resulting changes if you have some test data locally.