### PR TITLE
SWATCH-3507: Export subscriptions without metrics in CSV

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/SubscriptionCapacityViewMetricConverter.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/SubscriptionCapacityViewMetricConverter.java
@@ -78,7 +78,7 @@ public class SubscriptionCapacityViewMetricConverter
               });
       return metrics;
     } catch (JsonProcessingException e) {
-      throw new IllegalArgumentException("Error parsing metrics", e);
+      throw new IllegalArgumentException("Error parsing metrics with value: " + s, e);
     }
   }
 

--- a/swatch-contracts/src/main/resources/db/202504301500-update-subscription-capacity-view_h2_only-to-set-defaults.xml
+++ b/swatch-contracts/src/main/resources/db/202504301500-update-subscription-capacity-view_h2_only-to-set-defaults.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202504301500-01" author="jcarvaja" dbms="h2" runOnChange="true">
+    <comment>
+      Use defaults for the metrics in the view subscription_capacity_view
+    </comment>
+    <dropView viewName="subscription_capacity_view" ifExists="true"/>
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[select distinct s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.description as product_name,
+                        o.sla as service_level,
+                        o.usage,
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        CONCAT('[{"metric_id":"', sm.metric_id, '","value":',COALESCE(sm.value,0), ',"measurement_type":"',sm.measurement_type , '"}]') as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from subscription s
+                        inner join offering o on s.sku=o.sku
+                        inner join sku_product_tag spt on s.sku = spt.sku
+                        left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
+                 where s.start_date <= now() and (s.end_date is null or s.end_date >= now())
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o.usage , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity, sm.metric_id, sm.value, sm.measurement_type, s.start_date, s.end_date
+                 order by s.subscription_id asc
+      ]]>
+    </createView>
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changeLog.xml
+++ b/swatch-contracts/src/main/resources/db/changeLog.xml
@@ -21,4 +21,5 @@
   <include file="db/202407081616-add-level-columns-for-offering-table_h2_only.xml"/>
   <include file="db/202410171500-move-subscription-capacity-view_h2_only.xml"/>
   <include file="db/202412051144-primary-keys-on-changelog-table.xml"/>
+  <include file="db/202504301500-update-subscription-capacity-view_h2_only-to-set-defaults.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Jira issue: SWATCH-3507

## Description
Before these changes, we only exported subscriptions with metrics in CSV. Now, we'll export all the subscriptions regardless whether it has metrics or not.

## Testing
1.- Deploy the changes from the branch into an EE environment
2.- Port forward the database and the export-service services:
```
oc port-forward $(oc get pods | grep tally-db | cut -d' ' -f1) 5432:5432
oc port-forward $(oc get pods | grep export-service-service | cut -d' ' -f1) 8002:8000
```

3.- Get the credentials from the tally-db and connect to the database from localhost
4.- Create an export request:

```
curl -sS -X POST http://localhost:8002/api/export/v1/exports -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyNTk3NzUifSwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoidXNlcl9kZXYifX19" -H "Content-Type: application/json" -d '{
    "name": "Test Export Request",
    "format": "csv",
    "expires_at": "2025-01-01T00:00:00Z",
    "sources": [
        {
            "application": "subscriptions",
            "resource": "subscriptions",
            "filters": {
                "product_id": "RHEL for x86"
            }
        }
    ]
}'
```

Export output:
```
{"id":"6c25c690-702a-492b-9c5a-9afaa190d65e","created_at":"2025-05-02T07:56:42.020248617Z","expires_at":"2025-01-01T00:00:00Z","name":"Test Export Request","format":"csv","status":"pending","sources":[{"id":"e48a7dd2-9a34-4e72-9c28-e8724e5c4290","application":"subscriptions","status":"pending","resource":"subscriptions","filters":{"product_id":"RHEL for x86"}}]}
```

Note the id is 6c25c690-702a-492b-9c5a-9afaa190d65e which will be used in the following steps.

5.- Wait until export request is completed
```
curl -sS -X GET http://localhost:8002/api/export/v1/exports/6c25c690-702a-492b-9c5a-9afaa190d65e/status -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyNTk3NzUifSwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoidXNlcl9kZXYifX19" -H "Content-Type: application/json"
```

Exported output:
```
{"id":"6c25c690-702a-492b-9c5a-9afaa190d65e","created_at":"2025-05-02T07:56:42.020248Z","completed_at":"2025-05-02T07:56:43.692706Z","expires_at":"2025-01-01T00:00:00Z","name":"Test Export Request","format":"csv","status":"complete","sources":[{"id":"e48a7dd2-9a34-4e72-9c28-e8724e5c4290","application":"subscriptions","status":"success","resource":"subscriptions","filters":{"product_id":"RHEL for x86"}}]}
```

Check the status should be "complete", if not, wait a few seconds and try again.

6.- Download the export document:
```
curl -X GET http://localhost:8002/api/export/v1/exports/6c25c690-702a-492b-9c5a-9afaa190d65e -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTIzIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTMyNTk3NzUifSwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoidXNlcl9kZXYifX19" -H "Accept: file" --output report.zip
```

Then, unzip the report.zip and in the file, you should see no records.

## Verification

Let's now create one subscription without measurements and check the report.

1.- Create a subscription without measurements:

```
INSERT INTO offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered) VALUES ('MW02393', 'OpenShift Dedicated', 'OpenShift Enterprise', 0, 0, 0, 0, 'osd', 'Premium', 'Production', 'Red Hat OpenShift Service on AWS Hosted Control Planes (Hourly)', false, null, null);
INSERT INTO subscription (sku, org_id, subscription_id, quantity, start_date, billing_provider_id, subscription_number, billing_provider, billing_account_id) VALUES ('MW02393', '13259775', '13579593', 1, '2023-09-26 08:25:22.797423 +00:00', 'bcwuzc8ww10vvxfair55mliy8;4G5dKpAKahm', '13579750', 'aws', '505066801768');
insert into sku_product_tag values('MW02393', 'rosa');
```

2.- Identity header for the org id 13259775:

```
export IDENTITY_13259775=eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTMyNTk3NzUiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMzI1OTc3NSJ9LCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyX2RldiJ9fX0=
```

2.- Make a new export request:

```
curl -sS -X POST http://localhost:8002/api/export/v1/exports -H "x-rh-identity: $IDENTITY_13259775" -H "Content-Type: application/json" -d '{
    "name": "Test Export Request",
    "format": "csv",
    "expires_at": "2025-01-01T00:00:00Z",
    "sources": [
        {
            "application": "subscriptions",
            "resource": "subscriptions",
            "filters": {
                "product_id": "rosa"
            }
        }
    ]
}'
```

Expected output:
```
{"id":"f7410cdc-fb11-45cf-a488-ec623c29d196","created_at":"2025-05-02T10:17:21.268638396Z","expires_at":"2025-01-01T00:00:00Z","name":"Test Export Request","format":"csv","status":"pending","sources":[{"id":"6a6e4c49-aeb8-48f3-a782-365c03ecda3c","application":"subscriptions","status":"pending","resource":"subscriptions","filters":{"product_id":"rosa"}}]}
```

Note the id is f7410cdc-fb11-45cf-a488-ec623c29d196 that will be used in the following steps:
```
export EXPORT_ID=f7410cdc-fb11-45cf-a488-ec623c29d196
```

3.- Wait until export request is completed
```
curl -sS -X GET http://localhost:8002/api/export/v1/exports/$EXPORT_ID/status -H "x-rh-identity: $IDENTITY_13259775" -H "Content-Type: application/json"
```

Exported output:
```
{"id":"f7410cdc-fb11-45cf-a488-ec623c29d196","created_at":"2025-05-02T10:17:21.268638Z","completed_at":"2025-05-02T10:17:22.586722Z","expires_at":"2025-01-01T00:00:00Z","name":"Test Export Request","format":"csv","status":"complete","sources":[{"id":"6a6e4c49-aeb8-48f3-a782-365c03ecda3c","application":"subscriptions","status":"success","resource":"subscriptions","filters":{"product_id":"rosa"}}]}
```

Check the status should be "complete", if not, wait a few seconds and try again.

4.- Download the export document:
```
curl -X GET http://localhost:8002/api/export/v1/exports/$EXPORT_ID -H "x-rh-identity: $IDENTITY_13259775" --output report.zip
```

Then, unzip the report.zip and in the file, you should see one record. In main, you see no records.