### PR TITLE
SWATCH-3338: Add billing_account_id to SkuCapacity in subscriptions api v2

### DIFF
--- a/api/rhsm-subscriptions-api-v2-spec.yaml
+++ b/api/rhsm-subscriptions-api-v2-spec.yaml
@@ -304,6 +304,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SkuCapacitySubscription"
+        billing_account_id:
+          description: "The billing account ID."
+          type: string
         billing_provider:
           $ref: '#/components/schemas/BillingProviderType'
         next_event_date:

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
@@ -266,6 +266,7 @@ public class SubscriptionTableController {
         mapper.map(Optional.ofNullable(sub.getServiceLevel()).orElse(ServiceLevel.EMPTY)));
     inventory.setUsage(mapper.map(Optional.ofNullable(sub.getUsage()).orElse(Usage.EMPTY)));
     inventory.setHasInfiniteQuantity(sub.getHasUnlimitedUsage());
+    inventory.setBillingAccountId(sub.getBillingAccountId());
     inventory.setBillingProvider(
         mapper.map(Optional.ofNullable(sub.getBillingProvider()).orElse(BillingProvider.EMPTY)));
     inventory.setQuantity(0);

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableControllerTest.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.db.SubscriptionCapacityViewRepository;
 import org.candlepin.subscriptions.db.model.Offering;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -70,9 +69,9 @@ class SubscriptionTableControllerTest {
 
   private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
   private static final String OFFERING_DESCRIPTION_SUFFIX = " test description";
+  private static final String BILLING_ACCOUNT_ID = "billing_account_id_123";
 
   @MockitoBean SubscriptionCapacityViewRepository repository;
-  @Autowired ApplicationClock clock;
   @Autowired SubscriptionTableController subscriptionTableController;
 
   private static final MeasurementSpec RH0180191 =
@@ -161,6 +160,10 @@ class SubscriptionTableControllerTest {
         "Wrong upcoming event type");
     assertEquals(
         expectedSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+    assertEquals(
+        expectedSub.getBillingAccountId(),
+        actualItem.getBillingAccountId(),
+        "Wrong billing account ID");
   }
 
   @Test
@@ -195,7 +198,7 @@ class SubscriptionTableControllerTest {
     assertEquals(
         9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
     assertEquals(18, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
-    assertEquals(actualItem.getProductName(), actualItem.getProductName());
+    assertEquals(RH0180191.productName, actualItem.getProductName());
     assertEquals(
         SubscriptionEventType.SUBSCRIPTION_END,
         actualItem.getNextEventType(),
@@ -788,6 +791,7 @@ class SubscriptionTableControllerTest {
     subscription.setQuantity(quantity);
     subscription.setStartDate(subStart);
     subscription.setEndDate(subEnd);
+    subscription.setBillingAccountId(BILLING_ACCOUNT_ID);
     return subscription;
   }
 
@@ -827,11 +831,6 @@ class SubscriptionTableControllerTest {
       this.usage = usage;
       this.hasUnlimitedUsage = hasUnlimitedUsage;
       this.subscription = subscription;
-    }
-
-    public MeasurementSpec withMetric(String metric, Integer value) {
-      otherMetrics.put(metric, value);
-      return this;
     }
 
     public static MeasurementSpec offering(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
@@ -275,6 +275,7 @@ public class SubscriptionTableControllerV2 {
         mapper.map(Optional.ofNullable(sub.getServiceLevel()).orElse(ServiceLevel.EMPTY)));
     inventory.setUsage(mapper.map(Optional.ofNullable(sub.getUsage()).orElse(Usage.EMPTY)));
     inventory.setHasInfiniteQuantity(sub.getHasUnlimitedUsage());
+    inventory.setBillingAccountId(sub.getBillingAccountId());
     inventory.setBillingProvider(
         mapper.map(Optional.ofNullable(sub.getBillingProvider()).orElse(BillingProvider.EMPTY)));
     inventory.setQuantity(0);

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1637,6 +1637,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SkuCapacitySubscription"
+        billing_account_id:
+          description: "The billing account ID."
+          type: string
         billing_provider:
           $ref: '#/components/schemas/BillingProviderType'
         next_event_date:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
@@ -59,7 +59,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.candlepin.clock.ApplicationClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -69,9 +68,9 @@ class SubscriptionTableControllerV2Test {
 
   private static final ProductId RHEL_FOR_X86 = ProductId.fromString("RHEL for x86");
   private static final String OFFERING_DESCRIPTION_SUFFIX = " test description";
+  private static final String BILLING_ACCOUNT_ID = "billing_account_id_123";
 
   @InjectMock SubscriptionCapacityViewRepository repository;
-  @Inject ApplicationClock clock;
   @Inject SubscriptionTableControllerV2 subscriptionTableControllerV2;
 
   private static final MeasurementSpec RH0180191 =
@@ -169,6 +168,10 @@ class SubscriptionTableControllerV2Test {
         "Wrong upcoming event type");
     assertEquals(
         expectedSub.getEndDate(), actualItem.getNextEventDate(), "Wrong upcoming event date");
+    assertEquals(
+        expectedSub.getBillingAccountId(),
+        actualItem.getBillingAccountId(),
+        "Wrong billing account ID");
   }
 
   @Test
@@ -203,7 +206,7 @@ class SubscriptionTableControllerV2Test {
     assertEquals(
         9, actualItem.getQuantity(), "Item should contain the sum of all subs' quantities");
     assertEquals(18, actualItem.getMeasurements().get(0), "Wrong Standard Capacity");
-    assertEquals(actualItem.getProductName(), actualItem.getProductName());
+    assertEquals(RH0180191.productName, actualItem.getProductName());
     assertEquals(
         SubscriptionEventType.SUBSCRIPTION_END,
         actualItem.getNextEventType(),
@@ -825,6 +828,7 @@ class SubscriptionTableControllerV2Test {
     subscription.setQuantity(quantity);
     subscription.setStartDate(subStart);
     subscription.setEndDate(subEnd);
+    subscription.setBillingAccountId(BILLING_ACCOUNT_ID);
     return subscription;
   }
 
@@ -864,11 +868,6 @@ class SubscriptionTableControllerV2Test {
       this.usage = usage;
       this.hasUnlimitedUsage = hasUnlimitedUsage;
       this.subscription = subscription;
-    }
-
-    public MeasurementSpec withMetric(String metric, Integer value) {
-      otherMetrics.put(metric, value);
-      return this;
     }
 
     public static MeasurementSpec offering(


### PR DESCRIPTION
Jira issue: SWATCH-3338

## Description
When querying subscriptions for a given product id, the billing_account_id should be included in the result. This will enable filtering the subscription list on the GUI side without separate calls every time the billing_account_id is changed.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1060

## Manual

1.- Make sure you have a subscription in your database
2.- Start API service or swatch-contracts service
3.- Opt In for org ID of the subscription present in database
3.- Call the subscription api v2 endpoint:

```
curl -X GET \
  'http://localhost:8101/api/rhsm-subscriptions/v1/subscriptions/products/rosa' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: <IDENTITY>'
```

And the reponse should include the new billing_account_id field in the capacity.