### PR TITLE
Fix event trigger for swatch-metrics-hbi-push pipeline.

### DIFF
--- a/.tekton/swatch-metrics-hbi-push.yaml
+++ b/.tekton/swatch-metrics-hbi-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
       (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp: null
   labels:


### PR DESCRIPTION
 The pipeline was being triggered on pull_request instead of on push.
