### PR TITLE
SWATCH-2536 Subscription doesn't show if sku socket limit is unlimited

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -90,7 +90,9 @@ public class SubscriptionCapacityViewRepository
       searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
     }
     if (Objects.nonNull(metricId)) {
-      searchCriteria = searchCriteria.and(hasMetricId(metricId));
+      Specification<SubscriptionCapacityView> metricOrUnlimitedSpec =
+          hasMetricId(metricId).or(hasUnlimitedUsage(true));
+      searchCriteria = searchCriteria.and(metricOrUnlimitedSpec);
     }
     if (Objects.nonNull(category)) {
       searchCriteria = searchCriteria.and(hasCategory(category));
@@ -176,5 +178,11 @@ public class SubscriptionCapacityViewRepository
                 Boolean.class,
                 root.get("metrics"),
                 builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
+  }
+
+  public static Specification<SubscriptionCapacityView> hasUnlimitedUsage(
+      Boolean hasUnlimitedUsage) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.hasUnlimitedUsage), hasUnlimitedUsage);
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2536

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
../rhsm-subscriptions/bin/iqe-ee-proxy.sh
iqe tests plugin rhsm_subscriptions -k test_unlimited_sku_capacity --pdb
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1056

### Setup
<!-- Add any steps required to set up the test case -->
1. Insert data from stage using the script or manually 
Using script
`import-from-gabi.py --org-id='17685818' --subscriptions --offerings --contracts`

`GABI_URL=https://gabi-subscription-watch-stage.apps.crcs02ue1.urby.p1.openshiftapps.com OCP_CONSOLE_TOKEN=$(oc whoami -t) gabitabi -q "SELECT * from sku_product_tag;" --sep "," -o "sku_producttag_full_data1.csv"`

Using manually:
Offering
```
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('RH02252', 'RHEL Developer', 'RHEL', null, null, null, null, 'Red Hat Enterprise Linux Compute Node', 'Self-Support', 'Development/Test', 'Red Hat Developer Subscription for Teams', true, '', false, '', 'RHEL', 'Server');
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('ESA0012', 'OpenShift Container Platform', 'OPENSHIFT ENTERPRISE', null, null, null, null, '', 'Premium', '', 'Red Hat OpenShift Container Platform, Premium (One Year, Enterprise Program)', true, '', false, 'ESA', 'OpenShift', 'OCP - OpenShift Container Platform');
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('RH00772', 'RHEL for SAP HANA', 'RED HAT ENTERPRISE LINUX', null, null, null, 2, '', 'Standard', 'Production', 'Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard', false, 'RH00772', false, '', 'RHEL', 'SAP');
```

sku_product_tag
```
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('ESA0012', 'OpenShift Container Platform', '4af7f8a7-6c84-4d7e-a928-773ada4e4a2d');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('ESA0012', 'RHEL for ARM', '27a693df-81ee-4d5e-8140-0072598e6558');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'rhel-for-x86-eus', 'b29eaa51-1f0b-4de4-a3fc-44362a2ae9af');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'RHEL for IBM z', '91120d2e-64a5-44a9-9b53-bb073c19a39e');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'rhel-for-x86-ha', '36239fcb-69a0-41aa-b5e4-1ca1d6b861fe');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'RHEL for ARM', 'f0056034-cd8f-489e-babf-0e4ca32ccc89');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'rhel-for-sap-x86', 'b3def2fc-02d6-430e-afef-bc52726f3715');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'RHEL for IBM Power', '1972a7eb-d33e-42bf-a473-ed0031ed1918');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'rhel-for-x86-rs', '97be1e18-0f5f-47ab-b786-d92faba532fb');
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('RH02252', 'RHEL for x86', '2d7d7a8b-5e4f-4386-9cbd-a2a7ed9e4cf8');
```

Subscription
```
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('ESA0012', '17685818', '14604439', 1, '2025-01-27 05:00:00.000000 +00:00', '2026-01-27 04:59:59.000000 +00:00', '', '14604596', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH02252', '17685818', '14604403', 1, '2025-01-27 05:00:00.000000 +00:00', '2026-01-27 04:59:59.000000 +00:00', '', '14604560', '', '');
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('RH00772', '17685818', '14358408', 2, '2024-02-27 05:00:00.000000 +00:00', '2025-02-26 05:00:00.000000 +00:00', '', '14358565', '', '');
```

Subscription_measurements
```
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES ('14358408', null, '14358408', '14358408', 14358408);
```


The subscription_capacity_view would look like:
```
14358408,14358565,RH00772,false,"Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard",Standard,Production,17685818,"","","",2024-02-27 05:00:00.000000 +00:00,2025-02-26 05:00:00.000000 +00:00,"[{""value"": 4, ""metric_id"": ""Sockets"", ""measurement_type"": ""HYPERVISOR""}]",rhel-for-sap-x86,2
14358408,14358565,RH00772,false,"Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard",Standard,Production,17685818,"","","",2024-02-27 05:00:00.000000 +00:00,2025-02-26 05:00:00.000000 +00:00,"[{""value"": 4, ""metric_id"": ""Sockets"", ""measurement_type"": ""HYPERVISOR""}]",RHEL for x86,2
14358408,14358565,RH00772,false,"Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard",Standard,Production,17685818,"","","",2024-02-27 05:00:00.000000 +00:00,2025-02-26 05:00:00.000000 +00:00,"[{""value"": 4, ""metric_id"": ""Sockets"", ""measurement_type"": ""HYPERVISOR""}]",rhel-for-x86-eus,2
14358408,14358565,RH00772,false,"Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard",Standard,Production,17685818,"","","",2024-02-27 05:00:00.000000 +00:00,2025-02-26 05:00:00.000000 +00:00,"[{""value"": 4, ""metric_id"": ""Sockets"", ""measurement_type"": ""HYPERVISOR""}]",rhel-for-x86-ha,2
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",RHEL Compute Node,1
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",RHEL for ARM,1
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",RHEL for IBM Power,1
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",RHEL for IBM z,1
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",rhel-for-sap-x86,1
14604403,14604560,RH02252,true,Red Hat Developer Subscription for Teams,Self-Support,Development/Test,17685818,"","","",2025-01-27 05:00:00.000000 +00:00,2026-01-27 04:59:59.000000 +00:00,"[{""value"": null, ""metric_id"": null, ""measurement_type"": null}]",RHEL for x86,1

```

The view is formed by:
```
select distinct s.subscription_id,
                s.subscription_number,
                s.sku,
                o.has_unlimited_usage,
                o.description as product_name,
                o.sla as service_level,
                o.usage,
                s.org_id,
                s.billing_provider,
                s.billing_provider_id,
                s.billing_account_id,
                s.start_date,
                s.end_date,
                CONCAT('[{"metric_id":"', sm.metric_id, '","value":',sm.value, ',"measurement_type":"',sm.measurement_type , '"}]') as metrics,
                spt.product_tag,
                s.quantity as quantity
from subscription s
         inner join offering o on s.sku=o.sku
         inner join sku_product_tag spt on s.sku = spt.sku
         left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
where s.start_date <= now() and (s.end_date is null or s.end_date >= now()) 
group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o.usage , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity, sm.metric_id, sm.value, sm.measurement_type, s.start_date, s.end_date
order by s.subscription_id asc
```

### Verification Steps before the changes on main
<!-- Enter the steps needed to verify the test passed -->
`SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev`

1. **For Rhel**:

Request:
`http GET ':8001/api/rhsm-subscriptions/v2/subscriptions/products/RHEL%20for%20x86?dir=desc&ending=2025-02-16T23:59:59.999Z&limit=100&offset=0&metric_id=Sockets&sort=next_event_date&beginning=2025-01-17T00:00:00.000Z'  x-rh-identity:$(echo '{"identity":{"type":"User","org_id":"17685818"}}' | base64 -w0)`

```
select
        scv1_0.start_date,
        scv1_0.subscription_id,
        scv1_0.billing_account_id,
        scv1_0.billing_provider,
        scv1_0.billing_provider_id,
        scv1_0.end_date,
        scv1_0.has_unlimited_usage,
        scv1_0.metrics,
        scv1_0.org_id,
        scv1_0.product_name,
        scv1_0.product_tag,
        scv1_0.quantity,
        scv1_0.service_level,
        scv1_0.sku,
        scv1_0.subscription_number,
        scv1_0.usage 
    from
        subscription_capacity_view scv1_0 
    where
        scv1_0.org_id=? 
        and scv1_0.product_tag=? 
        and jsonb_path_exists(scv1_0.metrics, '$[*] ? (@.metric_id == "Sockets")')
2025-02-17 19:03:17,768 TRACE [org.hib.orm.jdb.bind] (executor-thread-1) {user=17685818} binding parameter (1:VARCHAR) <- [17685818]
2025-02-17 19:03:17,769 TRACE [org.hib.orm.jdb.bind] (executor-thread-1) {user=17685818} binding parameter (2:VARCHAR) <- [RHEL for x86]
```

This doesn't pull the unlimited subs as shown in UI.
![Screenshot From 2025-02-17 16-15-19](https://github.com/user-attachments/assets/2f3130fc-12b6-420f-beea-6cbe54c3c6fc)


2. **For Openshift**:
UI request
`http GET ':8001/api/rhsm-subscriptions/v2/subscriptions/products/OpenShift%20Container%20Platform?dir=desc&ending=2025-02-16T23:59:59.999Z&limit=100&offset=0&sort=next_event_date&beginning=2025-01-17T00:00:00.000Z' x-rh-identity:$(echo '{"identity":{"type":"User","org_id":"17685818"}}' | base64 -w0)`

```
select
    scv1_0.start_date,
    scv1_0.subscription_id,
        scv1_0.billing_account_id,
    scv1_0.billing_provider,
    scv1_0.billing_provider_id,
    scv1_0.end_date,
    scv1_0.has_unlimited_usage,
    scv1_0.metrics,
    scv1_0.org_id,
    scv1_0.product_name,
    scv1_0.product_tag,
    scv1_0.quantity,
    scv1_0.service_level,
    scv1_0.sku,
    scv1_0.subscription_number,
    scv1_0.usage
from
    subscription_capacity_view scv1_0
where
    scv1_0.org_id='17685818'
  and scv1_0.product_tag='OpenShift Container Platform'
```

Response includes both unlimited and limited subs.
```
{
  "data": [
    {
      "sku": "ESA0012",
      "product_name": "Red Hat OpenShift Container Platform, Premium (One Year, Enterprise Program)",
      "service_level": "Premium",
      "usage": "",
      "subscriptions": [
        {
          "id": "14604439",
          "number": "14604596"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2026-01-27T04:59:59Z",
      "next_event_type": "Subscription End",
      "quantity": 1,
      "measurements": [
        0,
        0
      ],
      "has_infinite_quantity": true
    },
    {
      "sku": "MCT2863",
      "product_name": "Red Hat OpenShift Container Platform, Standard (1-2 Sockets)",
      "service_level": "Standard",
      "usage": "",
      "subscriptions": [
        {
          "id": "14347785",
          "number": "14347942"
        },
        {
          "id": "14358414",
          "number": "14358571"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 354,
      "measurements": [
        0,
        708
      ],
      "category": "physical",
      "has_infinite_quantity": false
    },
    {
      "sku": "MCT2862",
      "product_name": "Red Hat OpenShift Container Platform, Premium (1-2 Sockets)",
      "service_level": "Premium",
      "usage": "",
      "subscriptions": [
        {
          "id": "14347784",
          "number": "14347941"
        },
        {
          "id": "14358413",
          "number": "14358570"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        0,
        788
      ],
      "category": "physical",
      "has_infinite_quantity": false
    },
    {
      "sku": "MCT2735",
      "product_name": "Red Hat OpenShift Container Platform Premium (2 Cores or 4 vCPUs)",
      "service_level": "Premium",
      "usage": "",
      "subscriptions": [
        {
          "id": "14347782",
          "number": "14347939"
        },
        {
          "id": "14358411",
          "number": "14358568"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        788,
        0
      ],
      "category": "physical",
      "has_infinite_quantity": false
    }
  ],
  "meta": {
    "count": 5,
    "product": "OpenShift Container Platform",
    "measurements": [
      "Cores",
      "Sockets"
    ],
    "subscription_type": "Annual"
  }
}
```

On UI it looks like below for console.stage.redhat.com create your own account:
![Screenshot From 2025-02-17 15-45-17](https://github.com/user-attachments/assets/a825af7a-4b6e-4247-b4cf-e7188cfa7642)


### Verification Steps after the changes on main
Run the same commands and you should see both limited and unlimited subscriptions:
```
{
  "data": [
    {
      "sku": "RH02252",
      "product_name": "Red Hat Developer Subscription for Teams",
      "service_level": "Self-Support",
      "usage": "Development/Test",
      "subscriptions": [
        {
          "id": "14604403",
          "number": "14604560"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2026-01-27T04:59:59Z",
      "next_event_type": "Subscription End",
      "quantity": 1,
      "measurements": [
        0
      ],
      "has_infinite_quantity": true
    },
    {
      "sku": "ESA0001",
      "product_name": "Red Hat Enterprise Linux, Premium (One Year, Enterprise Program)",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14604417",
          "number": "14604574"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2026-01-27T04:59:59Z",
      "next_event_type": "Subscription End",
      "quantity": 1,
      "measurements": [
        0
      ],
      "has_infinite_quantity": true
    },
    {
      "sku": "RH00772",
      "product_name": "Red Hat Enterprise Linux for Virtual Datacenters for SAP Solutions, Standard",
      "service_level": "Standard",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14347779",
          "number": "14347936"
        },
        {
          "id": "14358408",
          "number": "14358565"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        788
      ],
      "category": "hypervisor",
      "has_infinite_quantity": false
    },
    {
      "sku": "RH00151",
      "product_name": "Red Hat Enterprise Linux for SAP Applications, Standard (Physical or Virtual Nodes)",
      "service_level": "Standard",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14347778",
          "number": "14347935"
        },
        {
          "id": "14358407",
          "number": "14358564"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        788
      ],
      "category": "physical",
      "has_infinite_quantity": false
    },
    {
      "sku": "RH00006",
      "product_name": "Red Hat Enterprise Linux for Virtual Datacenters with Satellite, Premium",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14347777",
          "number": "14347934"
        },
        {
          "id": "14358406",
          "number": "14358563"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        788
      ],
      "category": "hypervisor",
      "has_infinite_quantity": false
    },
    {
      "sku": "RH00004",
      "product_name": "Red Hat Enterprise Linux Server, Standard (Physical or Virtual Nodes)",
      "service_level": "Standard",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14347776",
          "number": "14347933"
        },
        {
          "id": "14473650",
          "number": "14473807"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 793,
      "measurements": [
        1586
      ],
      "category": "physical",
      "has_infinite_quantity": false
    },
    {
      "sku": "RH00003",
      "product_name": "Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "14347780",
          "number": "14347937"
        },
        {
          "id": "14358409",
          "number": "14358566"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-02-18T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 394,
      "measurements": [
        788
      ],
      "category": "physical",
      "has_infinite_quantity": false
    }
  ],
  "meta": {
    "count": 7,
    "product": "RHEL for x86",
    "measurements": [
      "Sockets"
    ],
    "subscription_type": "Annual"
  }
}
```