### PR TITLE
SWATCH-3527: Convert DebugClientLogger to use standard the JAX-RS API

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -172,6 +172,7 @@ quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".scope=jakarta.enterprise.context.ApplicationScoped
+quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
 
 # rest-client debug logging
 # NOTE: all of uri-filter-regex, log category level, and logging.scope need to be set for a request/response to be logged.
@@ -189,6 +190,7 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".connection-pool-size=${SUBSCRIPTION_MAX_CONNECTIONS}
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
 # Setting up the timeout to 2 minutes instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".read-timeout=120000
 
@@ -200,6 +202,7 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
 # Setting up the timeout to 60 seconds instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=60000
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.config;
+
+import static com.redhat.swatch.contract.config.DebugClientLogger.LOG_RESPONSES_PROPERTY;
+import static com.redhat.swatch.contract.config.DebugClientLogger.URI_FILTER_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi;
+import com.redhat.swatch.clients.subscription.api.model.Subscription;
+import com.redhat.swatch.clients.subscription.api.resources.ApiException;
+import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
+import com.redhat.swatch.contract.test.resources.InjectWireMock;
+import com.redhat.swatch.contract.test.resources.WireMockResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logmanager.Level;
+import org.jboss.logmanager.LogContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(DebugClientLoggerTest.LogAll.class)
+@QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
+public class DebugClientLoggerTest {
+  private static final LoggerCaptor LOGGER_CAPTOR = new LoggerCaptor();
+  @RestClient SearchApi searchApi;
+  @RestClient PartnerApi partnerApi;
+  @InjectWireMock WireMockServer wireMockServer;
+
+  @BeforeAll
+  static void configureLogging() {
+    LogContext.getLogContext()
+        .getLogger(DebugClientLogger.class.getName())
+        .addHandler(LOGGER_CAPTOR);
+  }
+
+  @BeforeEach
+  void setUp() {
+    LOGGER_CAPTOR.records.clear();
+  }
+
+  @Test
+  void testRequestLog() throws ApiException {
+    searchApi.getSubscriptionBySubscriptionNumber("any");
+    thenLogWithMessage(
+        "Request method=GET URI=https://localhost:%s/mock/subscription/search/criteria;subscription_number=any"
+            .formatted(wireMockServer.httpsPort()));
+  }
+
+  @Test
+  void testResponseLog() throws ApiException {
+    List<Subscription> response = searchApi.getSubscriptionBySubscriptionNumber("any");
+    assertNotNull(response);
+    assertEquals(1, response.size());
+    assertEquals(123456, response.get(0).getId());
+    thenLogWithMessage(
+        "Response method=GET URI=https://localhost:%s/mock/subscription/search/criteria;subscription_number=any"
+            .formatted(wireMockServer.httpsPort()));
+  }
+
+  @Test
+  void testNoLogsIfNotConfigured()
+      throws com.redhat.swatch.clients.rh.partner.gateway.api.resources.ApiException {
+    partnerApi.getPartnerEntitlements(null);
+    thenLogNothing();
+  }
+
+  private void thenLogWithMessage(String str) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    LOGGER_CAPTOR.records.stream()
+                        .anyMatch(
+                            r ->
+                                r.getLevel().equals(Level.DEBUG) && r.getMessage().contains(str))));
+  }
+
+  private void thenLogNothing() {
+    assertTrue(LOGGER_CAPTOR.records.isEmpty());
+  }
+
+  public static class LoggerCaptor extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord trace) {
+      records.add(trace);
+    }
+
+    @Override
+    public void flush() {
+      // no need to flush any sink
+    }
+
+    @Override
+    public void close() throws SecurityException {
+      clearRecords();
+    }
+
+    public void clearRecords() {
+      records.clear();
+    }
+  }
+
+  public static class LogAll implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      // Only debug the subscription mock rest client:
+      return Map.of(URI_FILTER_PROPERTY, ".*mock/subscription.*", LOG_RESPONSES_PROPERTY, "true");
+    }
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3527

## Description
Replaced Quarkus-based ClientLogger API with standard JAX-RS API: ClientRequestFilter, ClientResponseFilter, which works when using the resteasy rest-client framework.

Note that I added a new property "rest-client-debug-logging.log-responses" to log also the responses, since this is a very dangerous operation (we now need to copy the response in a temporal stream, log it, and copy it back to the original stream, so it's consumed by the following handlers).

## Testing
Added JUnit tests. Only regression testing.