### PR TITLE
SWATCH-2936: Prevent retries when handling export requests

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/export/ExportRequestConsumer.java
+++ b/src/main/java/org/candlepin/subscriptions/export/ExportRequestConsumer.java
@@ -55,7 +55,15 @@ public class ExportRequestConsumer extends SeekableKafkaConsumer {
       id = "#{__listener.groupId}",
       topics = "#{__listener.topic}",
       containerFactory = "exportListenerContainerFactory")
-  public void receive(String exportEvent) throws ExportServiceException {
-    exportService.handle(exportEvent);
+  public void receive(String exportEvent) {
+    try {
+      exportService.handle(exportEvent);
+    } catch (ExportServiceException ex) {
+      log.error(
+          "Error handling export request: {}. This request will be ignored. "
+              + "See the previous errors for further details",
+          exportEvent,
+          ex);
+    }
   }
 }

--- a/swatch-common-export/src/main/java/com/redhat/swatch/export/ExportRequestHandler.java
+++ b/swatch-common-export/src/main/java/com/redhat/swatch/export/ExportRequestHandler.java
@@ -54,9 +54,10 @@ public class ExportRequestHandler {
     var request = new ExportServiceRequest(parser.fromJsonString(exportEvent));
     try {
       if (!request.hasRequest()) {
-        throw new ExportServiceException(
-            INTERNAL_ERROR, "Cloud event doesn't have any Export data: " + request.getId());
+        log.warn("Cloud event doesn't have any Export data: {}", request.getId());
+        return;
       }
+
       if (request.isRequestForApplication(SWATCH_APP)) {
         for (var service : exporterServices) {
           if (service.handles(request)) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/export/ExportRequestConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/export/ExportRequestConsumer.java
@@ -41,7 +41,15 @@ public class ExportRequestConsumer {
   @Timed("rhsm-subscriptions.exports.upload")
   @Transactional
   @Incoming(EXPORT_REQUESTS_TOPIC)
-  public void receive(String exportEvent) throws ExportServiceException {
-    exportService.handle(exportEvent);
+  public void receive(String exportEvent) {
+    try {
+      exportService.handle(exportEvent);
+    } catch (ExportServiceException ex) {
+      log.error(
+          "Error handling export request: {}. This request will be ignored. "
+              + "See the previous errors for further details",
+          exportEvent,
+          ex);
+    }
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-2936

## Description
Log an error trace when this happens when the export request thas has failed. Change the log warn trace when the request does not contain the needed data.  

## Testing
Added unit tests to cover these scenarios.