### PR TITLE
SWATCH-3586: when sync offering, increase timeout to handle messages plus metrics in the Product API rest client

### DIFF
--- a/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
+++ b/buildSrc/src/main/groovy/swatch.quarkus-rest-client-conventions.gradle
@@ -44,6 +44,7 @@ openApiGenerate {
 dependencies {
     implementation enforcedPlatform(libraries["quarkus-bom"])
     api 'io.quarkus:quarkus-rest-client-jackson'
+    api 'io.quarkus:quarkus-micrometer'
     api libraries["jackson-databind-nullable"]
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/clients/quarkus/product-client/src/main/java/com/redhat/swatch/clients/product/ProductService.java
+++ b/clients/quarkus/product-client/src/main/java/com/redhat/swatch/clients/product/ProductService.java
@@ -25,6 +25,8 @@ import com.redhat.swatch.clients.product.api.model.RESTProductTree;
 import com.redhat.swatch.clients.product.api.model.SkuEngProduct;
 import com.redhat.swatch.clients.product.api.resources.ApiException;
 import com.redhat.swatch.clients.product.api.resources.ProductApi;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,6 +59,8 @@ public class ProductService implements ProductDataSource {
    * @return An optional containing the product tree, or an empty if the pro
    * @throws ApiException if fails to make API call
    */
+  @Timed("rhsm_subscriptions_clients_product_requests_time")
+  @Counted("rhsm_subscriptions_clients_product_requests_count")
   @Override
   public Optional<RESTProductTree> getTree(String sku) throws ApiException {
     LOGGER.debug("Retrieving product tree for sku={}", sku);
@@ -74,11 +78,8 @@ public class ProductService implements ProductDataSource {
     return skuTree;
   }
 
-  public List<EngineeringProduct> getEngineeringProductsForSku(String sku) throws ApiException {
-    Collection<String> skus = Collections.singletonList(sku);
-    return getEngineeringProductsForSkus(skus).get(sku);
-  }
-
+  @Timed("rhsm_subscriptions_clients_product_requests_time")
+  @Counted("rhsm_subscriptions_clients_product_requests_count")
   @Override
   public Map<String, List<EngineeringProduct>> getEngineeringProductsForSkus(
       Collection<String> skus) throws ApiException {

--- a/clients/quarkus/product-client/src/test/java/com/redhat/swatch/clients/product/ProductServiceTest.java
+++ b/clients/quarkus/product-client/src/test/java/com/redhat/swatch/clients/product/ProductServiceTest.java
@@ -96,7 +96,7 @@ class ProductServiceTest {
     productMap.addEntriesItem(engProds);
     when(productApi.getEngineeringProductsForSkus(anyString())).thenReturn(productMap);
 
-    List<EngineeringProduct> actualEngProds = subject.getEngineeringProductsForSku(sku);
+    List<EngineeringProduct> actualEngProds = getEngineeringProductsForSku(sku);
 
     verify(productApi).getEngineeringProductsForSkus(sku);
     assertEquals(
@@ -118,7 +118,7 @@ class ProductServiceTest {
     productMap.addEntriesItem(engProds);
     when(productApi.getEngineeringProductsForSkus(anyString())).thenReturn(productMap);
 
-    List<EngineeringProduct> actualEngProds = subject.getEngineeringProductsForSku(sku);
+    List<EngineeringProduct> actualEngProds = getEngineeringProductsForSku(sku);
 
     verify(productApi).getEngineeringProductsForSkus(sku);
     assertTrue(
@@ -205,5 +205,10 @@ class ProductServiceTest {
     assertTrue(
         actualEngProds.get(sku2).isEmpty(),
         sku2 + " should have an empty eng prods list because it wasn't found.");
+  }
+
+  public List<EngineeringProduct> getEngineeringProductsForSku(String sku) throws ApiException {
+    Collection<String> skus = Collections.singletonList(sku);
+    return subject.getEngineeringProductsForSkus(skus).get(sku);
   }
 }

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -204,7 +204,7 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
 # Setting up the timeout to 60 seconds instead of 30 seconds (default)
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=60000
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=90000
 
 # rbac service configuration
 RBAC_ENABLED=true
@@ -364,6 +364,13 @@ mp.messaging.incoming.offering-sync-task.topic=platform.rhsm-subscriptions.offer
 mp.messaging.incoming.offering-sync-task.group.id=offering-worker
 mp.messaging.incoming.offering-sync-task.value.deserializer=com.redhat.swatch.contract.service.json.OfferingSyncTaskDeserializer
 mp.messaging.incoming.offering-sync-task.failure-strategy=ignore
+# Consume num of records each time to not stress the Product API service. Default value is 500
+mp.messaging.incoming.offering-sync-task.max.poll.records=100
+# By default, the unprocessed max age is 60 seconds, and the timeout configuration for product API
+# rest client (see `quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout`)
+# is 90 seconds, so we need to configure the following property to a higher value.
+mp.messaging.incoming.offering-sync-task.throttled.unprocessed-record-max-age.ms=120000
+mp.messaging.incoming.offering-sync-task.commit-strategy=throttled
 
 mp.messaging.outgoing.offering-sync.connector=smallrye-kafka
 mp.messaging.outgoing.offering-sync.topic=platform.rhsm-subscriptions.offering-sync


### PR DESCRIPTION
Jira issue: SWATCH-3586

## Description
When consuming OfferingSync tasks, because the consumer is annotated with `@Blocking`  Quarkus manages the ack() automatically only after the method completes successfully (i.e., no exception is thrown).

The problem could be caused when the Product API call takes more than 60 seconds (which is the current timeout setting). When this happens, since 60 seconds exceeds the allowed unacknowledged time, the kafka record is unack and throws the TooManyMessagesWithoutAckException causing the service to be restarted. 

After the service is restarted, the OfferingSync tasks are reprocessed causing the topic lag to increase even more. 

Changes:
- Increase the kafka allowed unacknowledged time to 90 seconds.
- Explicitly set the commit strategy to throttled (which was already set like this)
- Not consume more than 20 records at a time per replica. This might cause the Product API to stress and start returning errors. Before these changes, we were consuming 500 messages which is probably too much.
- Add metrics around the Product API rest client, so we can monitor how this API behaves. 

## Testing

How to verify the Product API rest client?

1. Start contracts service: `PRODUCT_URL=XXX PRODUCT_KEYSTORE_RESOURCE=XXX PRODUCT_KEYSTORE_PASSWORD=XXX RBAC_ENABLED=false ./gradlew :swatch-contracts:quarkusDev`

2. curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: placeholder" -X PUT "http://localhost:8000/api/swatch-contracts/internal/rpc/offerings/sync/RH0180192"

3. curl http://localhost:9000/metrics where we should now see:
```
# HELP rhsm_subscriptions_clients_product_requests_time_seconds  
# TYPE rhsm_subscriptions_clients_product_requests_time_seconds summary
rhsm_subscriptions_clients_product_requests_time_seconds_count{class="com.redhat.swatch.clients.product.ProductService",exception="none",method="getTree",} 1.0
rhsm_subscriptions_clients_product_requests_time_seconds_sum{class="com.redhat.swatch.clients.product.ProductService",exception="none",method="getTree",} 1.280648157
# HELP rhsm_subscriptions_clients_product_requests_time_seconds_max  
# TYPE rhsm_subscriptions_clients_product_requests_time_seconds_max gauge
rhsm_subscriptions_clients_product_requests_time_seconds_max{class="com.redhat.swatch.clients.product.ProductService",exception="none",method="getTree",} 1.280648157
```