### PR TITLE
[HOTFIX] Switch to rosa:cluster:vcpu_hours

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rosa.yaml
@@ -43,5 +43,5 @@ metrics:
       queryParams:
         instanceKey: _id
         productLabelRegex: (moa-hostedcontrolplane|moa)
-        metric: cluster:usage:workload:capacity_virtual_cpu_hours
+        metric: rosa:cluster:vcpu_hours
         metadataMetric: ocm_subscription


### PR DESCRIPTION
`hostedcluster:hypershift_cluster_vcpus:vcpu_hours` is not valid for classic clusters. `rosa:cluster:vcpu_hours` is defined as `hostedcluster:hypershift_cluster_vcpus:vcpu_hours` if it exists, otherwise `cluster:usage:workload:capacity_virtual_cpu_hours`

See the definition at https://github.com/Nikokolas3270/telemeter/blob/086530ffb35ecadbc986c0fca465f362c1bfdcd3/jsonnet/telemeter/rules.libsonnet#L218-L221