### PR TITLE
SWATCH-3559: Add time-bound filtering to Billable Usage Account ID APIs

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionRepository.java
@@ -90,7 +90,12 @@ public class SubscriptionRepository
       String orgId, Optional<String> productTag) {
     StringBuilder query =
         new StringBuilder(
-            "select distinct subscription.orgId, subscription.billingAccountId, subscription.billingProvider, productTag from SubscriptionEntity subscription join subscription.offering offering join offering.productTags productTag where orgId = ?1");
+            "select distinct subscription.orgId, subscription.billingAccountId, subscription.billingProvider, productTag from SubscriptionEntity subscription "
+                + "join subscription.offering offering "
+                + "join offering.productTags productTag "
+                + "where orgId = ?1 "
+                + "and subscription.startDate <= CURRENT_TIMESTAMP "
+                + "and subscription.endDate >= CURRENT_TIMESTAMP");
     Object[] queryParams;
     if (productTag.isPresent()) {
       query.append(" and productTag = ?2");

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/repository/SubscriptionRepositoryTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/repository/SubscriptionRepositoryTest.java
@@ -481,6 +481,14 @@ class SubscriptionRepositoryTest {
       subscription.setOffering(rosa);
       subscriptionRepo.persistAndFlush(subscription);
     }
+    // Create subscriptions that have expected orgId and product_tag but are expired
+    for (int i = 0; i < 5; i++) {
+      SubscriptionEntity subscription =
+          createOldSubscription(
+              expectedOrgId, String.valueOf(new Random().nextInt()), "expectedSellerAcctId" + i);
+      subscription.setOffering(rosa);
+      subscriptionRepo.persistAndFlush(subscription);
+    }
 
     var result = subscriptionRepo.findBillingAccountInfo(expectedOrgId, Optional.of("rosa"));
     assertEquals(5, result.size());
@@ -580,6 +588,20 @@ class SubscriptionRepositoryTest {
     // at the same resolution as the JVM
     OffsetDateTime startDate = now.truncatedTo(ChronoUnit.SECONDS);
     return createSubscription(orgId, subId, billingAccountId, startDate, startDate.plusDays(30));
+  }
+
+  private SubscriptionEntity createOldSubscription(
+      String orgId, String subId, String billingAccountId) {
+
+    // Truncate to avoid issues around nanosecond mismatches -- HSQLDB doesn't store timestamps
+    // at the same resolution as the JVM
+    OffsetDateTime startDate = now.truncatedTo(ChronoUnit.SECONDS);
+    return createSubscription(
+        orgId,
+        subId,
+        billingAccountId,
+        startDate.minusYears(1),
+        startDate.plusDays(30).minusYears(1));
   }
 
   private SubscriptionEntity createSubscription(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/HostTallyBucketRepository.java
@@ -28,6 +28,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -86,6 +87,10 @@ public interface HostTallyBucketRepository
     // And Criteria: b.billing_account_id != _ANY
     predicates.add(
         criteriaBuilder.notEqual(key.get(HostBucketKey_.BILLING_ACCOUNT_ID), ResourceUtils.ANY));
+    // And Criteria: b.last_seen this month
+    predicates.add(
+        criteriaBuilder.greaterThanOrEqualTo(
+            hostPath.get(Host_.LAST_SEEN), getFirstDayOfMonth(OffsetDateTime.now())));
     // if billing provider is set, then: and Criteria: b.billing_provider = ?
     if (Objects.nonNull(criteria.getBillingProvider())
         && !criteria.getBillingProvider().equals(BillingProvider._ANY)
@@ -116,5 +121,9 @@ public interface HostTallyBucketRepository
             .distinct(true);
 
     return getEntityManager().createQuery(query).getResultList();
+  }
+
+  default OffsetDateTime getFirstDayOfMonth(OffsetDateTime date) {
+    return date.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3559

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Added filter on BillingAccountId queries for time constraints

## Testing
 
Added to unit tests so that time filtering is expressed.
