### PR TITLE
SWATCH-3128: Disabling Kafka client config providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,9 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod -R g=u /deployments
 
 USER default
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.BootApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -7,7 +7,7 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
-  - name: JAVA_OPTS_APPEND
+  - name: USER_OPTS_APPEND
     value: ''
   - name: DEV_MODE
     value: 'false'
@@ -149,8 +149,8 @@ objects:
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}
-              - name: JAVA_OPTS_APPEND
-                value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
+              - name: USER_OPTS_APPEND
+                value: -javaagent:/opt/splunk-otel-javaagent.jar
               - name: DEV_MODE
                 value: ${DEV_MODE}
               - name: LOG_FILE

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -143,5 +143,10 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -142,5 +142,10 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -143,5 +143,10 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -144,5 +144,10 @@ RUN chmod 775 /deployments /deployments/*
 EXPOSE 8080
 
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -144,5 +144,10 @@ RUN chmod 775 /deployments /deployments/*
 EXPOSE 8080
 
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -142,5 +142,10 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Standard Quarkus JVM properties
+ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
+++ b/swatch-producer-red-hat-marketplace/deploy/clowdapp.yaml
@@ -7,7 +7,7 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
-  - name: JAVA_OPTS_APPEND
+  - name: USER_OPTS_APPEND
     value: ''
   - name: SERVER_MAX_HTTP_HEADER_SIZE
     value: '96000'
@@ -184,8 +184,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
-            - name: JAVA_OPTS_APPEND
-              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
+            - name: USER_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar
             - name: SPRING_LIQUIBASE_ENABLED
               value: 'false'
             - name: ENABLE_SPLUNK_HEC

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -7,7 +7,7 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
-  - name: JAVA_OPTS_APPEND
+  - name: USER_OPTS_APPEND
     value: ''
   - name: ENV_NAME
     value: env-swatch-subscription-sync
@@ -186,8 +186,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
-            - name: JAVA_OPTS_APPEND
-              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
+            - name: USER_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar
             - name: SPRING_LIQUIBASE_ENABLED
               value: 'false'
             - name: ENABLE_SPLUNK_HEC

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -53,5 +53,9 @@ COPY --from=0 /stage/swatch-system-conduit/build/javaagent/* /opt/
 RUN chmod -R g=u /deployments
 
 USER default
+# Custom JVM properties
+## Fix CVE-2024-31141: Disabling Kafka client config providers
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.SystemConduitApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -7,7 +7,7 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
-  - name: JAVA_OPTS_APPEND
+  - name: USER_OPTS_APPEND
     value: ''
   - name: TOLERATE_MISSING_ACCOUNT_NUMBER
     value: 'false'
@@ -153,8 +153,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
-            - name: JAVA_OPTS_APPEND
-              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
+            - name: USER_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar
             - name: SPRING_LIQUIBASE_ENABLED
               value: 'false'
             - name: ENABLE_SPLUNK_HEC

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -7,7 +7,7 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
-  - name: JAVA_OPTS_APPEND
+  - name: USER_OPTS_APPEND
     value: ''
   - name: ENV_NAME
     value: env-swatch-tally
@@ -308,8 +308,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
-            - name: JAVA_OPTS_APPEND
-              value: -javaagent:/opt/splunk-otel-javaagent.jar ${JAVA_OPTS_APPEND}
+            - name: USER_OPTS_APPEND
+              value: -javaagent:/opt/splunk-otel-javaagent.jar
             - name: ENABLE_SPLUNK_HEC
               value: ${ENABLE_SPLUNK_HEC}
             - name: SPLUNKMETA_namespace


### PR DESCRIPTION
Jira issue: SWATCH-3128

## Description
I confirmed that we're already using kafka-clients >=3.8.0, so we need to explicitly set the JVM system property "org.apache.kafka.automatic.config.providers=none" to avoid this security risk. 

## Tests
Only regression testing.