### PR TITLE
Add test helper pods to iqe proxy

### DIFF
--- a/bin/iqe-ee-proxy.sh
+++ b/bin/iqe-ee-proxy.sh
@@ -49,6 +49,9 @@ fi
 
 oc port-forward $(oc get pod -o name | grep kafka-0) 9092:9092 &
 oc port-forward $(oc get service -o name | grep kafka-bridge-bridge-service) 8080:8080 &
+oc port-forward $(oc get service -o name | grep wiremock-service) 8101:8101 &
+oc port-forward $(oc get service -o name | grep swatch-mock-prometheus-test-service) 9090:9090 &
+
 
 oc create configmap caddyfile \
     --from-file=${TMP_DIR}/Caddyfile

--- a/docs/iqe-ee-proxy.md
+++ b/docs/iqe-ee-proxy.md
@@ -26,6 +26,15 @@ https://insights-qe.pages.redhat.com/iqe-core-docs/tutorial/part3.html#download-
 `oc login …`
 `bonfire namespace reserve`
 `bonfire deploy rhsm …`
+
+If necessary, don't forget to deploy the additional "helper" containers (e.g. wiremock, kafka-bridge, mock prometheus), since they're EE specific and defined outside of the rhsm clowdapp.  If you're using `--source=appsre`, or if you have them defined in your local `~/.config/bonfire/config.yaml`, they should be automatically deployed.
+
+Otherwise, here's how you can deploy them manually.
+
+`oc process -f ../rhsm-subscriptions/stub/wiremock.yaml | oc apply -f -`
+`oc process -f ../rhsm-subscriptions/kafka-bridge/deploy/template.yaml | oc apply -f -`
+`oc process -f ../rhsm-subscriptions/swatch-metrics/deploy/mock-prometheus-clowdapp.yaml | oc apply -f -`
+
 9. Start the proxy:  
 `../rhsm-subscriptions/bin/iqe-ee-proxy.sh`
 10. Run iqe tests:  

--- a/stub/wiremock.yaml
+++ b/stub/wiremock.yaml
@@ -29,7 +29,7 @@ objects:
   - apiVersion: v1
     kind: Service
     metadata:
-      name: wiremock
+      name: wiremock-service
     spec:
       selector:
         app: wiremock


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

After following the guide for standing up the iqe proxy, I was encountering errors running my IQE tests that were due to not being able to connect to various services.  This PR:

- Updates the name of the wiremock service when it's deployed to match the naming convention of the other pods we deploy
- Updates the iqe proxy script so wiremock-service:8101 and swatch-mock-prometheus-test-service:9090 get their ports forwarded
- Adds a reminder to the docs/iqe-ee-proxy.md guide that you need to make sure all the parts and pieces are 

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Following the iqe-ee-proxy.md guide and then running this iqe test locally is successful

```
iqe tests plugin rhsm_subscriptions -m ephemeral -k test_verify_metering_operation_for_events_received_from_prometheus_for_openshift_products
```

