### PR TITLE
SWATCH-2297: Rename metric for ingested usage data from Prometheus

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -621,7 +621,7 @@ class EventControllerTest {
         .filter(
             m ->
                 INGESTED_USAGE_METRIC.equals(m.getId().getName())
-                    && productTag.equals(m.getId().getTag("product_tag"))
+                    && productTag.equals(m.getId().getTag("product"))
                     && metricId.equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))
         .findFirst();


### PR DESCRIPTION
Jira issue: SWATCH-2297
Relates to https://github.com/RedHatInsights/rhsm-subscriptions/pull/3888

## Description
These changes include:
- Rename metric from "rhsm-subscriptions.swatch_metrics_ingested_usage_total" to "swatch_metrics_ingested_usage_total"
- Rename tag from "product_tag" to "product"
- Use Counter.Builder for better readibility. 

This is to follow the same convention as written in the document attached in the JIRA ticket epic.

## Testing
### Setup
1. Start the needed services
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew :bootRun`

### Steps
1. Input event messages to the Kafka queue. Remember to increment the hour for each submission.
`{
  "sla": "Premium",
  "org_id": "111111111",
  "timestamp": "2024-10-24T15:00:00.0000+04:00",
  "conversion": false,
  "event_type": "snapshot_rhel-for-x86-els-payg-addon_vCPUs",
  "expiration": "2025-06-10T11:00:00.0000+04:00",
  "instance_id": "d147ddf2-be4a-4a59-acf7-7f222758b47d",
  "product_tag": [
    "rhel-for-x86-els-payg-addon"
  ],
  "display_name": "automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
  "event_source": "prometheus",
  "billing_provider": "aws",
  "measurements": [
    {
      "value": 4.0,
      "metric_id": "vCPUs"
    }
  ],
  "service_type": "RHEL System"
}`
2. Call the metrics endpoint.
`http ':9000/metrics' | grep 'swatch_metrics'`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Confirm the counter's sum based on the number of submissions.
`
swatch_metrics_ingested_usage_total{billing_provider="aws",metric_id="vCPUs",product="rhel-for-x86-els-payg-addon"} 8.0
`
