### PR TITLE
SWATCH-3108: Use feeds name when openshift cluster uuid does not exist

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -183,11 +183,7 @@ public class InventoryController {
     log.debug("Received message from consumer: {}", consumer);
     ConduitFacts facts = new ConduitFacts();
     facts.setOrgId(consumer.getOrgId());
-    String clusterUuid = rhsmFacts.get(OPENSHIFT_CLUSTER_UUID);
-    // NOTE future displayName logic could consider more facts here
-    if (clusterUuid != null) {
-      facts.setDisplayName(clusterUuid);
-    }
+    extractDisplayName(consumer, rhsmFacts, facts);
     facts.setSubscriptionManagerId(normalizeUuid(consumer.getUuid()));
     facts.setInsightsId(normalizeUuid(rhsmFacts.get(INSIGHTS_ID)));
 
@@ -216,6 +212,20 @@ public class InventoryController {
 
     extractMarketPlaceFacts(rhsmFacts, facts);
     return facts;
+  }
+
+  private void extractDisplayName(
+      Consumer consumer, Map<String, String> rhsmFacts, ConduitFacts facts) {
+    // by the default, we use the consumer.name
+    String displayName = consumer.getName();
+
+    String clusterUuid = rhsmFacts.get(OPENSHIFT_CLUSTER_UUID);
+    if (clusterUuid != null) {
+      // When the openshift cluster UUID is set, we use it as display name.
+      displayName = clusterUuid;
+    }
+
+    facts.setDisplayName(displayName);
   }
 
   private void extractConversionsActivity(Map<String, String> rhsmFacts, ConduitFacts facts) {

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -902,6 +902,29 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testNameUsedAsDisplayNameWhenItIsNotOpenShiftCluster() throws ApiException {
+    UUID uuid = UUID.randomUUID();
+    Consumer consumer = new Consumer();
+    consumer.setName("TheName");
+    consumer.setOrgId("123");
+    consumer.setUuid(uuid.toString());
+
+    ConduitFacts expected = new ConduitFacts();
+    expected.setOrgId("123");
+    expected.setDisplayName("TheName");
+    expected.setSubscriptionManagerId(uuid.toString());
+    expected.setRhProd(new ArrayList<>());
+    expected.setSysPurposeAddons(new ArrayList<>());
+
+    when(rhsmService.getPageOfConsumers(eq("123"), nullable(String.class), anyString()))
+        .thenReturn(pageOf(consumer));
+
+    controller.updateInventoryForOrg("123");
+    verify(inventoryService).scheduleHostUpdate(expected);
+    verify(inventoryService, times(1)).flushHostUpdates();
+  }
+
+  @Test
   void testAdditionalFactsMapping() {
     Consumer consumer = new Consumer();
     // Operating System


### PR DESCRIPTION
Jira issue: SWATCH-3108

## Description
Before these changes, when the system was not an openshift cluster, we were not setting the display name.  When sending the message without display name, the inventory service in [here](https://github.com/RedHatInsights/insights-host-inventory/blob/b4b3f1d6d6ad79cc5ad93ac09f5bbe4df684e232/app/models.py#L97) uses the instance ID as display name.

To prevent the inventory service to use the instance ID as display name, conduit service needs to populate the display name always regardless if it's an openshift system.

## Testing
Added a test to reproduce the issue.