### PR TITLE
Bump quarkusVersion from 3.15.1 to 3.16.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,7 @@ Since having multiple clients in the classpath will cause that the exception map
 ```
 # Disable the auto-discovery of providers (for ex: exception mappers).
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
-quarkus.rest-client-reactive.provider-autodiscovery=false
+quarkus.rest-client.provider-autodiscovery=false
 ```
 
 The generated client from openapi already uses the `@RegisterProdiver` annotation, so nothing else should be needed.

--- a/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
@@ -43,7 +43,7 @@ openApiGenerate {
 
 dependencies {
     implementation enforcedPlatform(libraries["quarkus-bom"])
-    api 'io.quarkus:quarkus-rest-client-reactive-jackson'
+    api 'io.quarkus:quarkus-rest-client-jackson'
     api libraries["jackson-databind-nullable"]
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 // inspired by mockito's gradle structure, which dependabot uses as a test case
 
 ext {
-    quarkusVersion='3.15.1'
+    quarkusVersion='3.16.1'
     springVersion='3.3.5'
     resteasyVersion='6.2.10.Final'
     jacksonVersion='2.18.1'

--- a/swatch-billable-usage/build.gradle
+++ b/swatch-billable-usage/build.gradle
@@ -7,12 +7,12 @@ plugins {
 dependencies {
     compileOnly libraries["lombok"]
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-opentelemetry'
     implementation 'io.quarkus:quarkus-oidc-client'
     implementation 'io.quarkus:quarkus-kafka-streams'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation("io.quarkus:quarkus-jdbc-postgresql")
     implementation project(":clients:quarkus:contracts-client")

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -186,3 +186,6 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 # 70 days worth
 rhsm-subscriptions.remittance-retention-policy.duration=${REMITTANCE_RETENTION_DURATION:70d}
 rhsm-subscriptions.billable-usage.retry-remittances-batch-size=${RETRY_REMITTANCES_BATCH_SIZE:1024}
+
+# Disable keycloak dev services
+quarkus.keycloak.devservices.enabled=false

--- a/swatch-common-kafka/build.gradle
+++ b/swatch-common-kafka/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation enforcedPlatform(libraries["quarkus-bom"])
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
 }
 
 description = 'Shared kafka logic for swatch services'

--- a/swatch-common-trace-response/build.gradle
+++ b/swatch-common-trace-response/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation enforcedPlatform(libraries["quarkus-bom"])
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
     implementation('io.opentelemetry:opentelemetry-api')
 }
 

--- a/swatch-contracts/build.gradle
+++ b/swatch-contracts/build.gradle
@@ -22,17 +22,16 @@ liquibase {
 dependencies {
     compileOnly libraries["lombok"]
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-jackson'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-security'
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation("io.quarkus:quarkus-liquibase")
     implementation("io.quarkus:quarkus-jdbc-postgresql")
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-amqp'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-amqp'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation 'io.smallrye.reactive:smallrye-reactive-messaging-in-memory'
     implementation project(':clients:quarkus:subscription-client')
     implementation project(':swatch-common-clock')

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -159,7 +159,7 @@ quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyRe
 
 # Disable the auto-discovery of providers (for ex: exception mappers).
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
-quarkus.rest-client-reactive.provider-autodiscovery=false
+quarkus.rest-client.provider-autodiscovery=false
 # The time in ms for which a connection remains unused in the connection pool before being evicted and closed.
 # 300000 = 5 min to keep it consistent with the one used in the monolith
 quarkus.rest-client.connection-ttl=300000

--- a/swatch-metrics-hbi/build.gradle
+++ b/swatch-metrics-hbi/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-config-yaml'
     implementation project(':swatch-common-config-workaround')
     implementation libraries["clowder-quarkus-config-source"]
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation 'io.quarkus:quarkus-rest' // TODO: Remove later since REST API is temporary
     implementation project(':swatch-common-smallrye-fault-tolerance')
     implementation project(':swatch-common-kafka')

--- a/swatch-metrics/build.gradle
+++ b/swatch-metrics/build.gradle
@@ -9,12 +9,12 @@ dependencies {
     implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
-    implementation 'io.quarkus:quarkus-rest-client-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
+    implementation 'io.quarkus:quarkus-rest-client-jackson'
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation project(':swatch-product-configuration')
     implementation project(':swatch-common-kafka')
     implementation project(':swatch-common-resteasy-client')

--- a/swatch-model-billable-usage/build.gradle
+++ b/swatch-model-billable-usage/build.gradle
@@ -8,7 +8,7 @@ description = 'Billable usage model definition'
 dependencies {
     annotationProcessor enforcedPlatform(libraries["quarkus-bom"])
 
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation libraries["jackson-annotations"] // for json generated models
     implementation libraries["jakarta-validation-api"] // for validation API in generated models
     implementation "com.fasterxml.jackson.core:jackson-databind"

--- a/swatch-producer-aws/build.gradle
+++ b/swatch-producer-aws/build.gradle
@@ -11,11 +11,10 @@ dependencies {
     implementation 'io.quarkus:quarkus-logging-json'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation 'software.amazon.awssdk:marketplacemetering'
     implementation 'software.amazon.awssdk:sts'
     implementation libraries["clowder-quarkus-config-source"]

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -126,7 +126,7 @@ mp.messaging.outgoing.billable-usage-status-out.value.serializer=org.candlepin.s
 
 # Disable the auto-discovery of providers (for ex: exception mappers).
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
-quarkus.rest-client-reactive.provider-autodiscovery=false
+quarkus.rest-client.provider-autodiscovery=false
 
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".url=${SWATCH_CONTRACTS_ENDPOINT}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-contracts-service.trust-store-path}

--- a/swatch-producer-azure/build.gradle
+++ b/swatch-producer-azure/build.gradle
@@ -6,14 +6,13 @@ plugins {
 dependencies {
     compileOnly libraries["lombok"]
     implementation 'io.quarkus:quarkus-hibernate-validator'
-    implementation 'io.quarkus:quarkus-jackson'
     implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'
     implementation 'io.quarkus:quarkus-opentelemetry'
-    implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
+    implementation 'io.quarkus:quarkus-rest-jackson'
     implementation 'io.quarkus:quarkus-security'
     implementation 'io.quarkus:quarkus-smallrye-fault-tolerance'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging-kafka'
+    implementation 'io.quarkus:quarkus-messaging-kafka'
     implementation 'io.quarkus:quarkus-oidc-client'
     implementation project(':clients:quarkus:contracts-client')
     implementation project(':swatch-common-config-workaround')

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -137,7 +137,7 @@ mp.messaging.outgoing.billable-usage-status-out.value.serializer=org.candlepin.s
 
 # Disable the auto-discovery of providers (for ex: exception mappers).
 # All the clients must use either the "quarkus.rest-client.*.providers" property or the `@RegisterProvider` instead.
-quarkus.rest-client-reactive.provider-autodiscovery=false
+quarkus.rest-client.provider-autodiscovery=false
 
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".url=${SWATCH_CONTRACTS_ENDPOINT}
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".trust-store=${clowder.endpoints.swatch-contracts-service.trust-store-path}
@@ -167,3 +167,6 @@ quarkus.otel.sdk.disabled=${DISABLE_OTEL}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-otel-collector:4317}
 # Metrics and logging are not yet supported - 30 Jul 2024
 quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
+
+# Disable keycloak dev services
+quarkus.keycloak.devservices.enabled=false


### PR DESCRIPTION
## Description
Bump quarkusVersion from 3.15.1 to 3.16.1
Quarkus 3.16 fixes the opentelemetry traces exporter issue: https://github.com/quarkusio/quarkus/pull/43752
