### PR TITLE
Fix secret azure-marketplace-credentials indent that makes swatch-producer-azure to fail

### DIFF
--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -167,7 +167,7 @@ objects:
   kind: Secret
   metadata:
     name: azure-marketplace-credentials
-    data:
-      # Decodes to:
-      # {"credentials":{"azure":{"clients":[{"tenantId":"test","clientId":"test","clientSecret":"test","publisher":"test"}]}}}
-      credentials: eyJjcmVkZW50aWFscyI6eyJhenVyZSI6eyJjbGllbnRzIjpbeyJ0ZW5hbnRJZCI6InRlc3QiLCJjbGllbnRJZCI6InRlc3QiLCJjbGllbnRTZWNyZXQiOiJ0ZXN0IiwicHVibGlzaGVyIjoidGVzdCJ9XX19fQ==
+  data:
+    # Decodes to:
+    # {"credentials":{"azure":{"clients":[{"tenantId":"test","clientId":"test","clientSecret":"test","publisher":"test"}]}}}
+    credentials: eyJjcmVkZW50aWFscyI6eyJhenVyZSI6eyJjbGllbnRzIjpbeyJ0ZW5hbnRJZCI6InRlc3QiLCJjbGllbnRJZCI6InRlc3QiLCJjbGllbnRTZWNyZXQiOiJ0ZXN0IiwicHVibGlzaGVyIjoidGVzdCJ9XX19fQ==


### PR DESCRIPTION
## Description
The service swatch-producer-azure was failing to be deployed with the following error `Error: couldn't find key credentials in Secret ephemeral-tkc06t/azure-marketplace-credentials`.

The problem is that indentation was wrong. Note sure how this was not spotted earlier, maybe clowder was fixing it automagically.

## Testing
CI is green. Regression testing.