### PR TITLE
SWATCH-2536 Subscription doesn't show if sku socket limit is unlimited

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v2/SubscriptionTableController.java
@@ -91,6 +91,17 @@ public class SubscriptionTableController {
       String metricId,
       SkuCapacityReportSort sort,
       SortDirection dir) {
+    log.info(
+        "Capacity sku report with criteria productId:{} offset:{} limit:{} category:{} servicelevel:{} usage:{} billingProviderType:{} billingAccountId:{} metricId:{}",
+        productId,
+        offset,
+        limit,
+        category,
+        serviceLevel,
+        usage,
+        billingProviderType,
+        billingAccountId,
+        metricId);
     var subscriptionSpec =
         SubscriptionCapacityViewRepository.buildSearchSpecification(
             getOrgId(),
@@ -144,7 +155,7 @@ public class SubscriptionTableController {
     sortCapacities(reportItems, sort, dir);
     Pageable pageable = ResourceUtils.getPageable(offset, limit);
     var page = InMemoryPager.paginate(reportItems, pageable);
-
+    log.debug("Report items {}", reportItems);
     return new SkuCapacityReport()
         .data(page.getContent())
         .meta(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -90,7 +90,9 @@ public class SubscriptionCapacityViewRepository
       searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
     }
     if (Objects.nonNull(metricId)) {
-      searchCriteria = searchCriteria.and(hasMetricId(metricId));
+      Specification<SubscriptionCapacityView> metricOrUnlimitedSpec =
+          hasMetricId(metricId).or(hasUnlimitedUsage(true));
+      searchCriteria = searchCriteria.and(metricOrUnlimitedSpec);
     }
     if (Objects.nonNull(category)) {
       searchCriteria = searchCriteria.and(hasCategory(category));
@@ -176,5 +178,11 @@ public class SubscriptionCapacityViewRepository
                 Boolean.class,
                 root.get("metrics"),
                 builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
+  }
+
+  public static Specification<SubscriptionCapacityView> hasUnlimitedUsage(
+      Boolean hasUnlimitedUsage) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.hasUnlimitedUsage), hasUnlimitedUsage);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
@@ -163,7 +163,7 @@ public class SubscriptionTableControllerV2 {
     // As an improvement this should be pushed lower into the Repository layer
     sortCapacities(reportItems, sort, dir);
     var page = InMemoryPager.paginate(reportItems, offset, limit);
-    log.info("Report items {}", reportItems);
+    log.debug("Report items {}", reportItems);
     return new SkuCapacityReportV2()
         .data(page)
         .meta(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v2/SubscriptionTableControllerV2.java
@@ -100,6 +100,17 @@ public class SubscriptionTableControllerV2 {
       SkuCapacityReportSortV2 sort,
       SortDirection dir) {
 
+    log.info(
+        "Capacity report with criteria productId:{} offset:{} limit:{} category:{} servicelevel:{} usage:{} billingProviderType:{} billingAccountId:{} metricId:{}",
+        productId,
+        offset,
+        limit,
+        category,
+        serviceLevel,
+        usage,
+        billingProviderType,
+        billingAccountId,
+        metricId);
     var subscriptionSpec =
         SubscriptionCapacityViewRepository.buildSearchSpecification(
             getOrgId(),
@@ -152,7 +163,7 @@ public class SubscriptionTableControllerV2 {
     // As an improvement this should be pushed lower into the Repository layer
     sortCapacities(reportItems, sort, dir);
     var page = InMemoryPager.paginate(reportItems, offset, limit);
-
+    log.info("Report items {}", reportItems);
     return new SkuCapacityReportV2()
         .data(page)
         .meta(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/SubscriptionCapacityViewRepository.java
@@ -91,7 +91,9 @@ public interface SubscriptionCapacityViewRepository
       searchCriteria = searchCriteria.and(billingProviderEquals(sanitizedBillingProvider));
     }
     if (Objects.nonNull(metricId)) {
-      searchCriteria = searchCriteria.and(hasMetricId(metricId));
+      Specification<SubscriptionCapacityView> metricOrUnlimitedSpec =
+          hasMetricId(metricId).or(hasUnlimitedUsage(true));
+      searchCriteria = searchCriteria.and(metricOrUnlimitedSpec);
     }
     if (Objects.nonNull(category)) {
       searchCriteria = searchCriteria.and(hasCategory(category));
@@ -177,5 +179,11 @@ public interface SubscriptionCapacityViewRepository
                 Boolean.class,
                 root.get("metrics"),
                 builder.literal("$[*] ? (@." + key + " == \"" + value + "\")")));
+  }
+
+  private static Specification<SubscriptionCapacityView> hasUnlimitedUsage(
+      Boolean hasUnlimitedUsage) {
+    return (root, query, builder) ->
+        builder.equal(root.get(SubscriptionCapacityView_.hasUnlimitedUsage), hasUnlimitedUsage);
   }
 }


### PR DESCRIPTION
SWATCH-2536
Test steps: https://github.com/RedHatInsights/rhsm-subscriptions/pull/4188
Reverts RedHatInsights/rhsm-subscriptions#4219