### PR TITLE
Allow response content to be json formatted

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -64,6 +64,7 @@ quarkus.http.access-log.pattern=combined
 quarkus.management.enabled=true
 quarkus.management.port=9000
 quarkus.management.root-path=/
+quarkus.micrometer.export.json.enabled=true
 
 # database configuration
 quarkus.datasource.db-kind=postgresql

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -119,6 +119,7 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
+quarkus.micrometer.export.json.enabled=true
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -47,6 +47,7 @@ quarkus.http.access-log.pattern=combined
 quarkus.management.enabled=true
 quarkus.management.port=9000
 quarkus.management.root-path=/
+quarkus.micrometer.export.json.enabled=true
 
 #clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -50,6 +50,10 @@ quarkus:
     port: 9000
     # Configure the Quarkus non application paths to listen on "/" instead of "/q"
     root-path: /
+  micrometer:
+    export:
+      json:
+        enabled: true
   http:
     port: ${SERVER_PORT}
     test-port: 0

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -70,6 +70,7 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
+quarkus.micrometer.export.json.enabled=true
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -84,6 +84,7 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
+quarkus.micrometer.export.json.enabled=true
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
In the Prometheus metering endpoint, we will benefit from the response content being JSON formatted instead of plain text. This will allow built-in JSON parsers to be used.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1. Startup one of the Quarkus apps locally
`./gradlew :swatch-producer-aws:quarkusDev`

### Steps
<!-- Enter each step of the test below -->
1. Run against the Prometheus metrics endpoint
`http :9000/metrics Accept:application/json`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. The response should be in JSON format
2. You should get the plain text response if the Accept header is left off.
