### PR TITLE
SWATCH-3126: Improve traceability for swatch conduit service

### DIFF
--- a/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
+++ b/clients/rhsm-client/src/main/java/org/candlepin/subscriptions/conduit/rhsm/client/StubRhsmApi.java
@@ -21,23 +21,24 @@
 package org.candlepin.subscriptions.conduit.rhsm.client;
 
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.conduit.rhsm.client.model.Consumer;
 import org.candlepin.subscriptions.conduit.rhsm.client.model.InstalledProducts;
 import org.candlepin.subscriptions.conduit.rhsm.client.model.OrgInventory;
 import org.candlepin.subscriptions.conduit.rhsm.client.model.Pagination;
 import org.candlepin.subscriptions.conduit.rhsm.client.resources.RhsmApi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Stub class implementing RhsmApi that we can use for development against if the real thing is
  * unavailable
  */
+@Slf4j
 public class StubRhsmApi extends RhsmApi {
-  private static Logger log = LoggerFactory.getLogger(StubRhsmApi.class);
 
   private static final String MAX_ALLOWED_MEMORY_ORG_ID = "maxAllowedMemoryOrg";
   private static final String GCP_ORG_ID = "gcpOrg";
+  private static final String CONSUMER_1_ID = "consumer1id";
+  private static final String CONSUMER_2_ID = "consumer2id";
 
   @Override
   public OrgInventory getConsumersForOrg(
@@ -55,6 +56,7 @@ public class StubRhsmApi extends RhsmApi {
     OrgInventory inventory = new OrgInventory();
 
     Consumer consumer1 = new Consumer();
+    consumer1.setId(CONSUMER_1_ID);
     consumer1.setUuid(UUID.randomUUID().toString());
     consumer1.setOrgId(xRhsmApiAccountID);
     consumer1.setHypervisorName("hypervisor1.test.com");
@@ -94,8 +96,8 @@ public class StubRhsmApi extends RhsmApi {
     applyOrgIdUpdates(xRhsmApiAccountID, consumer1);
 
     Consumer consumer2 = new Consumer();
-    String consumer2Uuid = UUID.randomUUID().toString();
-    consumer2.setUuid(consumer2Uuid);
+    consumer2.setId(CONSUMER_2_ID);
+    consumer2.setUuid(UUID.randomUUID().toString());
     consumer2.setOrgId(xRhsmApiAccountID);
     consumer2.getFacts().put("network.fqdn", "host2.test.com");
 
@@ -103,7 +105,7 @@ public class StubRhsmApi extends RhsmApi {
     if (offset == null) {
       inventory.addBodyItem(consumer1);
       pagination.count(1L);
-    } else if (!consumer2Uuid.equals(offset)) {
+    } else if (!CONSUMER_2_ID.equals(offset)) {
       inventory.addBodyItem(consumer2);
       pagination.count(1L);
     } else {

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/SystemConduitConfiguration.java
@@ -22,13 +22,16 @@ package org.candlepin.subscriptions;
 
 import org.candlepin.subscriptions.clowder.KafkaSslBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
+import org.candlepin.subscriptions.tracing.TracingConfiguration;
 import org.candlepin.subscriptions.validator.IpAddressValidator;
 import org.candlepin.subscriptions.validator.MacAddressValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
 @Configuration
+@Import(TracingConfiguration.class)
 public class SystemConduitConfiguration {
   /**
    * A bean post-processor responsible for setting up Kafka truststores correctly. It's declared

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -632,12 +632,13 @@ public class InventoryController {
 
     if (size > 0) {
       inventoryService.flushHostUpdates();
+      log.info(
+          "Finished page w/ offset '{}' of inventory updates for org {}, producing {} updates",
+          Optional.ofNullable(offset).orElse(""),
+          orgId,
+          size);
     }
-    log.debug(
-        "Finished page w/ offset {} of inventory updates for org {}, producing {} updates",
-        offset,
-        orgId,
-        updateSize);
+
     Optional<String> nextOffset = getNextOffset(feedPage);
     if (nextOffset.isPresent()) {
       log.debug("Queueing up task for next page of org {}", orgId);
@@ -651,11 +652,16 @@ public class InventoryController {
 
   private Optional<String> getNextOffset(
       org.candlepin.subscriptions.conduit.rhsm.client.model.OrgInventory feedPage) {
+    String nextOffset = null;
     Pagination pagination = feedPage.getPagination();
-    if (pagination != null && pagination.getLimit().equals(pagination.getCount())) {
-      return Optional.of(feedPage.getBody().get(pagination.getCount().intValue() - 1).getId());
+    if (feedPage.getBody() != null
+        && !feedPage.getBody().isEmpty()
+        && pagination != null
+        && pagination.getLimit().equals(pagination.getCount())) {
+      nextOffset = feedPage.getBody().get(pagination.getCount().intValue() - 1).getId();
     }
-    return Optional.empty();
+
+    return Optional.ofNullable(nextOffset);
   }
 
   public OrgInventory getInventoryForOrg(String orgId, String offset)

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/tasks/UpdateOrgInventoryTask.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/tasks/UpdateOrgInventoryTask.java
@@ -20,24 +20,23 @@
  */
 package org.candlepin.subscriptions.conduit.tasks;
 
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.conduit.InventoryController;
 import org.candlepin.subscriptions.exception.ErrorCode;
 import org.candlepin.subscriptions.exception.ExternalServiceException;
 import org.candlepin.subscriptions.task.Task;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.candlepin.subscriptions.util.LogUtils;
 
 /**
  * A task that retrieves the Consumer data associated with an organization from RHSM API, and sends
  * that data into the insights host inventory.
  */
+@Slf4j
 public class UpdateOrgInventoryTask implements Task {
 
-  private static Logger log = LoggerFactory.getLogger(UpdateOrgInventoryTask.class);
-
-  private String orgId;
-  private String offset;
-  private InventoryController controller;
+  private final String orgId;
+  private final String offset;
+  private final InventoryController controller;
 
   public UpdateOrgInventoryTask(InventoryController controller, String orgId, String offset) {
     this.orgId = orgId;
@@ -47,6 +46,7 @@ public class UpdateOrgInventoryTask implements Task {
 
   @Override
   public void execute() {
+    LogUtils.addOrgIdToMdc(orgId);
     log.info("Updating inventory for org {} with offset {}", orgId, offset);
     try {
       controller.updateInventoryForOrg(orgId, offset);
@@ -56,6 +56,8 @@ public class UpdateOrgInventoryTask implements Task {
       } else {
         log.error("Exception calling RHSM for org {}", orgId, e);
       }
+    } finally {
+      LogUtils.clearOrgIdFromMdc();
     }
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-3126

## Description
- Add orgId MDC to sync orgs workflow
- Add traceId for every logs
- Support for traceresponse for HTTP requests
- Fixed stub rhsm API to work fine with the offset: before these changes, it was using the uuid which is not correct; after these changes the id is used and this identifier should not be autogenerated, so the equal condition works 

When doing a sync for one account. Example:
```
http :8005/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=org123
```
We should see the trace ID in the "traceresponse" response:
```
HTTP/1.1 200 
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: keep-alive
Content-Length: 20
Content-Type: application/vnd.api+json
Date: Wed, 20 Nov 2024 06:12:47 GMT
Expires: 0
Keep-Alive: timeout=60
Pragma: no-cache
Set-Cookie: JSESSIONID=D91C434F673A9D97EDC73676A1A95126; Path=/; HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0
traceresponse: 00-e861d11055c4675e01093c73ed606fa9-344caadf992b1d6c-01
```

The trace ID is the second token "e861d11055c4675e01093c73ed606fa9".

Searching in Splunk by this trace ID: `properties.traceId="e861d11055c4675e01093c73ed606fa9"`, we should see at least the following messages correlated: 

```
2024-11-20 06:58:55,295 [thread=http-nio-8005-exec-3] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/syncOrg requested by user: self
2024-11-20 06:58:43,581 [thread=rhsm-conduit-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.conduit.InventoryController] - Finished page w/ offset '' of inventory updates for org org123, producing 1 updates
2024-11-20 06:58:43,610 [thread=rhsm-conduit-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.conduit.InventoryController] - Finished page w/ offset 'consumer1id' of inventory updates for org org123, producing 1 updates
2024-11-20 06:58:43,660 [thread=rhsm-conduit-task-processor-0-C-1] [INFO ] [org.candlepin.subscriptions.conduit.InventoryController] - Host inventory update completed for org org123.
```

## Testing
To verify these changes, follow the new section from the playbook observability guide.