### PR TITLE
SWATCH-3341: Update konflux pipelines to run junit tests

### DIFF
--- a/.tekton/rhsm-pull-request.yaml
+++ b/.tekton/rhsm-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,41 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +246,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/run-tests-task.yaml
+++ b/.tekton/run-tests-task.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: run-tests
+spec:
+  params:
+    - name: SERVICE
+      description: The service to be tested. By default, it will run all the tests.
+      default: ""
+    - name: PROVISION_EAAS_SPACE_SECRET_REF
+      description: The secret ref of the "provision-eaas-space" task output
+  workspaces:
+    - name: source
+  steps:
+    - image: registry.access.redhat.com/ubi9/openjdk-17-runtime
+      name: builder
+      workingDir: $(workspaces.source.path)/source
+      env:
+        - name: SERVICE
+          value: $(params.SERVICE)
+        - name: DOCKER_HOST
+          value: tcp://127.0.0.1:2475
+      script: |
+        #!/bin/bash
+        if [ -n "$SERVICE" ]; then
+          GRADLE_OPTS=":${SERVICE}:"
+        fi
+        ./gradlew ${GRADLE_OPTS}test
+      computeResources:
+        limits:
+          memory: '6Gi'
+          cpu: 6
+        requests:
+          memory: '2Gi'
+          cpu: 2
+  sidecars:
+    - image: quay.io/cloudservices/kubedock:latest
+      name: kubedock
+      env:
+        - name: KUBECONFIG
+          value: /tmp/kubeconfig
+        - name: KUBECONFIG_VALUE
+          valueFrom:
+            secretKeyRef:
+              name: $(params.PROVISION_EAAS_SPACE_SECRET_REF)
+              key: kubeconfig
+        - name: EAAS_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              name: $(params.PROVISION_EAAS_SPACE_SECRET_REF)
+              key: namespace
+      script: |
+        #!/bin/bash -ex
+
+        echo "$KUBECONFIG_VALUE" > "$KUBECONFIG"
+        /usr/local/bin/kubedock server --kubeconfig $KUBECONFIG --namespace $EAAS_NAMESPACE --port-forward -v=9      

--- a/.tekton/swatch-api-pull-request.yaml
+++ b/.tekton/swatch-api-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,41 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +246,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-contracts-pull-request.yaml
+++ b/.tekton/swatch-contracts-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -200,6 +200,43 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+      - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-contracts
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+      - name: source
+        workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -217,7 +254,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-metrics-hbi-pull-request.yaml
+++ b/.tekton/swatch-metrics-hbi-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions

--- a/.tekton/swatch-metrics-hbi-pull-request.yaml
+++ b/.tekton/swatch-metrics-hbi-pull-request.yaml
@@ -208,6 +208,43 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-metrics-hbi
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -230,7 +267,7 @@ spec:
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-metrics-pull-request.yaml
+++ b/.tekton/swatch-metrics-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    #pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #== "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -203,6 +202,43 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-metrics
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -220,7 +256,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-producer-aws-pull-request.yaml
+++ b/.tekton/swatch-producer-aws-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,43 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-producer-aws
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +248,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-producer-azure-pull-request.yaml
+++ b/.tekton/swatch-producer-azure-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    #pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #== "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -203,6 +202,43 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-producer-azure
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -220,7 +256,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-producer-red-hat-marketplace-pull-request.yaml
+++ b/.tekton/swatch-producer-red-hat-marketplace-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,41 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +246,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-subscription-sync-pull-request.yaml
+++ b/.tekton/swatch-subscription-sync-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions

--- a/.tekton/swatch-system-conduit-pull-request.yaml
+++ b/.tekton/swatch-system-conduit-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,43 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: SERVICE
+          value: swatch-system-conduit
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +248,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-tally-pull-request.yaml
+++ b/.tekton/swatch-tally-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: false
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-    #   == "main"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "hotfix")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions
@@ -195,6 +194,41 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: provision-eaas-space
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: run-tests
+      runAfter:
+        - provision-eaas-space
+      params:
+        - name: PROVISION_EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/RedHatInsights/rhsm-subscriptions
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: .tekton/run-tests-task.yaml
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -212,7 +246,7 @@ spec:
       - name: COMMIT_SHA
         value: $(tasks.clone-repository.results.commit)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/SWATCH-3341

Provision a EaaS name to run kubedock (https://konflux.pages.redhat.com/docs/users/testing/namespace-provisioning.html)

Create a `run-tests` custom Task to run after the eaas space is provisioned.  Use a kubedock sidecar that uses the kubeconfig that was generated from the eaas space.  The `run-tests` task will run the gradlew test task via CLI script.

Depends on https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/5167
https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/5183