### PR TITLE
Hardcode the quarkus application name in quarkus.swagger-ui.path property

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -167,7 +167,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 # to expose it on the server port 8000:
 quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
-quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+quarkus.swagger-ui.path=/api/swatch-billable-usage/internal/swagger-ui
 
 # configuration properties for contracts client
 rhsm-subscriptions.contracts.use-stub=${CONTRACT_USE_STUB:false}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -377,7 +377,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 # to expose it on the server port 8000:
 quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
-quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+quarkus.swagger-ui.path=/api/swatch-contracts/internal/swagger-ui
 
 rhsm-subscriptions.subscription-sync-enabled=${SUBSCRIPTION_SYNC_ENABLED:true}
 rhsm-subscriptions.subscription-client.use-stub=${SUBSCRIPTION_CLIENT_USE_STUB:false}

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -84,7 +84,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 # to expose it on the server port 8000:
 quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
-quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+quarkus.swagger-ui.path=/api/swatch-producer-aws/internal/swagger-ui
 
 #clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -85,7 +85,7 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 # to expose it on the server port 8000:
 quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
-quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+quarkus.swagger-ui.path=/api/swatch-producer-azure/internal/swagger-ui
 
 #clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092


### PR DESCRIPTION
This is a workaround for an issue running quarkusDev gradle task after bumping the quarkusVersion to 3.19.1.

See https://github.com/quarkusio/quarkus/issues/46662

The quarkusDev gradle tasked stopped working because of that version bump.  It was resulting in this stack trace

```
./gradlew :swatch-contracts:quarkusDev
```
```
2025-03-06 15:34:26,557 ERROR [io.qua.dep.dev.IsolatedDevModeMain] (main) Failed to start quarkus: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
        [error]: Build step io.quarkus.devui.deployment.menu.EndpointsProcessor#createEndpointsPage threw an exception: java.lang.IllegalArgumentException: Specified path is an invalid URI. Path was /api/${quarkus.application.name}/internal/swagger-ui
        at io.quarkus.deployment.util.UriNormalizationUtil.toURI(UriNormalizationUtil.java:52)
        at io.quarkus.deployment.util.UriNormalizationUtil.normalizeWithBase(UriNormalizationUtil.java:107)
        at io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem.resolvePath(NonApplicationRootPathBuildItem.java:165)
        at io.quarkus.devui.deployment.menu.EndpointsProcessor.createEndpointsPage(EndpointsProcessor.java:29)
        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
        at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
        at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
        at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
        at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
        at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
        at java.base/java.lang.Thread.run(Thread.java:840)
        at org.jboss.threads.JBossThread.run(JBossThread.java:499)
Caused by: java.net.URISyntaxException: Illegal character in path at index 6: /api/${quarkus.application.name}/internal/swagger-ui
        at java.base/java.net.URI$Parser.fail(URI.java:2976)
        ```
        