### PR TITLE
SWATCH-3152: Configure swatch-producer-azure to skip bad messages

### DIFF
--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -10,7 +10,7 @@ SPLUNK_HEC_BATCH_SIZE=1000
 SPLUNK_HEC_BATCH_INTERVAL=10S
 SPLUNK_HEC_RETRY_COUNT=3
 SPLUNK_HEC_INCLUDE_EX=true
-USAGE_AGGREGATE_FAIL_ON_DESER_FAILURE=true
+USAGE_AGGREGATE_FAIL_ON_DESER_FAILURE=false
 WIREMOCK_ENDPOINT=http://wiremock-service:8000
 CORS_ORIGINS=/.+\\\\.redhat\\\\.com/
 DISABLE_OTEL=true
@@ -113,6 +113,7 @@ mp.messaging.incoming.billable-usage-hourly-aggregate-in.fail-on-deserialization
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.connector=smallrye-kafka
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.topic=platform.rhsm-subscriptions.billable-usage-hourly-aggregate
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.group.id=swatch-producer-azure-usage-aggregate-consumer
+mp.messaging.incoming.billable-usage-hourly-aggregate-in.failure-strategy=ignore
 # Start at end of topic to prevent duplicate billing
 mp.messaging.incoming.billable-usage-hourly-aggregate-in.auto.offset.reset=earliest
 # This value needs to be synced with the retry configuration of the contracts API which will retry up to


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3152

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
[MR 987](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/987)

### Setup
<!-- Add any steps required to set up the test case -->
1. I used an ephemeral instance and the local IQE proxy

### Steps
<!-- Enter each step of the test below -->
1. Run the tests in the IQE MR

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Tests pass
2. Observe the swatch-azure-producer-service pod for a few minutes to confirm that it does not restart. You will also see the bad and good messages in the logs for that pod.
