### PR TITLE
SWATCH-3151: skip setting credential provider when using moto

### DIFF
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsMarketplaceMeteringClientFactory.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsMarketplaceMeteringClientFactory.java
@@ -52,13 +52,14 @@ public class AwsMarketplaceMeteringClientFactory {
     MarketplaceMeteringClientBuilder builder = MarketplaceMeteringClient.builder();
     if (awsMarketplaceEndpointOverride) {
       builder = builder.endpointOverride(URI.create(awsMarketplaceEndpointUrl));
+    } else {
+      builder.credentialsProvider(
+          awsCredentialsLookup.getCredentialsProvider(context.getAwsSellerAccountId()));
     }
     if (awsRegion != null) {
       builder = builder.region(Region.of(awsRegion));
     }
-    return builder
-        .credentialsProvider(
-            awsCredentialsLookup.getCredentialsProvider(context.getAwsSellerAccountId()))
-        .build();
+
+    return builder.build();
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsMarketplaceMeteringClientFactory.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsMarketplaceMeteringClientFactory.java
@@ -25,6 +25,10 @@ import com.redhat.swatch.clients.contracts.api.model.AwsUsageContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.net.URI;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClient;
 import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClientBuilder;
@@ -50,16 +54,21 @@ public class AwsMarketplaceMeteringClientFactory {
 
   public MarketplaceMeteringClient buildMarketplaceMeteringClient(AwsUsageContext context) {
     MarketplaceMeteringClientBuilder builder = MarketplaceMeteringClient.builder();
+    AwsCredentialsProvider awsCredentialsProvider;
     if (awsMarketplaceEndpointOverride) {
       builder = builder.endpointOverride(URI.create(awsMarketplaceEndpointUrl));
-    } else {
-      builder.credentialsProvider(
-          awsCredentialsLookup.getCredentialsProvider(context.getAwsSellerAccountId()));
+        awsCredentialsProvider = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("placeholder_id", "placeholder_key")
+        );
+    }
+    else {
+      awsCredentialsProvider = awsCredentialsLookup.getCredentialsProvider(context.getAwsSellerAccountId());
     }
     if (awsRegion != null) {
       builder = builder.region(Region.of(awsRegion));
     }
-
-    return builder.build();
+    return builder
+        .credentialsProvider(awsCredentialsProvider)
+        .build();
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3151

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Skip setting aws credentials when moto is being used.
