### PR TITLE
SWATCH-3295: Normalize the payg metrics to use the same tags and format

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -397,19 +397,11 @@ public class EventController {
     if (event.getBillingProvider() != null) {
       counter.tag("billing_provider", event.getBillingProvider().value());
     }
-    try {
-      counter
-          .tag("metric_id", MetricId.fromString(measurement.getMetricId()).toUpperCaseFormatted())
-          .withRegistry(meterRegistry)
-          .withTags("product", tag)
-          .increment(measurement.getValue());
-    } catch (Exception e) {
-      log.error(
-          "Error to increment counter '{}'. Event was '{}' and measurement '{}'",
-          INGESTED_USAGE_METRIC,
-          event,
-          measurement);
-    }
+    counter
+        .tag("metric_id", MetricId.tryGetValueFromString(measurement.getMetricId()))
+        .withRegistry(meterRegistry)
+        .withTags("product", tag)
+        .increment(measurement.getValue());
   }
 
   private static class ServiceInstancesResult {

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
 import io.micrometer.core.annotation.Timed;
@@ -142,7 +143,7 @@ public class TallySnapshotController {
                                   "product",
                                   snap.getProductId(),
                                   "metric_id",
-                                  entry.getKey().getMetricId(),
+                                  MetricId.tryGetValueFromString(entry.getKey().getMetricId()),
                                   "billing_provider",
                                   snap.getBillingProvider().getValue());
                           c.increment(entry.getValue());

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static org.candlepin.subscriptions.tally.SnapshotSummaryProducer.removeTotalMeasurements;
+
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
@@ -33,19 +35,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.TallyStateRepository;
 import org.candlepin.subscriptions.db.model.Granularity;
-import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
-import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.TallyState;
 import org.candlepin.subscriptions.db.model.TallyStateKey;
-import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.event.EventController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.support.RetryTemplate;
@@ -54,11 +52,11 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Provides the logic for updating Tally snapshots. */
+@Slf4j
 @Component
 public class TallySnapshotController {
 
   protected static final String TALLIED_USAGE_TOTAL_METRIC = "swatch_tally_tallied_usage_total";
-  private static final Logger log = LoggerFactory.getLogger(TallySnapshotController.class);
 
   private final ApplicationProperties appProps;
   private final InventoryAccountUsageCollector usageCollector;
@@ -118,43 +116,6 @@ public class TallySnapshotController {
     var snapshots = maxSeenSnapshotStrategy.produceSnapshotsFromCalculations(accountCalc);
     // Record tally values on the counter now that the transaction has closed.
     recordTallyCount(snapshots);
-  }
-
-  protected void recordTallyCount(List<TallySnapshot> savedSnapshots) {
-    var count = Counter.builder(TALLIED_USAGE_TOTAL_METRIC).withRegistry(meterRegistry);
-    // Only increment the counter at the finest granularity level to prevent over-counting
-    savedSnapshots.parallelStream()
-        .filter(this::isDuplicateSnap)
-        .forEach(
-            snap ->
-                snap.getTallyMeasurements().entrySet().stream()
-                    // Filter out TOTAL measurement types since those are aggregates and we don't
-                    // want to double count
-                    .filter(
-                        entry ->
-                            !entry
-                                .getKey()
-                                .getMeasurementType()
-                                .equals(HardwareMeasurementType.TOTAL))
-                    .forEach(
-                        entry -> {
-                          var c =
-                              count.withTags(
-                                  "product",
-                                  snap.getProductId(),
-                                  "metric_id",
-                                  MetricId.tryGetValueFromString(entry.getKey().getMetricId()),
-                                  "billing_provider",
-                                  snap.getBillingProvider().getValue());
-                          c.increment(entry.getValue());
-                        }));
-  }
-
-  protected boolean isDuplicateSnap(TallySnapshot snap) {
-    return SubscriptionDefinition.isFinestGranularity(
-            snap.getProductId(), snap.getGranularity().toString())
-        && snap.getServiceLevel() != ServiceLevel._ANY
-        && snap.getUsage() != Usage._ANY;
   }
 
   // Because we want to ensure that our DB operations have been completed before
@@ -239,6 +200,39 @@ public class TallySnapshotController {
             e);
       }
     }
+  }
+
+  private void recordTallyCount(List<TallySnapshot> snapshots) {
+    var count = Counter.builder(TALLIED_USAGE_TOTAL_METRIC).withRegistry(meterRegistry);
+    // Only increment the counter at the finest granularity level to prevent over-counting
+    snapshots.stream()
+        .filter(this::filterByFinestGranularityAndNotAnySnapshots)
+        .map(
+            snapshot -> {
+              removeTotalMeasurements(snapshot);
+              return snapshot;
+            })
+        .forEach(
+            snap ->
+                snap.getTallyMeasurements()
+                    .entrySet()
+                    .forEach(
+                        entry -> {
+                          var c =
+                              count.withTags(
+                                  "product",
+                                  snap.getProductId(),
+                                  "metric_id",
+                                  MetricId.tryGetValueFromString(entry.getKey().getMetricId()),
+                                  "billing_provider",
+                                  snap.getBillingProvider().getValue());
+                          c.increment(entry.getValue());
+                        }));
+  }
+
+  private boolean filterByFinestGranularityAndNotAnySnapshots(TallySnapshot snapshot) {
+    return SnapshotSummaryProducer.filterByGranularityAndNotAnySnapshots(
+        snapshot, SubscriptionDefinition.getFinestGranularity(snapshot.getProductId()));
   }
 
   private boolean isCombiningRollupStrategySupported(

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -56,6 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class TallySnapshotController {
 
+  protected static final String TALLIED_USAGE_TOTAL_METRIC = "swatch_tally_tallied_usage_total";
   private static final Logger log = LoggerFactory.getLogger(TallySnapshotController.class);
 
   private final ApplicationProperties appProps;
@@ -119,7 +120,7 @@ public class TallySnapshotController {
   }
 
   protected void recordTallyCount(List<TallySnapshot> savedSnapshots) {
-    var count = Counter.builder("swatch_tally_tallied_usage_total").withRegistry(meterRegistry);
+    var count = Counter.builder(TALLIED_USAGE_TOTAL_METRIC).withRegistry(meterRegistry);
     // Only increment the counter at the finest granularity level to prevent over-counting
     savedSnapshots.parallelStream()
         .filter(this::isDuplicateSnap)
@@ -142,7 +143,7 @@ public class TallySnapshotController {
                                   snap.getProductId(),
                                   "metric_id",
                                   entry.getKey().getMetricId(),
-                                  "billing_provider_id",
+                                  "billing_provider",
                                   snap.getBillingProvider().getValue());
                           c.increment(entry.getValue());
                         }));

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.configuration.registry.MetricId;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.persistence.EntityManager;
@@ -622,7 +623,9 @@ class EventControllerTest {
             m ->
                 INGESTED_USAGE_METRIC.equals(m.getId().getName())
                     && productTag.equals(m.getId().getTag("product"))
-                    && metricId.equals(m.getId().getTag("metric_id"))
+                    && MetricId.fromString(metricId)
+                        .toUpperCaseFormatted()
+                        .equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))
         .findFirst();
   }

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -624,7 +624,7 @@ class EventControllerTest {
                 INGESTED_USAGE_METRIC.equals(m.getId().getName())
                     && productTag.equals(m.getId().getTag("product"))
                     && MetricId.fromString(metricId)
-                        .toUpperCaseFormatted()
+                        .getValue()
                         .equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))
         .findFirst();

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
@@ -20,6 +20,7 @@
  */
 package org.candlepin.subscriptions.tally;
 
+import static org.candlepin.subscriptions.tally.TallySnapshotController.TALLIED_USAGE_TOTAL_METRIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -77,12 +78,8 @@ class TallySnapshotControllerMetricsTest {
     controller.produceSnapshotsForOrg("123");
 
     var counter =
-        Counter.builder("swatch_tally_tallied_usage_total")
-            .tags(
-                "product",
-                "RHEL for x86",
-                "billing_provider_id",
-                BillingProvider.RED_HAT.getValue())
+        Counter.builder(TALLIED_USAGE_TOTAL_METRIC)
+            .tags("product", "RHEL for x86", "billing_provider", BillingProvider.RED_HAT.getValue())
             .withRegistry(registry);
 
     for (var s : Set.of("CORES", "SOCKETS")) {
@@ -128,8 +125,8 @@ class TallySnapshotControllerMetricsTest {
     controller.produceHourlySnapshotsForOrg("123");
 
     var counter =
-        Counter.builder("swatch_tally_tallied_usage_total")
-            .tags("product", "rosa", "billing_provider_id", BillingProvider.RED_HAT.getValue())
+        Counter.builder(TALLIED_USAGE_TOTAL_METRIC)
+            .tags("product", "rosa", "billing_provider", BillingProvider.RED_HAT.getValue())
             .withRegistry(registry);
 
     for (var s : Set.of("CORES", "SOCKETS")) {

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerMetricsTest.java
@@ -82,7 +82,7 @@ class TallySnapshotControllerMetricsTest {
             .tags("product", "RHEL for x86", "billing_provider", BillingProvider.RED_HAT.getValue())
             .withRegistry(registry);
 
-    for (var s : Set.of("CORES", "SOCKETS")) {
+    for (var s : Set.of("Cores", "Sockets")) {
       var c = counter.withTag("metric_id", s);
       assertEquals(10.0, c.count());
     }
@@ -129,7 +129,7 @@ class TallySnapshotControllerMetricsTest {
             .tags("product", "rosa", "billing_provider", BillingProvider.RED_HAT.getValue())
             .withRegistry(registry);
 
-    for (var s : Set.of("CORES", "SOCKETS")) {
+    for (var s : Set.of("Cores", "Sockets")) {
       var c = counter.withTag("metric_id", s);
       assertEquals(10.0, c.count());
     }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/kafka/streams/StreamTopologyProducer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/kafka/streams/StreamTopologyProducer.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.billable.usage.kafka.streams;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.configuration.registry.MetricId;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.profile.UnlessBuildProfile;
@@ -116,7 +117,11 @@ public class StreamTopologyProducer {
 
       counter
           .withRegistry(meterRegistry)
-          .withTags("product", key.key().getProductId(), "metric_id", key.key().getMetricId())
+          .withTags(
+              "product",
+              key.key().getProductId(),
+              "metric_id",
+              MetricId.tryGetValueFromString(key.key().getMetricId()))
           .increment(aggregate.getTotalValue().doubleValue());
     }
   }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -261,7 +261,7 @@ public class BillableUsageService {
         new ArrayList<>(
             List.of(
                 "product", usage.getProductId(),
-                "metric_id", usage.getMetricId(),
+                "metric_id", MetricId.tryGetValueFromString(usage.getMetricId()),
                 "billing_provider", usage.getBillingProvider().value(),
                 "status", usage.getStatus().value()));
     double coverage =

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/model/Quantity.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/model/Quantity.java
@@ -68,8 +68,12 @@ public class Quantity<U extends Unit> {
     return this;
   }
 
+  public double toMetricUnits() {
+    return value / unit.getBillingFactor();
+  }
+
   public <T extends Unit> Quantity<T> to(T targetUnit) {
-    var valueInMetricUnits = value / unit.getBillingFactor();
+    var valueInMetricUnits = toMetricUnits();
     var valueInTargetUnits = valueInMetricUnits * targetUnit.getBillingFactor();
     return new Quantity<>(valueInTargetUnits, targetUnit);
   }

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -64,7 +64,6 @@ quarkus.http.access-log.pattern=combined
 quarkus.management.enabled=true
 quarkus.management.port=9000
 quarkus.management.root-path=/
-quarkus.micrometer.export.json.enabled=true
 
 # database configuration
 quarkus.datasource.db-kind=postgresql

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/BillableUsageAggregateStreamTopologyTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/kafka/BillableUsageAggregateStreamTopologyTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.redhat.swatch.billable.usage.kafka.streams.BillableUsageAggregationStreamProperties;
 import com.redhat.swatch.billable.usage.kafka.streams.StreamTopologyProducer;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -230,7 +231,9 @@ class BillableUsageAggregateStreamTopologyTest {
             m ->
                 USAGE_TOTAL_AGGREGATED_METRIC.equals(m.getId().getName())
                     && productTag.equals(m.getId().getTag("product"))
-                    && metricId.equals(m.getId().getTag("metric_id"))
+                    && MetricId.fromString(metricId)
+                        .getValue()
+                        .equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))
         .findFirst();
   }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -816,7 +816,9 @@ class BillableUsageServiceTest {
             m ->
                 metric.equals(m.getId().getName())
                     && productTag.equals(m.getId().getTag("product"))
-                    && metricId.equals(m.getId().getTag("metric_id"))
+                    && MetricId.fromString(metricId)
+                        .getValue()
+                        .equals(m.getId().getTag("metric_id"))
                     && billingProvider.equals(m.getId().getTag("billing_provider")))
         .findFirst();
   }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -163,7 +163,7 @@ class BillableUsageServiceTest {
     // 4(Billing_factor) = 72
     thenRemittanceIsUpdated(usage, 72.0);
     thenUsageIsSent(usage, 18.0);
-    thenBillableMeterMatches(usage, 18.0);
+    thenBillableMeterMatches(usage, 72.0);
   }
 
   @Test
@@ -207,7 +207,7 @@ class BillableUsageServiceTest {
 
     thenRemittanceIsUpdated(usage, 12.0);
     thenUsageIsSent(usage, usage.getValue());
-    thenBillableMeterMatches(usage, usage.getValue());
+    thenBillableMeterMatches(usage, 12.0);
   }
 
   @Test
@@ -220,7 +220,7 @@ class BillableUsageServiceTest {
 
     thenRemittanceIsUpdated(usage, 28.0);
     thenUsageIsSent(usage, usage.getValue());
-    thenBillableMeterMatches(usage, usage.getValue());
+    thenBillableMeterMatches(usage, 28.0);
   }
 
   // Simulates progression through contract billing.
@@ -662,36 +662,28 @@ class BillableUsageServiceTest {
     }
 
     thenUsageIsSent(usage, expectedBilledValue);
-    thenBillableMeterMatches(usage, expectedBilledValue);
-    if (!contracts.isEmpty()) {
-      thenCoveredMeterMatches(usage, getCoveredAmount(usage, currentUsage, contracts, usageDate));
+    thenBillableMeterMatches(usage, expectedRemitted);
+    if (expectedRemitted > 0 && !contracts.isEmpty()) {
+      thenCoveredMeterMatches(usage, getCoveredAmount(usage, contracts, usageDate));
     }
   }
 
   private double getCoveredAmount(
-      BillableUsage usage,
-      Double currentUsage,
-      List<Contract> contracts,
-      OffsetDateTime usageDate) {
-    double coverage =
-        contracts.stream()
-            .filter(
-                x ->
-                    (x.getStartDate() == null
-                            || x.getStartDate().isBefore(usageDate)
-                            || x.getStartDate().isEqual(usageDate))
-                        && (x.getEndDate() == null
-                            || x.getEndDate().isAfter(usageDate)
-                            || x.getEndDate().isEqual(usageDate)))
-            .map(Contract::getMetrics)
-            .flatMap(List::stream)
-            .filter(
-                x -> x.getMetricId().equals(MetricId.fromString(usage.getMetricId()).toString()))
-            .mapToInt(Metric::getValue)
-            .sum();
-    return currentUsage * usage.getBillingFactor() > coverage
-        ? coverage
-        : currentUsage * usage.getBillingFactor();
+      BillableUsage usage, List<Contract> contracts, OffsetDateTime usageDate) {
+    return contracts.stream()
+        .filter(
+            x ->
+                (x.getStartDate() == null
+                        || x.getStartDate().isBefore(usageDate)
+                        || x.getStartDate().isEqual(usageDate))
+                    && (x.getEndDate() == null
+                        || x.getEndDate().isAfter(usageDate)
+                        || x.getEndDate().isEqual(usageDate)))
+        .map(Contract::getMetrics)
+        .flatMap(List::stream)
+        .filter(x -> x.getMetricId().equals(MetricId.fromString(usage.getMetricId()).toString()))
+        .mapToDouble(m -> m.getValue() / usage.getBillingFactor())
+        .sum();
   }
 
   private void thenUsageIsSent(BillableUsage usage, double expectedValue) {

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -119,7 +119,6 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
-quarkus.micrometer.export.json.enabled=true
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -47,7 +47,6 @@ quarkus.http.access-log.pattern=combined
 quarkus.management.enabled=true
 quarkus.management.port=9000
 quarkus.management.root-path=/
-quarkus.micrometer.export.json.enabled=true
 
 #clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092

--- a/swatch-metrics/src/main/resources/application.yaml
+++ b/swatch-metrics/src/main/resources/application.yaml
@@ -50,10 +50,6 @@ quarkus:
     port: 9000
     # Configure the Quarkus non application paths to listen on "/" instead of "/q"
     root-path: /
-  micrometer:
-    export:
-      json:
-        enabled: true
   http:
     port: ${SERVER_PORT}
     test-port: 0

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -375,7 +375,11 @@ public class AwsBillableUsageAggregateConsumer {
 
     swatchProducerMeteredTotal
         .withRegistry(meterRegistry)
-        .withTags("product", aggregateKey.getProductId(), "metric_id", aggregateKey.getMetricId())
+        .withTags(
+            "product",
+            aggregateKey.getProductId(),
+            "metric_id",
+            MetricId.fromString(aggregateKey.getMetricId()).getValue())
         .increment(usage.getTotalValue().doubleValue());
   }
 

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -77,7 +77,6 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
-quarkus.micrometer.export.json.enabled=true
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -315,7 +315,7 @@ public class AzureBillableUsageAggregateConsumer {
             "product",
             usage.getAggregateKey().getProductId(),
             "metric_id",
-            usage.getAggregateKey().getMetricId())
+            MetricId.tryGetValueFromString(usage.getAggregateKey().getMetricId()))
         .increment(usage.getTotalValue().doubleValue());
   }
 }

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -78,7 +78,6 @@ quarkus.management.enabled=true
 %test.quarkus.management.enabled=false
 quarkus.management.port=9000
 quarkus.management.root-path=/
-quarkus.micrometer.export.json.enabled=true
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_HOUR
 import static com.redhat.swatch.azure.configuration.Channels.BILLABLE_USAGE_STATUS;
 import static com.redhat.swatch.azure.service.AzureBillableUsageAggregateConsumer.METERED_TOTAL_METRIC;
 import static com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource.IN_MEMORY_CONNECTOR;
+import static com.redhat.swatch.configuration.registry.SubscriptionDefinition.getBillingFactor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -228,7 +229,8 @@ class AzureBillableUsageAggregateConsumerTest {
               assertTrue(metric.isPresent());
               assertEquals(
                   metric.get().measure().iterator().next().getValue(),
-                  EXPECTED_VALUE.doubleValue());
+                  EXPECTED_VALUE.doubleValue()
+                      / getBillingFactor(PRODUCT_ID, MetricIdUtils.getCores().getValue()));
             });
   }
 

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumerTest.java
@@ -31,6 +31,7 @@ import com.redhat.swatch.azure.test.resources.InMemoryMessageBrokerKafkaResource
 import com.redhat.swatch.azure.test.resources.InjectWireMock;
 import com.redhat.swatch.azure.test.resources.WireMockResource;
 import com.redhat.swatch.clients.contracts.api.model.AzureUsageContext;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -237,7 +238,9 @@ class AzureBillableUsageAggregateConsumerTest {
             m ->
                 METERED_TOTAL_METRIC.equals(m.getId().getName())
                     && PRODUCT_ID.equals(m.getId().getTag("product"))
-                    && metricId.equals(m.getId().getTag("metric_id"))
+                    && MetricId.fromString(metricId)
+                        .getValue()
+                        .equals(m.getId().getTag("metric_id"))
                     && BillableUsage.BillingProvider.AZURE
                         .toString()
                         .equals(m.getId().getTag("billing_provider")))

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/MetricId.java
@@ -28,10 +28,12 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Data
 // constructor is private so that the factory method is the only way to get a MetricId
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public class MetricId implements Serializable {
 
   private final String value;
@@ -60,6 +62,19 @@ public class MetricId implements Serializable {
             () ->
                 new IllegalArgumentException(
                     String.format("MetricId: %s not found in configuration", value)));
+  }
+
+  /**
+   * Get the metric id value from a String. In case of it does not exist, it returns the string
+   * instead of throwing an exception.
+   */
+  public static String tryGetValueFromString(String metricId) {
+    try {
+      return MetricId.fromString(metricId).getValue();
+    } catch (IllegalArgumentException e) {
+      log.warn("Failed to get the MetricId.value from {}", metricId);
+      return metricId;
+    }
   }
 
   public static Set<MetricId> getAll() {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -148,17 +148,21 @@ public class SubscriptionDefinition {
   }
 
   public static boolean isFinestGranularity(String tag, String granularity) {
-    var subscription =
-        SubscriptionDefinition.lookupSubscriptionByTag(tag)
-            .orElseThrow(
-                () -> new IllegalStateException(tag + " missing in subscription configuration"));
-
-    var finestTagGranularity = subscription.getFinestGranularity().toString();
+    String finestTagGranularity = getFinestGranularity(tag);
 
     // Compare as strings because granularity is represented by two different enumerations:
     // org.candlepin.subscriptions.db.model.Granularity and
     // com.redhat.swatch.configuration.registry.SubscriptionDefinitionGranularity
     return finestTagGranularity.equalsIgnoreCase(granularity);
+  }
+
+  public static String getFinestGranularity(String tag) {
+    var subscription =
+        SubscriptionDefinition.lookupSubscriptionByTag(tag)
+            .orElseThrow(
+                () -> new IllegalStateException(tag + " missing in subscription configuration"));
+
+    return subscription.getFinestGranularity().toString();
   }
 
   public SubscriptionDefinitionGranularity getFinestGranularity() {

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -182,6 +182,16 @@ public class SubscriptionDefinition {
     return granularity;
   }
 
+  public static double getBillingFactor(String tag, String metricId) {
+    var metricOptional =
+        Variant.findByTag(tag)
+            .map(Variant::getSubscription)
+            .flatMap(
+                subscriptionDefinition ->
+                    subscriptionDefinition.getMetric(MetricId.fromString(metricId).getValue()));
+    return metricOptional.map(Metric::getBillingFactor).orElse(1.0);
+  }
+
   public static boolean supportsGranularity(SubscriptionDefinition sub, String granularity) {
     return sub.getSupportedGranularity().stream()
         .map(x -> x.toString().toLowerCase())


### PR DESCRIPTION
Jira issue: SWATCH-3295

Depends on https://github.com/RedHatInsights/rhsm-subscriptions/pull/4157

## Description
All the payg metrics should have the same tags, units and use the same format to be used in the grafana dashboard.

This pull request addresses the following changes:
- Change format of metric ID to use the metric ID code instead of the uppercase format
Some metrics were using one format or the another. All the metrics should use the same one. 

- Wrong billing_provider_id in "swatch_tally_tallied_usage_total", it should be "billing_provider"
- The metric "swatch_tally_tallied_usage_total" was double counting. Fixed by reusing the logic to exclude duplicate snaps.
- The metrics "swatch_contract_usage_total", "swatch_billable_usage_total" and "swatch_producer_metered_total" were expressed in billing units instead of metric units. We need to use the metric units, so the numbers in the grafana dashboard are consistent.
- Reverts commit d831fdce235af513caac4b08e4482045512d2765. We're not using the json format anylonger in tests. 

## Testing

IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1040