### PR TITLE
SWATCH-3294: Rename "swatch_billable_usage_total" to aggregated

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/kafka/streams/StreamTopologyProducer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/kafka/streams/StreamTopologyProducer.java
@@ -51,7 +51,8 @@ import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 @UnlessBuildProfile("test")
 public class StreamTopologyProducer {
 
-  public static final String USAGE_TOTAL_METRIC = "swatch_billable_usage_total";
+  public static final String USAGE_TOTAL_AGGREGATED_METRIC =
+      "swatch_billable_usage_total_aggregated";
 
   private final BillableUsageAggregationStreamProperties properties;
   private final ObjectMapper objectMapper;
@@ -104,7 +105,7 @@ public class StreamTopologyProducer {
     log.info("Sending aggregate to hourly topic: {}", aggregate);
     if (key.key().getProductId() != null && key.key().getMetricId() != null) {
       // add metrics for aggregation
-      var counter = Counter.builder(USAGE_TOTAL_METRIC);
+      var counter = Counter.builder(USAGE_TOTAL_AGGREGATED_METRIC);
       if (key.key().getBillingProvider() != null) {
         counter.tag("billing_provider", key.key().getBillingProvider());
       }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/BillableUsageAggregateStreamTopologyTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/BillableUsageAggregateStreamTopologyTest.java
@@ -20,7 +20,7 @@
  */
 package com.redhat.swatch.billable.usage.kafka;
 
-import static com.redhat.swatch.billable.usage.kafka.streams.StreamTopologyProducer.USAGE_TOTAL_METRIC;
+import static com.redhat.swatch.billable.usage.kafka.streams.StreamTopologyProducer.USAGE_TOTAL_AGGREGATED_METRIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -115,7 +115,7 @@ class BillableUsageAggregateStreamTopologyTest {
     assertEquals(Set.of(usage.getSnapshotDate()), actualAggregate.getSnapshotDates());
     assertEquals(usage.getUuid().toString(), actualAggregate.getRemittanceUuids().get(0));
     assertNotNull(actualAggregate.getWindowTimestamp());
-    assertUsageTotalMetricIs(36.0);
+    assertUsageTotalAggregatedMetricIs(36.0);
   }
 
   @Test
@@ -152,7 +152,7 @@ class BillableUsageAggregateStreamTopologyTest {
             usage1.getUuid().toString(), usage2.getUuid().toString(), usage3.getUuid().toString()),
         actualAggregate.getRemittanceUuids());
     assertNotNull(actualAggregate.getWindowTimestamp());
-    assertUsageTotalMetricIs(9.0);
+    assertUsageTotalAggregatedMetricIs(9.0);
   }
 
   @Test
@@ -194,12 +194,12 @@ class BillableUsageAggregateStreamTopologyTest {
     assertIterableEquals(
         List.of(secondSubUsage1.getUuid().toString(), secondSubUsage2.getUuid().toString()),
         actualSecondAggregate.getRemittanceUuids());
-    assertUsageTotalMetricIs(11.0);
+    assertUsageTotalAggregatedMetricIs(11.0);
   }
 
-  private void assertUsageTotalMetricIs(double expectedTotal) {
+  private void assertUsageTotalAggregatedMetricIs(double expectedTotal) {
     var metric =
-        getIngestedUsageMetric(
+        getIngestedUsageAggregatedMetric(
             PRODUCT,
             MetricIdUtils.getCores().toUpperCaseFormatted(),
             BillableUsage.BillingProvider.AZURE.toString());
@@ -223,12 +223,12 @@ class BillableUsageAggregateStreamTopologyTest {
     return usage;
   }
 
-  private Optional<Meter> getIngestedUsageMetric(
+  private Optional<Meter> getIngestedUsageAggregatedMetric(
       String productTag, String metricId, String billingProvider) {
     return meterRegistry.getMeters().stream()
         .filter(
             m ->
-                USAGE_TOTAL_METRIC.equals(m.getId().getName())
+                USAGE_TOTAL_AGGREGATED_METRIC.equals(m.getId().getName())
                     && productTag.equals(m.getId().getTag("product"))
                     && metricId.equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))


### PR DESCRIPTION
Jira issue: SWATCH-3294

## Description
This is caused because the tickets SWATCH-2301 and SWATCH-2304 were about to create the same metric in two different places, but the changes in SWATCH-2304 didn't include an special status "aggregated", so we're couting the same metric twice with the same values.

After speaking with Kevin Howell, we aggreed to replace the one from SWATCH-2304 to use a new metric counter named "swatch_billable_usage_total_aggregated" to avoid confusions.

## Testing

1. podman-compose up
2. setup database schema: `./gradlew liquibaseUpdate`
3. start the tally worker: `RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api ./gradlew clean :bootRun`
4.- start the contracts service: `SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-contracts:quarkusDev`
5.- start the azure service: `SERVER_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 ./gradlew :swatch-producer-azure:quarkusDev`
6.- start the billable usage service: `SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 KSTREAM_BILLABLE_USAGE_AGGREGATION_WINDOW_DURATION=10s KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=2s ./gradlew :swatch-billable-usage:quarkusDev`

Note that we need all the above services to ensure all the Kafka topics are created automatically.

7. insert test data:
```
insert into offering(sku) values ('MW02393');
insert into sku_product_tag(sku,product_tag) values ('MW02393','ansible-aap-managed');
INSERT INTO contracts VALUES ('b3a5e8b7-6260-48f4-a9eb-63a584763ce9', '12914277', now(), '2024-08-01 01:01:01.717275+00', NULL, 'org123', 'MW02393', 'aws', 'aws123', 'ansible-aap-managed', 'bcwuzc8ww10vvxfair55mliy8');
```

8. create a few messages in `platform.rhsm-subscriptions.tally`:
1:
```
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "aws123", "snapshot_date": "2024-08-10T01:10:28Z", "product_id": "ansible-aap-managed", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Managed-nodes", "value": 12, "currentTotal": 100}]}]}
``` 
2:
```
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Cores", "value": 12, "currentTotal": 100}]}]}
```
3:
```
{"org_id": "org123", "tally_snapshots": [{"billing_provider":"aws", "billing_account_id": "123", "snapshot_date": "2023-12-21T01:10:28Z", "product_id": "rosa", "sla": "Premium", "usage": "Production", "granularity": "Hourly", "tally_measurements": [{"hardware_measurement_type": "AWS", "metric_id": "Cores", "value": 12, "currentTotal": 100}]}]}
```

9. verification: 

The metrics from the swatch billable usage service should contain the new metric:

```
curl http://localhost:9001/metrics  | grep swatch_
# TYPE swatch_billable_usage_total_aggregated counter
# HELP swatch_billable_usage_total_aggregated  
swatch_billable_usage_total_aggregated{billing_provider="aws",metric_id="CORES",product="rosa"} 25.0
```