### PR TITLE
Use ocp-c1 cloud for running pr checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     }
     agent {
         kubernetes {
+            cloud 'ocp-c1'
             label 'swatch-17-kubedock-2023-12-06' // this value + unique identifier becomes the pod name
             idleMinutes 5  // how long the pod will live after no jobs have run on it
             defaultContainer 'openjdk17'


### PR DESCRIPTION
Since new jenkins cluster default service account do not have enough permissions, this PR is to fall back to using old cluster in the meanwhile. 

Old cluster definition added in https://gitlab.cee.redhat.com/smqe/swatch-ci/-/merge_requests/332 

This change can be revered once Kubedock issues/122 or CCITJEN-2066 fixed.  
