### PR TITLE
SWATCH-2820: Add IMAGE_TAG to swatch-database job to ensure unique name

### DIFF
--- a/swatch-database/deploy/clowdapp.yaml
+++ b/swatch-database/deploy/clowdapp.yaml
@@ -34,6 +34,9 @@ parameters:
     value: quay.io/cloudservices/swatch-database
   - name: IMAGE_TAG
     value: latest
+  - name: JOB_SUFFIX
+    from: '[a-z]{10}'
+    generate: expression
 
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
@@ -50,7 +53,7 @@ objects:
         version: 13
 
       jobs:
-        - name: migrations-job
+        - name: migrations-job-${JOB_SUFFIX}
           activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2
           podSpec:
@@ -108,8 +111,8 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdJobInvocation
     metadata:
-      name: swatch-database
+      name: swatch-database-${JOB_SUFFIX}
     spec:
       appName: swatch-database
       jobs:
-        - migrations-job
+        - migrations-job-${JOB_SUFFIX}


### PR DESCRIPTION
## Description
If a ClowdJobInvocation with the same name is applied again, the job doesn't trigger.  This patch adds a unique suffix so the job will run each time.

Jira issue: SWATCH-2820

## Testing
None