### PR TITLE
SWATCH-3364: Improve troubleshooting when hosts didn't match any products

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/ProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/ProductRule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import java.util.Set;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
+
+/** Rules to apply when normalizing product tags. */
+public interface ProductRule {
+
+  Set<String> APPLICABLE_METRIC_IDS =
+      Set.of(MetricIdUtils.getCores().toString(), MetricIdUtils.getSockets().toString());
+
+  /**
+   * @return if the product rule must be applied for the host.
+   */
+  boolean appliesTo(ProductRuleContext context);
+
+  /**
+   * @return the matched product tags from configuration.
+   */
+  Set<String> getFilteredProductTags(ProductRuleContext context);
+
+  /**
+   * @return all the product tags that are configured for the current rule.
+   */
+  Set<String> getAllProductTagsFromConfiguration(ProductRuleContext context);
+
+  record ProductRuleContext(
+      InventoryHostFacts hostFacts, boolean is3rdPartyMigrated, boolean skipRhsmFacts) {}
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/QpcProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/QpcProductRule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QpcProductRule implements ProductRule {
+
+  public static final String RHEL = "RHEL";
+  public static final String RHEL_FOR_X86 = "RHEL for x86";
+  public static final String RHEL_FOR_ARM = "RHEL for ARM";
+  public static final String RHEL_FOR_IBM_POWER = "RHEL for IBM Power";
+
+  @Override
+  public boolean appliesTo(ProductRuleContext context) {
+    Set<String> qpcProducts = context.hostFacts().getQpcProducts();
+    return qpcProducts != null && qpcProducts.contains("RHEL");
+  }
+
+  @Override
+  public Set<String> getFilteredProductTags(ProductRuleContext context) {
+    Set<String> products = new HashSet<>();
+    if (context.hostFacts().getSystemProfileArch() != null
+        && CollectionUtils.isEmpty(context.hostFacts().getSystemProfileProductIds())) {
+      switch (context.hostFacts().getSystemProfileArch()) {
+        case "x86_64", "i686", "i386":
+          products.add(RHEL_FOR_X86);
+          break;
+        case "aarch64":
+          products.add(RHEL_FOR_ARM);
+          break;
+        case "ppc64le":
+          products.add(RHEL_FOR_IBM_POWER);
+          break;
+        default:
+          break;
+      }
+    }
+    products.add(RHEL);
+    return products;
+  }
+
+  @Override
+  public Set<String> getAllProductTagsFromConfiguration(ProductRuleContext context) {
+    return Set.of(RHEL_FOR_X86, RHEL_FOR_ARM, RHEL_FOR_IBM_POWER, RHEL);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/RhsmProductsProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/RhsmProductsProductRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.util.ProductTagLookupParams;
+import java.util.Set;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RhsmProductsProductRule implements ProductRule {
+
+  @Override
+  public boolean appliesTo(ProductRuleContext context) {
+    return !context.skipRhsmFacts()
+        && (context.hostFacts().getSyspurposeRole() != null
+            || CollectionUtils.isNotEmpty(context.hostFacts().getProducts()));
+  }
+
+  @Override
+  public Set<String> getFilteredProductTags(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder()
+            .engIds(context.hostFacts().getProducts())
+            .role(context.hostFacts().getSyspurposeRole())
+            .metricIds(APPLICABLE_METRIC_IDS)
+            .is3rdPartyMigration(context.is3rdPartyMigrated())
+            .isPaygEligibleProduct(false)
+            .build();
+
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+
+  @Override
+  public Set<String> getAllProductTagsFromConfiguration(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder()
+            .engIds(context.hostFacts().getProducts())
+            .role(context.hostFacts().getSyspurposeRole())
+            .build();
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/SatelliteRoleProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/SatelliteRoleProductRule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.util.ProductTagLookupParams;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SatelliteRoleProductRule implements ProductRule {
+
+  @Override
+  public boolean appliesTo(ProductRuleContext context) {
+    return context.hostFacts().getSatelliteRole() != null;
+  }
+
+  @Override
+  public Set<String> getFilteredProductTags(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder()
+            .role(context.hostFacts().getSatelliteRole())
+            .metricIds(APPLICABLE_METRIC_IDS)
+            .is3rdPartyMigration(context.is3rdPartyMigrated())
+            .isPaygEligibleProduct(false)
+            .build();
+
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+
+  @Override
+  public Set<String> getAllProductTagsFromConfiguration(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder().role(context.hostFacts().getSatelliteRole()).build();
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/SystemProfileProductIdsProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/SystemProfileProductIdsProductRule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.util.ProductTagLookupParams;
+import java.util.Set;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SystemProfileProductIdsProductRule implements ProductRule {
+
+  @Override
+  public boolean appliesTo(ProductRuleContext context) {
+    return CollectionUtils.isNotEmpty(context.hostFacts().getSystemProfileProductIds());
+  }
+
+  @Override
+  public Set<String> getFilteredProductTags(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder()
+            .engIds(context.hostFacts().getSystemProfileProductIds())
+            .metricIds(APPLICABLE_METRIC_IDS)
+            .is3rdPartyMigration(context.is3rdPartyMigrated())
+            .isPaygEligibleProduct(false)
+            .build();
+
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+
+  @Override
+  public Set<String> getAllProductTagsFromConfiguration(ProductRuleContext context) {
+    var lookupParams =
+        ProductTagLookupParams.builder()
+            .engIds(context.hostFacts().getSystemProfileProductIds())
+            .build();
+    return SubscriptionDefinition.getAllProductTags(lookupParams);
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
@@ -58,7 +57,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
-import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.db.AccountServiceInventoryRepository;
 import org.candlepin.subscriptions.db.HostTallyBucketRepository;
@@ -78,17 +76,16 @@ import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.tally.collector.ProductUsageCollectorFactory;
 import org.candlepin.subscriptions.tally.facts.FactNormalizer;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
-import org.candlepin.subscriptions.tally.facts.ProductNormalizer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.StringUtils;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@ActiveProfiles({"worker", "test", "test-inventory"})
 class InventoryAccountUsageCollectorTallyTest {
   private static final String TEST_PRODUCT = "RHEL for x86";
   public static final Integer TEST_PRODUCT_ID = 69;
@@ -100,20 +97,13 @@ class InventoryAccountUsageCollectorTallyTest {
   private static final String BILLING_ACCOUNT_ID_ANY = "_ANY";
   public static final String ORG_ID = "org123";
 
-  @Mock(strictness = LENIENT)
-  private InventoryRepository inventoryRepo;
-
-  @Mock private HostTallyBucketRepository hostBucketRepository;
-
-  @Mock(strictness = LENIENT)
-  private AccountServiceInventoryRepository accountServiceInventoryRepository;
-
-  @Mock private ApplicationProperties props;
-  @Spy private ApplicationClock clock = new ApplicationClock();
-  @InjectMocks private InventoryAccountUsageCollector collector;
-  @InjectMocks private InventoryDatabaseOperations inventory;
-  @InjectMocks private FactNormalizer factNormalizer;
-  @Spy private ProductNormalizer productNormalizer;
+  @MockitoBean InventoryRepository inventoryRepo;
+  @MockitoBean HostTallyBucketRepository hostBucketRepository;
+  @MockitoBean AccountServiceInventoryRepository accountServiceInventoryRepository;
+  @Autowired ApplicationProperties props;
+  @Autowired InventoryAccountUsageCollector collector;
+  @Autowired InventoryDatabaseOperations inventory;
+  @Autowired FactNormalizer factNormalizer;
 
   @Test
   void hypervisorCountsIgnoredForNonRhelProduct() {

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/FactNormalizerTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
@@ -146,7 +147,7 @@ class FactNormalizerTest {
     subscriptionDefinitionMockedStatic.clearInvocations();
     normalizer.normalize(rhsmHost, hypervisorData());
     subscriptionDefinitionMockedStatic.verify(
-        () -> SubscriptionDefinition.getAllProductTags(any()), times(1));
+        () -> SubscriptionDefinition.getAllProductTags(any()), atLeastOnce());
   }
 
   @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/product/QpcProductRuleTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/product/QpcProductRuleTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.tally.facts.product;
+
+import static org.candlepin.subscriptions.tally.InventoryHostFactTestHelper.createQpcHost;
+import static org.candlepin.subscriptions.tally.facts.product.QpcProductRule.RHEL;
+import static org.candlepin.subscriptions.tally.facts.product.QpcProductRule.RHEL_FOR_ARM;
+import static org.candlepin.subscriptions.tally.facts.product.QpcProductRule.RHEL_FOR_IBM_POWER;
+import static org.candlepin.subscriptions.tally.facts.product.QpcProductRule.RHEL_FOR_X86;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.stream.Stream;
+import org.candlepin.subscriptions.tally.facts.product.ProductRule.ProductRuleContext;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class QpcProductRuleTest {
+
+  private final ProductRule rule = new QpcProductRule();
+
+  @ParameterizedTest
+  @MethodSource("provideArchCombinations")
+  void testQpcSystemArchProduct(String arch, String expectedProduct) {
+    var hostFacts = createQpcHost(RHEL, arch, OffsetDateTime.now(Clock.systemUTC()));
+    boolean is3rdPartyMigrated = false;
+    var skipRhsm = false;
+
+    ProductRuleContext context = new ProductRuleContext(hostFacts, is3rdPartyMigrated, skipRhsm);
+
+    assertTrue(rule.appliesTo(context));
+    assertThat(rule.getFilteredProductTags(context), Matchers.hasItem(expectedProduct));
+  }
+
+  private static Stream<Arguments> provideArchCombinations() {
+
+    return Stream.of(
+        Arguments.of("x86_64", RHEL_FOR_X86),
+        Arguments.of("i386", RHEL_FOR_X86),
+        Arguments.of("i686", RHEL_FOR_X86),
+        Arguments.of("i686", RHEL_FOR_X86),
+        Arguments.of("ppc64le", RHEL_FOR_IBM_POWER),
+        Arguments.of("aarch64", RHEL_FOR_ARM));
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3364

## Description
In order to improve the troubleshooting and to avoid duplicating logic here and there, I had to refactor the ProductNormalizer class to split out the rules into ProductRule implementations.

This way I can loop over these rules to:
- aggregate the matching product tags as done before these changes.
- aggregate the configured product tags to detect when a product tag was a candidate for the host or not

Also, these changes improve the responsibility segregation chain of the product normalizer. Before, this normalizer contained different logic/rules to aggregate the products, and to reconcile the matching products. Now, it delegates the aggregation to the product rules as mentioned before.

## Testing
IQE tests and regression

### Verification

After these changes, when no products are matched for a given host, we'll see a warning trace:

```
2025-03-21 10:01:45,603 [thread=Test worker] [WARN ] [org.candlepin.subscriptions.tally.facts.ProductNormalizer] - No products matched for host with name '4c757a30-9265-462c-9598-b82e2fc7c975' and subscription-manager ID 'Test System'. The candidate products for this host were '[RHEL for x86]'
```
