### PR TITLE
Update iqe ee proxy documentation to enable live logging

### DIFF
--- a/docs/iqe-ee-proxy.md
+++ b/docs/iqe-ee-proxy.md
@@ -48,8 +48,10 @@ Use JetBrains toolbox to install PyCharm since the flatpak version has issues.
 Run -> Edit Configurations -> Edit Configuration templates ... -> Python tests -> pytest  
 - Paths to ".env" files: /home/[username]/iqe-workspace/iqe_env 
 - both iqe-core and iqe-rhsm-subscriptions-plugin tabs should have this value
-- Additional arguments: -m ephemeral
+- Additional arguments: "-m ephemeral --log-cli-level=10"
 - Ensure that the python interpreter is using ~/iqe-workspace/.iqe_env/bin/python3
+
+**Note**: Using "--log-cli-level=10" will enable the live logging when running tests directly on Pycharm. More information in [this link](https://docs.pytest.org/en/latest/how-to/logging.html#live-logs).
 
 
 


### PR DESCRIPTION
## Testing
Follow the iqe ee proxy steps and when running a test directly from pycharm, you should see the logs as in:

![Screenshot From 2025-01-30 11-49-57](https://github.com/user-attachments/assets/681affaa-5e5e-4d9c-911f-6f43d8fc8a50)

Before these changes, when not adding the "--log-cli-level" argument, I only saw Passed or Failed :/
