### PR TITLE
SWATCH-3456: Allow to mock product api responses for offering sync

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -71,6 +71,7 @@ SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=60d
 %wiremock.SUBSCRIPTION_URL=http://wiremock:8101/mock/subs
 
 # Product Service configuration
+%ephemeral.PRODUCT_URL=${WIREMOCK_ENDPOINT}/mock/product
 %prod.PRODUCT_URL=https://product.api.redhat.com/svcrest/product/v3
 
 # dev-specific config items that don't need to be overridden via env var


### PR DESCRIPTION
Jira issue: SWATCH-3456

## Description
Allow to mock product API using wiremock + removing unnecesary extra configuration to set the AMQP topic names. 

Related to https://github.com/RedHatInsights/wiremock-consoledot/pull/19