### PR TITLE
Configure Jenkins pipelines to use kubedock latest image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ kind: Pod
 spec:
   containers:
     - name: kubedock
-      image: quay.io/cloudservices/kubedock:f8452a8
+      image: quay.io/cloudservices/kubedock:latest
+      imagePullPolicy: Always
       tty: true
       args:
        - server


### PR DESCRIPTION
Jira issue: No JIRA

## Description
Use latest tag for kubedock image. 

## Testing
Only regression testing.