### PR TITLE
SWATCH-3054 Update reset remittance API to include billing_account_id

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
@@ -83,8 +83,13 @@ public class InternalBillableUsageController {
 
   @Transactional
   public int resetBillableUsageRemittance(
-      String productId, OffsetDateTime start, OffsetDateTime end, Set<String> orgIds) {
-    return remittanceRepository.resetBillableUsageRemittance(productId, start, end, orgIds);
+      String productId,
+      OffsetDateTime start,
+      OffsetDateTime end,
+      Set<String> orgIds,
+      Set<String> billingAccountIds) {
+    return remittanceRepository.resetBillableUsageRemittance(
+        productId, start, end, orgIds, billingAccountIds);
   }
 
   @Transactional

--- a/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
@@ -91,17 +91,26 @@ paths:
   /api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance:
     put:
       description: Reset remittance_pending_value in Billable Usage Remittance table when it matches certain criteria
-      summary: Update billable usage remittance records.
+      summary: Update billable usage remittance records. Use org_ids to update by orgs, or billing_account_ids to update by billing accounts. Only one of these parameters should be specified at a time, do not provide both.
       operationId: resetBillableUsageRemittance
       parameters:
-        - in: query
-          name: org_id
+        - name: org_ids
+          in: query
           schema:
             type: array
             uniqueItems: true
             items:
               $ref: "#/components/schemas/OrgIds"
-          required: true
+            description: "List of organization IDs. Use this parameter if updating by organization IDs."
+          allowEmptyValue: false
+        - name: billing_account_ids
+          in: query
+          schema:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+            description: "List of billing account IDs. Use this parameter if updating by billing account IDs."
           allowEmptyValue: false
         - name: product_id
           in: query

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
@@ -266,13 +266,15 @@ class InternalBillableUsageControllerTest {
             "rosa",
             clock.startOfCurrentMonth().minusDays(1),
             clock.startOfCurrentMonth().plusDays(1),
-            Set.of("1234", "5678"));
+            Set.of("1234", "5678"),
+            null);
     int remittanceNotPresent =
         controller.resetBillableUsageRemittance(
             "rosa",
             clock.startOfCurrentMonth().plusDays(1),
             clock.startOfCurrentMonth().plusDays(2),
-            Set.of("1234"));
+            Set.of("1234"),
+            null);
     assertEquals(2, remittancePresent);
     assertEquals(0, remittanceNotPresent);
   }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
@@ -149,16 +149,43 @@ class InternalBillableUsageResourceTest {
   }
 
   @Test
-  void testResetBillableUsageRemittance() {
+  void testResetBillableUsageRemittanceOrgOnly() {
     givenRemittanceForOrgId(ORG_ID);
     given()
         .queryParam("product_id", PRODUCT_ID)
-        .queryParam("org_id", ORG_ID)
+        .queryParam("org_ids", ORG_ID)
         .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
         .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
         .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
         .then()
         .statusCode(HttpStatus.SC_OK);
+  }
+
+  @Test
+  void testResetBillableUsageRemittanceBillingAccountOnly() {
+    givenRemittanceForOrgId(ORG_ID);
+    given()
+        .queryParam("product_id", PRODUCT_ID)
+        .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
+        .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
+        .queryParam("billing_account_ids", String.format("%s_%s_ba", ORG_ID, PRODUCT_ID))
+        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .then()
+        .statusCode(HttpStatus.SC_OK);
+  }
+
+  @Test
+  void testResetBillableUsageRemittanceBoth() {
+    givenRemittanceForOrgId(ORG_ID);
+    given()
+        .queryParam("product_id", PRODUCT_ID)
+        .queryParam("org_ids", ORG_ID)
+        .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
+        .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
+        .queryParam("billing_account_ids", String.format("%s_%s_ba", ORG_ID, PRODUCT_ID))
+        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .then()
+        .statusCode(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3054

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Update billable usage remittance records. Use org_ids to update by orgs, or billing_account_ids to update by billing accounts. Only one of these parameters should be specified at a time, do not provide both.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. `SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev`

2. Insert into billable_usage_remittance table
```
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '12345678', 'rhel-for-x86-els-payg', 'vCPUs', '2024-06', 'Premium', 'Production', 'aws', 'customerAccount12345678', 0, '2024-10-18 17:38:39.768882 +00:00', null, '2019ef80-cefb-433b-be30-2dd0ef98ff13', 'PHYSICAL', '477c4796-e0cf-495f-b172-9b2357560878', null, null, 'pending');
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '12345678', 'rhel-for-x86-els-payg', 'vCPUs', '2024-06', 'Premium', 'Production', 'aws', 'customerAccount12345678', 0, '2024-10-23 19:11:05.028257 +00:00', null, 'daa73412-1165-4140-aa22-41df6358299e', 'PHYSICAL', '00849c07-a9b5-470f-8a84-05b57978600e', null, null, 'pending');
INSERT INTO public.billable_usage_remittance (account_number, org_id, product_id, metric_id, accumulation_period, sla, usage, billing_provider, billing_account_id, remitted_pending_value, remittance_pending_date, retry_after, tally_id, hardware_measurement_type, uuid, billed_on, error_code, status) VALUES (null, '123456789', 'rhel-for-x86-els-payg', 'vCPUs', '2024-06', 'Premium', 'Production', 'aws', 'customerAccount123456789', 0, '2024-10-18 17:38:07.058908 +00:00', '2024-10-18 18:38:40.158580 +00:00', 'faa73412-1165-4140-aa22-41df6358299e', 'PHYSICAL', '6c6348a9-5b7e-4007-af43-fcfd3024a344', null, 'subscription_not_found', 'retryable');
```


### Steps to reset by billing_account_ids
<!-- Enter each step of the test below -->
1.   
``` 
curl -X 'PUT' \
'http://localhost:8002/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance?billing_account_ids=customerAccount123456789&billing_account_ids=customerAccount12345678&product_id=rhel-for-x86-els-payg&start=2024-10-10T12%3A15%3A50-04%3A00&end=2024-10-24T12%3A15%3A50-04%3A00' \
  -H 'accept: application/json'
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Remittance value should change to zero.


### Steps to reset by org_ids
<!-- Enter each step of the test below -->
1. Run the setup steps again
2. 
 ```
curl -X 'PUT' \
  'http://localhost:8002/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance?org_ids=12345678&org_ids=123456789&product_id=rhel-for-x86-els-payg&start=2024-10-10T12%3A15%3A50-04%3A00&end=2024-10-24T12%3A15%3A50-04%3A00' \
  -H 'accept: application/json'
```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Remittance value should change to zero.

### Verify if we pass both org and billing_account_id then it should throw badrequest exception.