### PR TITLE
SWATCH-2299: Use micrometer to count tally values by product, metric, and billing ID

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/roller/BaseSnapshotRoller.java
@@ -175,8 +175,10 @@ public abstract class BaseSnapshotRoller {
   }
 
   private boolean isFinestGranularity(TallySnapshot snap) {
-    Granularity finestGranularity = getFinestGranularity(snap);
-    return finestGranularity.equals(snap.getGranularity());
+    // The snapshot calls this a "product ID" but in the SubscriptionDefinition world it's actually
+    // a variant's tag
+    return SubscriptionDefinition.isFinestGranularity(
+        snap.getProductId(), snap.getGranularity().toString());
   }
 
   private boolean updateMaxValues(TallySnapshot snap, UsageCalculation calc) {
@@ -188,20 +190,6 @@ public abstract class BaseSnapshotRoller {
       changed |= updateTotals(overrideMaxCheck, snap, type, calc);
     }
     return changed;
-  }
-
-  private Granularity getFinestGranularity(TallySnapshot snap) {
-    // The snapshot calls this a "product ID" but in the SubscriptionDefinition world it's actually
-    // a variant's tag
-    String productId = snap.getProductId();
-    var subscription =
-        SubscriptionDefinition.lookupSubscriptionByTag(productId)
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        productId + " missing in subscription configuration"));
-
-    return Granularity.fromString(subscription.getFinestGranularity().toString());
   }
 
   private boolean updateTotals(

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.Sets;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.Granularity;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.TallyMeasurementKey;
+import org.candlepin.subscriptions.db.model.TallySnapshot;
+import org.candlepin.subscriptions.db.model.Usage;
+import org.candlepin.subscriptions.event.EventController;
+import org.candlepin.subscriptions.json.Event;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"worker", "test"})
+class TallySnapshotControllerMetricsTest {
+  @MockBean MaxSeenSnapshotStrategy maxSeenStrat;
+  @MockBean CombiningRollupSnapshotStrategy combiningStrat;
+  @MockBean InventoryAccountUsageCollector accountUsageCollector;
+  @MockBean EventController eventController;
+  @MockBean MetricUsageCollector usageCollector;
+
+  @Autowired TallySnapshotController controller;
+  @Autowired MeterRegistry registry;
+
+  @Test
+  void produceSnapshotsForOrg() {
+    var snapList = createSnaps(10, Granularity.DAILY, "RHEL for x86");
+    when(maxSeenStrat.produceSnapshotsFromCalculations(any(AccountUsageCalculation.class)))
+        .thenReturn(snapList);
+    when(accountUsageCollector.tally("123")).thenReturn(new AccountUsageCalculation("123"));
+
+    controller.produceSnapshotsForOrg("123");
+
+    var counter =
+        Counter.builder("swatch_tally_tallied_usage_total")
+            .tags(
+                "product",
+                "RHEL for x86",
+                "billing_provider_id",
+                BillingProvider.RED_HAT.getValue())
+            .withRegistry(registry);
+
+    for (var s : Set.of("CORES", "SOCKETS")) {
+      var c = counter.withTag("metric_id", s);
+      assertEquals(10.0, c.count());
+    }
+  }
+
+  @Test
+  void produceHourlySnapshotsForOrg() {
+    var snapList = createSnaps(10, Granularity.HOURLY, "rosa");
+
+    doAnswer(
+            AdditionalAnswers.answerVoid(
+                (orgId, serviceType, eventRecordDate, batchSize, batchConsumer) -> {
+                  var e1 = new Event();
+                  e1.setTimestamp(OffsetDateTime.now());
+                  e1.setRecordDate(OffsetDateTime.now());
+                  var e2 = new Event();
+                  e2.setTimestamp(OffsetDateTime.now());
+                  e2.setRecordDate(OffsetDateTime.now());
+                  ((Consumer) batchConsumer).accept(List.of(e1, e2));
+                }))
+        .when(eventController)
+        .processEventsInBatches(eq("123"), any(), any(), anyInt(), any());
+
+    // Perform these operations just to get calcCache.isEmpty() to evaluate to false
+    doAnswer(
+            AdditionalAnswers.answerVoid(
+                (batch, cache) -> {
+                  var calc = new AccountUsageCalculation("123");
+                  var event = new Event();
+                  event.setTimestamp(OffsetDateTime.now());
+                  ((AccountUsageCalculationCache) cache).put(event, calc);
+                }))
+        .when(usageCollector)
+        .calculateUsage(anyList(), any(AccountUsageCalculationCache.class));
+
+    when(combiningStrat.produceSnapshotsFromCalculations(
+            eq("123"), any(), eq(Set.of("rosa")), any(), eq(Granularity.HOURLY), any()))
+        .thenReturn(Map.of("123", snapList));
+
+    controller.produceHourlySnapshotsForOrg("123");
+
+    var counter =
+        Counter.builder("swatch_tally_tallied_usage_total")
+            .tags("product", "rosa", "billing_provider_id", BillingProvider.RED_HAT.getValue())
+            .withRegistry(registry);
+
+    for (var s : Set.of("CORES", "SOCKETS")) {
+      var c = counter.withTag("metric_id", s);
+      assertEquals(10.0, c.count());
+    }
+  }
+
+  private ArrayList<TallySnapshot> createSnaps(
+      int numSnaps, Granularity granularity, String productId) {
+    var snapList = new ArrayList<TallySnapshot>(numSnaps);
+    for (int i = 0; i < numSnaps; i++) {
+      var measurements = new HashMap<TallyMeasurementKey, Double>();
+
+      for (int j = 0; j < 4; j++) {
+        var measurement = generateMeasurements(j);
+        measurements.put(measurement, 1.0);
+      }
+
+      Set<Usage> usages = Set.of(Usage.PRODUCTION, Usage._ANY);
+      Set<ServiceLevel> slas = Set.of(ServiceLevel.PREMIUM, ServiceLevel._ANY);
+      Set<BillingProvider> providers = Set.of(BillingProvider.RED_HAT);
+
+      // Emulate the creation of all the superset tally buckets.  We want to ensure that the less
+      // specific buckets are
+      // filtered out
+      Set<List<Object>> tuples = Sets.cartesianProduct(usages, slas, providers);
+      tuples.forEach(
+          t -> {
+            Usage u = (Usage) t.get(0);
+            ServiceLevel s = (ServiceLevel) t.get(1);
+            BillingProvider bp = (BillingProvider) t.get(2);
+            var snap = new TallySnapshot();
+            snap.setProductId(productId);
+            snap.setGranularity(granularity);
+            snap.setServiceLevel(s);
+            snap.setUsage(u);
+            snap.setBillingProvider(bp);
+            snap.setTallyMeasurements(measurements);
+            snapList.add(snap);
+          });
+    }
+    return snapList;
+  }
+
+  private @NotNull TallyMeasurementKey generateMeasurements(int j) {
+    var measurement = new TallyMeasurementKey();
+    switch (j) {
+      case 0 -> {
+        measurement.setMetricId("CORES");
+        measurement.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+      }
+      case 1 -> {
+        measurement.setMetricId("CORES");
+        measurement.setMeasurementType(HardwareMeasurementType.TOTAL);
+      }
+      case 2 -> {
+        measurement.setMetricId("SOCKETS");
+        measurement.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+      }
+      case 3 -> {
+        measurement.setMetricId("SOCKETS");
+        measurement.setMeasurementType(HardwareMeasurementType.TOTAL);
+      }
+      default -> throw new IllegalStateException("MeasurementKey creation failed");
+    }
+    return measurement;
+  }
+}

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -149,8 +149,21 @@ public class SubscriptionDefinition {
     return this.getMetrics().stream().anyMatch(metric -> Objects.nonNull(metric.getPrometheus()));
   }
 
-  public SubscriptionDefinitionGranularity getFinestGranularity() {
+  public static boolean isFinestGranularity(String tag, String granularity) {
+    var subscription =
+        SubscriptionDefinition.lookupSubscriptionByTag(tag)
+            .orElseThrow(
+                () -> new IllegalStateException(tag + " missing in subscription configuration"));
 
+    var finestTagGranularity = subscription.getFinestGranularity().toString();
+
+    // Compare as strings because granularity is represented by two different enumerations:
+    // org.candlepin.subscriptions.db.model.Granularity and
+    // com.redhat.swatch.configuration.registry.SubscriptionDefinitionGranularity
+    return finestTagGranularity.equalsIgnoreCase(granularity);
+  }
+
+  public SubscriptionDefinitionGranularity getFinestGranularity() {
     return this.isPrometheusEnabled()
         ? SubscriptionDefinitionGranularity.HOURLY
         : SubscriptionDefinitionGranularity.DAILY;


### PR DESCRIPTION
The tally counters are tagged by product, metric ID, and billing
provider.  The counter should only be incremented at the finest
granularity level to prevent over-counting.

Jira issue: SWATCH-2299

## Description
Recording tally values for product, metrics, and billing providers will allow us to create Grafana dashboards to monitor PAYG metrics and create alerts for PAYG metric discrepancies.

To improve the performance of looping through all the tally snapshots, I used `parallelStream()`.  `parallelStream()` is not a magic bullet though and it can actually be slower in cases where the overhead of delegating to the worker thread pool exceeds the cost of basic iteration.  I did some benchmarking on my machine and found `parallelStream()` to be superior in most cases.  However, my machine is not a pod.  I haven't done benchmarking there, but OpenShift [should](https://serverfault.com/a/1065826) handle the parallel execution just fine.

|snapshots| parallel (ms) | single-threaded (ms) |
|---------------|--------------------|-------------------------------|
| 10 | 3 | 14 |
| 100 | 4 | 18 |
| 1000 | 28 | 91 |
| 10,000 | 86 | 214 |
| 100,000 | 584 | 803 |

## Testing
Unit tests are provided.

### Setup
1.  Opt `org123` in if you need to.
    ```shell
    bin/insert-mock-hosts --org org123 --opt-in
    ```
1.  Insert a mock host into the **insights** db for `rhel-for-x86-ha`
    ```sql
    INSERT INTO hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups)
    VALUES ('e5406d59-5cf3-4e83-abf8-84c149f8b6ba', 'account123', 'd125f119-0c98-43f2-a5de-ccf2e8e1ab55', '1993-03-26 00:00:00.000000 +00:00', '1993-03-26 00:00:00.000000 +00:00', '{"rhsm": {"orgId": "org123", "IS_VIRTUAL": null, "VM_HOST_UUID": null}}', null, '{"insights_id": "d125f119-0c98-43f2-a5de-ccf2e8e1ab55", "subscription_manager_id": "ef5a9896-242c-44a4-908d-9e6a1ffb9df6"}', '{"host_type": null, "cloud_provider": null, "is_marketplace": false, "cores_per_socket": 4, "number_of_sockets": 1, "installed_products": [{"id": "83"}], "infrastructure_type": "PHYSICAL"}', null, '2030-01-01 00:00:00.000000 +00:00', 'rhsm-conduit', '{}', 'org123', '{}');
    ```
1.  Start the application
    ```shell
    DEV_MODE=true ./gradlew :bootRun --args="--spring.profiles.active=kafka-queue,api,worker"
    ```

### Steps
1.  Confirm the count is zero (i.e. there are no counters with `tally_tallied` in the name)
    ```shell
    http :9000/metrics | grep tally_tallied
    ```
1.  Perform a tally for `org123`
    ```shell
    http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" x-rh-swatch-synchronous-request:true x-rh-swatch-psk:placeholder
    ```

### Verification
1. Confirm a tally occurred
    ```shell
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select count(*) from host_tally_buckets htb join hosts h on h.id = htb.host_id where h.org_id = 'org123';"
    ```
1. Confirm the counters were incremented for `rhel-for-x86-ha`.  Cores should be 4, instance hours 1, and sockets 2.
    ```shell
    http :9000/metrics | grep tally_tallied
    ```