### PR TITLE
Update IQE ee proxy instructions to remove dynaconf props

### DIFF
--- a/docs/iqe-ee-proxy.md
+++ b/docs/iqe-ee-proxy.md
@@ -10,9 +10,7 @@ https://insights-qe.pages.redhat.com/iqe-core-docs/tutorial/part3.html#download-
 3. Run the script  
 `python3.12 ./get-iqe.py`
 4. Create a file in the iqe-workspace directory named iqe_env:  
-`export ENV_FOR_DYNACONF=clowder_smoke`  
-`export DYNACONF_IQE_VAULT_OIDC_HEADLESS=true`  
-`export DYNACONF_SETTINGS__pre_check=0`    
+`export ENV_FOR_DYNACONF=clowder_smoke`
 `export NAMESPACE=[current namespace]`    
 5. Activate the venv while in the iqe-workspace directory:  
 `source activate_iqe_venv && source ./iqe_env`  


### PR DESCRIPTION
## Description
I've been using IQE EE proxy for a while, but recently, it started failing to me due to some auth credentials issue and then some ports being in used (this is because the IQE framework tries to start the vault server twice after failures).

After investigating the issue, it seems related to the two properties deleted from these changes, without it, now it always work for me. 

## Testing
Follow the IQE ee proxy instructions and confirm it's still working without these two properties.