### PR TITLE
SWATCH-2969: Configure the logging to NOT use json format in Quarkus

### DIFF
--- a/swatch-metrics/build.gradle
+++ b/swatch-metrics/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     implementation 'io.quarkus:quarkus-config-yaml'
-    implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -24,11 +24,8 @@ DISABLE_OTEL: true
   HOST_NAME: ${USER}@${HOSTNAME}
   SPLUNKMETA_namespace: local
   SPLUNK_HEC_INCLUDE_EX: true
+  SPLUNK_DISABLE_CERTIFICATE_VALIDATION: true
   CORS_ORIGINS: /.*/
-  quarkus:
-    log:
-      console:
-        json: false
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 "%test":
@@ -39,9 +36,6 @@ DISABLE_OTEL: true
     management:
       # disable during testing to prevent port conflict during parallel runs
       enabled: false
-    log:
-      console:
-        json: false
 
 "%ephemeral":
   quarkus:
@@ -73,6 +67,7 @@ quarkus:
       splunk:
         enabled: ${ENABLE_SPLUNK_HEC:false}
         url: ${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
+        disable-certificate-validation: ${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
         metadata-source: ${SPLUNK_SOURCE:swatch-metrics}
         max-retries: ${SPLUNK_HEC_RETRY_COUNT:0}
         metadata-source-type: ${SPLUNK_SOURCE_TYPE:quarkus_service}

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation platform(libraries["awssdk-bom"])
     implementation 'io.quarkus:quarkus-hibernate-validator'
     implementation 'io.quarkus:quarkus-jackson'
-    implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -55,8 +55,6 @@ DISABLE_OTEL=true
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev and test modes
-%dev.quarkus.log.console.json=false
-%test.quarkus.log.console.json=false
 quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG


### PR DESCRIPTION
Jira issue: SWATCH-2969

## Description
These changes do not have effects in stage/production, it's only for better dev experience (pod logs should be in plain text, instead of json format).


## Testing

### Setup

1. podman-compose up -d
2. ./gradlew clean build -x test
3. podman-compose -f config/splunk/docker-compose.yml up -d


### Verify swatch-metrics

1. Run application in production mode:

```
java -jar -DENABLE_SPLUNK_HEC=true -DSPLUNK_HEC_URL=https://localhost:8088 -DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 -DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true -DEVENT_SOURCE=telemeter -DSWATCH_SELF_PSK=placeholder -DSERVER_PORT=8001 swatch-metrics/build/quarkus-app/quarkus-run.jar
```

2. Check traces in splunk: browse to "localhost:8000" and search by "source=swatch-metrics". You should see the same messages formatting as previously. 

### Verify swatch-producer-aws

1. Build an uber-jar (for some reason, the default fast-jar is not working for me):

```
./gradlew clean :swatch-producer-aws:build -x test -Dquarkus.package.jar.type=uber-jar
```

2. Run application in production mode:

```
java -jar -DENABLE_SPLUNK_HEC=true -DSPLUNK_HEC_URL=https://localhost:8088 -DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 -DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true -DSWATCH_SELF_PSK=placeholder -DSERVER_PORT=8001 swatch-producer-aws/build/swatch-producer-aws-*.jar
```

3. Check traces in splunk: browse to "localhost:8000" and search by "source=swatch-producer-aws". You should see the same messages formatting as previously.