### PR TITLE
SWATCH-3405: Add billing_account_id as param for Capacity

### DIFF
--- a/api/rhsm-subscriptions-api-v1-spec.yaml
+++ b/api/rhsm-subscriptions-api-v1-spec.yaml
@@ -305,6 +305,12 @@ paths:
       summary: "Fetch a capacity report for an account and product."
       operationId: getCapacityReportByMetricId
       parameters:
+        - name: billing_account_id
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/BillingAccountId"
+          description: "The billing account ID for the product we wish to query"
         - name: granularity
           in: query
           required: true
@@ -1000,6 +1006,8 @@ components:
             product:
               type: string
             metric_id:
+              type: string
+            billing_account_id:
               type: string
             granularity:
               $ref: '#/components/schemas/GranularityType'

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
@@ -104,6 +104,7 @@ public class CapacityResource implements CapacityApi {
       @NotNull OffsetDateTime ending,
       Integer offset,
       @Min(1) Integer limit,
+      String billingAccountId,
       ReportCategory reportCategory,
       ServiceLevelType sla,
       UsageType usage) {
@@ -136,6 +137,7 @@ public class CapacityResource implements CapacityApi {
             orgId,
             productId,
             metricId,
+            billingAccountId,
             hypervisorReportCategory,
             sanitizedServiceLevel,
             sanitizedUsage,
@@ -161,6 +163,7 @@ public class CapacityResource implements CapacityApi {
     meta.setGranularity(granularityType);
     meta.setProduct(productId.toString());
     meta.setMetricId(metricId.toString());
+    meta.setBillingAccountId(billingAccountId);
     meta.setCategory(reportCategory);
     meta.setCount(capacities.size());
 
@@ -192,6 +195,7 @@ public class CapacityResource implements CapacityApi {
       String orgId,
       ProductId product,
       MetricId metricId,
+      String billingAccountId,
       HypervisorReportCategory hypervisorReportCategory,
       ServiceLevel sla,
       Usage usage,
@@ -209,6 +213,7 @@ public class CapacityResource implements CapacityApi {
         DbReportCriteria.builder()
             .orgId(orgId)
             .productTag(product.toString())
+            .billingAccountId(billingAccountId)
             .serviceLevel(sla)
             .usage(usage)
             .beginning(reportBegin)

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/CapacityResource.java
@@ -110,9 +110,10 @@ public class CapacityResource implements CapacityApi {
       UsageType usage) {
 
     log.debug(
-        "Get capacity report for product {} by metric {} in range [{}, {}] for category {}",
+        "Get capacity report for product {} by metric {} and billing account {} in range [{}, {}] for category {}",
         productId,
         metricId,
+        billingAccountId,
         beginning,
         ending,
         reportCategory);

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
@@ -167,6 +167,7 @@ public class TallyResource implements TallyApi {
                 ending,
                 offset,
                 limit,
+                billingAcctId,
                 category,
                 sla,
                 usageType)
@@ -264,6 +265,7 @@ public class TallyResource implements TallyApi {
       OffsetDateTime ending,
       Integer offset,
       Integer limit,
+      String billingAccountId,
       ReportCategory category,
       ServiceLevelType sla,
       UsageType usageType) {
@@ -277,6 +279,7 @@ public class TallyResource implements TallyApi {
             ending,
             offset,
             limit,
+            billingAccountId,
             Optional.ofNullable(category).map(c -> ReportCategory.valueOf(c.name())).orElse(null),
             Optional.ofNullable(sla).map(s -> ServiceLevelType.valueOf(s.name())).orElse(null),
             Optional.ofNullable(usageType).map(ut -> UsageType.valueOf(ut.name())).orElse(null));

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/CapacityResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/CapacityResourceTest.java
@@ -159,6 +159,7 @@ class CapacityResourceTest {
             max,
             null,
             null,
+            null,
             ReportCategory.PHYSICAL,
             null,
             null);
@@ -193,6 +194,7 @@ class CapacityResourceTest {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -233,6 +235,7 @@ class CapacityResourceTest {
             null,
             null,
             null,
+            null,
             UsageType.PRODUCTION);
 
     assertEquals(9, report.getData().size());
@@ -265,6 +268,7 @@ class CapacityResourceTest {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -301,6 +305,7 @@ class CapacityResourceTest {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -360,6 +365,7 @@ class CapacityResourceTest {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -409,6 +415,7 @@ class CapacityResourceTest {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -452,6 +459,7 @@ class CapacityResourceTest {
             max,
             null,
             null,
+            null,
             ReportCategory.VIRTUAL,
             null,
             null);
@@ -483,6 +491,7 @@ class CapacityResourceTest {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             ReportCategory.PHYSICAL,
@@ -531,6 +540,7 @@ class CapacityResourceTest {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -572,6 +582,7 @@ class CapacityResourceTest {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             ReportCategory.VIRTUAL,
@@ -619,6 +630,7 @@ class CapacityResourceTest {
             max,
             null,
             null,
+            null,
             ReportCategory.PHYSICAL,
             null,
             null);
@@ -641,6 +653,7 @@ class CapacityResourceTest {
                   max,
                   11,
                   10,
+                  null,
                   null,
                   null,
                   null);
@@ -670,7 +683,17 @@ class CapacityResourceTest {
 
     CapacityReportByMetricId report =
         resource.getCapacityReportByMetricId(
-            RHEL_FOR_ARM, METRIC_ID_CORES, GranularityType.DAILY, min, max, 1, 1, null, null, null);
+            RHEL_FOR_ARM,
+            METRIC_ID_CORES,
+            GranularityType.DAILY,
+            min,
+            max,
+            1,
+            1,
+            null,
+            null,
+            null,
+            null);
 
     assertEquals(1, report.getData().size());
     assertEquals(
@@ -694,6 +717,7 @@ class CapacityResourceTest {
               null,
               null,
               null,
+              null,
               null);
         });
   }
@@ -712,6 +736,7 @@ class CapacityResourceTest {
               GranularityType.DAILY,
               min,
               max,
+              null,
               null,
               null,
               null,
@@ -748,6 +773,7 @@ class CapacityResourceTest {
             "owner123456",
             RHEL_FOR_ARM,
             METRIC_ID_CORES,
+            null,
             HypervisorReportCategory.HYPERVISOR,
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
@@ -811,6 +837,7 @@ class CapacityResourceTest {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -833,6 +860,7 @@ class CapacityResourceTest {
                     null,
                     null,
                     null,
+                    null,
                     null));
 
     assertEquals(
@@ -846,7 +874,17 @@ class CapacityResourceTest {
     assertDoesNotThrow(
         () ->
             resource.getCapacityReportByMetricId(
-                productId, METRIC_ID_CORES, granularity, min, max, null, null, null, null, null));
+                productId,
+                METRIC_ID_CORES,
+                granularity,
+                min,
+                max,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
   }
 
   private static Stream<Arguments> generateFinestGranularityCases() {

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
@@ -843,6 +843,7 @@ class TallyResourceTest {
             eq(ending),
             any(),
             any(),
+            any(),
             eq(resolvedReportCategory),
             eq(resolvedSla),
             eq(resolvedUsage)))

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1.java
@@ -105,14 +105,16 @@ public class CapacityResourceV1 implements CapacityApi {
       @NotNull OffsetDateTime ending,
       Integer offset,
       @Min(1) Integer limit,
+      String billingAccountId,
       ReportCategory reportCategory,
       ServiceLevelType sla,
       UsageType usage) {
 
     log.debug(
-        "Get capacity report for product {} by metric {} in range [{}, {}] for category {}",
+        "Get capacity report for product {} by metric {} and billing account {} in range [{}, {}] for category {}",
         productId,
         metricId,
+        billingAccountId,
         beginning,
         ending,
         reportCategory);
@@ -137,6 +139,7 @@ public class CapacityResourceV1 implements CapacityApi {
             orgId,
             productId,
             metricId,
+            billingAccountId,
             hypervisorReportCategory,
             sanitizedServiceLevel,
             sanitizedUsage,
@@ -162,6 +165,7 @@ public class CapacityResourceV1 implements CapacityApi {
     meta.setGranularity(granularityType);
     meta.setProduct(productId.toString());
     meta.setMetricId(metricId.toString());
+    meta.setBillingAccountId(billingAccountId);
     meta.setCategory(reportCategory);
     meta.setCount(capacities.size());
 
@@ -193,6 +197,7 @@ public class CapacityResourceV1 implements CapacityApi {
       String orgId,
       ProductId product,
       MetricId metricId,
+      String billingAccountId,
       HypervisorReportCategory hypervisorReportCategory,
       ServiceLevel sla,
       Usage usage,
@@ -216,6 +221,7 @@ public class CapacityResourceV1 implements CapacityApi {
             .ending(reportEnd)
             .hypervisorReportCategory(hypervisorReportCategory)
             .metricId(metricId == null ? null : metricId.toString())
+            .billingAccountId(billingAccountId)
             .build();
 
     var subscriptions = subscriptionRepository.findByCriteria(dbReportCriteria, Sort.empty());

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1149,6 +1149,12 @@ paths:
       summary: "Fetch a capacity report for an account and product."
       operationId: getCapacityReportByMetricId
       parameters:
+        - name: billing_account_id
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/BillingAccountId"
+          description: "The billing account ID for the product we wish to query"
         - name: granularity
           in: query
           required: true
@@ -1833,6 +1839,8 @@ components:
             product:
               type: string
             metric_id:
+              type: string
+            billing_account_id:
               type: string
             granularity:
               $ref: '#/components/schemas/GranularityType'

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1Test.java
@@ -89,7 +89,7 @@ class CapacityResourceV1Test {
   @InjectMock UriInfo uriInfo;
 
   @BeforeEach
-  public void updateSecurityContext() {
+  void updateSecurityContext() {
     SecurityContext mockSecurityContext = Mockito.mock(SecurityContext.class);
     Principal mockPrincipal = Mockito.mock(Principal.class);
     resource.setTestSecurityContext(mockSecurityContext);
@@ -160,6 +160,7 @@ class CapacityResourceV1Test {
             max,
             null,
             null,
+            null,
             ReportCategory.PHYSICAL,
             null,
             null);
@@ -194,6 +195,7 @@ class CapacityResourceV1Test {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -234,7 +236,46 @@ class CapacityResourceV1Test {
             null,
             null,
             null,
+            null,
             UsageType.PRODUCTION);
+
+    assertEquals(9, report.getData().size());
+  }
+
+  @Test
+  void testReportByMetricIdShouldUseBillableAccountQueryParam() {
+
+    var dbReportCriteria =
+        DbReportCriteria.builder()
+            .orgId("owner123456")
+            .productTag(RHEL_FOR_ARM.toString())
+            .billingAccountId("account123456")
+            .serviceLevel(ServiceLevel._ANY)
+            .usage(Usage._ANY)
+            .beginning(min)
+            .ending(max)
+            .metricId(METRIC_ID_CORES.toString())
+            .build();
+
+    SubscriptionEntity s = new SubscriptionEntity();
+    s.setSubscriptionMeasurements(basicMeasurement());
+
+    when(subscriptionRepository.findByCriteria(eq(dbReportCriteria), any(Sort.class)))
+        .thenReturn(List.of(s));
+
+    CapacityReportByMetricId report =
+        resource.getCapacityReportByMetricId(
+            RHEL_FOR_ARM,
+            METRIC_ID_CORES,
+            GranularityType.DAILY,
+            min,
+            max,
+            null,
+            null,
+            "account123456",
+            null,
+            null,
+            null);
 
     assertEquals(9, report.getData().size());
   }
@@ -266,6 +307,7 @@ class CapacityResourceV1Test {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -302,6 +344,7 @@ class CapacityResourceV1Test {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             null,
@@ -362,6 +405,7 @@ class CapacityResourceV1Test {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -412,6 +456,7 @@ class CapacityResourceV1Test {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -455,6 +500,7 @@ class CapacityResourceV1Test {
             max,
             null,
             null,
+            null,
             ReportCategory.VIRTUAL,
             null,
             null);
@@ -486,6 +532,7 @@ class CapacityResourceV1Test {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             ReportCategory.PHYSICAL,
@@ -534,6 +581,7 @@ class CapacityResourceV1Test {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -575,6 +623,7 @@ class CapacityResourceV1Test {
             GranularityType.DAILY,
             min,
             max,
+            null,
             null,
             null,
             ReportCategory.VIRTUAL,
@@ -622,6 +671,7 @@ class CapacityResourceV1Test {
             max,
             null,
             null,
+            null,
             ReportCategory.PHYSICAL,
             null,
             null);
@@ -644,6 +694,7 @@ class CapacityResourceV1Test {
                   max,
                   11,
                   10,
+                  null,
                   null,
                   null,
                   null);
@@ -673,7 +724,17 @@ class CapacityResourceV1Test {
 
     CapacityReportByMetricId report =
         resource.getCapacityReportByMetricId(
-            RHEL_FOR_ARM, METRIC_ID_CORES, GranularityType.DAILY, min, max, 1, 1, null, null, null);
+            RHEL_FOR_ARM,
+            METRIC_ID_CORES,
+            GranularityType.DAILY,
+            min,
+            max,
+            1,
+            1,
+            null,
+            null,
+            null,
+            null);
 
     assertEquals(1, report.getData().size());
     assertEquals(
@@ -695,6 +756,7 @@ class CapacityResourceV1Test {
               GranularityType.DAILY,
               min,
               max,
+              null,
               null,
               null,
               null,
@@ -731,6 +793,7 @@ class CapacityResourceV1Test {
             "owner123456",
             RHEL_FOR_ARM,
             METRIC_ID_CORES,
+            null,
             HypervisorReportCategory.HYPERVISOR,
             ServiceLevel.STANDARD,
             Usage.PRODUCTION,
@@ -796,6 +859,7 @@ class CapacityResourceV1Test {
             null,
             null,
             null,
+            null,
             null);
 
     CapacitySnapshotByMetricId capacitySnapshot = report.getData().get(0);
@@ -818,6 +882,7 @@ class CapacityResourceV1Test {
                     null,
                     null,
                     null,
+                    null,
                     null));
 
     assertEquals(
@@ -831,7 +896,17 @@ class CapacityResourceV1Test {
     assertDoesNotThrow(
         () ->
             resource.getCapacityReportByMetricId(
-                productId, METRIC_ID_CORES, granularity, min, max, null, null, null, null, null));
+                productId,
+                METRIC_ID_CORES,
+                granularity,
+                min,
+                max,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
   }
 
   private static Stream<Arguments> generateFinestGranularityCases() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3405

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
We want to filter the results in the capacity report, optionally by billing_account_id.
This change is in both the monolith version and the swatch-contracts version.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1115

### Setup
<!-- Add any steps required to set up the test case -->
1. Start the core services in rhsm-subscriptions with podman
    ```podman-compose up -d```
2. oc login to the prod environment and use the project rhsm-prod
    ```oc login --token=[token] --server=https://api.crcp01ue1.o9m8.p1.openshiftapps.com:6443```
3. Make sure you have the latest version of swatch-support-scripts
4. Import data from org 18284865 to the local db:
     ```
     ../swatch-support-scripts/import-from-gabi.py --offerings --org-id='18284865'
     ../swatch-support-scripts/import-from-gabi.py --subscriptions --org-id='18284865'
     ../swatch-support-scripts/import-from-gabi.py --contracts --org-id='18284865'
     ../swatch-support-scripts/import-from-gabi.py --tallies --org-id='18284865'
     ```
5. Wiremock the product service
    ```https://inscope.corp.redhat.com/docs/default/Component/swatch-support-scripts/wiremock_stub_generator/```
    Note: Use ```MW02393``` as the SKU. The data you imported has what we need for that SKU. Substitute this command for create_subs_from_product_service:
    ```SWATCH_SUPPORT_SCRIPT_DIR=../swatch-support-scripts ./create_stubs_from_product_service.sh MW02393 SVCMW02393-C,MW02393,SVCMW02393-B,SVCMW02393-A``` 

6. Add the org_id 18284865 to the org_config table. The monolith will need an opt-in.
    ```INSERT INTO org_config VALUES('18284865', 'API', '2025-04-02 18:00:51.406822 +00:00', '2025-04-02 18:00:51.406822 +00:00')```
7. Start up the services:
    ```DEV_MODE=true SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress ./gradlew clean :bootRun```
    ```PRODUCT_URL=http://localhost:8101/svcrest/product/v3 SERVER_PORT=8003 QUARKUS_MANAGEMENT_PORT=9003 ./gradlew :swatch-contracts:quarkusDev```
    Note: The product service mock was started and should be running from step 5.

### Steps
<!-- Enter each step of the test below -->
Run http commands against either 8000 or 8003. The result should be the same
1. ``` http PUT :8000/api/rhsm-subscriptions/v1/opt-in x-rh-identity:$(echo '{"identity":{"account_number":"10001","org_id":"18284865","internal":{"org_id":"18284865"},"type":"User","user":{"username":"user_dev"}}}' | base64 -w0) ```
    ``` http ':8000/api/rhsm-subscriptions/v1/capacity/products/rosa/Sockets' x-rh-identity:$(echo '{"identity":{"account_number":"10001","org_id":"18284865","internal":{"org_id":"18284865"},"type":"User","user":{"username":"user_dev"}}}' | base64 -w0) granularity==HOURLY beginning=='2025-04-03T22:00Z' ending=='2025-04-03T23:59Z' billing_account_id=='891377390770' ```

3. [no opt-in for swatch-contracts]
    ``` http ':8003/api/rhsm-subscriptions/v1/capacity/products/rosa/Sockets' x-rh-identity:$(echo '{"identity":{"account_number":"10001","org_id":"18284865","internal":{"org_id":"18284865"},"type":"User","user":{"username":"user_dev"}}}' | base64 -w0) granularity==HOURLY beginning=='2025-04-03T22:00Z' ending=='2025-04-03T23:59Z' billing_account_id=='891377390770' ```


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. While the headers will be different, the data should look like this:
```
{
    "data": [
        {
            "date": "2025-04-03T22:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 2
        },
        {
            "date": "2025-04-03T23:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 2
        }
    ],
    "meta": {
        "billing_account_id": "891377390770",
        "count": 2,
        "granularity": "Hourly",
        "metric_id": "Sockets",
        "product": "rosa"
    }
}
```

2. If you change the billing_account_id you should get:
```
{
    "data": [
        {
            "date": "2025-04-03T22:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        },
        {
            "date": "2025-04-03T23:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        }
    ],
    "meta": {
        "billing_account_id": "91377390770",
        "count": 2,
        "granularity": "Hourly",
        "metric_id": "Sockets",
        "product": "rosa"
    }
}
```
Note: The match for billing_account_id is ```like '123456%'```, so dropping digits from the end of the value will not change the result.
4. If you drop the billing_account_id from the query, you will get the result from step 1.

