### PR TITLE
Fix swatchdog

### DIFF
--- a/swatchdog/swatchdog/deploy/command.py
+++ b/swatchdog/swatchdog/deploy/command.py
@@ -1,21 +1,21 @@
 import logging
 import os
-
-import click
 import re
 import sys
-import iterfzf
-import openshift
 import typing as t
 
+import click
+import iterfzf
+import openshift_client as openshift
+from invoke import Context as InvokeContext
+from invoke import UnexpectedExit, StreamWatcher
+
 from .. import SwatchDogError, info, err, invoke_config, pass_swatch
+
 
 # Trying to avoid some confusion here because otherwise we have invoke.Context
 # calls (from the Invoke library we use for shell commands) and context.Invoke() calls
 # from Click.
-
-from invoke import Context as InvokeContext
-from invoke import UnexpectedExit, StreamWatcher
 
 
 class GradleWatcher(StreamWatcher):


### PR DESCRIPTION
Jira issue: None

## Description
Version 2.0 of the openshift Python library changed the import name from
`openshift` to `openshift_client`.  See
https://github.com/openshift/openshift-client-python/issues/75

## Testing

### Setup
1. `poetry install` to make sure you have the latest dependencies

### Steps
1. `poetry run swatchdog prometheus promql --product rosa`

### Verification
1. The above command will fail on `main` with an import error
1. It will succeed on this branch
