### PR TITLE
WIP: Add new consumer for the product service-owned offering topic

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
@@ -29,7 +29,8 @@ public final class Channels {
   public static final String SUBSCRIPTION_SYNC_TASK_UMB = "subscription-sync-umb";
   public static final String OFFERING_SYNC = "offering-sync";
   public static final String OFFERING_SYNC_TASK_TOPIC = "offering-sync-task";
-  public static final String OFFERING_SYNC_TASK_UMB = "offering-sync-umb";
+  public static final String OFFERING_SYNC_TASK_CANONICAL_UMB = "offering-sync-canonical-umb";
+  public static final String OFFERING_SYNC_TASK_SERVICE_UMB = "offering-sync-service-umb";
   public static final String EXPORT_REQUESTS_TOPIC = "export-requests";
 
   private Channels() {}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/ProductStatusUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/ProductStatusUMBMessageConsumer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.product.umb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.model.SyncResult;
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
+import com.redhat.swatch.contract.service.OfferingSyncService;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_SERVICE_UMB;
+
+@ApplicationScoped
+@Slf4j
+public class ProductStatusUMBMessageConsumer {
+
+  @Inject ObjectMapper mapper;
+  @Inject OfferingSyncService service;
+
+  @ConfigProperty(name = "UMB_ENABLED")
+  boolean umbEnabled;
+
+  @Blocking
+  @Incoming(OFFERING_SYNC_TASK_SERVICE_UMB)
+  public void consumeMessage(String dtoProduct) {
+    log.info("Consumer was called");
+    if (umbEnabled) {
+      consumeProduct(dtoProduct);
+    }
+  }
+
+  public SyncResult consumeProduct(String dtoProduct) {
+    // process UMB operational product.
+    log.info(dtoProduct);
+
+    try {
+      OperationalProductEvent productEvent =
+          mapper.readValue(dtoProduct, OperationalProductEvent.class);
+
+      return service.syncUmbProductFromEvent(productEvent);
+    } catch (Exception e) {
+      log.warn("Unable to read UMB message from JSON.", e);
+      return SyncResult.FAILED;
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
@@ -30,8 +30,10 @@ import com.redhat.swatch.contract.config.ProductDenylist;
 import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.model.OfferingSyncTask;
 import com.redhat.swatch.contract.model.SyncResult;
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
 import com.redhat.swatch.contract.product.UpstreamProductData;
 import com.redhat.swatch.contract.product.umb.CanonicalMessage;
+import com.redhat.swatch.contract.product.umb.ProductAttribute;
 import com.redhat.swatch.contract.product.umb.UmbOperationalProduct;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
@@ -296,6 +298,24 @@ public class OfferingSyncService {
             .getPayload()
             .getSync()
             .getOperationalProduct());
+  }
+
+  /**
+   * Sync offering state based on a Json UMB event.
+   *
+   * <p>See syncRootSku and syncChildSku for more details.
+   *
+   * @param productEvent UMB event for product
+   * @return result describing results of sync (for testing purposes)
+   */
+  @Transactional
+  public SyncResult syncUmbProductFromEvent(OperationalProductEvent productEvent) throws JsonProcessingException {
+    // The event from the Product Service UMB topic only has the SKU and no attributes
+    UmbOperationalProduct product = UmbOperationalProduct.builder()
+            .sku(productEvent.getProductCode())
+            .attributes(new ProductAttribute[]{})
+            .build();
+    return syncUmbProduct(product);
   }
 
   private SyncResult syncUmbProduct(UmbOperationalProduct umbOperationalProduct) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncTaskConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncTaskConsumer.java
@@ -21,7 +21,7 @@
 package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_TOPIC;
-import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_UMB;
+import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_CANONICAL_UMB;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.redhat.swatch.contract.model.OfferingSyncTask;
@@ -54,7 +54,7 @@ public class OfferingSyncTaskConsumer {
   }
 
   @Blocking
-  @Incoming(OFFERING_SYNC_TASK_UMB)
+  @Incoming(OFFERING_SYNC_TASK_CANONICAL_UMB)
   public void consumeFromUmb(String productMessageXml) throws JsonProcessingException {
     log.debug("Received message from UMB offering product{}", productMessageXml);
     if (!umbEnabled) {

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1442,6 +1442,27 @@ components:
           type: array
           items:
             type: string
+    OperationalProductEvent:
+      properties:
+        occurredOn:
+          description: timestamp that event occurred
+          example: '2023-05-29T16:00:54.279Z'
+          type: string
+        productCode:
+          description: Sku of Pproduct
+          type: string
+        productCategory:
+          description: Parent or Child SKU
+          type: string
+          enum:
+            - Parent SKU
+            - Child SKU
+        eventType:
+          description: Create or update product
+          type: string
+          enum:
+            - Create
+            - Update
     PartnerEntitlementContract:
       properties:
         action:

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1449,7 +1449,7 @@ components:
           example: '2023-05-29T16:00:54.279Z'
           type: string
         productCode:
-          description: Sku of Pproduct
+          description: Sku of Product
           type: string
         productCategory:
           description: Parent or Child SKU

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -251,10 +251,15 @@ CONTRACT_UMB_QUEUE=umb-contract
 %stage.CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 %prod.CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 
-OFFERING_UMB_QUEUE=umb-offering
-%ephemeral.OFFERING_UMB_QUEUE=VirtualTopic.canonical.operationalProduct
-%stage.OFFERING_UMB_QUEUE=VirtualTopic.canonical.operationalProduct
-%prod.OFFERING_UMB_QUEUE=VirtualTopic.canonical.operationalProduct
+OFFERING_UMB_CANONICAL_QUEUE=umb-offering-canonical
+%ephemeral.OFFERING_UMB_CANONICAL_QUEUE=VirtualTopic.canonical.operationalProduct
+%stage.OFFERING_UMB_CANONICAL_QUEUE=VirtualTopic.canonical.operationalProduct
+%prod.OFFERING_UMB_CANONICAL_QUEUE=VirtualTopic.canonical.operationalProduct
+
+OFFERING_UMB_SERVICE_QUEUE=umb-offering-service
+%ephemeral.OFFERING_UMB_SERVICE_QUEUE=VirtualTopic.services.productservice.Product
+%stage.OFFERING_UMB_SERVICE_QUEUE=VirtualTopic.services.productservice.Product
+%prod.OFFERING_UMB_SERVICE_QUEUE=VirtualTopic.services.productservice.Product
 
 SUBSCRIPTION_UMB_QUEUE=umb-subscription
 %ephemeral.SUBSCRIPTION_UMB_QUEUE=VirtualTopic.canonical.subscription
@@ -319,12 +324,19 @@ mp.messaging.outgoing.capacity-reconcile.topic=platform.rhsm-subscriptions.capac
 mp.messaging.outgoing.capacity-reconcile.group.id=capacity-reconciliation-worker
 mp.messaging.outgoing.capacity-reconcile.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 
-mp.messaging.incoming.offering-sync-umb.connector=smallrye-amqp
-%test.mp.messaging.incoming.offering-sync-umb.connector=smallrye-in-memory
-mp.messaging.incoming.offering-sync-umb.address=${OFFERING_UMB_QUEUE}
-mp.messaging.incoming.offering-sync-umb.client-options-name=umb
-mp.messaging.incoming.offering-sync-umb.enabled=${UMB_ENABLED}
-mp.messaging.incoming.offering-sync-umb.failure-strategy=accept
+mp.messaging.incoming.offering-sync-canonical-umb.connector=smallrye-amqp
+%test.mp.messaging.incoming.offering-sync-canonical-umb.connector=smallrye-in-memory
+mp.messaging.incoming.offering-sync-canonical-umb.address=${OFFERING_UMB_CANONICAL_QUEUE}
+mp.messaging.incoming.offering-sync-canonical-umb.client-options-name=umb
+mp.messaging.incoming.offering-sync-canonical-umb.enabled=${UMB_ENABLED}
+mp.messaging.incoming.offering-sync-canonical-umb.failure-strategy=accept
+
+mp.messaging.incoming.offering-sync-service-umb.connector=smallrye-amqp
+%test.mp.messaging.incoming.offering-sync-service-umb.connector=smallrye-in-memory
+mp.messaging.incoming.offering-sync-service-umb.address=${OFFERING_UMB_SERVICE_QUEUE}
+mp.messaging.incoming.offering-sync-service-umb.client-options-name=umb
+mp.messaging.incoming.offering-sync-service-umb.enabled=${UMB_ENABLED}
+mp.messaging.incoming.offering-sync-service-umb.failure-strategy=accept
 
 mp.messaging.incoming.subscription-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.subscription-sync-umb.connector=smallrye-in-memory

--- a/swatch-contracts/src/test/resources/mocked-product-event.json
+++ b/swatch-contracts/src/test/resources/mocked-product-event.json
@@ -1,0 +1,6 @@
+{
+  "occurredOn" : "2023-05-29T16:00:54.279Z",
+  "productCode" : "RH0180191",
+  "productCategory": "Parent SKU",
+  "eventType" : "Create"
+}


### PR DESCRIPTION
Jira issue: SWATCH-XXXX

## Description
The offering topic owned by ESB (i.e. "Canonical") is being retired (the goal-date being within a month or so) and consumers need to use the topic owned by the product service. However, the topic owned by the product service does not publish any attributes or hierarchy information, just the sku/product code.

So in addition to the topic change, there is a behavioral change as well because SWatch will no longer to able to compare the message contents to the copy in the DB and will now have to call product service for every single message that is consumed.

This is an MR intended to help kickstart the investigation process, since the request for the topic switch is coming in last-minute.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
