### PR TITLE
Disable swatch-database konflux pipelines for now

### DIFF
--- a/.tekton/swatch-database-pull-request.yaml
+++ b/.tekton/swatch-database-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && source_branch == "awood/SWATCH-2820-migrations-again"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions

--- a/.tekton/swatch-database-push.yaml
+++ b/.tekton/swatch-database-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && source_branch == "awood/SWATCH-2820-migrations-again"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rhsm-subscriptions


### PR DESCRIPTION
## Description
Disable swatch-database konflux pipelines for now which will be merged next week (after prod release) by https://github.com/RedHatInsights/rhsm-subscriptions/pull/4409

## Testing
CI is green.