### PR TITLE
SWATCH-3372: Update podman compose and test containers to use Postgresql 13

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
           jbang trust add https://github.com/yaml-path/jbang/
           curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force yamlpath@yaml-path/jbang
       - name: Setup Postgresql Database
-        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/centos7/postgresql-12-centos7:centos7
+        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/centos7/postgresql-13-centos7:centos7
       - name: Setup Postgresql Client
         run: sudo apt-get install -y postgresql-client
       - name: Execute migrations

--- a/deploy/dev-clowdenv.yaml
+++ b/deploy/dev-clowdenv.yaml
@@ -43,10 +43,8 @@ objects:
         clusterName: minikube-cluster
         mode: local
 
-      # Clowder supports postgres 10 and 12. Specify the name
-      # and other details in the clowdapp
       db:
-        image: registry.redhat.io/rhel8/postgresql-12:1-36
+        image: quay.io/centos7/postgresql-13-centos7:centos7
         mode: local
 
       logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # When updating the image, remember to also update the following locations:
     # - SwatchPostgreSQLContainer.POSTGRESQL_IMAGE
     # - .github/workflows/pr.yaml (step "Setup Postgresql Database")
-    image: quay.io/centos7/postgresql-12-centos7:centos7
+    image: quay.io/centos7/postgresql-13-centos7:centos7
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRESQL_MAX_CONNECTIONS=5000

--- a/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
+++ b/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
@@ -35,7 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @EqualsAndHashCode(callSuper = true)
 public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgreSQLContainer> {
-  private static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-12-centos7:centos7";
+  private static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-13-centos7:centos7";
 
   public SwatchPostgreSQLContainer(String database) {
     super(DockerImageName.parse(POSTGRESQL_IMAGE).asCompatibleSubstituteFor("postgres"));


### PR DESCRIPTION
Jira issue: SWATCH-3372

## Description
Since we have upgrade in production to Postgresql 13, we need to update our podman compose and test containers to match.

## Testing
The test containers will be verified using the CI.
About the podman compose changes:
- start: `podman compose -f docker-compose.yml up`
- execute the migrations to verify the database is up and running: `./gradlew liquibaseUpdate`