### PR TITLE
SWATCH-3530: Use branch to resolve product configuration

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -63,6 +63,9 @@ for EXTRA_COMPONENT_NAME in $EXTRA_COMPONENTS; do
   export EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} --set-template-ref ${EXTRA_COMPONENT_NAME}=${GIT_COMMIT}"
 done
 
+# Propagate git branch into the IQE pod env variables
+export IQE_ENV_VARS="${IQE_ENV_VARS:+$IQE_ENV_VARS,}GIT_BRANCH=$GIT_BRANCH"
+
 # Delete comment about the IQE tests output if exists
 source bin/delete_comment_iqe_summary.sh
 


### PR DESCRIPTION
Jira issue: SWATCH-3530

## Description
Jenkins PR provides the following "GIT_COMMIT" property to get the full sha commit, however it does not work when using it with the GitHub API because this commit sha belongs to a local cloned repository.

Moreover, we can't use the git log or any other git command utility for the same reason than above.

Therefore, the only option is to use the branch name which is provided by Jenkins by GIT_BRANCH.

Depends on https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1150.

## Testing
In the "ci.ext.devshift.net PR build" job , check that contains this trace:

```
INFO:root:Fetching swatch-product-configuration from jcarvaja/SWATCH-3530 ...
```