### PR TITLE
WIP SWATCH-3532 Enable local testing for wiremock profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 ---
 version: '3.8'
 services:
+  nginx:
+    image: docker.io/library/nginx:latest
+    ports:
+      - "8000:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:z
   wiremock:
     image: docker.io/wiremock/wiremock:latest
+    container_name: wiremock
     ports:
       - "127.0.0.1:8006:8080"
     networks:

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,17 +11,17 @@ http {
 
 
         location /api/swatch-contracts/ {
-            proxy_pass http://172.17.0.1:8001;
+            proxy_pass http://host.containers.internal:8001;
         }
 
 
         location /api/swatch-billable-usage/ {
-            proxy_pass http://172.17.0.1:8002;
+            proxy_pass http://host.containers.internal:8002;
         }
 
 
         location /api/swatch-producer-aws/ {
-            proxy_pass http://172.17.0.1:8003;
+            proxy_pass http://host.containers.internal:8003;
         }
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,27 @@
+events {}
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            return 200 'Custom Nginx Config is Working!';
+            add_header Content-Type text/plain;
+        }
+
+
+        location /api/swatch-contracts/ {
+            proxy_pass http://172.17.0.1:8001;
+        }
+
+
+        location /api/swatch-billable-usage/ {
+            proxy_pass http://172.17.0.1:8002;
+        }
+
+
+        location /api/swatch-producer-aws/ {
+            proxy_pass http://172.17.0.1:8003;
+        }
+    }
+}

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -44,6 +44,7 @@ KAFKA_BILLABLE_USAGE_PARTITIONS=1
 
 #dev wiremock specific profile defaults; these can still be overridden by env var
 %wiremock.SERVER_PORT=8002
+%wiremock.QUARKUS_MANAGEMENT_PORT=9002
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3532

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Run it with internet if you want to call stage apis with dev mode and run with/without internet for wiremock profile that does local testing.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE MRs to enable local testing: <!-- IQE MR link here -->
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1180
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1177

Github supporting PRs:
https://github.com/RedHatInsights/rhsm-subscriptions/commit/467cb0d83c4e7826bd619ed4bb1c49e7a897e230

### Setup
<!-- Add any steps required to set up the test case -->
1. `podman-compose down`
2. `podman-compose up -d`
3. `./gradlew liquibaseUpdate`
4. Pycharm add env file that is located at iqe-rhsm-subscriptions-plugin/iqe_rhsm_subscriptions/conf/iqe_env
![Screenshot From 2025-05-21 17-06-09](https://github.com/user-attachments/assets/a780184b-cfe3-44a3-8efd-710d34e9c422)

5. Run applications on different ports like 
swatch-billable-usage: `QUARKUS_HTTP_HOST=0.0.0.0 QUARKUS_PROFILE=wiremock ./gradlew :swatch-billable-usage:quarkusDev --rerun-tasks`


### Steps
<!-- Enter each step of the test below -->
1. Run the pure component test that wiremocks contract service in billable usage and see the test passes. Billable usage component tests like: test_verify_ansible_usage, will pass

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. If billable usage service is up then check:
 -  if we get a response back `curl -X 'GET'   'http://localhost:8000/api/swatch-billable-usage/internal/remittance/accountRemittances/7c4f78a8-585c-4020-b5cf-e4865ec2b987'   -H 'accept: application/json'`
 - Check to see if you can see open api swagger doc on http://localhost:8002/api/swatch-billable-usage/internal/swagger-ui/#/default/getRemittancesByTally
2. If contract service is up then check
 - if we get response back `curl -X 'GET'   'http://localhost:8000/api/swatch-contracts/internal/offerings/RH00001/product_tags'   -H 'accept: application/json'`
- Check to see if you can see open api swagger doc on http://localhost:8001/api/swatch-contracts/internal/swagger-ui/#/default/getSkuProductTags


FAQs:
- `ip addr show docker0` this command should show `172.17.0.1` IP. When you run something in Docker (like Nginx), and you want it to reach an app running on your Fedora host (like Quarkus on localhost:8001), the container can’t use localhost. So to reach your Fedora machine, it must use 172.17.0.1
- `curl http://localhost:8000/` This should connect to nginx default response
- `podman logs rhsm-subscriptions_nginx_1` to see if there are any issues
- You can see if the nginx is setup properly by `docker run --rm curlimages/curl http://172.17.0.1:8001/api/swatch-contracts/internal/offerings/RH00001/product_tags` or its equivalent curl request `curl -X 'GET'   'http://172.17.0.1:8001/api/swatch-contracts/internal/offerings/RH00001/product_tags'   -H 'accept: application/json'`
- 