### PR TITLE
SWATCH-2579: Filter Capacity API by the most recent active subscription

### DIFF
--- a/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
+++ b/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <comment>
+      Update subscription_capacity_view to filter measurements by subscription ID plus start date
+    </comment>
+    <dropView viewName="subscription_capacity_view" />
+    <createView
+            replaceIfExists="true"
+            viewName="subscription_capacity_view">
+        <![CDATA[with active_subscriptions as
+                        (
+                          select org_id, subscription_id, MAX(start_date) as start_date
+                          from "subscription"
+                          where start_date <= now() and (end_date is null or end_date >= now())
+                          group by org_id, subscription_id
+                        )
+                 select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.description as product_name,
+                        coalesce(o.sla, '') as service_level,
+                        coalesce(o."usage", '') as "usage",
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from active_subscriptions a
+                 inner join "subscription" s on a.subscription_id=s.subscription_id and a.start_date=s.start_date and a.org_id=s.org_id
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id and s.start_date=sm.start_date
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        ]]>
+    </createView>
+    <rollback>
+      <createView
+        replaceIfExists="true"
+        viewName="subscription_capacity_view">
+        <![CDATA[with active_subscriptions as
+                        (
+                          select org_id, subscription_id, MAX(start_date) as start_date
+                          from "subscription"
+                          where start_date <= now() and (end_date is null or end_date >= now())
+                          group by org_id, subscription_id
+                        )
+                 select s.subscription_id,
+                        s.subscription_number,
+                        s.sku,
+                        o.has_unlimited_usage,
+                        o.description as product_name,
+                        coalesce(o.sla, '') as service_level,
+                        coalesce(o."usage", '') as "usage",
+                        s.org_id,
+                        s.billing_provider,
+                        s.billing_provider_id,
+                        s.billing_account_id,
+                        s.start_date,
+                        s.end_date,
+                        jsonb_agg(jsonb_build_object('metric_id',sm.metric_id,'value', sm.value, 'measurement_type', sm.measurement_type)) as metrics,
+                        spt.product_tag,
+                        s.quantity as quantity
+                 from active_subscriptions a
+                 inner join "subscription" s on a.subscription_id=s.subscription_id and a.start_date=s.start_date and a.org_id=s.org_id
+                 inner join offering o on s.sku=o.sku
+                 inner join sku_product_tag spt on s.sku = spt.sku
+                 left join subscription_measurements sm on s.subscription_id = sm.subscription_id
+                 group by s.subscription_id, s.subscription_number, s.sku, o.has_unlimited_usage, o.description, o.sla, o."usage" , s.org_id, s.billing_provider, s.billing_provider_id, s.billing_account_id, spt.product_tag,s.quantity,s.start_date,s.end_date
+        ]]>
+      </createView>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -179,5 +179,6 @@
     <include file="/liquibase/202501081035-remove-backup-tables.xml"/>
     <include file="/liquibase/202412091327-drop-hardware-measurement-type-from-billable-usage-remittance.xml"/>
     <include file="/liquibase/202504291554-add-updated-at-column-to-billable-usage-remittance.xml"/>
+    <include file="/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-2579

## Description
These changes affect to the following endpoints:

- /api/rhsm-subscriptions/v1/subscriptions/products/{product}
- /api/rhsm-subscriptions/v2/subscriptions/products/{product}
- /api/rhsm-subscriptions/v1/capacity/products/{product}/{metric}

in swatch-api and swatch-contracts.

The root cause of the problem is that we might have multiple active subscriptions, and we're double counting them even when the subscription number (subscription ID) is the same.

The general fix is to always select the most recent active subscription (the one with earliest start_date).

Note that to get the actual subscriptions values (API: /api/rhsm-subscriptions/v2/subscriptions/products/), this was already working fine, but I found that we were not filtering by start_date when getting the measurements. Though this is not affecting the data we return, we save a lot of data when querying subscriptions.

About the rest of the endpoints, I added unit tests to validate the new behaviour plus manual verification.

## Testing
MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1173

### Manual testing
1. start db: `docker compose -f docker-compose.yml up -d`
2. run migrations using the main branch: `./gradlew liquibaseUpdate`
3. setup data:
```sql
-- the RH00001 offering
INSERT INTO offering (sku, product_name, product_family, cores, sockets, hypervisor_cores, hypervisor_sockets, role, sla, usage, description, has_unlimited_usage, derived_sku, metered, special_pricing_flag) VALUES ('RH00001', 'RHEL Server', 'Red Hat Enterprise Linux', null, null, null, 2, 'Red Hat Enterprise Linux Server', 'Premium', 'Production', 'Red Hat Enterprise Linux for Virtual Datacenters, Premium', false, 'RH00049', false, null);

-- map the RH00001 offering to the product "RHEL for x86"
INSERT INTO sku_product_tag (sku, product_tag) VALUES ('RH00001', 'RHEL for x86');

-- two subscriptions with the same subscription ID for the org 123456
INSERT INTO "subscription"
(sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id)
VALUES('RH00001', '123456', '12217509', 48, '2024-06-11 12:10:38.532', '2025-12-31 06:00:00.000', '', '12217667', '', '');

INSERT INTO "subscription"
(sku, org_id, subscription_id, quantity, start_date, end_date, billing_provider_id, subscription_number, billing_provider, billing_account_id)
VALUES('RH00001', '123456', '12217509', 48, '2024-06-07 12:37:20.249', '2025-12-31 06:00:00.000', '', '12217667', '', '');

-- and their measurements:
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES('12217509', '2024-06-11 12:10:38.532', 'Sockets', 'PHYSICAL', 96.0);
INSERT INTO public.subscription_measurements (subscription_id, start_date, metric_id, measurement_type, value) VALUES('12217509', '2024-06-07 12:37:20.249', 'Sockets', 'PHYSICAL', 96.0);
```

4. opt-in:

```
echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"123456"}}}' | base64 -w 0
-- eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NTYifX19
```

```
curl -X 'PUT' \
  'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NTYifX19'
```

5. get subscriptions report from v2 (this endpoint was already working fine):

```
curl -X GET \
  'http://localhost:8000/api/rhsm-subscriptions/v2/subscriptions/products/RHEL%20for%20x86' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NTYifX19' | jq
```

Output:
```json
{
  "data": [
    {
      "sku": "RH00001",
      "product_name": "Red Hat Enterprise Linux for Virtual Datacenters, Premium",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "12217509",
          "number": "12217667"
        }
      ],
      "billing_account_id": "",
      "billing_provider": "",
      "next_event_date": "2025-12-31T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 48,
      "measurements": [
        96.0
      ],
      "category": "physical",
      "has_infinite_quantity": false
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "subscription_type": "Annual",
    "measurements": [
      "Sockets"
    ]
  }
}
```

Note the measurements is 96 which is the correct value. 


5. get subscriptions report from v1 (this endpoint was NOT working fine):

```
curl -X GET \
  'http://localhost:8000/api/rhsm-subscriptions/v1/subscriptions/products/RHEL%20for%20x86' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NTYifX19' | jq
```

Output:

```json
{
  "data": [
    {
      "sku": "RH00001",
      "product_name": "Red Hat Enterprise Linux for Virtual Datacenters, Premium",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "12217509",
          "number": "12217667"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-12-31T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 48,
      "capacity": 96,
      "hypervisor_capacity": 0,
      "total_capacity": 96,
      "has_infinite_quantity": false,
      "metric_id": "Sockets"
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "subscription_type": "Annual"
  }
}
```

Note the capacity is 96 which is correct.

Before these changes (you can check it runnin the API from main), the output was:

```json
{
  "data": [
    {
      "sku": "RH00001",
      "product_name": "Red Hat Enterprise Linux for Virtual Datacenters, Premium",
      "service_level": "Premium",
      "usage": "Production",
      "subscriptions": [
        {
          "id": "12217509",
          "number": "12217667"
        }
      ],
      "billing_provider": "",
      "next_event_date": "2025-12-31T05:00:00Z",
      "next_event_type": "Subscription End",
      "quantity": 48,
      "capacity": 192,
      "hypervisor_capacity": 0,
      "total_capacity": 192,
      "has_infinite_quantity": false,
      "metric_id": "Sockets"
    }
  ],
  "meta": {
    "count": 1,
    "product": "RHEL for x86",
    "subscription_type": "Annual"
  }
}
```

Where capacity was incorrectly set to 192.

6. check the capacity API:

``` 
http GET ':8000/api/rhsm-subscriptions/v1/capacity/products/RHEL for x86/Sockets' x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMjM0NTYifX19  granularity==DAILY beginning=='2025-06-27T08:22:33.604106+00:00' ending=='2025-06-28T08:22:33.604106+00:00' 
```

Output:

```json
{
    "data": [
        {
            "date": "2025-06-27T00:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 96
        },
        {
            "date": "2025-06-28T00:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 96
        }
    ],
    "meta": {
        "count": 2,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86"
    }
}
```

Before these changes, the output was:

```json
{
    "data": [
        {
            "date": "2025-06-27T00:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 192
        },
        {
            "date": "2025-06-28T00:00:00Z",
            "has_data": true,
            "has_infinite_quantity": false,
            "value": 192
        }
    ],
    "meta": {
        "count": 2,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86"
    }
}

```