### PR TITLE
Fix gradle bootRun command

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplacePayloadMapper.java
@@ -54,7 +54,7 @@ public class RhMarketplacePayloadMapper {
 
   @Autowired
   public RhMarketplacePayloadMapper(
-      DefaultApi contractsClient,
+      @Qualifier("marketplaceContractsApi") DefaultApi contractsClient,
       @Qualifier("rhmUsageContextLookupRetryTemplate") RetryTemplate usageContextRetryTemplate) {
     this.contractsClient = contractsClient;
     this.usageContextRetryTemplate = usageContextRetryTemplate;

--- a/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/rhmarketplace/RhMarketplaceWorkerConfiguration.java
@@ -159,8 +159,8 @@ public class RhMarketplaceWorkerConfiguration {
     return new RhMarketplaceApiFactory(properties);
   }
 
-  @Bean
-  public ContractsApiFactory contractsApiFactory(RhmUsageContextLookupProperties props) {
+  @Bean(name = "marketplaceContractsApi")
+  public ContractsApiFactory marketplaceContractsApiFactory(RhmUsageContextLookupProperties props) {
     return new ContractsApiFactory(props);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/contracts/ContractsConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/contracts/ContractsConfiguration.java
@@ -36,7 +36,7 @@ public class ContractsConfiguration {
     return new ContractsClientProperties();
   }
 
-  @Bean
+  @Bean(name = "contractsApi")
   public ContractsApiFactory contractsApiFactory(ContractsClientProperties clientProperties) {
     return new ContractsApiFactory(clientProperties);
   }


### PR DESCRIPTION
Jira issue: None

## Description
Starting in late August, a commit got introduced that added a bean with a name
already in use.  Normally, that type of issue would lead to an immediate
deployment failure, but in this case, the redundant bean is only present in a
lesser used profile: rh-marketplace.

This commit renames the conflicting bean.

## Testing

### Steps
1. Deploy the application with only the stock configuration.  I was unaware of
   this issue for a long time as I have a custom
   `confign/application.properties` file with a reduced set of profiles.
   Consequently, I never saw this error until someone else brought it to my
   attention.
    ```
    ./gradlew :bootRun --args="--spring.config.location=classpath:application.yaml"
    ```

### Verification
1. Run the above command on `main`.  Deployment fails.
1. Run the above command on this branch.  Deployment succeeds.
