### PR TITLE
Reduce layer churn during builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,11 @@
 .kube
 .docker
 artifacts
+
+# Files that churn after every build.  You can track what's changing after
+# a build with the command inotifywait -e modify,create,delete -r . -m --exclude '.*/build/.*'
+.idea
+buildSrc/.gradle
+.gradle
+!.gradle/wrapper
+.git/index.lock


### PR DESCRIPTION
Jira issue: None

## Description
By excluding some of the directories that are constantly being updated due to IDE activity or Gradle activity, we can take better advantage of layer caching in our builds.

With this change in place, the `COPY . .` command in most of our Dockerfiles no longer has to rerun almost every time.  On my system, this brings the total runtime of `bin/build-images.sh` from 9m30s down to 8m40s.  It's a modest savings, but a welcome one.

### Steps
1.  Just run `bin/build-images.sh` to verify the builds occur correctly.  CI will do the same for its container build process.
