### PR TITLE
Fix random build failure in swatch-common-panache

### DIFF
--- a/swatch-common-panache/build.gradle
+++ b/swatch-common-panache/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'swatch.java-library-conventions'
+    id 'io.quarkus'
 }
 
 dependencies {
@@ -10,9 +11,6 @@ dependencies {
     testImplementation("io.quarkus:quarkus-jdbc-h2")
 }
 
-test {
-    apply plugin: 'io.quarkus'
-    tasks."quarkusDependenciesBuild".dependsOn tasks.jandex
-}
+tasks."quarkusDependenciesBuild".dependsOn tasks.jandex
 
 description = 'Shared panache logic for swatch services'


### PR DESCRIPTION
Some CI jobs are randomly failing due to:

```
Execution failed for task ':swatch-common-panache:quarkusAppPartsBuild'.
> There was a failure while executing work items
   > A failure occurred while executing io.quarkus.gradle.tasks.worker.BuildWorker
      > Configuration validation failed:
        	java.util.NoSuchElementException: SRCFG00011: Could not expand value platform.quarkus.native.builder-image in property quarkus.native.builder-image
```

These changes try to fix these failures.

