### PR TITLE
SWATCH-3267: Disable UMB in swatch-contracts in ephemeral environment

### DIFF
--- a/deploy_ephemeral_env.sh
+++ b/deploy_ephemeral_env.sh
@@ -13,12 +13,15 @@ source ${CICD_ROOT}/_common_deploy_logic.sh
 # Whether or not to deploy frontends (default: false)
 : ${DEPLOY_FRONTENDS:="false"}
 
+# Bonfire namespace timeout
+: ${IQE_CJI_TIMEOUT:="120m"}
+
 # Deploy k8s resources for app and its dependencies (use insights-stage instead of insights-production for now)
 # -> use this PR as the template ref when downloading configurations for this component
 # -> use this PR's newly built image in the deployed configurations
 set -x
 export BONFIRE_NS_REQUESTER="${JOB_NAME}-${BUILD_NUMBER}"
-export NAMESPACE=$(bonfire namespace reserve --pool ${NAMESPACE_POOL})
+export NAMESPACE=$(bonfire namespace reserve --pool ${NAMESPACE_POOL} -d ${IQE_CJI_TIMEOUT})
 SMOKE_NAMESPACE=$NAMESPACE  # track which namespace was used here for 'teardown' in common_deploy_logic
 
 # NOTE(khowell) this line added to force enable sidecars
@@ -37,4 +40,5 @@ bonfire deploy \
     ${COMPONENTS_ARG} \
     ${COMPONENTS_RESOURCES_ARG} \
     ${EXTRA_DEPLOY_ARGS}
+
 set +x

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -231,7 +231,8 @@ mp.openapi.scan.exclude.packages=com.redhat.swatch.contract.openapi
 SWATCH_CONTRACT_PRODUCER_ENABLED = false
 
 UMB_ENABLED=false
-%ephemeral.UMB_ENABLED=true
+# Disable UMB in ephemeral due to certificate errors. To be reverted after SWATCH-3267 is resolved.
+%ephemeral.UMB_ENABLED=false
 %test.UMB_ENABLED=true
 %stage.UMB_ENABLED=true
 %prod.UMB_ENABLED=true


### PR DESCRIPTION
Jira issue: SWATCH-3267

## Description
he errors at the swatch contracts service start up:

```
2025-01-31 06:44:51,427 INFO [io.sma.rea.mes.amqp] (executor-thread-1) {} SRMSG16212: Establishing connection with AMQP broker
2025-01-31 06:44:51,532 ERROR [io.ver.cor.net.imp.ConnectionBase] (vert.x-eventloop-thread-0) {} javax.net.ssl.SSLHandshakeException: Received fatal alert: certificate_unknown
```

## Testing
SWATCH contracts should be able to start up correctly in EE.