### PR TITLE
Remove the tomcat-embed-el dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -64,7 +64,6 @@ libraries["jackson-dataformat-xml"] = "com.fasterxml.jackson.dataformat:jackson-
 libraries["jackson-module-jakarta-xmlbind-annotations"] = "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:${jacksonVersion}"
 libraries["jackson-datatype-jsr310"] = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 libraries["jakarta-validation-api"] = "jakarta.validation:jakarta.validation-api:3.1.0"
-libraries["jakarta-el-impl"] = "org.apache.tomcat.embed:tomcat-embed-el:11.0.0"
 libraries["hibernate-validator"] = "org.hibernate.validator:hibernate-validator:8.0.1.Final"
 libraries["resteasy-client"] = "org.jboss.resteasy:resteasy-client:${resteasyVersion}"
 libraries["resteasy-multipart-provider"] = "org.jboss.resteasy:resteasy-multipart-provider:${resteasyVersion}"

--- a/swatch-product-configuration/build.gradle
+++ b/swatch-product-configuration/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     testImplementation libraries["junit-jupiter"]
     testImplementation libraries["hamcrest-all"]
     testImplementation libraries["hibernate-validator"]
-    testImplementation libraries["jakarta-el-impl"]
 }
 
 tasks.register("generateYamlIndex") {

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionRegistryTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -61,7 +62,11 @@ class SubscriptionDefinitionRegistryTest {
 
   @Test
   void testValidations() {
-    try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+    try (ValidatorFactory factory =
+        Validation.byDefaultProvider()
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory()) {
       var validator = factory.getValidator();
       for (var definition : subscriptionDefinitionRegistry.getSubscriptions()) {
         var violations = validator.validate(definition);


### PR DESCRIPTION
## Description
This dependency was used only in swatch-product-configuration for testing purposes and we don't really need it if we use the ParameterMessageInterpolator configuration instead.

Confirmed that the validations still work.

## Testing
Only regression testing.