### PR TITLE
Configure renovate to update the Konflux tasks at any time when there are new versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "tekton": {
+    "automerge": true,
+    "schedule": ["* * * * *"]
+  }
+}
+


### PR DESCRIPTION
## Description
By default, the Konflux task images are bumped once a week, however the verify build fails when it detects that there are newer version.
To prevent the verify build to fail, we need to update the Konflux task images as soon as there is a new image (not wait for the weekly pull request).