### PR TITLE
SWATCH-3147: Configure swatch-producer-aws to use wiremock proxy in ephemeral

### DIFF
--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsThrottlingException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsThrottlingException.java
@@ -31,9 +31,4 @@ public class AwsThrottlingException extends AwsProducerException {
     super(ErrorCode.AWS_THROTTLING_ERROR, String.format("count=%d", count));
     this.count = count;
   }
-
-  public AwsThrottlingException(int count, Exception e) {
-    super(ErrorCode.AWS_THROTTLING_ERROR, String.format("count=%d", count), e);
-    this.count = count;
-  }
 }

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -29,6 +29,9 @@ DISABLE_OTEL=true
 # ephemeral specifics
 %ephemeral.DISABLE_OTEL=true
 %ephemeral.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractApi
+%ephemeral.AWS_MARKETPLACE_ENDPOINT_OVERRIDE=true
+%ephemeral.AWS_MANUAL_SUBMISSION_ENABLED=true
+%ephemeral.AWS_MARKETPLACE_ENDPOINT_URL=${WIREMOCK_ENDPOINT}/mock/aws
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG


### PR DESCRIPTION
Jira issue: SWATCH-3147

Depends on https://github.com/RedHatInsights/wiremock-consoledot/pull/6

## Description
Configure swatch-producer-aws to use wiremock proxy in ephemeral.
By default, wiremock is configured to keep using the moto instance. 
Only when the usage request contains the text marker "_UseWiremock_" in any field, then the wiremock instance will be used.

## Testing
MR Test: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1021