### PR TITLE
SWATCH-3352: Capture events from any event source for metric swatch_metrics_ingested_usage_total

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventController.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventController.java
@@ -377,11 +377,9 @@ public class EventController {
       if (event.getProductTag() == null || event.getMeasurements() == null) {
         continue;
       }
-      if ("prometheus".equalsIgnoreCase(event.getEventSource())) {
-        for (String tag : event.getProductTag()) {
-          for (Measurement measurement : event.getMeasurements()) {
-            updateIngestedUsageCounterFor(event, tag, measurement);
-          }
+      for (String tag : event.getProductTag()) {
+        for (Measurement measurement : event.getMeasurements()) {
+          updateIngestedUsageCounterFor(event, tag, measurement);
         }
       }
     }
@@ -394,6 +392,7 @@ public class EventController {
     }
     counter
         .tag("metric_id", MetricId.tryGetValueFromString(measurement.getMetricId()))
+        .tag("event_source", event.getEventSource())
         .withRegistry(meterRegistry)
         .withTags("product", tag)
         .increment(measurement.getValue());

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -22,7 +22,6 @@ package org.candlepin.subscriptions.event;
 
 import static org.candlepin.subscriptions.event.EventController.INGESTED_USAGE_METRIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +50,8 @@ import org.candlepin.subscriptions.json.Measurement;
 import org.candlepin.subscriptions.security.OptInController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -456,8 +457,9 @@ class EventControllerTest {
     assertEquals(1, events.size());
   }
 
-  @Test
-  void testMeterRegistryCounter() {
+  @ParameterizedTest
+  @ValueSource(strings = {"prometheus", "rhelmeter"})
+  void testMeterRegistryCounter(String eventSource) {
     var validProductTagEventRecord1 =
         """
                     {
@@ -472,7 +474,7 @@ class EventControllerTest {
                         "rhel-for-x86-els-payg-addon"
                      ],
                      "display_name":"automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
-                     "event_source":"prometheus",
+                     "event_source":"%s",
                      "measurements":[
                         {
                            "value":4.0,
@@ -481,7 +483,8 @@ class EventControllerTest {
                      ],
                      "service_type":"RHEL System"
                   }
-            """;
+            """
+            .formatted(eventSource);
     when(eventRecordRepository.saveAll(any()))
         .thenReturn(
             List.of(
@@ -492,57 +495,14 @@ class EventControllerTest {
                         .withMeasurements(
                             List.of(new Measurement().withMetricId("vCPUs").withValue(4.0)))
                         .withBillingProvider(Event.BillingProvider.AZURE)
-                        .withEventSource("prometheus"))));
+                        .withEventSource(eventSource))));
     eventController.persistServiceInstances(List.of(validProductTagEventRecord1));
 
     verify(eventRecordRepository).saveAll(eventsSaved.capture());
-    var meter = getIngestedUsageMetric("rhel-for-x86-els-payg-addon", "vCPUs", "azure");
+    var meter =
+        getIngestedUsageMetric("rhel-for-x86-els-payg-addon", "vCPUs", "azure", eventSource);
     assertTrue(meter.isPresent());
     assertEquals(4.0, meter.get().measure().iterator().next().getValue());
-  }
-
-  @Test
-  void testMeterRegistryCounterNotPrometheus() {
-    var validProductTagEventRecord1 =
-        """
-                    {
-                     "sla":"Premium",
-                     "org_id":"111111111",
-                     "timestamp":"2024-06-10T10:00:00Z",
-                     "conversion":false,
-                     "event_type":"snapshot_rhel-for-x86-els-payg-addon_vCPUs",
-                     "expiration":"2024-06-10T11:00:00Z",
-                     "instance_id":"d147ddf2-be4a-4a59-acf7-7f222758b47c",
-                     "product_tag":[
-                        "rhel-for-x86-els-payg-addon"
-                     ],
-                     "display_name":"automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
-                     "event_source":"cost-management",
-                     "measurements":[
-                        {
-                           "value":4.0,
-                           "metric_id":"vCPUs"
-                        }
-                     ],
-                     "service_type":"RHEL System"
-                  }
-            """;
-    when(eventRecordRepository.saveAll(any()))
-        .thenReturn(
-            List.of(
-                new EventRecord(
-                    new Event()
-                        .withEventId(UUID.randomUUID())
-                        .withProductTag(Set.of("rhel-for-x86-els-payg-addon"))
-                        .withMeasurements(
-                            List.of(new Measurement().withMetricId("vCPUs").withValue(4.0)))
-                        .withBillingProvider(Event.BillingProvider.AWS)
-                        .withEventSource("cost-management"))));
-    eventController.persistServiceInstances(List.of(validProductTagEventRecord1));
-
-    verify(eventRecordRepository).saveAll(eventsSaved.capture());
-    var meter = getIngestedUsageMetric("rhel-for-x86-els-payg-addon", "vCPUs", "aws");
-    assertFalse(meter.isPresent());
   }
 
   @Test
@@ -617,7 +577,7 @@ class EventControllerTest {
   }
 
   private Optional<Meter> getIngestedUsageMetric(
-      String productTag, String metricId, String billingProvider) {
+      String productTag, String metricId, String billingProvider, String eventSource) {
     return meterRegistry.getMeters().stream()
         .filter(
             m ->
@@ -626,7 +586,8 @@ class EventControllerTest {
                     && MetricId.fromString(metricId)
                         .getValue()
                         .equals(m.getId().getTag("metric_id"))
-                    && billingProvider.equals(m.getId().getTag("billing_provider")))
+                    && billingProvider.equals(m.getId().getTag("billing_provider"))
+                    && eventSource.equals(m.getId().getTag("event_source")))
         .findFirst();
   }
 


### PR DESCRIPTION
Jira issue: SWATCH-3352

## Description
Capture all successfully saved events, regardless of event_source. Start including event_source as a label in swatch_metrics_ingested_usage_total. that we can use to have more fine-grained grafana panels.  This might also be a way to identify if we've got product tags/billing_providers combos with totals from different event_sources (potential indicator of double counting going on)

## Testing
IQE Test MR:  

### Setup
1. Start the needed services
`RHSM_SUBSCRIPTIONS_ENABLE_SYNCHRONOUS_OPERATIONS=true DEV_MODE=true PROM_URL=http://localhost:8082/api/metrics/v1/telemeter/api/v1 SWATCH_CONTRACTS_INTERNAL_SERVICE=http://localhost:8003 SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress,kafka-queue,rhsm-conduit ./gradlew :bootRun`

### Steps
1. Input event messages to the Kafka queue. Remember to increment the hour for each submission.
`{
  "sla": "Premium",
  "org_id": "111111111",
  "timestamp": "2024-10-24T15:00:00.0000+04:00",
  "conversion": false,
  "event_type": "snapshot_rhel-for-x86-els-payg-addon_vCPUs",
  "expiration": "2025-06-10T11:00:00.0000+04:00",
  "instance_id": "d147ddf2-be4a-4a59-acf7-7f222758b47d",
  "product_tag": [
    "rhel-for-x86-els-payg-addon"
  ],
  "display_name": "automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
  "event_source": "prometheus",
  "billing_provider": "aws",
  "measurements": [
    {
      "value": 4.0,
      "metric_id": "vCPUs"
    }
  ],
  "service_type": "RHEL System"
}`
2. Call the metrics endpoint.
`http ':9000/metrics' | grep 'swatch_metrics'`

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Confirm the counter's sum based on the number of submissions.
`
swatch_metrics_ingested_usage_total{billing_provider="aws",metric_id="vCPUs",product="rhel-for-x86-els-payg-addon", event_source="prometheus"} 8.0
`
