### PR TITLE
Fix shouldSyncSubscriptionsSkipSubIfTooExpired

### DIFF
--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -326,7 +326,7 @@ class SubscriptionSyncServiceTest {
     // When syncing an org's subs, don't sync subscriptions that expired more than 2 months ago
     var dto = createDto("456", 10);
     dto.setEffectiveStartDate(toEpochMillis(NOW.minusMonths(14)));
-    dto.setEffectiveEndDate(toEpochMillis(NOW.minusMonths(2)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.minusDays(60)));
     Mockito.when(subscriptionService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
 
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);


### PR DESCRIPTION
## Description
This test was failing because we were adding two months in the test, but comparing this date with 60 days which is not the same for months that do not have 30 days.

## Testing
CI is green.