### PR TITLE
SWATCH-3167: Remove unused tables

### DIFF
--- a/src/main/resources/liquibase/202501081035-remove-backup-tables.xml
+++ b/src/main/resources/liquibase/202501081035-remove-backup-tables.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202501081035-01" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="subscription_backup"/>
+    </preConditions>
+    <dropTable tableName="subscription_backup"/>
+  </changeSet>
+
+  <changeSet id="202501081035-02" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="subscription_product_ids_backup"/>
+    </preConditions>
+    <dropTable tableName="subscription_product_ids_backup"/>
+  </changeSet>
+
+  <changeSet id="202501081035-03" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="subscription_measurements_backup"/>
+    </preConditions>
+    <dropTable tableName="subscription_measurements_backup"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -176,5 +176,6 @@
     <include file="/liquibase/202410211200-retry-after-billable-usage-index.xml"/>
     <include file="/liquibase/202410241408-clear-retryable.xml"/>
     <include file="/liquibase/202412041537-primary-keys-on-all-tables.xml"/>
+    <include file="/liquibase/202501081035-remove-backup-tables.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-3167

## Description
There are 3 backup tables in stage and production that we do not need any
longer.  These tables do not have primary keys and would, therefore, interfere
with logical replication.

## Testing

### Steps
1. `./gradlew liquibaseUpdate`

### Verification
1. In a dev set up, liquibase will run, but nothing will happen because it's
   unlikely you'll have those tables.  You'll be able to see the changesets as
   records in the `databasechangelog` table, however.
