### PR TITLE
SWATCH-3535: Re-Add run-tests tasks in swatch components Konflux pipelines

### DIFF
--- a/.tekton/run-tests-task.yaml
+++ b/.tekton/run-tests-task.yaml
@@ -9,12 +9,9 @@ spec:
       default: ""
     - name: PROVISION_EAAS_SPACE_SECRET_REF
       description: The secret ref of the "provision-eaas-space" task output
-  workspaces:
-    - name: source
   steps:
     - image: registry.access.redhat.com/ubi9/openjdk-17-runtime
       name: builder
-      workingDir: $(workspaces.source.path)/source
       env:
         - name: SERVICE
           value: $(params.SERVICE)

--- a/.tekton/swatch-contracts-pull-request.yaml
+++ b/.tekton/swatch-contracts-pull-request.yaml
@@ -199,6 +199,50 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: provision-eaas-space
+      params:
+      - name: ownerName
+        value: $(context.pipelineRun.name)
+      - name: ownerUid
+        value: $(context.pipelineRun.uid)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/konflux-ci/build-definitions.git
+        - name: revision
+          value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+        - name: pathInRepo
+          value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+          - "true"
+    - name: run-tests
+      params:
+      - name: SERVICE
+        value: swatch-contracts
+      - name: PROVISION_EAAS_SPACE_SECRET_REF
+        value: $(tasks.provision-eaas-space.results.secretRef)
+      runAfter:
+      - provision-eaas-space
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/RedHatInsights/rhsm-subscriptions
+        - name: revision
+          value: $(params.revision)
+        - name: pathInRepo
+          value: .tekton/run-tests-task.yaml
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+          - "true"
     - name: build-container
       params:
       - name: IMAGE
@@ -227,7 +271,7 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/swatch-contracts-push.yaml
+++ b/.tekton/swatch-contracts-push.yaml
@@ -196,6 +196,50 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: provision-eaas-space
+      params:
+      - name: ownerName
+        value: $(context.pipelineRun.name)
+      - name: ownerUid
+        value: $(context.pipelineRun.uid)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/konflux-ci/build-definitions.git
+        - name: revision
+          value: 4e4fa7355a6a51083954408e7e3b647e3bddb8d8
+        - name: pathInRepo
+          value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+          - "true"
+    - name: run-tests
+      params:
+      - name: SERVICE
+        value: swatch-contracts
+      - name: PROVISION_EAAS_SPACE_SECRET_REF
+        value: $(tasks.provision-eaas-space.results.secretRef)
+      runAfter:
+      - provision-eaas-space
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/RedHatInsights/rhsm-subscriptions
+        - name: revision
+          value: $(params.revision)
+        - name: pathInRepo
+          value: .tekton/run-tests-task.yaml
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+          - "true"
     - name: build-container
       params:
       - name: IMAGE
@@ -224,7 +268,7 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - prefetch-dependencies
+      - run-tests
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
Jira issue: SWATCH-3535

## Description
Re-Add run-tests tasks in swatch components Konflux pipelines

## Testing
CI is green