### PR TITLE
Revert "chore(deps): Bump quarkusVersion from 3.21.3 to 3.22.1 (#4446)"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 // inspired by mockito's gradle structure, which dependabot uses as a test case
 
 ext {
-    quarkusVersion='3.22.1'
+    quarkusVersion='3.21.3'
     springVersion='3.4.5'
     resteasyVersion='6.2.12.Final'
     jacksonVersion='2.19.0'


### PR DESCRIPTION
## Description
This reverts commit 7fbeb1f8cd159c163a484d8aa2c2b165d0a2dd58, reversing changes made to a050daa6b47c72e9fe1390d544557d104a9cfc53.

The quarkus version is causing the swatch-common-panache build to fail much more often than before.
Reported by https://issues.redhat.com/browse/SWATCH-3541