### PR TITLE
SWATCH-3066: Log traces for "com.redhat.swatch" in spring services

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -165,6 +165,8 @@ objects:
                 value: ${LOGGING_LEVEL_ROOT}
               - name: LOGGING_LEVEL_ORG_CANDLEPIN
                 value: ${LOGGING_LEVEL}
+              - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+                value: ${LOGGING_LEVEL}
               - name: LOGGING_SHOW_SQL_QUERIES
                 value: ${LOGGING_SHOW_SQL_QUERIES}
               - name: DATABASE_HOST

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -227,6 +227,8 @@ objects:
                 value: ${LOGGING_LEVEL_ROOT}
               - name: LOGGING_LEVEL_ORG_CANDLEPIN
                 value: ${LOGGING_LEVEL}
+              - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+                value: ${LOGGING_LEVEL}
               - name: KAFKA_MESSAGE_THREADS
                 value: ${KAFKA_MESSAGE_THREADS}
               - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
@@ -423,6 +425,8 @@ objects:
               - name: LOGGING_LEVEL_ROOT
                 value: ${LOGGING_LEVEL_ROOT}
               - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                value: ${METRICS_RHEL_LOGGING_LEVEL}
+              - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
                 value: ${METRICS_RHEL_LOGGING_LEVEL}
               - name: KAFKA_MESSAGE_THREADS
                 value: ${KAFKA_MESSAGE_THREADS}

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -247,6 +247,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+              value: ${LOGGING_LEVEL}
             - name: LOGGING_SHOW_SQL_QUERIES
               value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -247,6 +247,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+              value: ${LOGGING_LEVEL}
             - name: LOGGING_SHOW_SQL_QUERIES
               value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -214,6 +214,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+              value: ${LOGGING_LEVEL}
             - name: KAFKA_TASK_GROUP
               value: platform.rhsm-conduit.tasks
             - name: KAFKA_MESSAGE_THREADS

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -353,6 +353,8 @@ objects:
               value: ${LOGGING_LEVEL_ROOT}
             - name: LOGGING_LEVEL_ORG_CANDLEPIN
               value: ${LOGGING_LEVEL}
+            - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
+              value: ${LOGGING_LEVEL}
             - name: LOGGING_SHOW_SQL_QUERIES
               value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: KAFKA_MESSAGE_THREADS


### PR DESCRIPTION
Jira issue: SWATCH-3066

## Description
When investaging the random failure of the test "test_export_instances_payg_product_filters" in SWATCH-3066, I found that we're only seeing the WARN traces when handling the export requests. 

This is because we moved the export handling into a separated module that uses the package "com.redhat.swatch" and the spring boot services are only configured to print the info traces for the package "org.candlepin".

For the Quarkus services, this is already working fine because it's configured as:

```
quarkus.log.level=${LOGGING_LEVEL_ROOT}
quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
```

After these changes, the package "com.redhat.swatch" should also be configured for the spring services to print the info traces and see them in splunk.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/939