### PR TITLE
Remove DebugClientLogger from %stage to Reduce Log Noise

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -178,6 +178,7 @@ rest-client-debug-logging.uri-filter=.*(partnerSubscriptions|search|products).*
 quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level=DEBUG
 %test.quarkus.rest-client.logging.scope=request-response
 %dev.quarkus.rest-client.logging.scope=request-response
+%ephemeral.quarkus.rest-client.logging.scope=request-response
 
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -178,7 +178,6 @@ rest-client-debug-logging.uri-filter=.*(partnerSubscriptions|search|products).*
 quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level=DEBUG
 %test.quarkus.rest-client.logging.scope=request-response
 %dev.quarkus.rest-client.logging.scope=request-response
-%stage.quarkus.rest-client.logging.scope=request-response
 
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".url=${SUBSCRIPTION_URL:http://localhost:8102}


### PR DESCRIPTION
This PR updates the `application.properties` for the `swatch-contracts` service to reduce log clutter and splunk storage impact.  The logger currently emits thousands of large entries daily, some over a megabyte each, consuming excessive log volume.  

Slack thread for context: https://redhat-internal.slack.com/archives/C01F7QFNATC/p1745590531531909

Changes:
* Removed verbose HTTP client debug logging from the `%stage` profile:
  * Specifically, `DebugClientLogger` log level has been removed.
  * This was initially added under SWATCH-2206 to help troubleshoot an issue with `redhat-subscription-created` messages from the Partner Gateway failing due to a missing `orgId`.
  * Since the issue has not reoccurred and hasn't required troubleshooting support for quite some time, the debug logs are no longer necessary in the `%stage` profile.

* Enabled the same debug logging only for the `%ephemeral` profile, because that might be helpful.