### PR TITLE
SWATCH-3370: Host tally buckets sync is not updating the measurement type

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/model/HostTest.java
@@ -198,6 +198,44 @@ class HostTest {
   }
 
   @Test
+  void testExistingBucketsAreUpdatedWhenDifferentMeasurementType() {
+    Host host = new Host();
+    host.setId(UUID.randomUUID());
+
+    HostTallyBucket b1 =
+        new HostTallyBucket(
+            null, // NOTE: it is important to pass null here to simulate a new bucket
+            "foo",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "bar",
+            true,
+            1,
+            1,
+            HardwareMeasurementType.VIRTUAL);
+    HostTallyBucket b2 =
+        new HostTallyBucket(
+            null, // NOTE: it is important to pass null here to simulate a new bucket
+            "foo",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "bar",
+            true,
+            1,
+            1,
+            HardwareMeasurementType.PHYSICAL);
+
+    host.addBucket(b1);
+    host.addBucket(b2);
+
+    assertEquals(1, host.getBuckets().size());
+    HostTallyBucket actualBucket = host.getBuckets().stream().findFirst().orElseThrow();
+    assertEquals(HardwareMeasurementType.PHYSICAL, actualBucket.getMeasurementType());
+  }
+
+  @Test
   void testIsMeteredTrueOrFalse() {
     Host host = new Host();
     HostTallyBucket hostTallyBucket = mock(HostTallyBucket.class);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -230,6 +230,7 @@ public class Host implements Serializable {
       HostTallyBucket b = existingBucket.get();
       b.setSockets(bucket.getSockets());
       b.setCores(bucket.getCores());
+      b.setMeasurementType(bucket.getMeasurementType());
       b.setStale(false);
     } else {
       bucket.setHost(this);


### PR DESCRIPTION
Jira issue: SWATCH-3370

## Description
We were not updating the measurement type (the physical or virtual...) and because the measurement type is not part of the bucket key, this was not removed.

After adding b.setMeasurementType(bucket.getMeasurementType());  and syncing the org again, I see this host as physical as expected according to the HBI facts.

## Testing

### Steps
1. `podman compose -f docker-compose.yml up`
2. start tally and api: `INVENTORY_DATABASE_SCHEMA=hbi ENABLE_SYNCHRONOUS_OPERATIONS=true LOGGING_SHOW_SQL_QUERIES=true DEV_MODE=true ./gradlew :bootRun`
3. insert the following data into the swatch database:

The host which is physical:
```
insert into account_services (account_number, org_id,service_type) values ('account123', 'org123','HBI_HOST');
```
```
INSERT INTO hosts (id,inventory_id,insights_id,org_id,display_name,subscription_manager_id,is_guest,hypervisor_uuid,hardware_type,num_of_guests,last_seen,is_unmapped_guest,is_hypervisor,cloud_provider,instance_type,instance_id,billing_provider,billing_account_id,last_applied_event_record_date) VALUES
	 ('88130b9d-964c-445a-85ae-6f25cdd2a035'::uuid,'b26a6630-6f8b-4911-8372-b3851be27b1b','92280b09-50e8-4027-be45-acd3b49d2ece','org123','my_host','92280b09-50e8-4027-be45-acd3b49d2ece',false,NULL,'PHYSICAL',NULL,'2025-03-13 02:54:09.02962+01',false,false,'','HBI_HOST','b26a6630-6f8b-4911-8372-b3851be27b1b','','',NULL);
```

The buckets:

```
INSERT INTO public.host_tally_buckets (host_id,"usage",product_id,sla,as_hypervisor,cores,sockets,measurement_type,billing_provider,billing_account_id,"version") VALUES
	 ('88130b9d-964c-445a-85ae-6f25cdd2a035'::uuid,'','RHEL for x86','_ANY',false,8,8,'VIRTUAL','_ANY','_ANY',45),
	 ('88130b9d-964c-445a-85ae-6f25cdd2a035'::uuid,'','RHEL for x86','Standard',false,8,8,'PHYSICAL','_ANY','_ANY',44),
	 ('88130b9d-964c-445a-85ae-6f25cdd2a035'::uuid,'_ANY','RHEL for x86','_ANY',false,8,8,'VIRTUAL','_ANY','_ANY',45),
	 ('88130b9d-964c-445a-85ae-6f25cdd2a035'::uuid,'_ANY','RHEL for x86','Standard',false,8,8,'PHYSICAL','_ANY','_ANY',44);
```

Note that there are a couple of buckets that are virtual and others that are virtual.

4. insert the HBI data into the insights database: https://privatebin.corp.redhat.com/?16255128df880903#7PRo1P6XS8VZWJFbTifNrL4ghEozxG3HEfGZHSxzi7uP
5. get the instances API:

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=org123' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19'
```

```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/RHEL%20for%20x86" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19 | jq
```

And you should see:
```
{
  "data": [
    {
      "id": "88130b9d-964c-445a-85ae-6f25cdd2a035",
      "instance_id": "b26a6630-6f8b-4911-8372-b3851be27b1b",
      "display_name": "my_host",
      "billing_provider": "",
      "billing_account_id": "",
      "measurements": [
        8.0
      ],
      "last_seen": "2025-03-13T01:54:09.02962Z",
      "number_of_guests": 0,
      "category": "virtual",
      "subscription_manager_id": "92280b09-50e8-4027-be45-acd3b49d2ece",
      "inventory_id": "b26a6630-6f8b-4911-8372-b3851be27b1b"
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "measurements": [
      "Sockets"
    ]
  }
}
```

Note that the category says it's virtual which is not.

6. Run the tally for this org:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/org123" \
Origin:console.redhat.com \
x-rh-swatch-psk:placeholder
```

7. Verify that the category is physical now:

```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/RHEL%20for%20x86" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19 | jq
```

And you should see:
```
{
  "data": [
    {
      "id": "88130b9d-964c-445a-85ae-6f25cdd2a035",
      "instance_id": "b26a6630-6f8b-4911-8372-b3851be27b1b",
      "display_name": "my_host",
      "billing_provider": "",
      "billing_account_id": "",
      "measurements": [
        8.0
      ],
      "last_seen": "2025-03-13T01:54:09.02962Z",
      "number_of_guests": 0,
      "category": "physical",
      "subscription_manager_id": "92280b09-50e8-4027-be45-acd3b49d2ece",
      "inventory_id": "b26a6630-6f8b-4911-8372-b3851be27b1b"
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "measurements": [
      "Sockets"
    ]
  }
}
```