### PR TITLE
SWATCH-3134: Adding JVM config to disable the trimming of stack traces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,10 @@ COPY --from=0 /stage/LICENSE /licenses/
 RUN chmod -R g=u /deployments
 
 USER default
-# Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+# Custom JVM properties:
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.BootApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -144,8 +144,9 @@ RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -143,8 +143,9 @@ RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -144,8 +144,9 @@ RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -145,8 +145,9 @@ EXPOSE 8080
 
 ENV AB_JOLOKIA_OFF=""
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -145,8 +145,9 @@ EXPOSE 8080
 
 ENV AB_JOLOKIA_OFF=""
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -143,8 +143,9 @@ RUN chmod 775 /deployments /deployments/*
 
 EXPOSE 8080
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -54,8 +54,9 @@ RUN chmod -R g=u /deployments
 
 USER default
 # Custom JVM properties
-## Fix CVE-2024-31141: Disabling Kafka client config providers
-ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none"
+## - Fix CVE-2024-31141: Disabling Kafka client config providers
+## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
+ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.SystemConduitApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*


### PR DESCRIPTION
Jira issue: SWATCH-3134

## Description
The “OmitStackTraceInFastThrow” was first introduced in JDK5. According to the release note of JDK5, the compiler in the server VM stops outputting the stack trace of the exceptions which have been thrown a few times. This is a one of optimizations which happens in C2 compile. And by adding “-XX:-OmitStackTraceInFastThrow”, we can disable this optimization.

This seems to be the cause why we're not getting the full stacktraces in production.

## Testing
Only regression testing.