### PR TITLE
SWATCH-3211: Ignore failures when consuming tally summary messages

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
@@ -37,6 +37,7 @@ public enum RemittanceErrorCode {
   SUBSCRIPTION_TERMINATED("subscription_terminated"),
   USAGE_CONTEXT_LOOKUP("usage_context_lookup"),
   UNKNOWN("unknown"),
+  UNSUPPORTED_METRIC("unsupported_metric"),
   MARKETPLACE_RATE_LIMIT("marketplace_rate_limit");
 
   private static final Map<String, RemittanceErrorCode> VALUE_ENUM_MAP =

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.billable.usage.services;
 import com.redhat.swatch.billable.usage.model.TallyMeasurement;
 import com.redhat.swatch.billable.usage.model.TallySnapshot;
 import com.redhat.swatch.billable.usage.model.TallySummary;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -95,7 +96,21 @@ public class BillableUsageMapper {
                     // Filter out any HardwareMeasurementType.TOTAL measurements to prevent
                     // duplicates
                     .filter(this::isNotHardwareMeasurementTypeTotal)
+                    .filter(m -> isSupportedMetric(m, snapshot))
                     .map(m -> toBillableUsage(m, summary, snapshot)));
+  }
+
+  private boolean isSupportedMetric(TallyMeasurement measurement, TallySnapshot snapshot) {
+    try {
+      MetricId.fromString(measurement.getMetricId());
+      return true;
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Ignoring unsupported measurement '{}' for snapshot '{}'",
+          measurement.getMetricId(),
+          snapshot);
+      return false;
+    }
   }
 
   private BillableUsage toBillableUsage(

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -125,6 +125,7 @@ mp.messaging.incoming.billable-usage-status-in.connector=smallrye-kafka
 mp.messaging.incoming.billable-usage-status-in.topic=platform.rhsm-subscriptions.billable-usage.status
 mp.messaging.incoming.billable-usage-status-in.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 mp.messaging.incoming.billable-usage-status-in.key.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+mp.messaging.incoming.billable-usage-status-in.failure-strategy=ignore
 
 mp.messaging.incoming.remittances-purge-task.connector=smallrye-kafka
 mp.messaging.incoming.remittances-purge-task.topic=platform.rhsm-subscriptions.remittances-purge-task
@@ -137,6 +138,7 @@ mp.messaging.outgoing.enabled-orgs.value.serializer=io.quarkus.kafka.client.seri
 mp.messaging.incoming.tally-summary.connector=smallrye-kafka
 mp.messaging.incoming.tally-summary.topic=platform.rhsm-subscriptions.tally
 mp.messaging.incoming.tally-summary.value.deserializer=com.redhat.swatch.billable.usage.services.json.TallySummaryDeserializer
+mp.messaging.incoming.tally-summary.failure-strategy=ignore
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
@@ -43,7 +43,8 @@ import org.junit.jupiter.api.Test;
 
 class BillableUsageMapperTest {
 
-  private static final String STORAGE_GIBIBYTES = "Storage-gibibytes";
+  private static final String CORES = "Cores";
+  private static final String ROSA = "rosa";
 
   private static SubscriptionDefinitionRegistry originalReference;
   private SubscriptionDefinitionRegistry subscriptionDefinitionRegistry;
@@ -69,11 +70,11 @@ class BillableUsageMapperTest {
   void setupTest() {
     subscriptionDefinitionRegistry = mock(SubscriptionDefinitionRegistry.class);
     setMock(subscriptionDefinitionRegistry);
-    var variant = Variant.builder().tag("rosa").build();
+    var variant = Variant.builder().tag(ROSA).build();
     var awsMetric =
         com.redhat.swatch.configuration.registry.Metric.builder()
             .awsDimension("AWS_METRIC_ID")
-            .id("Cores")
+            .id(CORES)
             .build();
     var subscriptionDefinition =
         SubscriptionDefinition.builder()
@@ -117,7 +118,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.ANY,
                     TallySnapshot.Usage.PRODUCTION,
@@ -133,7 +134,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.ANY,
@@ -149,7 +150,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -165,7 +166,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -178,28 +179,26 @@ class BillableUsageMapperTest {
   @Test
   void shouldProduceBillableUsageWhenOrgIdPresent() {
     String expectedOrgId = "org123";
-    String expectedProductId = "rosa";
     String expectedBillingAccountId = "bill123";
     double expectedCurrentTotal = 88.0;
     OffsetDateTime expectedSnapshotDate = OffsetDateTime.MIN;
-    String expectedMetricId = "Storage-gibibytes";
     BillableUsage expected =
         new BillableUsage()
             .withOrgId(expectedOrgId)
-            .withProductId(expectedProductId)
+            .withProductId(ROSA)
             .withSnapshotDate(expectedSnapshotDate)
             .withUsage(BillableUsage.Usage.PRODUCTION)
             .withSla(BillableUsage.Sla.STANDARD)
             .withBillingProvider(BillableUsage.BillingProvider.AWS)
             .withBillingAccountId(expectedBillingAccountId)
-            .withMetricId(expectedMetricId)
+            .withMetricId(CORES)
             .withValue(42.0)
             .withHardwareMeasurementType("PHYSICAL")
             .withCurrentTotal(expectedCurrentTotal);
 
     var summary =
         createExampleTallySummaryWithOrgId(
-            expectedProductId,
+            ROSA,
             TallySnapshot.Granularity.HOURLY,
             TallySnapshot.Sla.STANDARD,
             TallySnapshot.Usage.PRODUCTION,
@@ -220,7 +219,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.YEARLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -234,7 +233,7 @@ class BillableUsageMapperTest {
   void shouldSkipSummaryWithNoMeasurements() {
     TallySummary tallySummary =
         createExampleTallySummaryWithOrgId(
-            "rosa",
+            ROSA,
             TallySnapshot.Granularity.HOURLY,
             TallySnapshot.Sla.STANDARD,
             TallySnapshot.Usage.PRODUCTION,
@@ -262,11 +261,11 @@ class BillableUsageMapperTest {
                     .withTallyMeasurements(
                         List.of(
                             new TallyMeasurement()
-                                .withMetricId(STORAGE_GIBIBYTES)
+                                .withMetricId(CORES)
                                 .withHardwareMeasurementType("PHYSICAL")
                                 .withValue(42.0),
                             new TallyMeasurement()
-                                .withMetricId(STORAGE_GIBIBYTES)
+                                .withMetricId(CORES)
                                 .withHardwareMeasurementType("TOTAL")
                                 .withValue(42.0)))
                     .withSla(sla)


### PR DESCRIPTION
Jira issue: SWATCH-3211

## Description
Using `mp.messaging.incoming.tally-summary.failure-strategy=ignore` will prevent the service to enter in a crash loop exceptions state when consuming invalid messages.

An invalid message might be a message using an unexisting metric.

With these changes, we prevent remittances to be created for invalid snapshots and configure the tally snapshot consumer to ignore failures.

## Testing
IQE Test MR will be added as part of [SWATCH-3141](https://issues.redhat.com/browse/SWATCH-3141)

### Setup

1.- podman compose -f docker-compose.yml up
2. apply liquibase migrations: `./gradlew liquibaseUpdate`
3.- start billable usage service: `./gradlew :swatch-billable-usage:quarkusDev`
4.- send message to the topic "platform.rhsm-subscriptions.tally" with invalid metric ID: 

```json
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "wrong!", "value": 12, "currentTotal": 100}]}]}
```

5.- verify the IllegalArgumentException in the service logs

6.- send another message with a valid metric, this message should be consumed.