### PR TITLE
SWATCH-3186: Fix null pointer exception when tallying snapshots

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -189,7 +189,8 @@ public class InventorySwatchDataCollator {
   private OrgHostsData trackActiveHypervisor(
       String hypervisorUuid, PeekingIterator<String> activeSubmanIds) {
     log.debug("Active hypervisorUuid={}", hypervisorUuid);
-    while (activeSubmanIds.hasNext() && activeSubmanIds.peek().compareTo(hypervisorUuid) < 0) {
+    while (activeSubmanIds.hasNext()
+        && compareStrings(activeSubmanIds.peek(), hypervisorUuid) < 0) {
       // discard any subman IDs less than the specified hypervisor UUID
       activeSubmanIds.next();
     }
@@ -203,6 +204,16 @@ public class InventorySwatchDataCollator {
       orgHostsData.addHostMapping(hypervisorUuid, hypervisorUuid);
     }
     return orgHostsData;
+  }
+
+  private int compareStrings(String a, String b) {
+    if (a == null) {
+      return 1;
+    } else if (b == null) {
+      return -1;
+    }
+
+    return a.compareTo(b);
   }
 
   /**

--- a/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
@@ -160,6 +160,22 @@ class InventorySwatchDataCollatorTest {
   }
 
   @Test
+  void testCollatorPreventNullPointerWhenNoMoreSubscriptionManagerIdsArePresent() {
+    InventoryHostFacts hbiSystem = new InventoryHostFacts();
+    hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
+    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+        .thenReturn(Stream.of((String) null));
+    when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
+
+    InventorySwatchDataCollator collator =
+        new InventorySwatchDataCollator(inventoryRepository, hostRepository);
+    collator.collateData("foo", 7, processor);
+    verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
+  }
+
+  @Test
   void testCollatorTracksPresentHypervisorUuidViaSatelliteHypervisorUuidForGuest() {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));


### PR DESCRIPTION
Jira issue: SWATCH-3186

## Description
From the Peeking Collections javadocs, the `.peek()` method might return null values, so we need to prevent the null pointers to happen.

Digging further into this issue, the root cause is that when peeking elements, we're also consuming the inner iterator without checking the iterator.hasNext() method: https://github.com/google/guava/blob/3644d6155fdeca4c97d51329b66d1272d2905735/guava/src/com/google/common/collect/Iterators.java#L1220

So, it sounds like a bug in the peeking collection.

## Testing
Added JUnit test to reproduce scenario.
To reproduce exactly the same issue than in production, you would need to load the HBI and Swatch data of a given organization (more details in the JIRA ticket) and run the tally snapshots:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/<ORG>" x-rh-swatch-psk:placeholder
```