### PR TITLE
SWATCH-3015: Add the kafka key with "org_id" to host-inventory topic

### DIFF
--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryService.java
@@ -111,7 +111,7 @@ public class KafkaEnabledInventoryService extends InventoryService {
   private void sendToKafka(OffsetDateTime now, ConduitFacts factSet) {
     CreateUpdateHostMessage message = new CreateUpdateHostMessage(createHost(factSet, now));
     message.setMetadata("request_id", UUID.randomUUID().toString());
-    producer.send(hostIngressTopic, message).handle(this::handleResult);
+    producer.send(hostIngressTopic, factSet.getOrgId(), message).handle(this::handleResult);
   }
 
   private SendResult<String, CreateUpdateHostMessage> handleResult(


### PR DESCRIPTION
Jira issue: SWATCH-3015

## Description
The key in a Kafka message ensures that the messages the same key are delivered to the same Kafka partition and the order of messages arrival is maintained.  This should help host-inventory to to avoid host-duplication.

 Add "key: org_id" to Kafka messages destined for "Host-Inventory" for creating/update hosts.

## Testing
1. podman-compose up
2. RHSM_USE_STUB=true DEV_MODE=true ./gradlew :swatch-system-conduit:bootRun
3. http :8000/api/rhsm-subscriptions/v1/internal/rpc/syncOrg   x-rh-swatch-psk:placeholder   org_id=7687094
4. verify key is now the org_id in http://localhost:3030/#/cluster/default/topic/n/platform.inventory.host-ingress/

Before these changes, the key was empty:

![Captura de pantalla de 2024-12-02 10-43-45](https://github.com/user-attachments/assets/e53a71d6-99c1-4de2-a81e-c887b355ab8f)

After these changes, the key is property setup:

![Captura de pantalla de 2024-12-02 10-41-45](https://github.com/user-attachments/assets/86c4c41b-206f-4b0b-8e96-139e37bba512)


