### PR TITLE
SWATCH-3141: Configure swatch-billable-usage to skip bad messages

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -139,6 +139,7 @@ mp.messaging.incoming.tally-summary.connector=smallrye-kafka
 mp.messaging.incoming.tally-summary.topic=platform.rhsm-subscriptions.tally
 mp.messaging.incoming.tally-summary.value.deserializer=com.redhat.swatch.billable.usage.services.json.TallySummaryDeserializer
 mp.messaging.incoming.tally-summary.failure-strategy=ignore
+mp.messaging.incoming.tally-summary.fail-on-deserialization-failure=false
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3141

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
[IQE MR](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/992)

### Setup
<!-- Add any steps required to set up the test case -->
1. I used an ephemeral instance and the local IQE proxy

### Steps
<!-- Enter each step of the test below -->
1. Run the tests in the IQE MR

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Tests pass
2. Observe the swatch-billable-usage-service pod for a few minutes to confirm that it does not restart. You will also see the bad and good messages in the logs for that pod.
