### PR TITLE
SWATCH-3167: Add primary keys to all tables

### DIFF
--- a/init_dbs.sh
+++ b/init_dbs.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/bin/bash -x
+# https://github.com/olivergondza/bash-strict-mode
+set -eEuo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 if [[ -v POSTGRESQL_USER || -v POSTGRESQL_PASSWORD || -v POSTGRESQL_DATABASE ]]; then
   cat >&2 <<EOF

--- a/postgresql.conf
+++ b/postgresql.conf
@@ -1,2 +1,3 @@
 hba_file = '/pg_hba.conf'
 listen_addresses = '*'
+shared_preload_libraries = 'pg_stat_statements'

--- a/src/main/resources/liquibase/202412041537-primary-keys-on-all-tables.xml
+++ b/src/main/resources/liquibase/202412041537-primary-keys-on-all-tables.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <!--
+  These changeSets are only for PostgreSQL because the primary keys we're adding are just to satisfy
+  PostgreSQL's requirements for logical replication.  See
+  https://www.postgresql.org/docs/12/logical-replication-publication.html
+
+  Consequently, these keys aren't mapped in JPA so we don't need to worry about them during
+  in-memory DB tests.
+  -->
+  <changeSet id="202412041537-01" author="awood" dbms="postgresql">
+    <!--
+    Creating an extension requires superuser permissions.  But in production and stage, we don't
+    have those permissions.  We have to create the extension in an out-of-band migration.
+
+    The creation command checks permissions before it checks the extensions existence, so even an
+    invocation that would have no effect will cause the changeset to fail.  Accordingly, we have to
+    have a pre-condition to check if we should even attempt to create the extension.  That way we
+    can use the same changeset in both development and production.
+    -->
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT count(1) FROM pg_extension WHERE extname = 'uuid-ossp';
+      </sqlCheck>
+    </preConditions>
+
+    <sql>
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    </sql>
+    <!--
+    I am intentionally not providing a rollback because we have two change logs: this one and
+    the one for swatch-contracts.  Rolling back the extension in one changelog could adversely
+    affect the operations of the other changelog.
+    -->
+  </changeSet>
+
+  <changeSet id="202412041537-02" author="awood" dbms="postgresql">
+    <addColumn tableName="databasechangelog">
+      <column name="uuid" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202412041537-03" author="awood" dbms="postgresql">
+    <addColumn tableName="sku_child_sku">
+      <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202412041537-04" author="awood" dbms="postgresql">
+    <addColumn tableName="sku_oid">
+      <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202412041537-05" author="awood" dbms="postgresql">
+    <addColumn tableName="sku_product_tag">
+      <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -175,5 +175,6 @@
     <include file="/liquibase/202410021300-update_usages_to_unknown.xml"/>
     <include file="/liquibase/202410211200-retry-after-billable-usage-index.xml"/>
     <include file="/liquibase/202410241408-clear-retryable.xml"/>
+    <include file="/liquibase/202412041537-primary-keys-on-all-tables.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-contracts/src/main/resources/db/202412051144-primary-keys-on-changelog-table.xml
+++ b/swatch-contracts/src/main/resources/db/202412051144-primary-keys-on-changelog-table.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <!--
+  These changeSets are only for PostgreSQL because the primary keys we're adding are just to satisfy
+  PostgreSQL's requirements for logical replication.  See
+  https://www.postgresql.org/docs/12/logical-replication-publication.html
+
+  Consequently, these keys aren't mapped in JPA so we don't need to worry about them during
+  in-memory DB tests.
+  -->
+  <changeSet id="202412051144-01" author="awood" dbms="postgresql">
+    <!--
+    Creating an extension requires superuser permissions.  But in production and stage, we don't
+    have those permissions.  We have to create the extension in an out-of-band migration.
+
+    The creation command checks permissions before it checks the extensions existence, so even an
+    invocation that would have no effect will cause the changeset to fail.  Accordingly, we have to
+    have a pre-condition to check if we should even attempt to create the extension.  That way we
+    can use the same changeset in both development and production.
+    -->
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT count(1) FROM pg_extension WHERE extname = 'uuid-ossp';
+      </sqlCheck>
+    </preConditions>
+    <sql>
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    </sql>
+    <!--
+    I am intentionally not providing a rollback because we have two change logs: this one and
+    the one for swatch-contracts.  Rolling back the extension in one changelog could adversely
+    affect the operations of the other changelog.
+    -->
+  </changeSet>
+
+  <changeSet id="202412051144-02" author="awood" dbms="postgresql">
+    <addColumn tableName="databasechangelog_swatch_contracts">
+      <column name="uuid" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202412051144-03" author="awood" dbms="postgresql">
+    <addColumn tableName="contract_metrics">
+      <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -20,4 +20,5 @@
   <include file="db/202406111405_change_billing_account_id_nullable.xml"/>
   <include file="db/202407081616-add-level-columns-for-offering-table_h2_only.xml"/>
   <include file="db/202410171500-move-subscription-capacity-view_h2_only.xml"/>
+  <include file="db/202412051144-primary-keys-on-changelog-table.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Jira issue: SWATCH-3167

## Description
For logical replication, Postgres requires that all tables have a
primary key.  This commit adds primary keys to tables like the
databasechangelog and join tables.  It also adds the
"pg_stat_statements" library to our database container so that we can
monitor queries in development.

"A published table must have a 'replica identity' configured in order to
be able to replicate UPDATE and DELETE operations, so that appropriate
rows to update or delete can be identified on the subscriber side. By
default, this is the primary key, if there is one."

From https://www.postgresql.org/docs/12/logical-replication-publication.html

## Testing
On my system, adding the PKs on a fully loaded database took a couple seconds.

### Steps
1. Run the following query and observe the tables lacking a primary key.
    ```sql
    select tab.table_schema,
      tab.table_name
    from information_schema.tables tab
    left join information_schema.table_constraints tco
      on tab.table_schema = tco.table_schema
      and tab.table_name = tco.table_name
      and tco.constraint_type = 'PRIMARY KEY'
    where tab.table_type = 'BASE TABLE'
      and tab.table_schema not in ('pg_catalog', 'information_schema')
      and tco.constraint_name is null
    order by table_schema, table_name;
    ```
1. `./gradlew liquibaseUpdate`

### Verification
1. Run the query again and observe that no tables are returned in the results.
