### PR TITLE
SWATCH-3531: Add additional product filter to RHEL ELS PAYG promql

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_els_payg.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_els_payg.yaml
@@ -29,6 +29,6 @@ metrics:
     prometheus:
       queryKey: rhelemeter
       queryParams:
-        productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
+        productLabelRegex: .*(^|,)(204)($|,).*",product=~".*(^|,)69(,|$).*" # Filter metrics to include only those with product IDs 69 and 204.
         metric: system_cpu_logical_count
         instanceKey: billing_marketplace_instance_id

--- a/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_els_payg_addon.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/RHEL/rhel_for_x86_els_payg_addon.yaml
@@ -28,6 +28,6 @@ metrics:
     prometheus:
       queryKey: rhelemeter
       queryParams:
-        productLabelRegex: .*(^|,)(204)($|,).* # this regex is used to fetch metrics for the product label that contains the product/engineering ID 204. the number here needs to map to a tag defined in the variant section of this file
+        productLabelRegex: .*(^|,)(204)($|,).*",product=~".*(^|,)69(,|$).*" # Filter metrics to include only those with product IDs 69 and 204.
         metric: system_cpu_logical_count
         instanceKey: billing_marketplace_instance_id


### PR DESCRIPTION
The change to productLabelRegex is a workaround to filter metrics based on the presence of two product IDs (69 and 204) within the product label. This is necessary because PromQL doesn't support matching multiple values within a single label using standard regex. This approach emulates the desired logic by concatenating two regex patterns, ensuring both product IDs are present. This change adds a product filter to the Prometheus metrics query for RHEL Extended Life Support (ELS) Pay-as-You-Go (PAYG) and its add-on. This ensures that the query only returns metrics for product ID 69, in addition to the existing filter for product/engineering ID 204.

A more robust solution would involve modifying the PromQL template or query building logic to handle more complex filtering scenarios, but this workaround addresses the immediate need without extensive code changes.