### PR TITLE
SWATCH-3267: Re-enable UMB in ephemeral

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -231,8 +231,7 @@ mp.openapi.scan.exclude.packages=com.redhat.swatch.contract.openapi
 SWATCH_CONTRACT_PRODUCER_ENABLED = false
 
 UMB_ENABLED=false
-# Disable UMB in ephemeral due to certificate errors. To be reverted after SWATCH-3267 is resolved.
-%ephemeral.UMB_ENABLED=false
+%ephemeral.UMB_ENABLED=true
 %test.UMB_ENABLED=true
 %stage.UMB_ENABLED=true
 %prod.UMB_ENABLED=true


### PR DESCRIPTION
Jira issue: SWATCH-3267

## Description
This reverts commit 9467194ebbc2596525b3fbe0f72428c7a4293079 after the merge of
MR 131623 now that the certificates have been renewed.
