### PR TITLE
Revert "SWATCH-2536 Subscription doesn't show if sku socket limit is unlimited"

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -90,9 +90,7 @@ public class SubscriptionCapacityViewRepository
       searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
     }
     if (Objects.nonNull(metricId)) {
-      Specification<SubscriptionCapacityView> metricOrUnlimitedSpec =
-          hasMetricId(metricId).or(hasUnlimitedUsage(true));
-      searchCriteria = searchCriteria.and(metricOrUnlimitedSpec);
+      searchCriteria = searchCriteria.and(hasMetricId(metricId));
     }
     if (Objects.nonNull(category)) {
       searchCriteria = searchCriteria.and(hasCategory(category));
@@ -178,11 +176,5 @@ public class SubscriptionCapacityViewRepository
                 Boolean.class,
                 root.get("metrics"),
                 builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
-  }
-
-  public static Specification<SubscriptionCapacityView> hasUnlimitedUsage(
-      Boolean hasUnlimitedUsage) {
-    return (root, query, builder) ->
-        builder.equal(root.get(SubscriptionCapacityView_.hasUnlimitedUsage), hasUnlimitedUsage);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2Test.java
@@ -91,7 +91,7 @@ class SubscriptionTableControllerV2Test {
           "RH0180194", "RHEL Server", 2, 2, ServiceLevel.STANDARD, Usage.PRODUCTION, false);
   private static final MeasurementSpec RH0180195_UNLIMITED_USAGE =
       MeasurementSpec.offering(
-          "RH0180195", "RHEL Server", null, null, ServiceLevel.STANDARD, Usage.PRODUCTION, true);
+          "RH0180192", "RHEL Server", null, null, ServiceLevel.STANDARD, Usage.PRODUCTION, true);
   private static final MeasurementSpec RH0180196_HYPERVISOR_SOCKETS =
       MeasurementSpec.offering(
           "RH0180196",
@@ -625,35 +625,6 @@ class SubscriptionTableControllerV2Test {
     assertEquals(1, actual.getData().size(), "Wrong number of items returned");
     var actualItem = actual.getData().get(0);
     assertTrue(actualItem.getHasInfiniteQuantity(), "HasInfiniteQuantity should be true");
-  }
-
-  @Test
-  void testGetSkuCapacityReportLimitedAndUnlimitedQuantityWithMetric() {
-    var productId = RHEL_FOR_X86;
-    var expectedSub = stubSubscription("1234", "1235", 4);
-    var unlimitedSpec = RH0180195_UNLIMITED_USAGE.withSub(expectedSub);
-    var expectedNewerSub = stubSubscription("12345", "12345", 4, 5, 7);
-    var spec1 = RH0180191.withSub(expectedNewerSub);
-
-    givenCapacities(productId, spec1, unlimitedSpec);
-    givenSubscriptionsInRepository(expectedNewerSub, expectedSub);
-
-    when(repository.streamBy(any()))
-        .thenReturn(Stream.of(unlimitedSpec.subscription, expectedNewerSub));
-    givenOfferings(unlimitedSpec);
-
-    // When requesting a SKU capacity report for the eng product and metric
-    var actual =
-        subscriptionTableControllerV2.capacityReportBySkuV2(
-            productId, null, null, null, null, null, null, null, "Sockets", null, null);
-
-    // Then the report contains an inventory item containing the sub with HasInfiniteQuantity true
-    // and a sub with HasInfiniteQuantity false.
-    assertEquals(2, actual.getData().size(), "Wrong number of items returned");
-    var actualLimitedItem = actual.getData().get(1);
-    assertTrue(actualLimitedItem.getHasInfiniteQuantity(), "HasInfiniteQuantity should be false");
-    var actualUnlimitedItem = actual.getData().get(1);
-    assertTrue(actualUnlimitedItem.getHasInfiniteQuantity(), "HasInfiniteQuantity should be true");
   }
 
   @Test


### PR DESCRIPTION
Reverts RedHatInsights/rhsm-subscriptions#4188
To check what was the outcome of the stage before the merge