### PR TITLE
SWATCH-3177 Fix invalid remittance calculation when an amendment is applied

### DIFF
--- a/src/main/resources/liquibase/202412091327-drop-hardware-measurement-type-from-billable-usage-remittance.xml
+++ b/src/main/resources/liquibase/202412091327-drop-hardware-measurement-type-from-billable-usage-remittance.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202412091327-01" author="mstead">
+    <comment>Drop the hardware_measurement_type column from billable_usage_remittance table.</comment>
+    <dropColumn tableName="billable_usage_remittance" columnName="hardware_measurement_type" />
+    <rollback>
+      <addColumn tableName="billable_usage_remittance">
+        <column name="hardware_measurement_type" type="varchar(32)" />
+      </addColumn>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -177,5 +177,6 @@
     <include file="/liquibase/202410241408-clear-retryable.xml"/>
     <include file="/liquibase/202412041537-primary-keys-on-all-tables.xml"/>
     <include file="/liquibase/202501081035-remove-backup-tables.xml"/>
+    <include file="/liquibase/202412091327-drop-hardware-measurement-type-from-billable-usage-remittance.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceEntity.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceEntity.java
@@ -85,9 +85,6 @@ public class BillableUsageRemittanceEntity implements Serializable {
   @Column(name = "tally_id")
   private UUID tallyId;
 
-  @Column(name = "hardware_measurement_type")
-  private String hardwareMeasurementType;
-
   @Column(name = "status")
   private RemittanceStatus status;
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
@@ -53,7 +53,7 @@ public class BillableUsageRemittanceFilter {
   private boolean excludeFailures;
   private UUID tallyId;
 
-  public static BillableUsageRemittanceFilter fromUsage(BillableUsage usage) {
+  public static BillableUsageRemittanceFilter totalRemittedFilter(BillableUsage usage) {
     return BillableUsageRemittanceFilter.builder()
         .orgId(usage.getOrgId())
         .billingAccountId(usage.getBillingAccountId())
@@ -63,7 +63,7 @@ public class BillableUsageRemittanceFilter {
         .productId(usage.getProductId())
         .sla(usage.getSla().value())
         .usage(usage.getUsage().value())
-        .hardwareMeasurementType(usage.getHardwareMeasurementType())
+        .excludeFailures(true)
         .build();
   }
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceFilter.java
@@ -46,7 +46,6 @@ public class BillableUsageRemittanceFilter {
   private String metricId;
   private String billingProvider;
   private String billingAccountId;
-  private String hardwareMeasurementType;
   private OffsetDateTime beginning;
   private OffsetDateTime ending;
   private String accumulationPeriod;

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -64,7 +64,6 @@ public class BillableUsageRemittanceRepository
           root.get(BillableUsageRemittanceEntity_.METRIC_ID),
           root.get(BillableUsageRemittanceEntity_.ORG_ID),
           root.get(BillableUsageRemittanceEntity_.PRODUCT_ID),
-          root.get(BillableUsageRemittanceEntity_.HARDWARE_MEASUREMENT_TYPE),
           root.get(BillableUsageRemittanceEntity_.STATUS),
           root.get(BillableUsageRemittanceEntity_.ERROR_CODE));
     }
@@ -81,7 +80,6 @@ public class BillableUsageRemittanceRepository
             root.get(BillableUsageRemittanceEntity_.BILLING_PROVIDER),
             root.get(BillableUsageRemittanceEntity_.BILLING_ACCOUNT_ID),
             root.get(BillableUsageRemittanceEntity_.METRIC_ID),
-            root.get(BillableUsageRemittanceEntity_.HARDWARE_MEASUREMENT_TYPE),
             root.get(BillableUsageRemittanceEntity_.STATUS),
             root.get(BillableUsageRemittanceEntity_.ERROR_CODE)));
     return entityManager.createQuery(query).getResultList();
@@ -171,10 +169,6 @@ public class BillableUsageRemittanceRepository
     if (Objects.nonNull(filter.getSla())) {
       searchCriteria = searchCriteria.and(matchingSla(filter.getSla()));
     }
-    if (Objects.nonNull(filter.getHardwareMeasurementType())) {
-      searchCriteria =
-          searchCriteria.and(matchingHardwareMeasurementType(filter.getHardwareMeasurementType()));
-    }
     if (filter.isExcludeFailures()) {
       searchCriteria = searchCriteria.and(excludesFailures());
     }
@@ -191,14 +185,6 @@ public class BillableUsageRemittanceRepository
             builder.isNull(root.get(BillableUsageRemittanceEntity_.status)),
             builder.notEqual(
                 root.get(BillableUsageRemittanceEntity_.status), RemittanceStatus.FAILED));
-  }
-
-  private Specification<BillableUsageRemittanceEntity> matchingHardwareMeasurementType(
-      String hardwareMeasurementType) {
-    return (root, query, builder) ->
-        builder.equal(
-            root.get(BillableUsageRemittanceEntity_.hardwareMeasurementType),
-            hardwareMeasurementType);
   }
 
   private static Specification<BillableUsageRemittanceEntity> matchingProductId(String productId) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
@@ -41,7 +41,6 @@ public class RemittanceSummaryProjection {
   private String billingProvider;
   private String billingAccountId;
   private String metricId;
-  private String hardwareMeasurementType;
   private RemittanceStatus status;
   private RemittanceErrorCode errorCode;
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
@@ -112,7 +112,6 @@ public class BillableUsageMapper {
         .withBillingAccountId(snapshot.getBillingAccountId())
         .withMetricId(measurement.getMetricId())
         .withValue(measurement.getValue())
-        .withHardwareMeasurementType(measurement.getHardwareMeasurementType())
         .withCurrentTotal(measurement.getCurrentTotal());
   }
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -170,8 +170,7 @@ public class BillableUsageService {
   }
 
   protected double getTotalRemitted(BillableUsage billableUsage) {
-    var filter = BillableUsageRemittanceFilter.fromUsage(billableUsage);
-    filter.setExcludeFailures(true);
+    var filter = BillableUsageRemittanceFilter.totalRemittedFilter(billableUsage);
     return billableUsageRemittanceRepository.getRemittanceSummaries(filter).stream()
         .map(RemittanceSummaryProjection::getTotalRemittedPendingValue)
         .reduce(Double::sum)

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -235,7 +235,6 @@ public class BillableUsageService {
             .usage(usage.getUsage().value())
             .remittancePendingDate(clock.now())
             .tallyId(usage.getTallyId())
-            .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .status(
                 contractCoverage.isGratis() ? RemittanceStatus.GRATIS : RemittanceStatus.PENDING)
             .build();

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepositoryTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepositoryTest.java
@@ -135,7 +135,6 @@ class BillableUsageRemittanceRepositoryTest {
         .accumulationPeriod(AccumulationPeriodFormatter.toMonthId(remittanceDate))
         .remittancePendingDate(remittanceDate)
         .remittedPendingValue(value)
-        .hardwareMeasurementType("AWS")
         .build();
   }
 
@@ -335,7 +334,6 @@ class BillableUsageRemittanceRepositoryTest {
             .totalRemittedPendingValue(24.0)
             .sla(remittance1.getSla())
             .usage(remittance1.getUsage())
-            .hardwareMeasurementType("AWS")
             .build();
 
     var expectedSummary2 =
@@ -350,7 +348,6 @@ class BillableUsageRemittanceRepositoryTest {
             .totalRemittedPendingValue(15.0)
             .sla(remittance3.getSla())
             .usage(remittance3.getUsage())
-            .hardwareMeasurementType("AWS")
             .build();
 
     List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter1);
@@ -370,7 +367,6 @@ class BillableUsageRemittanceRepositoryTest {
     String billingProvider = "aws";
     String billingAccountId = "ba123456789";
     String remittancePendingDateStr = "2024-06-19T16:52:17.526219+00:00";
-    String hardwareMeasurementType = "AWS";
 
     var billableUsageNoExpected =
         BillableUsageRemittanceEntity.builder()
@@ -387,7 +383,6 @@ class BillableUsageRemittanceRepositoryTest {
                 OffsetDateTime.parse(
                     remittancePendingDateStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
             .tallyId(UUID.randomUUID())
-            .hardwareMeasurementType(hardwareMeasurementType)
             .status(RemittanceStatus.PENDING)
             .build();
 
@@ -406,7 +401,6 @@ class BillableUsageRemittanceRepositoryTest {
                 OffsetDateTime.parse(
                     remittancePendingDateStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
             .tallyId(UUID.randomUUID())
-            .hardwareMeasurementType(hardwareMeasurementType)
             .status(RemittanceStatus.PENDING)
             .build();
 
@@ -426,7 +420,6 @@ class BillableUsageRemittanceRepositoryTest {
                 OffsetDateTime.parse(
                     remittancePendingDateStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
             .tallyId(UUID.randomUUID())
-            .hardwareMeasurementType("PHYSICAL")
             .status(RemittanceStatus.SUCCEEDED)
             .build();
     repository.persist(
@@ -446,8 +439,7 @@ class BillableUsageRemittanceRepositoryTest {
         .withMetricId(metricId)
         .withProductId(productTag)
         .withUsage(BillableUsage.Usage.PRODUCTION)
-        .withSla(BillableUsage.Sla.PREMIUM)
-        .withHardwareMeasurementType("PHYSICAL");
+        .withSla(BillableUsage.Sla.PREMIUM);
 
     // Build the filter the same way that we do in the billable usage in the service.
     var filter = BillableUsageRemittanceFilter.totalRemittedFilter(incomingUsage);
@@ -470,8 +462,6 @@ class BillableUsageRemittanceRepositoryTest {
             .totalRemittedPendingValue(expectedRemittedPendingValue)
             .sla(billableUsageRemittanceFromRhelemeter.getSla())
             .usage(billableUsageRemittanceFromRhelemeter.getUsage())
-            .hardwareMeasurementType(
-                billableUsageRemittanceFromRhelemeter.getHardwareMeasurementType())
             .status(billableUsageRemittanceFromRhelemeter.getStatus())
             .build();
 
@@ -490,7 +480,6 @@ class BillableUsageRemittanceRepositoryTest {
             .totalRemittedPendingValue(billableUsageRemittanceFromCost.getRemittedPendingValue())
             .sla(billableUsageRemittanceFromCost.getSla())
             .usage(billableUsageRemittanceFromCost.getUsage())
-            .hardwareMeasurementType(billableUsageRemittanceFromCost.getHardwareMeasurementType())
             .status(billableUsageRemittanceFromCost.getStatus())
             .build();
 

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
@@ -194,7 +194,6 @@ class BillableUsageMapperTest {
             .withBillingAccountId(expectedBillingAccountId)
             .withMetricId(expectedMetricId)
             .withValue(42.0)
-            .withHardwareMeasurementType("PHYSICAL")
             .withCurrentTotal(expectedCurrentTotal);
 
     var summary =

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -593,7 +593,6 @@ class BillableUsageServiceTest {
             .usage(usage.getUsage().value())
             .remittancePendingDate(remittancePendingDate)
             .tallyId(usage.getTallyId())
-            .hardwareMeasurementType(usage.getHardwareMeasurementType())
             .status(status)
             .build();
     // Remitted value should be set to usages metric_value rather than billing_value

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -79,9 +79,6 @@ properties:
   vendor_product_code:
     description: Field used to specify a unique contract
     type: string
-  hardware_measurement_type:
-    type: string
-    format: string
   currentTotal:
     description: Sum of all measurements between the start of the month to the snapshot date.
     type: number


### PR DESCRIPTION
Jira issue: SWATCH-3177

## Description
This bug happens when the incoming events are in conflict (2 events with the same instance, metric and timestamp) and the hardware measurement type (HMT) is different. In the case of the reproducer events, the rhelemeter event does not specify the HMT which will get defaulted to PHYSICAL, not AWS. Since remittance uses the HMT to determine the current total remittance, it returns an incorrect value for the total when the usage for the second event is received.

This only happens when a conflict occurs and the value changes, since the measurements for the hour are replaced when tallied.

## Resolution
When determining the current remittance total, the billable usage
component no longer considers the hardware_measurement_type. As
such, when TallySummary messages are created during the hourly tally,
we must also exclude the measurement type when calculating the
current total for a metric, as this value is used when determining
remittance.

This PR also removes the hardware measurement type from billable usage
and remittance since it does not apply to remittance in general.

## Affected Components
1. swatch-billable-usage
  * The currentTotal of TallySummary.TallyMeasurement are now calculated to not include the hardware_type.
  * The billable_usage_remittance table no longer has the hardware_measurement_type.
2. All Swatch Billing Producers
  * Incoming BillableUsage messages no longer have the hardwareMeasurementType included.
  
## Testing
IQE Test MR: [IQE TEST](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/759/diffs#5778b0b64554323fc857787e871cbb411a26d9f9_368_372)

### Steps

#### Deployment Tips
**When testing locally, I deployed the following services. Please read the test steps carefully, since the first deployment should be done on the MAIN branch.**

swatch-contracts
```
QUARKUS_MANAGEMENT_ENABLED=false SERVER_PORT=8001 ./gradlew :swatch-contracts:quarkusDev
```
swatch-billable-usage
```
SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9004 DEV_MODE=true ./gradlew :swatch-billable-usage:quarkusDev
```

swatch-tally
```
SPRING_PROFILES_ACTIVE=api,worker,kafka-queue DEV_MODE=true ./gradlew clean :bootRun
```

#### Testing
First, reproduce the bug on the **MAIN** branch.

Create a cost-management event for a host instance that includes the hardware_type.
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "3340851",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2024-06-03T14:00:00Z",
              "expiration": "2024-07-03T15:00:00Z",
              "display_name": "automation__cluster_testHostgge",
              "measurements": [
                {
                  "value": 4,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204"
              ],
              "cloud_provider": "AWS",
              "hardware_type": "Cloud",
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "testkfk",
              "product_tag": [
                "rhel-for-x86-els-payg-addon"
              ],
              "conversion": false,
              "event_source": "cost-management",
              "event_type": "vCPUs",
              "org_id": "3340851",
              "instance_id": "testHostgge"
            }
          }
        ]
      }
	  '
```

Perform an hourly tally for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=3340851" x-rh-swatch-psk:placeholder
```

Verify 4 AWS vCPUs were remitted.
```
select * from billable_usage_remittance where org_id='3340851';
```

Create a rhelemeter style event for the **SAME HOST** (no cloud_provider or hardware type). 
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "3340851",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2024-06-03T14:00:00Z",
              "expiration": "2024-07-03T15:00:00Z",
              "display_name": "automation__cluster_testHostgge",
              "measurements": [
                {
                  "value": 8,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204"
              ],
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "testkfk",
              "product_tag": [
                "rhel-for-x86-els-payg-addon"
              ],
              "conversion": false,
              "event_source": "rhelemeter",
              "event_type": "vCPUs",
              "org_id": "3340851",
              "instance_id": "testHostgge"
            }
          }
        ]
      }
	  '
```

Run an hourly tally for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=3340851" x-rh-swatch-psk:placeholder
```

Because the event should have been amended (**4 - 4**) + 8, the expected billable usage should have been and additional 4 vCPUs since we already billed for 4 (from the first event). HOWEVER, you'll notice that there were 8 additional vCPUs billed due to the PHYSICAL hardware measurement type. We have overbilled by 4 vCPUs.
```
select * from billable_usage_remittance where org_id='3340851';
```

Check out the branch with the bug fix and deploy. After deploying, check the **billable_usage_remittance** table to make sure that the **hardware_measurement_type** column was dropped.

Next verify that we will recover correctly from the 4 additional vCPUs that we previously billed for.

```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "3340851",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2024-06-03T15:00:00Z",
              "expiration": "2024-07-03T15:00:00Z",
              "display_name": "automation__cluster_testHostgge",
              "measurements": [
                {
                  "value": 10,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204"
              ],
              "cloud_provider": "AWS",
              "hardware_type": "Cloud",
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "testkfk",
              "product_tag": [
                "rhel-for-x86-els-payg-addon"
              ],
              "conversion": false,
              "event_source": "cost-management",
              "event_type": "vCPUs",
              "org_id": "3340851",
              "instance_id": "testHostgge"
            }
          }
        ]
      }
	  '
```

Perform an hourly tally for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=3340851" x-rh-swatch-psk:placeholder
```

Since an additional 10 vCPUs were reported in the event we just sent, and we've previously overbilled for 4 vCPUs due to the bug, after the tally we should see that we billed for **6 vCPUs**.

Next, attempt to reproduce the bug scenario **WITH A DIFFERENT MONTH** to ensure the bug is addressed when starting fresh.

Create a cost-management event for a host instance that includes the hardware_type.
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "3340851",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2024-07-03T14:00:00Z",
              "expiration": "2024-08-03T15:00:00Z",
              "display_name": "automation__cluster_testHostgge",
              "measurements": [
                {
                  "value": 4,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204"
              ],
              "cloud_provider": "AWS",
              "hardware_type": "Cloud",
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "testkfk",
              "product_tag": [
                "rhel-for-x86-els-payg-addon"
              ],
              "conversion": false,
              "event_source": "cost-management",
              "event_type": "vCPUs",
              "org_id": "3340851",
              "instance_id": "testHostgge"
            }
          }
        ]
      }
	  '
```

Perform an hourly tally for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=3340851" x-rh-swatch-psk:placeholder
```

Create a rhelemeter style event for the **SAME HOST** (no cloud_provider or hardware type). 
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "3340851",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2024-07-03T14:00:00Z",
              "expiration": "2024-08-03T15:00:00Z",
              "display_name": "automation__cluster_testHostgge",
              "measurements": [
                {
                  "value": 8,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204"
              ],
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "testkfk",
              "product_tag": [
                "rhel-for-x86-els-payg-addon"
              ],
              "conversion": false,
              "event_source": "rhelemeter",
              "event_type": "vCPUs",
              "org_id": "3340851",
              "instance_id": "testHostgge"
            }
          }
        ]
      }
	  '
```

Run an hourly tally for the org.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=3340851" x-rh-swatch-psk:placeholder
```

Check the remittance for **2024-07** to ensure that we did not overbill by 4 vCPUs. Since an amendment had occurred when the 2nd event was received, we should have only remitted an additional 4 vCPUs, for a total of 8 vCPUs for 2024-07.
