### PR TITLE
SWATCH-3185: Fix duplicated traces in splunk for spring boot services

### DIFF
--- a/docs/playbooks/observability.md
+++ b/docs/playbooks/observability.md
@@ -43,6 +43,7 @@ java -DENABLE_SPLUNK_HEC=true \
 -DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
 -DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true \
 -DSPLUNK_SOURCE_TYPE=springboot_server \
+-DINVENTORY_DATABASE_SCHEMA=hbi \
 -Dspring.profiles.active=worker,api,kafka-queue \
 -jar build/libs/rhsm-subscriptions-*.jar
 ```

--- a/swatch-core/src/main/resources/logback-spring.xml
+++ b/swatch-core/src/main/resources/logback-spring.xml
@@ -21,7 +21,7 @@
         </encoder>
     </appender>
 
-    <appender name="SplunkAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE:-/tmp/rhsm-subscriptions.log}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
         <!-- daily rollover -->
@@ -38,7 +38,7 @@
 
     <root level="WARN">
         <appender-ref ref="ConsoleAppender" />
-        <appender-ref ref="SplunkAppender" />
+        <appender-ref ref="FileAppender" />
     </root>
 
     <!--
@@ -72,10 +72,6 @@
             </appender>
 
             <logger name="splunk.logger" additivity="false" level="INFO">
-                <appender-ref ref="http"/>
-            </logger>
-
-            <logger name="org.candlepin" level="INFO">
                 <appender-ref ref="http"/>
             </logger>
 


### PR DESCRIPTION
Jira issue: SWATCH-3185

## Description
Changes:
- Rename SplunkAppender to FileAppender since this is nothing to do with splunk
- Remove the "org.candlepin" logger in the splunk appender which is causing the duplicates

## Testing

1.- start kafka, database...: `podman-compose up`
2.- start local splunk: `podman-compose -f config/splunk/docker-compose.yml up -d`
3.- build: `./gradlew clean build -x test`
4.- start the tally service:

```
java -DENABLE_SPLUNK_HEC=true \
-DSERVER_PORT=8003 \
-DMANAGEMENT_PORT=9003 \
-DSPLUNK_HEC_URL=https://localhost:8088 \
-DSPLUNK_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
-DSPLUNK_DISABLE_CERTIFICATE_VALIDATION=true \
-DSPLUNK_SOURCE_TYPE=springboot_server \
-DINVENTORY_DATABASE_SCHEMA=hbi \
-Dspring.profiles.active=worker,api,kafka-queue \
-jar build/libs/rhsm-subscriptions-*.jar
```

5.- do any action, for example:
```
http PUT ":8003/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/12345678" x-rh-swatch-psk:placeholder
```

6.- verify the logs are not duplicated: go to your local splunk at http://localhost:8000 and search any logs, for example: "Started BootApplication".

In this branch, you should only see one trace. 
In main, doing the same above steps, you see the same trace duplicated.