### PR TITLE
SWATCH-3461: Increase Billable Usage Memory Limit

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -12,9 +12,9 @@ parameters:
   - name: IMAGE_PULL_SECRET
     value: quay-cloudservices-pull
   - name: MEMORY_REQUEST
-    value: 512Mi
+    value: 600Mi
   - name: MEMORY_LIMIT
-    value: 512Mi
+    value: 750Mi
   - name: CPU_REQUEST
     value: 200m
   - name: CPU_LIMIT


### PR DESCRIPTION
Jira issue: SWATCH-3461

## Description
In the ephemeral environments, the pod kept crash looping.  After
bumping up the memory request, I see that the total memory used is about
583 MiB so this patch should give us a little breathing room.

## Testing

### Setup
1. Do an ephemeral deployment from this branch

### Steps
1. Do an `oc edit` on the swatch-billable-usage-service pod and set the memory
   request and limit back to 512.  The billable-usage pod will start
   crash-looping.

### Verification
1. Set the memory limit back to 750 and the billable usage pod will stop
   crash-looping.
