### PR TITLE
Fix swatch-contracts test error due to wrong property when stub exports

### DIFF
--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/ExportServiceWireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/ExportServiceWireMockResource.java
@@ -45,7 +45,7 @@ public class ExportServiceWireMockResource implements QuarkusTestResourceLifecyc
     wireMockServer = startWireMockServer();
     wireMockServer.resetAll();
     wireMockServer.stubFor(post(urlPathMatching("/app/export/.*")));
-    return Map.of("clowder.privateEndpoints.export-service-service.url", wireMockServer.baseUrl());
+    return Map.of("clowder.private-endpoints.export-service-service.url", wireMockServer.baseUrl());
   }
 
   @Override


### PR DESCRIPTION
No JIRA. 
The ExportServiceWireMockResource was using a wrong property and hence the wiremock was not receiving requests.