### PR TITLE
SWATCH-3348: When offering sync, allow attributes with values 'N'

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -93,7 +93,7 @@ public class UpstreamProductData {
           .collect(Collectors.toUnmodifiableMap(Attr::name, attr -> attr, (a1, a2) -> a1));
 
   /** Ignore any product attribute whose value is in this set. */
-  private static final Set<String> ATTRIBUTE_DISALLOWED_VALUES = Set.of("n/a", "0", "n", "none");
+  private static final Set<String> ATTRIBUTE_DISALLOWED_VALUES = Set.of("n/a", "0", "none");
 
   private UpstreamProductData(String sku) {
     this.sku = sku;

--- a/swatch-contracts/src/main/resources/product-stub-data/engprods-RH02781MO.json
+++ b/swatch-contracts/src/main/resources/product-stub-data/engprods-RH02781MO.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "sku": "RH02781MO",
+      "engProducts": {
+        "engProducts": []
+      }
+    }
+  ]
+}

--- a/swatch-contracts/src/main/resources/product-stub-data/engprods-SVCRH02781.json
+++ b/swatch-contracts/src/main/resources/product-stub-data/engprods-SVCRH02781.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "sku": "SVCRH02781",
+      "engProducts": {
+        "engProducts": []
+      }
+    }
+  ]
+}

--- a/swatch-contracts/src/main/resources/product-stub-data/tree-RH02781MO_attrs-true.json
+++ b/swatch-contracts/src/main/resources/product-stub-data/tree-RH02781MO_attrs-true.json
@@ -2,31 +2,218 @@
   "products": [
     {
       "sku": "RH02781MO",
+      "name": null,
       "description": "Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Monthly Production Support)",
       "status": "ACTIVE",
       "attributes": [
         {
-          "code": "PRODUCT_FAMILY",
-          "value": "RHEL"
+          "code": "SPECIAL_PRICING_FLAG",
+          "name": "Special Pricing Flag",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "MIGRATION_OFFERING",
+          "startDate": null
         },
         {
-          "code": "SOCKET_LIMIT",
-          "value": "Unlimited"
+          "code": "PRODUCT_FAMILY",
+          "name": "Product Family",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL",
+          "startDate": null
+        },
+        {
+          "code": "SERVICE_LEVEL",
+          "name": "Service Level",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "L1-L3",
+          "startDate": null
         },
         {
           "code": "SERVICE_TYPE",
-          "value": "Premium"
+          "name": "Service Type",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Premium",
+          "startDate": null
+        },
+        {
+          "code": "USAGE",
+          "name": "Usage",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Production",
+          "startDate": null
+        },
+        {
+          "code": "METERED",
+          "name": "Metered",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "N",
+          "startDate": null
         },
         {
           "code": "PRODUCT_NAME",
-          "value": "RHEL Server"
+          "name": "Product Name",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL Server",
+          "startDate": null
         },
         {
-          "code": "SPECIAL_PRICING_FLAG",
-          "value": "MIGRATION_OFFERING"
+          "code": "LEVEL_1",
+          "name": "LEVEL 1",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL",
+          "startDate": null
+        },
+        {
+          "code": "LEVEL_2",
+          "name": "LEVEL 2",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Server",
+          "startDate": null
+        },
+        {
+          "code": "LEVEL_3",
+          "name": "LEVEL 3",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Null",
+          "startDate": null
         }
       ],
       "roles": []
+    },
+    {
+      "sku": "SVCRH02781",
+      "name": null,
+      "description": "Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Hourly Production Support)",
+      "itemType": "SPG",
+      "status": "ACTIVE",
+      "attributes": [
+        {
+          "code": "PRODUCT_FAMILY",
+          "name": "Product Family",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL",
+          "startDate": null
+        },
+        {
+          "code": "SERVICE_LEVEL",
+          "name": "Service Level",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "L1-L3",
+          "startDate": null
+        },
+        {
+          "code": "SERVICE_TYPE",
+          "name": "Service Type",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Premium",
+          "startDate": null
+        },
+        {
+          "code": "USAGE",
+          "name": "Usage",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Production",
+          "startDate": null
+        },
+        {
+          "code": "METERED",
+          "name": "Metered",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Y",
+          "startDate": null
+        },
+        {
+          "code": "PRODUCT_NAME",
+          "name": "Product Name",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL Server",
+          "startDate": null
+        },
+        {
+          "code": "LEVEL_1",
+          "name": "LEVEL 1",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "RHEL",
+          "startDate": null
+        },
+        {
+          "code": "LEVEL_2",
+          "name": "LEVEL 2",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Server",
+          "startDate": null
+        },
+        {
+          "code": "LEVEL_3",
+          "name": "LEVEL 3",
+          "description": null,
+          "contextCode": null,
+          "contextName": null,
+          "contextDescription": null,
+          "value": "Null",
+          "startDate": null
+        }
+      ]
+    }
+  ],
+  "parentMap": [
+    {
+      "parent": "RH02781MO",
+      "child": "SVCRH02781",
+      "duration": "30 days"
     }
   ]
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
@@ -271,6 +271,36 @@ class OfferingSyncServiceTest {
   }
 
   @Test
+  void testSyncOfferingWhenMeteredFlagChangedFromTrueToFalse() {
+    // Given an Offering that has metered true
+    // Using "RH02781MO" because it has the metered attribute as Y in
+    // tree-RH02781MO_attrs-true.json.
+    String sku = "RH02781MO";
+    OfferingEntity persisted = new OfferingEntity();
+    persisted.setSku(sku);
+    persisted.setProductName("RHEL Server");
+    persisted.setDescription(
+        "Red Hat Enterprise Linux for Third Party Linux Migration with Extended Life Cycle Support (On-Demand, Monthly Production Support)");
+    persisted.setProductFamily("RHEL");
+    persisted.setServiceLevel(ServiceLevel.PREMIUM);
+    persisted.setUsage(Usage.PRODUCTION);
+    persisted.setHasUnlimitedUsage(false);
+    persisted.setSpecialPricingFlag("MIGRATION_OFFERING");
+    persisted.setLevel1("RHEL");
+    persisted.setLevel2("Server");
+    persisted.setMetered(true);
+    persisted.setChildSkus(Set.of("SVCRH02781"));
+
+    when(repo.findByIdOptional(anyString())).thenReturn(Optional.of(persisted));
+
+    // When syncing the Offering,
+    SyncResult result = subject.syncOffering(sku);
+
+    // Then no persisting or capacity reconciliation should happen.
+    assertEquals(SyncResult.FETCHED_AND_SYNCED, result);
+  }
+
+  @Test
   void testSyncOfferingWithNoChangesFromUmbMessage() throws IOException {
     when(repo.findByIdOptional(any())).thenReturn(Optional.of(createTestOffering()));
     subject.syncUmbProductFromXml(read("mocked-product-message.xml"));


### PR DESCRIPTION
Jira issue: SWATCH-3348

## Description
The problem is when having the root sku with an attribute METERED: 'N', and a derived sku with an attribute METERED: 'Y', we're overwriting the root attribute with the derived attribute.

This is because we're ignoring the attributes with value 'n'.

## Testing
Added a test that reproduces the issue. 