### PR TITLE
Use Caddy to create iqe test proxy for ephemeral instances

### DIFF
--- a/bin/caddy.yaml
+++ b/bin/caddy.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy
+  labels:
+    app.kubernetes.io/name: caddy
+    app.kubernetes.io/instance: caddy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: http
+      protocol: TCP
+      name: moto
+    - port: 8000
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9000
+      targetPort: http
+      protocol: TCP
+      name: metrics
+    - port: 5432
+      targetPort: http
+      protocol: TCP
+      name: database
+  selector:
+    app.kubernetes.io/name: caddy
+    app.kubernetes.io/instance: caddy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: caddy
+      app.kubernetes.io/instance: caddy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: caddy
+        app.kubernetes.io/instance: caddy
+    spec:
+      serviceAccountName: caddy
+      securityContext:
+        {}
+      volumes:
+        - name: caddyfile
+          configMap:
+            name: caddyfile
+      containers:
+        - name: caddy
+          securityContext:
+            {}
+          image: "quay.io/cloudservices/caddy-ubi:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: moto
+              containerPort: 5000
+              protocol: TCP
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+            - name: metrics
+              containerPort: 9000
+              protocol: TCP
+            - name: database
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          volumeMounts:
+            - name: caddyfile
+              mountPath: /etc/caddy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: caddy

--- a/bin/iqe-ee-proxy.sh
+++ b/bin/iqe-ee-proxy.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+TMP_DIR=$(mktemp -d)
+echo "    {
+      auto_https off
+      debug
+    }
+    " >> ${TMP_DIR}/Caddyfile
+
+NAMESPACE=$(oc project -q)
+
+cleanup() {
+  sudo sed -i "/#===== NAMESPACE $NAMESPACE =====/,/#===== NAMESPACE $NAMESPACE =====/d" /etc/hosts
+  cat $(dirname $0)/caddy.yaml | oc delete -f -
+  rm -rf ${TMP_DIR}
+  oc delete configmap/caddyfile
+}
+
+trap cleanup TERM SIGINT
+
+if ! grep $NAMESPACE /etc/hosts -q; then
+  echo "#===== NAMESPACE $NAMESPACE =====" | sudo tee -a /etc/hosts
+  for line in $(oc get svc -o go-template='{{range .items}}{{.metadata.name}}{{";"}}{{range .spec.ports}}{{if .port}}{{.port}}{{";"}}{{end}}{{end}}{{" "}}{{end}}') ; do
+    service=$(echo $line | awk -F ";" '{ print $1 }')
+    hosts_line="127.0.0.1 $service $service.$NAMESPACE.svc"
+    echo "$hosts_line" | sudo tee -a /etc/hosts
+
+    ports=$(echo $line | cut -d ";" -f2- | tr ";" " ")
+    for port in $ports; do
+      echo "
+      http://$service:$port {
+        reverse_proxy {
+          dynamic a $service $port
+        }
+      }
+      http://$service.$NAMESPACE.svc:$port {
+        reverse_proxy {
+          dynamic a $service $port
+        }
+      }
+      " >> ${TMP_DIR}/Caddyfile
+    done
+  done
+  podname=$(oc get pod -o name | grep kafka-0 | awk -F "/" '{ print $2 }')
+  hostname=$(oc get service -o name | grep kafka-brokers | awk -F "/" '{ print $2 }')
+  pod_line="127.0.0.1 $podname.$hostname $podname.$hostname.$NAMESPACE.svc"
+  echo "$pod_line" | sudo tee -a /etc/hosts
+  echo "#===== NAMESPACE $NAMESPACE =====" | sudo tee -a /etc/hosts
+fi
+
+oc port-forward $(oc get pod -o name | grep kafka-0) 9092:9092 &
+oc port-forward $(oc get service -o name | grep kafka-bridge-bridge-service) 8080:8080 &
+
+oc create configmap caddyfile \
+    --from-file=${TMP_DIR}/Caddyfile
+cat $(dirname $0)/caddy.yaml | oc apply -f -
+
+oc wait --for=condition=Available deployment/swatch-tally-db
+oc port-forward deployment/swatch-tally-db 5432:5432 &
+
+oc wait --for=condition=Available deployment/caddy
+oc port-forward deployment/caddy 9000:9000 8000:8000 5000:5000
+


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This proxy will allow us to run iqe tests on a local machine against an Ephemeral instance.
The testing can be done on the command line or in PyCharm and enables line break debugging.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. https://docs.google.com/document/d/1m5ittnVQjPSs2b4HNtCO7QEeykSqsLeXqLJYw8Cmmxw
2. Please comment on the doc for questions or clarifications.

### Steps
<!-- Enter each step of the test below -->
1. Documented instructions 

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Once set up, all ephemeral specified tests should run successfully. This mirrors our CI configuration.
