### PR TITLE
Resolve OOM issue with archiving junit tests step in Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,12 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
+    - name: jnlp
+      env:
+        - name: JAVA_OPTS
+          value: "-Xms512m -Xmx2048m"
+        - name: JENKINS_JAVA_OPTIONS
+          value: "-Xms512m -Xmx2048m"
     - name: kubedock
       image: quay.io/cloudservices/kubedock:latest
       imagePullPolicy: Always


### PR DESCRIPTION
Last step of the Jenkins pipeline is consistently failing because of this.

```
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.lang.StringUTF16.newBytesFor(Unknown Source)
	at java.base/java.lang.AbstractStringBuilder.inflate(Unknown Source)
	at java.base/java.lang.AbstractStringBuilder.putStringAt(Unknown Source)
	at java.base/java.lang.AbstractStringBuilder.putStringAt(Unknown Source)
```
