### PR TITLE
Force the compileJava order when building the projects in parallel

### DIFF
--- a/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-conventions.gradle
@@ -16,6 +16,9 @@ dependencies {
     testImplementation 'io.quarkus:quarkus-jacoco'
 }
 
+// Workaround for https://github.com/quarkusio/quarkus/issues/38996 to force the compileJava order when building the projects in parallel
+compileJava.dependsOn tasks.compileQuarkusGeneratedSourcesJava
+
 test {
     finalizedBy jacocoTestReport
     jacoco {


### PR DESCRIPTION
## Description
This is a workaround for https://github.com/quarkusio/quarkus/issues/38996 which seems to be happening only randomly. Note that disabling the parallel build, it also works.

## Testing
Only regression testing. 