### PR TITLE
SWATCH-3247: Add missing "Managed-nodes" metric when exporting instances

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -62,7 +62,8 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
               InstancesExportCsvItem::setMeasurementStorageGibibyteMonths,
           MetricIdUtils.getTransferGibibytes(),
               InstancesExportCsvItem::setMeasurementTransferGibibytes,
-          MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus);
+          MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus,
+          MetricIdUtils.getManagedNodes(), InstancesExportCsvItem::setMeasurementManagedNodes);
 
   @Override
   public List<Object> mapDataItem(TallyInstanceView item, ExportServiceRequest request) {

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.export;
+
+import static org.candlepin.subscriptions.tally.export.InstancesCsvDataMapperService.METRIC_MAPPER;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class InstancesCsvDataMapperServiceTest {
+  @ParameterizedTest
+  @MethodSource("getMetricsFromConfiguration")
+  void testGeneratedModelShouldHaveAllMetricsFromConfiguration(MetricId metricId) {
+    assertTrue(METRIC_MAPPER.containsKey(metricId));
+  }
+
+  static Set<MetricId> getMetricsFromConfiguration() {
+    return MetricId.getAll();
+  }
+}

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -33,6 +33,9 @@ properties:
   measurement_vcpus:
     type: number
     format: double
+  measurement_managed_nodes:
+    type: number
+    format: double
   category:
     type: string
   last_seen:

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
@@ -58,6 +58,10 @@ public class MetricIdUtils {
     return MetricId.fromString("Transfer-gibibytes");
   }
 
+  public static MetricId getManagedNodes() {
+    return MetricId.fromString("Managed-nodes");
+  }
+
   public static Stream<MetricId> getMetricIdsFromConfigForTag(String tag) {
     return getMetricIdsFromConfigForVariant(Variant.findByTag(tag).orElse(null));
   }


### PR DESCRIPTION
Jira issue: SWATCH-3247

## Description
When exporting instances that use the "ansible-aap-managed" product, we were not exporting the configured Managed-nodes metric.

I've added a test, so we don't forget to add the mapping when adding a new metric in the future. Also, I covered the ansible export in our integration tests.

## Testing
MR test: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1008

Added integration tests as part of the pull request changes.