### PR TITLE
Add more validation around CloudProvider / HardwareMeasurementType

### DIFF
--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiEvent.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiEvent.java
@@ -29,7 +29,9 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+@ToString
 @Getter
 @Setter
 @JsonTypeInfo(use = Id.DEDUCTION)

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/normalization/FactNormalizer.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/normalization/FactNormalizer.java
@@ -40,7 +40,7 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.candlepin.clock.ApplicationClock;
-import org.candlepin.subscriptions.json.Event.CloudProvider;
+import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Event.HardwareType;
 
 /**
@@ -108,10 +108,7 @@ public class FactNormalizer {
             determineUsage(orgId, subscriptionManagerId, satelliteFacts, rhsmFacts, skipRhsmFacts))
         .sla(determineSla(orgId, subscriptionManagerId, satelliteFacts, rhsmFacts, skipRhsmFacts))
         .cloudProviderType(cloudProviderType)
-        .cloudProvider(
-            Objects.nonNull(cloudProviderType)
-                ? CloudProvider.fromValue(cloudProviderType.name())
-                : null)
+        .cloudProvider(toEventCloudProvider(cloudProviderType))
         .syncTimestamp(syncTimestamp)
         .isVirtual(isVirtual)
         .hardwareType(determineHardwareType(systemProfileFacts, isVirtual))
@@ -122,6 +119,20 @@ public class FactNormalizer {
         .productIds(productNormalizer.getProductIds())
         .lastSeen(determineLastSeenDate(host))
         .build();
+  }
+
+  private Event.CloudProvider toEventCloudProvider(HardwareMeasurementType measurementType) {
+    if (Objects.isNull(measurementType)) {
+      return null;
+    }
+
+    return switch (measurementType) {
+      case AWS, AWS_CLOUDIGRADE -> Event.CloudProvider.AWS;
+      case AZURE -> Event.CloudProvider.AZURE;
+      case ALIBABA -> Event.CloudProvider.ALIBABA;
+      case GOOGLE -> Event.CloudProvider.GOOGLE;
+      default -> null;
+    };
   }
 
   private String determineInstanceId(Host hbiHost) {

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/normalization/FactNormalizerTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/normalization/FactNormalizerTest.java
@@ -114,6 +114,13 @@ class FactNormalizerTest {
         Arguments.of("aws", HardwareMeasurementType.AWS, CloudProvider.AWS),
         Arguments.of("AwS", HardwareMeasurementType.AWS, CloudProvider.AWS),
         Arguments.of("Not Known", null, null),
+        Arguments.of("Azure", HardwareMeasurementType.AZURE, CloudProvider.AZURE),
+        Arguments.of("AZURE", HardwareMeasurementType.AZURE, CloudProvider.AZURE),
+        Arguments.of("GOOGLE", HardwareMeasurementType.GOOGLE, CloudProvider.GOOGLE),
+        Arguments.of("Google", HardwareMeasurementType.GOOGLE, CloudProvider.GOOGLE),
+        Arguments.of("GCP", HardwareMeasurementType.GOOGLE, CloudProvider.GOOGLE),
+        Arguments.of("Alibaba", HardwareMeasurementType.ALIBABA, CloudProvider.ALIBABA),
+        Arguments.of("ALIBABA", HardwareMeasurementType.ALIBABA, CloudProvider.ALIBABA),
         Arguments.of(null, null, null));
   }
 


### PR DESCRIPTION
Bug from #4306

## Summary by Sourcery

Improve cloud provider validation and mapping in the FactNormalizer

Bug Fixes:
- Add proper mapping for Azure cloud provider in event normalization

Enhancements:
- Refactor cloud provider mapping to use a more robust conversion method
- Add explicit handling for different cloud provider types

Tests:
- Extend test cases to cover Azure cloud provider mapping