### PR TITLE
SWATCH-3211: Billable Usage service validate supported metric by product

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -20,9 +20,10 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static com.redhat.swatch.configuration.registry.SubscriptionDefinition.isMetricSupportedByProduct;
+
 import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Sets;
-import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
@@ -391,7 +392,7 @@ public class MetricUsageCollector {
               .forEach(
                   measurement -> {
                     var metricId = MetricId.fromString(measurement.getMetricId());
-                    if (isMetricSupportedByProduct(metricId, productId)) {
+                    if (isMetricSupportedByProduct(productId, metricId.toString())) {
                       calc.addUsage(
                           usageKey, hardwareMeasurementType, metricId, measurement.getValue());
                     } else {
@@ -403,12 +404,6 @@ public class MetricUsageCollector {
                     }
                   });
         });
-  }
-
-  private boolean isMetricSupportedByProduct(MetricId metric, String productId) {
-    return Variant.getMetricsForTag(productId).stream()
-        .map(Metric::getId)
-        .anyMatch(definedMetricId -> definedMetricId.equals(metric.toString()));
   }
 
   private Set<List<Object>> buildBucketTuples(Event event) {
@@ -534,7 +529,7 @@ public class MetricUsageCollector {
                   entry -> {
                     var measurementKey = entry.getKey();
                     var metricId = MetricId.fromString(measurementKey.getMetricId());
-                    if (isMetricSupportedByProduct(metricId, usageKey.getProductId())) {
+                    if (isMetricSupportedByProduct(usageKey.getProductId(), metricId.toString())) {
                       calc.addUsage(
                           usageKey,
                           measurementKey.getMeasurementType(),

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageMapper.java
@@ -95,7 +95,22 @@ public class BillableUsageMapper {
                     // Filter out any HardwareMeasurementType.TOTAL measurements to prevent
                     // duplicates
                     .filter(this::isNotHardwareMeasurementTypeTotal)
+                    .filter(m -> isSupportedMetric(m, snapshot))
                     .map(m -> toBillableUsage(m, summary, snapshot)));
+  }
+
+  private boolean isSupportedMetric(TallyMeasurement measurement, TallySnapshot snapshot) {
+    boolean valid =
+        SubscriptionDefinition.isMetricSupportedByProduct(
+            snapshot.getProductId(), measurement.getMetricId());
+    if (!valid) {
+      log.warn(
+          "Ignoring unsupported measurement '{}' for snapshot '{}'",
+          measurement.getMetricId(),
+          snapshot);
+    }
+
+    return valid;
   }
 
   private BillableUsage toBillableUsage(

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -125,6 +125,7 @@ mp.messaging.incoming.billable-usage-status-in.connector=smallrye-kafka
 mp.messaging.incoming.billable-usage-status-in.topic=platform.rhsm-subscriptions.billable-usage.status
 mp.messaging.incoming.billable-usage-status-in.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 mp.messaging.incoming.billable-usage-status-in.key.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+mp.messaging.incoming.billable-usage-status-in.failure-strategy=ignore
 
 mp.messaging.incoming.remittances-purge-task.connector=smallrye-kafka
 mp.messaging.incoming.remittances-purge-task.topic=platform.rhsm-subscriptions.remittances-purge-task
@@ -137,6 +138,7 @@ mp.messaging.outgoing.enabled-orgs.value.serializer=io.quarkus.kafka.client.seri
 mp.messaging.incoming.tally-summary.connector=smallrye-kafka
 mp.messaging.incoming.tally-summary.topic=platform.rhsm-subscriptions.tally
 mp.messaging.incoming.tally-summary.value.deserializer=com.redhat.swatch.billable.usage.services.json.TallySummaryDeserializer
+mp.messaging.incoming.tally-summary.failure-strategy=ignore
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageMapperTest.java
@@ -43,7 +43,8 @@ import org.junit.jupiter.api.Test;
 
 class BillableUsageMapperTest {
 
-  private static final String STORAGE_GIBIBYTES = "Storage-gibibytes";
+  private static final String CORES = "Cores";
+  private static final String ROSA = "rosa";
 
   private static SubscriptionDefinitionRegistry originalReference;
   private SubscriptionDefinitionRegistry subscriptionDefinitionRegistry;
@@ -69,11 +70,11 @@ class BillableUsageMapperTest {
   void setupTest() {
     subscriptionDefinitionRegistry = mock(SubscriptionDefinitionRegistry.class);
     setMock(subscriptionDefinitionRegistry);
-    var variant = Variant.builder().tag("rosa").build();
+    var variant = Variant.builder().tag(ROSA).build();
     var awsMetric =
         com.redhat.swatch.configuration.registry.Metric.builder()
             .awsDimension("AWS_METRIC_ID")
-            .id("Cores")
+            .id(CORES)
             .build();
     var subscriptionDefinition =
         SubscriptionDefinition.builder()
@@ -117,7 +118,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.ANY,
                     TallySnapshot.Usage.PRODUCTION,
@@ -133,7 +134,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.ANY,
@@ -149,7 +150,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -165,7 +166,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.HOURLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -178,28 +179,26 @@ class BillableUsageMapperTest {
   @Test
   void shouldProduceBillableUsageWhenOrgIdPresent() {
     String expectedOrgId = "org123";
-    String expectedProductId = "rosa";
     String expectedBillingAccountId = "bill123";
     double expectedCurrentTotal = 88.0;
     OffsetDateTime expectedSnapshotDate = OffsetDateTime.MIN;
-    String expectedMetricId = "Storage-gibibytes";
     BillableUsage expected =
         new BillableUsage()
             .withOrgId(expectedOrgId)
-            .withProductId(expectedProductId)
+            .withProductId(ROSA)
             .withSnapshotDate(expectedSnapshotDate)
             .withUsage(BillableUsage.Usage.PRODUCTION)
             .withSla(BillableUsage.Sla.STANDARD)
             .withBillingProvider(BillableUsage.BillingProvider.AWS)
             .withBillingAccountId(expectedBillingAccountId)
-            .withMetricId(expectedMetricId)
+            .withMetricId(CORES)
             .withValue(42.0)
             .withHardwareMeasurementType("PHYSICAL")
             .withCurrentTotal(expectedCurrentTotal);
 
     var summary =
         createExampleTallySummaryWithOrgId(
-            expectedProductId,
+            ROSA,
             TallySnapshot.Granularity.HOURLY,
             TallySnapshot.Sla.STANDARD,
             TallySnapshot.Usage.PRODUCTION,
@@ -220,7 +219,7 @@ class BillableUsageMapperTest {
         mapper
             .fromTallySummary(
                 createExampleTallySummaryWithOrgId(
-                    "rosa",
+                    ROSA,
                     TallySnapshot.Granularity.YEARLY,
                     TallySnapshot.Sla.STANDARD,
                     TallySnapshot.Usage.PRODUCTION,
@@ -234,7 +233,7 @@ class BillableUsageMapperTest {
   void shouldSkipSummaryWithNoMeasurements() {
     TallySummary tallySummary =
         createExampleTallySummaryWithOrgId(
-            "rosa",
+            ROSA,
             TallySnapshot.Granularity.HOURLY,
             TallySnapshot.Sla.STANDARD,
             TallySnapshot.Usage.PRODUCTION,
@@ -262,11 +261,11 @@ class BillableUsageMapperTest {
                     .withTallyMeasurements(
                         List.of(
                             new TallyMeasurement()
-                                .withMetricId(STORAGE_GIBIBYTES)
+                                .withMetricId(CORES)
                                 .withHardwareMeasurementType("PHYSICAL")
                                 .withValue(42.0),
                             new TallyMeasurement()
-                                .withMetricId(STORAGE_GIBIBYTES)
+                                .withMetricId(CORES)
                                 .withHardwareMeasurementType("TOTAL")
                                 .withValue(42.0)))
                     .withSla(sla)

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/TallySummaryMessageConsumerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/TallySummaryMessageConsumerTest.java
@@ -23,9 +23,12 @@ package com.redhat.swatch.billable.usage.services;
 import static com.redhat.swatch.billable.usage.configuration.Channels.BILLABLE_USAGE_OUT;
 import static com.redhat.swatch.billable.usage.configuration.Channels.TALLY_SUMMARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.billable.usage.data.BillableUsageRemittanceRepository;
@@ -53,11 +56,17 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import org.awaitility.Awaitility;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logmanager.LogContext;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @QuarkusTest
 @QuarkusTestResource(
@@ -73,8 +82,10 @@ class TallySummaryMessageConsumerTest {
   private static final String HARDWARE_MEASUREMENT_TYPE = "AWS";
   private static final String PRODUCT_ID = "rosa";
   private static final String BILLING_ACCOUNT_ID = "456";
+  private static final LoggerCaptor LOGGER_CAPTOR = new LoggerCaptor();
 
   @InjectMock @RestClient DefaultApi contractsApi;
+  @InjectSpy BillableUsageMapper billableUsageMapper;
   @InjectSpy BillingProducer billingProducer;
   @InjectSpy BillableUsageRemittanceRepository usageRemittanceRepository;
   @Inject @Any InMemoryConnector connector;
@@ -83,6 +94,13 @@ class TallySummaryMessageConsumerTest {
   private InMemorySink<BillableUsage> target;
   OffsetDateTime snapshotDate;
   List<TallySnapshot> snapshots = new ArrayList<>();
+
+  @BeforeAll
+  static void configureLogging() {
+    LogContext.getLogContext()
+        .getLogger(BillableUsageMapper.class.getName())
+        .addHandler(LOGGER_CAPTOR);
+  }
 
   @Transactional
   @BeforeEach
@@ -93,6 +111,32 @@ class TallySummaryMessageConsumerTest {
     usageRemittanceRepository.deleteAll();
     snapshots.clear();
     target.clear();
+    Mockito.reset(billingProducer, billableUsageMapper, usageRemittanceRepository);
+  }
+
+  @Test
+  void testTallySummaryHasInvalidMetric() {
+    givenSnapshotWithMetric("wrong!");
+
+    whenSendSnapshots();
+
+    thenSnapshotsAreConsumed();
+    thenRemittanceIsNotEmitted();
+    thenWarningLogWithMessage("Ignoring unsupported measurement");
+    thenServiceIsReadyToAcceptMoreSnapshots();
+  }
+
+  @Test
+  void testTallySummaryHasUnsupportedMetricByProduct() {
+    // send snapshot with a "vCPUs" metric for product "rosa" which is not supported
+    givenSnapshotWithMetric("vCPUs");
+
+    whenSendSnapshots();
+
+    // then remittance is not emitted
+    thenSnapshotsAreConsumed();
+    thenRemittanceIsNotEmitted();
+    thenWarningLogWithMessage("Ignoring unsupported measurement");
   }
 
   @Test
@@ -108,7 +152,11 @@ class TallySummaryMessageConsumerTest {
     thenRemittanceIsEmitted();
   }
 
-  private void givenSnapshotWithUsages(double... usages) {
+  private void givenSnapshotWithMetric(String metricId) {
+    givenSnapshotWithUsages(2).getTallyMeasurements().forEach(m -> m.setMetricId(metricId));
+  }
+
+  private TallySnapshot givenSnapshotWithUsages(double... usages) {
     TallySnapshot snapshot = new TallySnapshot();
     List<TallyMeasurement> measurements = new ArrayList<>();
     for (Double usage : usages) {
@@ -130,6 +178,7 @@ class TallySummaryMessageConsumerTest {
     snapshot.setSla(SERVICE_LEVEL);
 
     snapshots.add(snapshot);
+    return snapshot;
   }
 
   /**
@@ -178,7 +227,59 @@ class TallySummaryMessageConsumerTest {
     assertEquals(expected, remittances.get(0).getRemittedPendingValue());
   }
 
+  private void thenSnapshotsAreConsumed() {
+    Awaitility.await().untilAsserted(() -> verify(billableUsageMapper).fromTallySummary(any()));
+  }
+
   private void thenRemittanceIsEmitted() {
     Awaitility.await().untilAsserted(() -> assertEquals(1, target.received().size()));
+  }
+
+  private void thenRemittanceIsNotEmitted() {
+    verify(billingProducer, times(0)).produce(any());
+  }
+
+  private void thenServiceIsReadyToAcceptMoreSnapshots() {
+    snapshots.clear();
+    givenValidContractWithMetric(8);
+    givenSnapshotWithUsages(80);
+    whenSendSnapshots();
+    thenRemittanceIsEmitted();
+  }
+
+  private void thenWarningLogWithMessage(String str) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    LOGGER_CAPTOR.records.stream()
+                        .anyMatch(
+                            r ->
+                                r.getLevel().equals(Level.WARNING)
+                                    && r.getMessage().contains(str))));
+  }
+
+  public static class LoggerCaptor extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord trace) {
+      records.add(trace);
+    }
+
+    @Override
+    public void flush() {
+      // no need to flush any sink
+    }
+
+    @Override
+    public void close() throws SecurityException {
+      clearRecords();
+    }
+
+    public void clearRecords() {
+      records.clear();
+    }
   }
 }

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -377,6 +377,12 @@ public class SubscriptionDefinition {
         .orElse(false);
   }
 
+  public static boolean isMetricSupportedByProduct(String productId, String metric) {
+    return Variant.getMetricsForTag(productId).stream()
+        .map(Metric::getId)
+        .anyMatch(definedMetricId -> definedMetricId.equals(metric));
+  }
+
   public static List<SubscriptionDefinition> getSubscriptionDefinitions() {
     return SubscriptionDefinitionRegistry.getInstance().getSubscriptions();
   }


### PR DESCRIPTION
Jira issue: SWATCH-3211
Depends on https://github.com/RedHatInsights/rhsm-subscriptions/pull/4081

## Description
After SWATCH-2910, we are not creating tally snapshots for unsupported metrics (not existing metrics or metrics not supported by product).

However, when programmatically sending tally snapshots in manual testing or in component tests, this scenario makes the billable usage service to fail and enter in a crash loop exceptions state.

With these changes, we prevent remittances to be created for invalid snapshots and configure the tally snapshot consumer to ignore failures.

## Testing
IQE Test MR will be added as part of [SWATCH-3141](https://issues.redhat.com/browse/SWATCH-3141)

### Setup

1.- podman compose -f docker-compose.yml up
2. apply liquibase migrations: `./gradlew liquibaseUpdate`
3.- start billable usage service: `./gradlew :swatch-billable-usage:quarkusDev`
4.- send message to the topic "platform.rhsm-subscriptions.tally" with invalid metric ID: 

```json
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "wrong!", "value": 12, "currentTotal": 100}]}]}
```

5.- verify the message is ignored by reading the service logs:

```
2025-01-08 12:10:11,388 WARN  [com.red.swa.bil.usa.ser.BillableUsageMapper] (vert.x-worker-thread-1) Ignoring unsupported measurement 'wrong!' for snapshot 'com.redhat.swatch.billable.usage.model.TallySnapshot@406dd35f[id=<null>,billingProvider=aws,billingAccountId=123,snapshotDate=2023-12-21T01:10:28Z,productId=rosa,sla=Premium,usage=Production,granularity=Hourly,tallyMeasurements=[com.redhat.swatch.billable.usage.model.TallyMeasurement@67539923[hardwareMeasurementType=AWS,metricId=wrong!,value=12.0,currentTotal=100.0]]]'

```

6.- send another message with a valid metric but unsupported for product:

```json
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Sockets", "value": 12, "currentTotal": 100}]}]}
```

7.- verify the message is ignored again:

```
2025-01-08 12:12:02,779 WARN  [com.red.swa.bil.usa.ser.BillableUsageMapper] (vert.x-worker-thread-1) Ignoring unsupported measurement 'Sockets' for snapshot 'com.redhat.swatch.billable.usage.model.TallySnapshot@4e96e20b[id=<null>,billingProvider=aws,billingAccountId=123,snapshotDate=2023-12-21T01:10:28Z,productId=rosa,sla=Premium,usage=Production,granularity=Hourly,tallyMeasurements=[com.redhat.swatch.billable.usage.model.TallyMeasurement@2dfafe71[hardwareMeasurementType=AWS,metricId=Sockets,value=12.0,currentTotal=100.0]]]'
```