### PR TITLE
SWATCH-3072: Better clowder truststore handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Some swatch services like Subscription Sync listen for the Export service reques
 podman-compose -f config/export-service/docker-compose.yml up -d
 ```
 
-The above export-service will expose the internal API via the port 10000 and the public API via the port 8002. The subscription-sync service is already configured to use the port 10000. 
+The above export-service will expose the internal API via the port 10000 and the public API via the port 8002. The subscription-sync service is already configured to use the port 10000.
 To create an export request, you can use the following example as a reference:
 
 ```
@@ -236,7 +236,7 @@ echo -n '{"identity":{"account_number":"<any>","org_id":"<org_id>","internal":{"
 > eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTMyNTk3NzUiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMzI1OTc3NSJ9LCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyX2RldiJ9fX0=
 ```
 
-The above request will trigger an event from the export-service to swatch via topics and swatch will eventually upload the report using the internal export service API. 
+The above request will trigger an event from the export-service to swatch via topics and swatch will eventually upload the report using the internal export service API.
 
 The uploaded reports are stored in minio (s3). You can verify that this report has been uploaded by checking the folder 'config/export-service/tmp/minio/exports-bucket' where should be a file at `<BUCKET ID>.json/xl.meta`. The `xl.meta` file is binary, but if you open the txt plain editor, you should see:
 ```
@@ -250,8 +250,8 @@ f9288f52-59dc-4ad6-9307-8c67de75c09c	fb177ea7-a8ea-43e4-8c2e-cb4bd7170601	subscr
 
 ### Wiremock service
 
-Wiremock is a very helpful tool that helps us to mock other services like Prometheus. 
-At the moment, the wiremock service is configured to stub a prometheus instance which is necessary for swatch-metrics. 
+Wiremock is a very helpful tool that helps us to mock other services like Prometheus.
+At the moment, the wiremock service is configured to stub a prometheus instance which is necessary for swatch-metrics.
 Let's see how we can start the swatch-metrics service to use the wiremock service as prometheus.
 We can start the Wiremock service via:
 ```
@@ -408,7 +408,7 @@ For example,
 }}
 ```
 
-These properties are then passed into the Spring Environment and may be used elsewhere (the 
+These properties are then passed into the Spring Environment and may be used elsewhere (the
 `ClowderJsonEnvironmentPostProcessor` runs *before* most other environment processing classes).
 
 The pattern we follow is to assign the Clowder style properties to an **intermediate** property
@@ -443,6 +443,20 @@ E.g.
 ```
 $ ACG_CONFIG=$(pwd)/swatch-core/src/test/resources/test-clowder-config.json ./gradlew bootRun
 ```
+
+Note that there are 3 properties which `ClowderJsonEnvironmentPostProcessor` actually **creates**.
+The `clowder.endpoint....trust-store-*` properties are actually synthetic. They don't appear in the `cdappconfig.json`
+file.  Clowder provides the CA information via a `tlsCAPath` property which is just a pointer to a PEM file.
+Our code generally doesn't want just a bare PEM file. Instead, we take that path and construct a temporary Java truststore (a PKCS12 file) from it.  We pass the reference to that keystore whenever CA information is required.
+
+Following the pattern of clowder-quarkus-config-source, we also configure the truststore information on a per-endpoint
+basis. To do that, *if and only if* the endpoint has a `tlsPort` key, then we generate three synthetic properties:
+trust-store-path, trust-store-password, and trust-store-type.  We populate those synthetic properties with the
+information from the generated PKS12.
+
+However, if an endpoint doesn't have a `tlsPort` defined on it or if the `tlsCAPath` isn't specified, the
+`ClowderJsonPropertyResolver` can't resolve the synthetic `clowder.endpoints.[...].trust-store-path` property. The
+Spring property resolver behavior is to just return the literal string instead.
 
 ### Viewing Kafka messages in an ephemeral environment
 
@@ -517,7 +531,7 @@ cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
         DEV_MODE: "true"
         swatch-tally/IMAGE: quay.io/cloudservices/rhsm-subscriptions
         RHSM_RBAC_USE_STUB: "true"
-        
+
     - name: swatch-producer-red-hat-marketplace
       host: local
       repo: $(pwd)/rhsm-subscriptions/swatch-producer-red-hat-marketplace
@@ -567,7 +581,7 @@ cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
       parameters:
         REPLICAS: 1
         swatch-producer-aws/IMAGE: quay.io/cloudservices/swatch-producer-aws
-    
+
     - name: swatch-contracts
       host: local
       repo: $(pwd)/rhsm-subscriptions/swatch-contracts
@@ -583,7 +597,7 @@ cat <<BONFIRE >>  ~/.config/bonfire/config.yaml
       parameters:
         REPLICAS: 1
         swatch-producer-azure/IMAGE: quay.io/cloudservices/swatch-producer-azure
-        
+
     - name: swatch-billable-usage
       host: local
       repo: $(pwd)/rhsm-subscriptions/swatch-billable-usage

--- a/buildSrc/src/main/groovy/swatch.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.java-conventions.gradle
@@ -2,9 +2,19 @@
 // gradle config common to all swatch java projects
 plugins {
     id "java"
+    id "idea"
     id "com.diffplug.spotless"
     id 'com.adarshr.test-logger'
     id 'jacoco'
+}
+
+idea {
+    module {
+        downloadSources = true
+        // Do not index the bin directories that IntelliJ drops its .class files and copies resource files to
+        // See https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html
+        excludeDirs += file("bin")
+    }
 }
 
 repositories {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/CertInfoContributor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/CertInfoContributor.java
@@ -56,8 +56,17 @@ public class CertInfoContributor implements InfoContributor {
       if (Objects.nonNull(store)) {
         String filename = store.getFilename();
         if (Objects.nonNull(filename) && !filename.isBlank()) {
+          /* The ${clowder.endpoints...trust-store-path property is actually a synthetic property created by our
+           * ClowderJsonPropertySource for the endpoints.  The value is based off of a Java truststore we create from the
+           * path given in tlsCACert and the presence of a tlsPort key in the endpoint section.  Since tlsCACert or tlsPort
+           * isn't always present, the trust-store-path might not resolve to an actual path name. */
+          if ((filename.startsWith("${clowder.endpoints")
+                  || filename.startsWith("${clowder.privateEndpoints"))
+              && filename.endsWith("trust-store-path}")) {
+            return Map.of("Unresolved clowder config value: " + filename, Collections.emptyMap());
+          }
           if (!store.isReadable()) {
-            return Map.of(store.getFilename() + " not readable", Collections.emptyMap());
+            return Map.of(filename + " not readable", Collections.emptyMap());
           }
           return CertInfoInquisitor.loadStoreInfo(store, password);
         }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonEnvironmentPostProcessor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonEnvironmentPostProcessor.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * An {@link org.springframework.boot.env.EnvironmentPostProcessor} that inserts a {@link
- * ClowderJsonPathPropertySource} into the list of property sources.
+ * ClowderJsonPropertySource} into the list of property sources.
  */
 public class ClowderJsonEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
   public static final String CLOWDER_CONFIG_LOCATION_PROPERTY = "ACG_CONFIG";
@@ -93,7 +93,7 @@ public class ClowderJsonEnvironmentPostProcessor implements EnvironmentPostProce
   }
 
   private void processJson(ConfigurableEnvironment environment, ClowderJson clowderJson) {
-    var jsonSource = new ClowderJsonPathPropertySource(clowderJson);
+    var jsonSource = new ClowderJsonPropertySource(clowderJson);
     jsonSource.addToEnvironment(environment, logger);
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/KafkaSslBeanPostProcessor.java
@@ -43,7 +43,7 @@ import org.springframework.core.io.Resource;
  *      trust-store-type: ${clowder.kafka.brokers.cacert.type:}
  * </pre>
  *
- * The {@link ClowderJsonPathPropertySource} will return null for the evaluation of
+ * The {@link ClowderJsonPropertySource} will return null for the evaluation of
  * <tt>clowder.kafka.brokers.cacert</tt> (since that key is missing in the Clowder JSON), but Spring
  * will then fall back to the default which is the empty string. If no default is provided, Spring
  * instead uses the literal value of "${clowder.kafka.brokers.cacert}". So this class exists to set

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.context.support.StandardServletEnvironment;
 
 @ContextConfiguration
-class ClowderJsonPathPropertySourceTest {
+class ClowderJsonPropertySourceTest {
   public static final String TEST_CLOWDER_CONFIG_JSON = "classpath:/test-clowder-config.json";
 
   private final ConfigurableEnvironment environment = new StandardEnvironment();
@@ -69,11 +69,11 @@ class ClowderJsonPathPropertySourceTest {
     MapPropertySource custom = getPropertySource("custom", "custom");
     environment.getPropertySources().addFirst(custom);
 
-    var clowder = new ClowderJsonPathPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
-    clowder.addToEnvironment(environment, logFactory.getLog(ClowderJsonPathPropertySource.class));
+    var clowder = new ClowderJsonPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
+    clowder.addToEnvironment(environment, logFactory.getLog(ClowderJsonPropertySource.class));
 
     PropertySource<?> json =
-        environment.getPropertySources().get(ClowderJsonPathPropertySource.PROPERTY_SOURCE_NAME);
+        environment.getPropertySources().get(ClowderJsonPropertySource.PROPERTY_SOURCE_NAME);
 
     // The "custom" property source should supersede the Clowder source in precedence.
     assertEquals("custom", environment.getProperty("clowder.database.name"));
@@ -102,7 +102,7 @@ class ClowderJsonPathPropertySourceTest {
   @Test
   void testKafkaBrokersPropertyWhenNoBrokersConfiguration() throws Exception {
     var source =
-        new ClowderJsonPathPropertySource(
+        new ClowderJsonPropertySource(
             jsonFromResource("classpath:/test-clowder-config-without-brokers.json"));
     var result = source.getProperty("clowder.kafka.brokers");
     assertNull(result);
@@ -128,7 +128,7 @@ class ClowderJsonPathPropertySourceTest {
       },
       delimiter = '|')
   void testCustomLogicInProperties(String property, String expectedValue) throws Exception {
-    var source = new ClowderJsonPathPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
+    var source = new ClowderJsonPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
     var result = source.getProperty(property);
     assertTrue(
         Pattern.matches(expectedValue, (String) result),
@@ -141,8 +141,8 @@ class ClowderJsonPathPropertySourceTest {
         .getPropertySources()
         .addFirst(getPropertySource(servletContextPropertySourceName, "servlet"));
 
-    var clowder = new ClowderJsonPathPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
-    clowder.addToEnvironment(environment, logFactory.getLog(ClowderJsonPathPropertySource.class));
+    var clowder = new ClowderJsonPropertySource(jsonFromResource(TEST_CLOWDER_CONFIG_JSON));
+    clowder.addToEnvironment(environment, logFactory.getLog(ClowderJsonPropertySource.class));
 
     assertEquals("swatch-tally-db", environment.getProperty("clowder.database.name"));
   }


### PR DESCRIPTION
Jira issue: SWATCH-3072

## Description
Handle unresolved Clowder truststore references better

Truststore handling for the Clowder configuration is complex.  The
Clowder json looks like:

```
"endpoints": [
  {
    "app": "foo",
    "name": "service",
    "hostname": "localhost",
    "tlsPort": 9443
  }
],
"tlsCAPath": "/tmp/ca.pem"
}
```

However, our code generally doesn't want just a bare PEM file.
Instead, we take that path and construct a temporary Java truststore (a
PKCS12 file) from it.  We pass the reference to that keystore along.

Following the pattern of clowder-quarkus-config-source, we also
configure the truststore information on a per-endpoint basis.  To do
that, *if and only if* the endpoint has a `tlsPort` key, then we
generate three synthetic properties: trust-store-path,
trust-store-password, and trust-store-type.  We populate those synthetic
properties with the information from the generated PKS12.

However, if an endpoint doesn't have a `tlsPort` defined on it or if the
`tlsCAPath` isn't specified, the ClowderJsonPropertyResolver can't
resolve the synthetic `clowder.endpoints.[...].trust-store-path`
property. The Spring property resolver behavior is to just return the
literal string instead.

This commit documents this behavior and modifies the CertInfoContributor
to better reflect what is actually going on with the configuration
handling.

## Testing
### Setup
1. Create a clowder configuration file in the root of the project
    ```
    cat <<EOF > clowder-3072.json
    {
    "kafka": {
     "brokers": [
       {
         "hostname": "localhost",
         "port": 9092
       }
     ],
     "topics": []
    },
    "endpoints": [
      {
        "app": "rbac",
        "name": "service",
        "hostname": "localhost",
        "port": 9000,
        "tlsPort": 9443
      },
      {
        "app": "swatch-contracts",
        "name": "service",
        "hostname": "localhost",
        "tlsPort": 9443
      }
    ],
    "metricsPath": "/metrics",
    "metricsPort": 9000,
    "privatePort": 10000,
    "publicPort": 8000,
    "webPort": 8000,
    "tlsCAPath": "$(pwd)/swatch-core/src/test/resources/ca-test.pem"
    }
    EOF
    ```

### Steps
1. Start the application with Clowder configuration enabled
    ```
    FOO_SERVICE_HOST='f' FOO_SERVICE_PORT='f' ACG_CONFIG=$(pwd)/clowder-3072.json  ./gradlew :bootRun --args="--spring.profiles.active=kafka-queue,api,worker
    ```
1. Hit the `/info` endpoint
    ```
    http :9000/info
    ```

### Verification
1. For something that doesn't have `tlsPort` configured, you'll see
    ```
    "billableUsageClientProperties.truststore": {
        "Unresolved clowder config value: ${clowder.endpoints.swatch-billable-usage-service.trust-store-path}": {}
    },
    ```
1. And if `tlsPort` is configured, you'll see the info for the test cert.
    ```
    "rbacServiceProperties.truststore": {
      "cert-0": {
          "Distinguished Name": "CN=localhost,O=unknown,L=unknown,ST=unknown,C=XX",
          "Issuer Distinguished Name": "CN=localhost,O=unknown,L=unknown,ST=unknown,C=XX",
          "Not After": "2023-04-05T18:57:04Z",
          "SHA-1 Fingerprint": "960f13f186301c2418265ab937b0af589576c248",
          "Serial Number": "17232293264883780949"
      }
    },
    ```
    Matching
    ```
    % openssl x509 -in swatch-core/src/test/resources/ca-test.pem -noout -fingerprint
    SHA1 Fingerprint=96:0F:13:F1:86:30:1C:24:18:26:5A:B9:37:B0:AF:58:95:76:C2:48
    ```
    
