### PR TITLE
Fix health check and dependency in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,12 @@ services:
       - UNLEASH_TOKEN=default:development.unleash-insecure-api-token
       - UNLEASH_URL=http://unleash:4242/api
       - UNLEASH_CACHE_DIR=/tmp/.unleashcache
+    healthcheck:
+      test: curl --fail http://localhost:8080/health
+      interval: 2s
+      timeout: 1m
+      retries: 5
+      start_period: 10s
     depends_on:
       kafka:
         condition: service_healthy
@@ -156,7 +162,7 @@ services:
       db:
         condition: service_healthy
       kafka-setup:
-        condition: service_healthy
+        condition: service_completed_successfully
       inventory:  # main inventory deployment runs the db migrations
         condition: service_healthy
     user: root


### PR DESCRIPTION
Without this fix, using podman-compose 1.3.0, `podman-compose up -d` hangs.

Note that I still get an error when running `podman-compose up -d`, but it doesn't seem to affect the overall environment:

```
Error: generating dependency graph for container 60ea07ff4907cf77c664182241a3b4a66b6ade80d88d00b4be40197be97b6ef2: container b05578d38195fd57a77aef16d5e54d606d880af91b48f74e31f9c8a620a7ad6c depends on container 7d69dc95d14b6902ee820274f671eb63bd6420c660d0071a02a8c22404c08edd not found in input list: no such container
Error: unable to start container "60ea07ff4907cf77c664182241a3b4a66b6ade80d88d00b4be40197be97b6ef2": generating dependency graph for container 60ea07ff4907cf77c664182241a3b4a66b6ade80d88d00b4be40197be97b6ef2: container b05578d38195fd57a77aef16d5e54d606d880af91b48f74e31f9c8a620a7ad6c depends on container 7d69dc95d14b6902ee820274f671eb63bd6420c660d0071a02a8c22404c08edd not found in input list: no such container
```
