### PR TITLE
Configure pre-commit hook to run spotlessCheck task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: spotless
+        name: spotless
+        entry: ./gradlew -q spotlessCheck
+        language: script
+        pass_filenames: false
+        types: [java]

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,0 +1,23 @@
+# Pre-commit Setup
+
+Install `rh-multi-pre-commit`.  It's on Gitlab under the
+`infosec-public/developer-workbench/tools` repo.  The README has information on
+installation.
+
+Alternatively, you can just install [pre-commit](https://pre-commit.com/) alone,
+but the RH variant has useful tooling to check for credential leaks and to apply
+global configuration which I find useful.
+
+If you are using the `rh-multi-pre-commit`, you need to enable local hooks for
+the rhsm-subscriptions repo with the command `git config --bool
+rh-pre-commit.enableLocalConfig true`.
+
+You can modify the `~/.config/pre-commit/config.yaml` file to add your own
+global hooks if you like.
+
+If you don't want to run the hooks for a particular commit, you can use
+`--no-verify` when you commit.  If you don't want to run the hooks at all, just
+don't configure `pre-commit`.
+
+Lastly, if you don't want colored status messages on the commit hooks, you can
+set the env var `PRE_COMMIT_COLOR=never`.


### PR DESCRIPTION
Jira issue: None

# Pre-commit Setup

Install `rh-multi-pre-commit`.  It's on Gitlab under the `infosec-public/developer-workbench/tools` repo.  The README has information on installation.

Alternatively, you can just install [pre-commit](https://pre-commit.com/) alone, but the RH variant has useful tooling to check for credential leaks and to apply global configuration which I find useful.

If you are using the `rh-multi-pre-commit`, you need to enable local hooks for the rhsm-subscriptions repo with the command `git config --bool rh-pre-commit.enableLocalConfig true`.

You can modify the `~/.config/pre-commit/config.yaml` file to add your own global hooks if you like.

Mine looks like

```yaml
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.5.0
    hooks:
      - id: check-merge-conflict
      - id: check-symlinks
      - id: check-yaml
      - id: end-of-file-fixer
      - id: fix-byte-order-marker
      - id: trailing-whitespace
  - repo: local
    hooks:
      - id: rh-pre-commit
        name: Global rh-pre-commit
        language: system
        entry: /usr/bin/python3 -m rh_pre_commit
        stages: [pre-commit]
        pass_filenames: false

      - id: rh-pre-commit.commit-msg
        name: Global rh-pre-commit.commit-msg
        language: system
        entry: /usr/bin/python3 -m rh_pre_commit --hook-type commit-msg --commit-msg-filename
        stages: [commit-msg]
        pass_filenames: true
```

If you don't want to run the hooks for a particular commit, you can use `--no-verify` when you commit.  If you don't want to run the hooks at all, just don't configure `pre-commit`.

Lastly, if you don't want colored status messages on the commit hooks, you can set the env var `PRE_COMMIT_COLOR=never`.
