### PR TITLE
SWATCH-3542: Filter out billing_provider and billing_account_id with values _ANY from the instances/billing_account_ids API

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/AccountServiceInventoryRepositoryTest.java
@@ -50,8 +50,6 @@ class AccountServiceInventoryRepositoryTest {
 
   @Autowired AccountServiceInventoryRepository repo;
 
-  @Autowired HostRepository hostRepo;
-
   @Transactional
   @BeforeAll
   void setupTestData() {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
@@ -40,6 +40,7 @@ import org.candlepin.subscriptions.db.model.HostBucketKey_;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.HostTallyBucket_;
 import org.candlepin.subscriptions.db.model.Host_;
+import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
@@ -77,7 +78,15 @@ public interface HostTallyBucketRepository
     var hostPath = root.join(HostTallyBucket_.host);
 
     List<Predicate> predicates = new ArrayList<>();
+    // Criteria: b.org_id = ?
     predicates.add(criteriaBuilder.equal(hostPath.get(Host_.ORG_ID), criteria.getOrgId()));
+    // And Criteria: b.billing_provider != _ANY
+    predicates.add(
+        criteriaBuilder.notEqual(key.get(HostBucketKey_.BILLING_PROVIDER), BillingProvider._ANY));
+    // And Criteria: b.billing_account_id != _ANY
+    predicates.add(
+        criteriaBuilder.notEqual(key.get(HostBucketKey_.BILLING_ACCOUNT_ID), ResourceUtils.ANY));
+    // if billing provider is set, then: and Criteria: b.billing_provider = ?
     if (Objects.nonNull(criteria.getBillingProvider())
         && !criteria.getBillingProvider().equals(BillingProvider._ANY)
         && !criteria.getBillingProvider().equals(BillingProvider.EMPTY)) {


### PR DESCRIPTION
Jira issue: SWATCH-3542

## Description
For example, having the following data in the tally_buckets:

```
"billing_provider":"_ANY","billing_account_id":"746157280291"
"billing_provider":"_ANY","billing_account_id":"_ANY"
"billing_provider":"aws","billing_account_id":"746157280291"
"billing_provider":"aws","billing_account_id":"_ANY"

"billing_provider":"_ANY","billing_account_id":"746157280292"
"billing_provider":"_ANY","billing_account_id":"_ANY"
"billing_provider":"azure","billing_account_id":"746157280292"
"billing_provider":"azure","billing_account_id":"_ANY"
```

For the same product and account, it should return only two records:

```
"billing_provider":"aws","billing_account_id":"746157280291"
"billing_provider":"azure","billing_account_id":"746157280292"
```

## Testing
Refactored the test to run real queries against the database, so we can verify the exact behaviour. 

MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1161