### PR TITLE
SWATCH-2844: Update nginx routing send capacity queries directly to swatch-contracts

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -363,6 +363,18 @@ objects:
               rewrite ^/api/rhsm-subscriptions/v1/subscriptions/billing_account_ids$ /api/swatch-contracts/v1/subscriptions/billing_account_ids break;
               proxy_pass http://swatch-contracts;
             }
+        
+            location /api/rhsm-subscriptions/v1/subscriptions/products {
+              proxy_pass http://swatch-contracts;
+            }
+    
+            location /api/rhsm-subscriptions/v2/subscriptions/products {
+              proxy_pass http://swatch-contracts;
+            }
+    
+            location /api/rhsm-subscriptions/v1/capacity/products {
+              proxy_pass http://swatch-contracts;
+            }
 
             location ^~/ {
               proxy_pass http://swatch-api;


### PR DESCRIPTION
Jira issue: SWATCH-2844

## Description
Endpoints to route:
- /api/rhsm-subscriptions/v1/subscriptions/billing_account_ids            ->  /api/swatch-contracts/v1/subscriptions/billing_account_ids
- /api/rhsm-subscriptions/v1/subscriptions/products/{product_id}          ->  /api/rhsm-subscriptions/v1/subscriptions/products/{product_id}
- /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}   ->  /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}
- /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}          ->  /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}

## Testing
Regression testing.

### Manual Testing

1. Deploy EE project using these changes
2. Run the iqe test "test_subscription_table_api_subscription_type"