### PR TITLE
SWATCH-3358: Use the metric "swatch_billable_usage_total" in the grafana dashboard to resolve all the variables

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
@@ -1213,7 +1213,7 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values(swatch_metrics_ingested_usage_total,product)",
+            "definition": "label_values(swatch_billable_usage_total,product)",
             "hide": 0,
             "includeAll": true,
             "label": "Product",
@@ -1222,7 +1222,7 @@ data:
             "options": [],
             "query": {
               "qryType": 5,
-              "query": "label_values(swatch_metrics_ingested_usage_total,product)",
+              "query": "label_values(swatch_billable_usage_total,product)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,
@@ -1241,7 +1241,7 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values(swatch_metrics_ingested_usage_total,metric_id)",
+            "definition": "label_values(swatch_billable_usage_total,metric_id)",
             "hide": 0,
             "includeAll": false,
             "label": "Metric",
@@ -1250,7 +1250,7 @@ data:
             "options": [],
             "query": {
               "qryType": 5,
-              "query": "label_values(swatch_metrics_ingested_usage_total,metric_id)",
+              "query": "label_values(swatch_billable_usage_total,metric_id)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,
@@ -1269,7 +1269,7 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values(swatch_metrics_ingested_usage_total,billing_provider)",
+            "definition": "label_values(swatch_billable_usage_total,billing_provider)",
             "hide": 0,
             "includeAll": false,
             "label": "Billing Provider",
@@ -1278,7 +1278,7 @@ data:
             "options": [],
             "query": {
               "qryType": 5,
-              "query": "label_values(swatch_metrics_ingested_usage_total,billing_provider)",
+              "query": "label_values(swatch_billable_usage_total,billing_provider)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,


### PR DESCRIPTION
Jira issue: SWATCH-3358

## Description
Before these changes, the products and metrics to be filtered are dynamically inspected using the metric "swatch_metrics_ingested_usage_total". The problem is that this metric is used when processing the events in the swatch-metrics, but only for the events coming from the "prometheus" event source (see [here](https://github.com/RedHatInsights/rhsm-subscriptions/blob/169b8b0d6cd935e0549be40bf37205650a0a70ba/src/main/java/org/candlepin/subscriptions/event/EventController.java#L380)). 

Therefore, let's use the "swatch_billable_usage_total" metric for all the variables in the dashboard, so we can see a more stable list of products, metrics, and others.

## Testing
Extract the new dashboard json using oc extract -f .rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml --confirm

Once you extract it from the .yaml that's checked into this repo, you can import it into the stage instance of grafana by going to Dashboards -> +Import from the left nav.