### PR TITLE
Revert "SWATCH-2844: Update nginx routing send capacity queries directly to swatch-contracts"

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -363,18 +363,6 @@ objects:
               rewrite ^/api/rhsm-subscriptions/v1/subscriptions/billing_account_ids$ /api/swatch-contracts/v1/subscriptions/billing_account_ids break;
               proxy_pass http://swatch-contracts;
             }
-        
-            location /api/rhsm-subscriptions/v1/subscriptions/products {
-              proxy_pass http://swatch-contracts;
-            }
-    
-            location /api/rhsm-subscriptions/v2/subscriptions/products {
-              proxy_pass http://swatch-contracts;
-            }
-    
-            location /api/rhsm-subscriptions/v1/capacity/products {
-              proxy_pass http://swatch-contracts;
-            }
 
             location ^~/ {
               proxy_pass http://swatch-api;


### PR DESCRIPTION
This reverts commit 2859248a9c7478d307f3922530af7818c26e1f3c.

Jira issue: SWATCH-3419

## Description
We're reverting the changes in https://github.com/RedHatInsights/rhsm-subscriptions/pull/4292 because Quarkus does not distinguish between empty and null. This issue was introduced in Quarkus 3.18 and reported by https://github.com/quarkusio/quarkus/issues/44885.

Note that before reverting the changes, I tried to make this query param optional, but the openapi does not generate it as optional. 

Other solutions imply to use the raw request param to check what was the original query value (either unset or empty), but I see this solution as flaky/workaround (since there are many query types affected). Let's wait for what is the reply from Quarkus about this issue, since they seem to be keen to not revert what caused the issue). 

## Testing
Regression testing. 