### PR TITLE
SWATCH-3360: Update rhel-for-x86-eus product configuration to be included in rhel-for-x86.

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -54,6 +54,10 @@ export IQE_IBUTSU_SOURCE="rhsm-ephemeral-${IMAGE_TAG}"
 EXTRA_DEPLOY_ARGS="--timeout 1800 ${IMAGES}"
 OPTIONAL_DEPS_METHOD=none
 
+# Propagate commit sha into the IQE pod
+git status
+export IQE_ENV_VARS="${IQE_ENV_VARS:+$IQE_ENV_VARS,}GITHUB_SHA=${GIT_COMMIT}"
+
 # set CLI option for --no-remove-resources
 export COMPONENTS_W_RESOURCES="app:rhsm app:export-service"
 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -55,8 +55,7 @@ EXTRA_DEPLOY_ARGS="--timeout 1800 ${IMAGES}"
 OPTIONAL_DEPS_METHOD=none
 
 # Propagate commit sha into the IQE pod
-git status
-export IQE_ENV_VARS="${IQE_ENV_VARS:+$IQE_ENV_VARS,}GITHUB_SHA=${GIT_COMMIT}"
+export IQE_ENV_VARS="${IQE_ENV_VARS:+$IQE_ENV_VARS,}GITHUB_SHA=$GIT_BRANCH"
 
 # set CLI option for --no-remove-resources
 export COMPONENTS_W_RESOURCES="app:rhsm app:export-service"

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_eus.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_eus.yaml
@@ -5,9 +5,8 @@ id: rhel-for-x86-eus
 
 vdcType: true
 
-# TODO: https://issues.redhat.com/browse/SWATCH-1692 keep this commented out until UI updates are in place.
-#includedSubscriptions:
-#  - rhel-for-x86
+includedSubscriptions:
+  - rhel-for-x86
 
 variants:
   - tag: rhel-for-x86-eus


### PR DESCRIPTION
Jira issue: SWATCH-3360

## Description
Uncomment this configuration which was causing a system to be seen as both hypervisor and physical.

The problem was that this system that was a hypervisor had:
 - 3 guests using rhel products but not the eus variant,
 - and the system was configured with the rhel products, and also the eus variant.

 This makes the tally process to consider the system both physical and hypervisor.

 With this change, now all the RHEL variants are hypervisor, and only the eus one is physical.

## Testing
- Start kafka and database: `podman compose -f docker-compose.yml up -d` 
- Start tally service: `INVENTORY_DATABASE_SCHEMA=hbi DEV_MODE=true ./gradlew :bootRun`
- Insert data into the rhsm-subscriptions schema, queries in: https://privatebin.corp.redhat.com/?1a28468260d0faaf#C9YZNrdfvhtJH6NLnSEmJVap3K5hn7p6pno7DF2PMMXa

- Insert data into the insights schema, queries in: https://privatebin.corp.redhat.com/?0a9965ca53a49c58#4PuNvzpRcmdH2teZcJ4J9DrPTzmjRDg16w5uKh5tvPeD

This data inserts one host plus three guests, in total, there are four hosts. 

- Run the tally for all the organizations: 

```
http PUT "http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/all-org-snapshots" Origin:console.redhat.com x-rh-swatch-psk:placeholder
```

Wait a few seconds, and run the following query:

```
select h.display_name, h.subscription_manager_id, b.*
from host_tally_buckets b
inner join hosts h on b.host_id = h.id
where h.display_name = 'sldohd2prhv0008.qr.qrgrp.local'
```

In main, you see duplicated buckets for measurement_type PHYSICAL and HYPERVISOR, for the product "RHEL for x86". 

This is causing that the Instances API endpoint, to return duplicates:

- opt in:

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=5244353' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiI1MjQ0MzUzIn19fQ=='
```

- instances API:
 
```
http GET ":8000/api/rhsm-subscriptions/v1/instances/products/RHEL%20for%20x86" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiI1MjQ0MzUzIn19fQ== | jq
```

Output:

```
{
  "data": [
    {
      "id": "XXX",
      "instance_id": "XXX",
      "display_name": "XXX",
      "measurements": [
        2.0
      ],
      "last_seen": "2025-04-23T02:20:43.586818Z",
      "number_of_guests": 3,
      "category": "hypervisor",
      "subscription_manager_id": "XXX",
      "inventory_id": "XXX"
    },
    {
      "id": "XXX",
      "instance_id": "XXX",
      "display_name": "XXX",
      "measurements": [
        2.0
      ],
      "last_seen": "2025-04-23T02:20:43.586818Z",
      "number_of_guests": 3,
      "category": "physical",
      "subscription_manager_id": "XXX",
      "inventory_id": "XXX"
    }
  ],
  "meta": {
    "count": 2,
    "product": "RHEL for x86",
    "measurements": [
      "Sockets"
    ]
  }
}
```

## Verification

Using the changes from this branch, restarting the service and running the tally again, you should see:

```
{
  "data": [
    {
      "id": "XXX",
      "instance_id": "XXX",
      "display_name": "XXX",
      "measurements": [
        2.0
      ],
      "last_seen": "2025-04-23T02:20:43.586818Z",
      "number_of_guests": 3,
      "category": "hypervisor",
      "subscription_manager_id": "XXX",
      "inventory_id": "XXX"
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "measurements": [
      "Sockets"
    ]
  }
}
```

In the tally buckets table, now, all the buckets are either hypervisor or physical (only for the rhel-for-x86-eus product), but never both. 