### PR TITLE
build: Increase amount of requested memory for build step

### DIFF
--- a/.tekton/swatch-contracts-pull-request.yaml
+++ b/.tekton/swatch-contracts-pull-request.yaml
@@ -30,6 +30,13 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 8Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/swatch-contracts-push.yaml
+++ b/.tekton/swatch-contracts-push.yaml
@@ -26,6 +26,13 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 8Gi
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
Jira issue: [KONFLUX-5392](https://issues.redhat.com/browse/KONFLUX-5392)

## Description
Increase amount of requested memory for build step as that memory is actualy being used. See this graph from `stone-prd-rh01`:

```
sum by (namespace, pod, container) (
    max_over_time(
        container_memory_working_set_bytes{container=~".*step-build.*", pod=~".*-build-container-pod", namespace="rh-subs-watch-tenant", pod=~"swatch-contracts-.*"}
    [1d])
)
```

![image](https://github.com/user-attachments/assets/1f591b17-904c-42ed-8d90-47bea0b28ff7)

Other components might need that change as well (only change in the query below is that `!~`):

```
sum by (namespace, pod, container) (
    max_over_time(
        container_memory_working_set_bytes{container=~".*step-build.*", pod=~".*-build-container-pod", namespace="rh-subs-watch-tenant", pod!~"swatch-contracts-.*"}
    [1d])
)
```

![image](https://github.com/user-attachments/assets/e0bcf284-07f1-483b-831d-ea0a20e44166)

### Verification
1. IMHO it is just necessary that build job in Konflux passes