### PR TITLE
SWATCH-3050: Update usage context subscriptions counters by product

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
@@ -41,26 +41,20 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class UsageContextSubscriptionProvider {
 
-  protected static final String MISSING_SUBSCRIPTIONS_COUNTER_NAME = "swatch_missing_subscriptions";
-  protected static final String AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME =
+  public static final String MISSING_SUBSCRIPTIONS_COUNTER_NAME = "swatch_missing_subscriptions";
+  public static final String AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME =
       "swatch_ambiguous_subscriptions";
   private final SubscriptionRepository subscriptionRepository;
   private final MeterRegistry meterRegistry;
 
   public Optional<SubscriptionEntity> getSubscription(DbReportCriteria criteria) {
-    var providerString = criteria.getBillingProvider().getValue();
-    var missingSubscriptionCounter =
-        meterRegistry.counter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, "provider", providerString);
-    var ambiguousSubscriptionCounter =
-        meterRegistry.counter(AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, "provider", providerString);
-
     List<SubscriptionEntity> subscriptions =
         subscriptionRepository.findByCriteria(
             criteria, Sort.descending(SubscriptionEntity_.START_DATE));
 
     if (subscriptions.isEmpty()) {
       log.warn("No subscription found for criteria {}", criteria);
-      missingSubscriptionCounter.increment();
+      incrementCounter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, criteria);
       throw new NotFoundException();
     }
 
@@ -90,15 +84,26 @@ public class UsageContextSubscriptionProvider {
             "");
       } else {
         log.warn("No active subscription found for criteria {}", criteria);
-        missingSubscriptionCounter.increment();
+        incrementCounter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, criteria);
         throw new NotFoundException();
       }
     }
 
     if (activeSubscriptions.size() > 1) {
-      ambiguousSubscriptionCounter.increment();
       log.warn("Multiple subscriptions found for criteria {}. Selecting first result", criteria);
+      incrementCounter(AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, criteria);
     }
     return activeSubscriptions.stream().findFirst();
+  }
+
+  private void incrementCounter(String counterName, DbReportCriteria criteria) {
+    meterRegistry
+        .counter(
+            counterName,
+            "provider",
+            criteria.getBillingProvider().getValue(),
+            "product",
+            criteria.getProductTag())
+        .increment();
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
@@ -41,15 +41,18 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class UsageContextSubscriptionProvider {
 
+  protected static final String MISSING_SUBSCRIPTIONS_COUNTER_NAME = "swatch_missing_subscriptions";
+  protected static final String AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME =
+      "swatch_ambiguous_subscriptions";
   private final SubscriptionRepository subscriptionRepository;
   private final MeterRegistry meterRegistry;
 
   public Optional<SubscriptionEntity> getSubscription(DbReportCriteria criteria) {
     var providerString = criteria.getBillingProvider().getValue();
     var missingSubscriptionCounter =
-        meterRegistry.counter("swatch_missing_subscriptions", "provider", providerString);
+        meterRegistry.counter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, "provider", providerString);
     var ambiguousSubscriptionCounter =
-        meterRegistry.counter("swatch_ambiguous_subscriptions", "provider", providerString);
+        meterRegistry.counter(AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, "provider", providerString);
 
     List<SubscriptionEntity> subscriptions =
         subscriptionRepository.findByCriteria(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -21,6 +21,8 @@
 package com.redhat.swatch.contract.resource;
 
 import static com.redhat.swatch.contract.resource.ContractsResource.FEATURE_NOT_ENABLED_MESSAGE;
+import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME;
+import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.MISSING_SUBSCRIPTIONS_COUNTER_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -47,7 +49,6 @@ import com.redhat.swatch.contract.service.EnabledOrgsProducer;
 import com.redhat.swatch.contract.service.OfferingProductTagLookupService;
 import com.redhat.swatch.contract.service.OfferingSyncService;
 import com.redhat.swatch.contract.service.SubscriptionSyncService;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -62,6 +63,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -73,6 +75,7 @@ class ContractsResourceTest {
 
   private static final String SKU = "mw123";
   private static final String ORG_ID = "org123";
+  private static final String ROSA = "rosa";
   private final OffsetDateTime defaultEndDate =
       OffsetDateTime.of(2022, 7, 22, 8, 0, 0, 0, ZoneOffset.UTC);
   private final OffsetDateTime defaultLookUpDate =
@@ -86,6 +89,11 @@ class ContractsResourceTest {
   @InjectMock SubscriptionRepository subscriptionRepository;
   @Inject ContractsResource resource;
   @Inject MeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setup() {
+    meterRegistry.clear();
+  }
 
   @Test
   void testSyncAllSubscriptionsWhenFeatureIsNotEnabled() {
@@ -175,34 +183,28 @@ class ContractsResourceTest {
 
   @Test
   void incrementsMissingCounterWhenAccountNumberPresent() {
-    Counter counter = meterRegistry.counter("swatch_missing_subscriptions", "provider", "aws");
-    var initialCount = counter.count();
     when(subscriptionRepository.findByCriteria(any())).thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                defaultLookUpDate, "rosa", null, "Premium", "Production", "123"));
-    assertEquals(1.0, counter.count() - initialCount);
+                defaultLookUpDate, ROSA, null, "Premium", "Production", "123"));
+    thenMissingSubscriptionsMetricIs("aws", 1.0);
   }
 
   @Test
   void incrementsMissingCounterWhenOrgIdPresent() {
-    Counter counter = meterRegistry.counter("swatch_missing_subscriptions", "provider", "aws");
-    var initialCount = counter.count();
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(Collections.emptyList());
     assertThrows(
         NotFoundException.class,
         () ->
             resource.getAwsUsageContext(
-                defaultLookUpDate, "rosa", "org123", "Premium", "Production", "123"));
-    assertEquals(1.0, counter.count() - initialCount);
+                defaultLookUpDate, ROSA, "org123", "Premium", "Production", "123"));
+    thenMissingSubscriptionsMetricIs("aws", 1.0);
   }
 
   @Test
   void incrementsAmbiguousCounterWhenOrgIdPresent() {
-    Counter counter = meterRegistry.counter("swatch_ambiguous_subscriptions", "provider", "aws");
-    var initialCount = counter.count();
     SubscriptionEntity sub1 = new SubscriptionEntity();
     sub1.setBillingProviderId("foo1;foo2;foo3");
     sub1.setEndDate(defaultEndDate);
@@ -212,9 +214,9 @@ class ContractsResourceTest {
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(List.of(sub1, sub2));
     AwsUsageContext awsUsageContext =
         resource.getAwsUsageContext(
-            defaultLookUpDate, "rosa", "org123", "Premium", "Production", "123");
+            defaultLookUpDate, ROSA, "org123", "Premium", "Production", "123");
 
-    assertEquals(1.0, counter.count() - initialCount);
+    thenAmbiguousSubscriptionsMetricIs("aws", 1.0);
     assertEquals("foo1", awsUsageContext.getProductCode());
     assertEquals("foo2", awsUsageContext.getCustomerId());
     assertEquals("foo3", awsUsageContext.getAwsSellerAccountId());
@@ -234,7 +236,7 @@ class ContractsResourceTest {
             ServiceException.class,
             () -> {
               resource.getAwsUsageContext(
-                  lookupDate, "rosa", "org123", "Premium", "Production", "123");
+                  lookupDate, ROSA, "org123", "Premium", "Production", "123");
             });
 
     assertEquals(
@@ -254,7 +256,7 @@ class ContractsResourceTest {
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
     AwsUsageContext awsUsageContext =
-        resource.getAwsUsageContext(lookupDate, "rosa", "org123", "Premium", "Production", "123");
+        resource.getAwsUsageContext(lookupDate, ROSA, "org123", "Premium", "Production", "123");
     assertEquals("bar1", awsUsageContext.getProductCode());
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());
@@ -277,8 +279,6 @@ class ContractsResourceTest {
 
   @Test
   void incrementsRhmMissingSubscriptionsCounter() {
-    Counter counter = meterRegistry.counter("swatch_missing_subscriptions", "provider", "red hat");
-    var initialValue = counter.count();
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(Collections.emptyList());
 
     OffsetDateTime now = OffsetDateTime.now();
@@ -287,18 +287,14 @@ class ContractsResourceTest {
     assertThrows(
         NotFoundException.class,
         () -> {
-          resource.getRhmUsageContext("org123", now, "productId", sla, usage);
+          resource.getRhmUsageContext("org123", now, ROSA, sla, usage);
         });
 
-    assertEquals(1.0, counter.count() - initialValue);
+    thenMissingSubscriptionsMetricIs("red hat", 1.0);
   }
 
   @Test
   void incrementsRhmAmbiguousSubscriptionsCounter() {
-    Counter counter =
-        meterRegistry.counter("swatch_ambiguous_subscriptions", "provider", "red hat");
-    var initialValue = counter.count();
-
     SubscriptionEntity sub1 = new SubscriptionEntity();
     sub1.setBillingProviderId("account123");
     sub1.setStartDate(OffsetDateTime.now());
@@ -315,11 +311,11 @@ class ContractsResourceTest {
         resource.getRhmUsageContext(
             "org123",
             OffsetDateTime.now(),
-            "productId",
+            ROSA,
             ServiceLevel.PREMIUM.toString(),
             Usage.PRODUCTION.toString());
 
-    assertEquals(1.0, counter.count() - initialValue);
+    thenAmbiguousSubscriptionsMetricIs("red hat", 1.0);
     assertEquals("account123", rhmUsageContext.getRhSubscriptionId());
   }
 
@@ -340,5 +336,18 @@ class ContractsResourceTest {
         resource.getAzureMarketplaceContext(
             lookupDate, "BASILISK", "org123", "Premium", "Production", "azureSubscriptionId2");
     assertEquals("resourceId2", azureUsageContext.getAzureResourceId());
+  }
+
+  void thenAmbiguousSubscriptionsMetricIs(String provider, double expected) {
+    thenMetricIs(AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, provider, expected);
+  }
+
+  void thenMissingSubscriptionsMetricIs(String provider, double expected) {
+    thenMetricIs(MISSING_SUBSCRIPTIONS_COUNTER_NAME, provider, expected);
+  }
+
+  void thenMetricIs(String metric, String provider, double expected) {
+    assertEquals(
+        expected, meterRegistry.counter(metric, "provider", provider, "product", ROSA).count());
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProviderTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProviderTest.java
@@ -20,11 +20,11 @@
  */
 package com.redhat.swatch.contract.service;
 
+import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME;
+import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.MISSING_SUBSCRIPTIONS_COUNTER_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.common.model.ServiceLevel;
 import com.redhat.swatch.common.model.Usage;
@@ -32,84 +32,79 @@ import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.DbReportCriteria;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.NotFoundException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@QuarkusTest
 class UsageContextSubscriptionProviderTest {
 
-  private static final String MISSING_SUBSCRIPTIONS_COUNTER_NAME = "swatch_missing_subscriptions";
-  private static final String AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME =
-      "swatch_ambiguous_subscriptions";
+  private static final String ORG_ID = "org123";
+  private static final String BILLING_ACCOUNT_ID = "123";
+  private static final Usage USAGE = Usage.PRODUCTION;
+  private static final ServiceLevel SLA = ServiceLevel.PREMIUM;
+  private static final String PRODUCT = "rosa";
+  private static final BillingProvider BILLING_PROVIDER = BillingProvider.AWS;
   private static final OffsetDateTime DEFAULT_END_DATE =
       OffsetDateTime.of(2022, 7, 22, 8, 0, 0, 0, ZoneOffset.UTC);
 
-  @Mock private SubscriptionRepository repo;
-  private MeterRegistry meterRegistry;
-  private UsageContextSubscriptionProvider provider;
+  @Inject SubscriptionRepository repo;
+  @Inject OfferingRepository offeringRepository;
+  @Inject MeterRegistry meterRegistry;
+  @Inject UsageContextSubscriptionProvider provider;
   private DbReportCriteria criteria;
+  private OfferingEntity offering;
 
+  @Transactional
   @BeforeEach
   void setupTest() {
     givenDefaultCriteria();
-    meterRegistry = new SimpleMeterRegistry();
-    provider = new UsageContextSubscriptionProvider(repo, meterRegistry);
+    repo.deleteAll();
+    offeringRepository.deleteAll();
+    givenExistingOffering();
   }
 
   @Test
   void incrementsMissingCounterWhenOrgIdPresent() {
-    when(repo.findByCriteria(any(), any())).thenReturn(Collections.emptyList());
     assertThrows(NotFoundException.class, this::whenGetSubscriptions);
-    Counter counter = meterRegistry.counter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, "provider", "aws");
+    Counter counter =
+        meterRegistry.counter(
+            MISSING_SUBSCRIPTIONS_COUNTER_NAME, "provider", BILLING_PROVIDER.getValue());
     assertEquals(1.0, counter.count());
   }
 
   @Test
   void incrementsAmbiguousCounterWhenOrgIdPresent() {
-    SubscriptionEntity sub1 = new SubscriptionEntity();
-    sub1.setSubscriptionId("SUB1");
-    sub1.setBillingProviderId("foo1;foo2;foo3");
-    sub1.setBillingAccountId("123");
-    sub1.setEndDate(DEFAULT_END_DATE);
-    SubscriptionEntity sub2 = new SubscriptionEntity();
-    sub2.setSubscriptionId("SUB2");
-    sub2.setBillingProviderId("bar1;bar2;bar3");
-    sub2.setBillingAccountId("123");
-    sub2.setEndDate(DEFAULT_END_DATE);
-
-    when(repo.findByCriteria(any(), any())).thenReturn(List.of(sub1, sub2));
-
+    var sub1 = givenNewSubscription();
+    givenNewSubscription();
     Optional<SubscriptionEntity> subscription = whenGetSubscriptions();
     assertTrue(subscription.isPresent());
-    assertEquals("SUB1", subscription.get().getSubscriptionId());
+    assertEquals(sub1.getSubscriptionId(), subscription.get().getSubscriptionId());
 
     Counter counter =
-        meterRegistry.counter(AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, "provider", "aws");
+        meterRegistry.counter(
+            AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME, "provider", BILLING_PROVIDER.getValue());
     assertEquals(1.0, counter.count());
   }
 
   @Test
   void shouldThrowSubscriptionsExceptionForTerminatedSubscriptionWhenOrgIdPresent() {
     var endDate = OffsetDateTime.of(2022, 1, 1, 6, 0, 0, 0, ZoneOffset.UTC);
-    SubscriptionEntity sub1 = new SubscriptionEntity();
-    sub1.setBillingProviderId("foo1;foo2;foo3");
-    sub1.setBillingAccountId("123");
-    sub1.setEndDate(endDate);
-    when(repo.findByCriteria(any(), any())).thenReturn(List.of(sub1));
+    givenNewSubscriptionWithEndDate(endDate);
 
     givenCriteriaWithEnding(endDate.plusMinutes(30));
     var exception = assertThrows(ServiceException.class, this::whenGetSubscriptions);
@@ -122,21 +117,45 @@ class UsageContextSubscriptionProviderTest {
   @Test
   void shouldReturnActiveSubscriptionAndNotTerminatedWhenOrgIdPresent() {
     var endDate = OffsetDateTime.of(2022, 1, 1, 6, 0, 0, 0, ZoneOffset.UTC);
-    SubscriptionEntity sub1 = new SubscriptionEntity();
-    sub1.setBillingProviderId("foo1;foo2;foo3");
-    sub1.setBillingAccountId("123");
-    sub1.setEndDate(endDate);
-    SubscriptionEntity sub2 = new SubscriptionEntity();
-    sub2.setBillingProviderId("bar1;bar2;bar3");
-    sub2.setBillingAccountId("123");
-    sub2.setEndDate(endDate.plusMinutes(45));
-
-    when(repo.findByCriteria(any(), any())).thenReturn(List.of(sub1, sub2));
+    givenNewSubscriptionWithEndDate(endDate);
+    var sub2 = givenNewSubscriptionWithEndDate(endDate.plusMinutes(30));
 
     givenCriteriaWithEnding(endDate.plusMinutes(30));
     Optional<SubscriptionEntity> subscription = whenGetSubscriptions();
     assertTrue(subscription.isPresent());
-    assertEquals(sub2, subscription.get());
+    assertEquals(sub2.getSubscriptionId(), subscription.get().getSubscriptionId());
+  }
+
+  SubscriptionEntity givenNewSubscription() {
+    return givenNewSubscription(DEFAULT_END_DATE);
+  }
+
+  SubscriptionEntity givenNewSubscriptionWithEndDate(OffsetDateTime endDate) {
+    return givenNewSubscription(endDate);
+  }
+
+  @Transactional
+  SubscriptionEntity givenNewSubscription(OffsetDateTime endDate) {
+    SubscriptionEntity sub = new SubscriptionEntity();
+    sub.setSubscriptionId(UUID.randomUUID().toString());
+    sub.setBillingProvider(BILLING_PROVIDER);
+    sub.setBillingProviderId(UUID.randomUUID().toString());
+    sub.setBillingAccountId(BILLING_ACCOUNT_ID);
+    sub.setStartDate(endDate.minusDays(10));
+    sub.setEndDate(endDate);
+    sub.setOrgId(ORG_ID);
+    sub.setOffering(offering);
+    repo.persist(sub);
+    return sub;
+  }
+
+  private void givenExistingOffering() {
+    offering = new OfferingEntity();
+    offering.setSku(UUID.randomUUID().toString());
+    offering.setUsage(USAGE);
+    offering.setServiceLevel(SLA);
+    offering.setProductTags(Set.of(PRODUCT));
+    offeringRepository.persist(offering);
   }
 
   private void givenDefaultCriteria() {
@@ -146,12 +165,12 @@ class UsageContextSubscriptionProviderTest {
   private void givenCriteriaWithEnding(OffsetDateTime ending) {
     this.criteria =
         DbReportCriteria.builder()
-            .orgId("org123")
-            .productTag("rosa")
-            .serviceLevel(ServiceLevel.PREMIUM)
-            .usage(Usage.PRODUCTION)
-            .billingProvider(BillingProvider.AWS)
-            .billingAccountId("123")
+            .orgId(ORG_ID)
+            .productTag(PRODUCT)
+            .serviceLevel(SLA)
+            .usage(USAGE)
+            .billingProvider(BILLING_PROVIDER)
+            .billingAccountId(BILLING_ACCOUNT_ID)
             .beginning(ending.minusHours(1))
             .ending(ending)
             .build();


### PR DESCRIPTION
Related to Jira issue: SWATCH-3050 and SWATCH-3125

## Description
These changes are about to update the existing counters when getting the subscription usage for aws and azure:
- swatch_missing_subscriptions
- swatch_ambiguous_subscriptions

By adding the "product" dimension. 
After merging these changes, we could add a plot to see the numbers by product to early detect misconfigurations.

Apart from these changes, I converted the existing UsageContextSubscriptionProviderTest to a QuarkusTest, to better cover the SQL query.

## Testing
Only regression testing.