### PR TITLE
Fix NPE in swatch-metrics-hbi when normalizing measurements for incoming events

### DIFF
--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostCreateUpdateEvent.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostCreateUpdateEvent.java
@@ -22,7 +22,9 @@ package com.redhat.swatch.hbi.events.dtos.hbi;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+@ToString
 @Getter
 @Setter
 public class HbiHostCreateUpdateEvent extends HbiEvent {

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostDeleteEvent.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostDeleteEvent.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+@ToString
 @Getter
 @Setter
 public class HbiHostDeleteEvent extends HbiEvent {

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/normalization/MeasurementNormalizer.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/normalization/MeasurementNormalizer.java
@@ -146,8 +146,6 @@ public class MeasurementNormalizer {
     //  For x86, guests: if we know the number of threads per core and is greater than one,
     //  then we divide the number of cores by that number.
     //  Otherwise, we divide by two.
-    int cpu = systemProfileFacts.getCoresPerSocket() * systemProfileFacts.getSockets();
-
     var threadsPerCore = THREADS_PER_CORE_DEFAULT;
     if (appConfig.isUseCpuSystemFactsForAllProducts()
         || products.contains(OPEN_SHIFT_CONTAINER_PLATFORM)) {
@@ -178,6 +176,15 @@ public class MeasurementNormalizer {
         }
       }
     }
+
+    if (!isGreaterThanZero(
+        systemProfileFacts.getCoresPerSocket(), systemProfileFacts.getSockets())) {
+      log.warn(
+          "Unable to calculate virtual CPU because cores/sockets were 0 or null. Defaulting to 'null'");
+      return null;
+    }
+
+    int cpu = systemProfileFacts.getCoresPerSocket() * systemProfileFacts.getSockets();
     return (int) Math.ceil(cpu / threadsPerCore);
   }
 

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventConsumer.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventConsumer.java
@@ -108,7 +108,7 @@ public class HbiEventConsumer {
       return;
     }
 
-    log.info("Received create/update host event from HBI - {}", hbiEvent);
+    logHbiEvent(hbiEvent);
     HbiHostCreateUpdateEvent hbiHostEvent = (HbiHostCreateUpdateEvent) hbiEvent;
 
     Host host = new Host(hbiHostEvent.getHost());
@@ -317,5 +317,16 @@ public class HbiEventConsumer {
         .withIsUnmappedGuest(facts.isUnmappedGuest())
         .withIsHypervisor(facts.isHypervisor())
         .withLastSeen(facts.getLastSeen());
+  }
+
+  private void logHbiEvent(HbiEvent hbiEvent) {
+    String eventString;
+    try {
+      eventString = objectMapper.writeValueAsString(hbiEvent);
+    } catch (JsonProcessingException e) {
+      // Just log the object via toString if serialization fails.
+      eventString = hbiEvent.toString();
+    }
+    log.info("Received create/update host event from HBI - {}", eventString);
   }
 }


### PR DESCRIPTION
Fix an NPE that was occurring when processing incoming HBI messages and calculating measurements. Also log the incoming HBI events in JSON format.