### PR TITLE
Update ConfigMap name because of naming conflict

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
@@ -1203,7 +1203,7 @@ data:
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: grafana-dashboard-subscription-watch
+  name: grafana-dashboard-subscription-watch-payg-metrics
   annotations:
     grafana-folder: /grafana-dashboard-definitions/Insights
   labels:


### PR DESCRIPTION
Failure deploying to prod because there's already another template with the same ConfigMap name.

```
17:27:58 [2025-04-16 17:27:58] [ERROR] [DRY-RUN] [saasherder.py:populate_desired_state_saas_file:1376] - [appsrep09ue1/****-observability-production] Duplicate resources in your deployment template detected. The following is defined multiple times in your deployment template: ConfigMap/grafana-dashboard-subscription-watch. saas file name: rhsm, resource template name: insights-subscription-watch.
```