### PR TITLE
SWATCH-3062: Use isPaygEligible when doing tally hourly in payg products

### DIFF
--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -139,12 +139,6 @@ public class SubscriptionDefinition {
         .collect(Collectors.toSet());
   }
 
-  public static boolean isPrometheusEnabled(@NotNull @NotEmpty String tag) {
-    return lookupSubscriptionByTag(tag).filter(SubscriptionDefinition::isPrometheusEnabled).stream()
-        .findFirst()
-        .isPresent();
-  }
-
   public boolean isPrometheusEnabled() {
     return this.getMetrics().stream().anyMatch(metric -> Objects.nonNull(metric.getPrometheus()));
   }
@@ -164,7 +158,7 @@ public class SubscriptionDefinition {
   }
 
   public SubscriptionDefinitionGranularity getFinestGranularity() {
-    return this.isPrometheusEnabled()
+    return this.isPaygEligible()
         ? SubscriptionDefinitionGranularity.HOURLY
         : SubscriptionDefinitionGranularity.DAILY;
   }
@@ -173,7 +167,7 @@ public class SubscriptionDefinition {
     List<SubscriptionDefinitionGranularity> granularity =
         new ArrayList<>(List.of(SubscriptionDefinitionGranularity.values()));
 
-    if (!isPrometheusEnabled()) {
+    if (!isPaygEligible()) {
       granularity.remove(SubscriptionDefinitionGranularity.HOURLY);
     }
 


### PR DESCRIPTION
Jira issue: SWATCH-3062

## Description
Replace the condition to use "isPaygEligible" instead of "isPrometheusEnabled" to filter by granularity HOURLY in PAYG products. Added test to cover this scenario.

## Testing
Added a test to reproduce and fix the issue.
IQE steps:

- `application.rhsm_subscriptions.get_today_tally_report(product_id="ansible-aap-managed",granularity="Hourly", metric_id="Managed-nodes", )`

The above call should not fail with:
```
2024-10-30 16:05:39.778 [   ERROR] [iqe_rhsm_subscriptions] (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Server': 'openresty', 'Content-Type': 'application/vnd.api+json', 'Content-Length': '160', 'x-rh-insights-request-id': 'e5567897fb824bad96c994fb02487329', 'traceresponse': '00-718e36745ed04f8f4b2706faeb884561-9ab1e4ac5c2c55cc-00', 'x-content-type-options': 'nosniff', 'x-xss-protection': '0', 'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate', 'Pragma': 'no-cache', 'Expires': '0', 'strict-transport-security': 'max-age=31536000 ; includeSubDomains', 'x-frame-options': 'DENY', 'Date': 'Wed, 30 Oct 2024 20:05:39 GMT', 'Connection': 'keep-alive', 'Set-Cookie': 'JSESSIONID=FDD3BA50DDCB985E908B209D56F71F72; Path=/; Secure; HttpOnly, e15dd7c1deaec3a6b67fca153d520b0b=7953e9f343aa427a870b6325a74d103f; path=/; HttpOnly; Secure; SameSite=None', 'x-rh-edge-request-id': '1b8bc7e6', 'x-rh-edge-reference-id': '0.4ededa17.1730318739.1b8bc7e6', 'x-rh-edge-cache-status': 'NotCacheable from child'})
HTTP response body: {"errors":[{"status":"400","code":"SUBSCRIPTIONS1001","title":"Bad Request","detail":"ansible-aap-managed does not support any granularity finer than Hourly"}]}False
```