### PR TITLE
SWATCH-3391: Fix logic to not assume `role` is always the same as the `product` label

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -272,15 +272,17 @@ public class PrometheusMeteringController {
                 .build());
 
     if (!matchingTags.contains(productTag)) {
-      // Warn that the event doesn't match the context of the product tag we're currently working
-      // in.
       log.warn(
-          "Starting product tag {} does not match derived product tags {} based on data contents. Skipping event creation.",
+          "Starting product tag {} does not match derived product tags {} based on data contents.",
           productTag,
           matchingTags);
-      // Clear the product tag before producing Event message to force Event ingestion to determine
-      // a product tag during normalization
-      productTag = null;
+
+      if (matchingTags.isEmpty()) {
+        role = null; // No match at all, clear role for fallback logic
+      } else {
+        log.warn("Mismatched product tags. Clearing productTag to trigger reconciliation.");
+        productTag = null; // Clear to allow ingestion to rederive correct context
+      }
     }
 
     log.info("Creating Event for product {}", productTag);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3391

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

swatch-metrics logic is written with the assumption that a product label was always going to match the role of a product.  We now have products that don't have roles.

Improves handling of mismatched product tags in metering events. Instead of simply logging a warning and clearing the productTag when the starting tag doesn't match the derived tags, the logic now differentiates between no matching tags and some matching tags. If no tags match, the role is also cleared to trigger fallback logic. If some tags match, only the productTag is cleared to allow the ingestion process to rederive the correct context. This prevents incorrect tag assignments and ensures accurate metering data.


## Testing
### init database
create Offering
```sql
INSERT INTO public.offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag, level_1, level_2) VALUES ('MW02023HR', 'Advanced Cluster Mgmt for Kubernetes', 'OpenShift Enterprise', 1, null, null, null, null, 'Premium', null, 'Red Hat Advanced Cluster Management for Kubernetes', false, null, true, null, 'OpenShift', 'ACM - Advanced Cluster Management');
```
create sku_product_tag mapping
```sql
INSERT INTO public.sku_product_tag (sku, product_tag, id) VALUES ('MW02023HR', 'rhacm', '6be23856-5de3-4c82-a378-5fb92b0acc50');
```
create subscription
```sql
INSERT INTO public.subscription (sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02023HR', '17496113', '13080195', 1, '2025-03-19 04:00:00.000000 +00:00', '2026-04-19 03:59:59.000000 +00:00', 'placeholder;746157280291', '13080352', 'aws', '746157280291');
```
tally_state
```sql
INSERT INTO public.tally_state (org_id, service_type, latest_event_record_date) VALUES ('17496113', 'rhacm Instance', '2024-04-24 00:00:00.000000 +00:00');
```

### start up token refresher for stage telemeter
https://gitlab.cee.redhat.com/rhsm/swatch-support-scripts/-/blob/main/telemeter-stage?ref_type=heads

### startup swatch-tally
```bash
DEV_MODE=true SERVER_PORT=8000 SPRING_PROFILES_ACTIVE=worker,kafka-queue,api,capacity-ingress ./gradlew :bootRun
```

### start swatch-metrics
```bash
SERVER_PORT=8002 QUARKUS_HTTP_PORT=8002 QUARKUS_MANAGEMENT_PORT=9002 EVENT_SOURCE=prometheus PROM_URL="http://localhost:8082/api/v1" ./gradlew :swatch-metrics:quarkusDev
```

### kick off metrics sync for rhacm and org
```bash
curl -X 'POST' \
  'http://localhost:8002/api/swatch-metrics/v1/internal/metering/rhacm?orgId=17496113' \
  -H 'accept: */*' \
  -H 'x-rh-swatch-synchronous-request: false' \
  -H 'x-rh-swatch-psk: placeholder' 
```
## Verification

swatch-metrics log should no longer have errors
swatch-metrics shouldn't be emitting Events with incorrect `role`
swatch-metrics should be emitting Events with product_tag set to `rhacm`

If you have swatch-tally running, you should be able to see the ingestion of the Event in the log to verify there's no role and that product_tag is set.