### PR TITLE
SWATCH-2820: swatch-database image should install tar & rsync from ubi-9-baseos-rpms

### DIFF
--- a/swatch-database/src/main/docker/Dockerfile.jvm
+++ b/swatch-database/src/main/docker/Dockerfile.jvm
@@ -103,7 +103,6 @@ FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1747241887
 USER root
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
   --enablerepo=ubi-9-baseos-rpms \
   install -y tar rsync
 RUN microdnf \


### PR DESCRIPTION
This is consistent with all our other Dockerfiles


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-2820

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
