### PR TITLE
SWATCH-3453: Add write permissions for GitHub Actions summary task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,8 @@ jobs:
 
   summary:
     name: PR Summary
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: [validate-format, validate-floorplan-queries, build, test]
     if: always()


### PR DESCRIPTION
Jira issue: SWATCH-3453

## Description
We need to add pull-request write permissions to the Job Summary task.  See the documentation [here](https://github.com/marketplace/actions/sticky-pull-request-comment#error-resource-not-accessible-by-integration)

## Testing
None really.  We just need to make sure the workflow passes on this PR and then we'll have to see if it passes when Dependabot opens a pull request since that is where it was failing.