### PR TITLE
SWATCH-2820: Update database fallback name

### DIFF
--- a/swatch-database/deploy/clowdapp.yaml
+++ b/swatch-database/deploy/clowdapp.yaml
@@ -28,8 +28,8 @@ objects:
         # any secrets by looking for a secret with 'db.host' starting with '<name>-<env>' where
         # env is usually 'stage' or 'prod'
 
-        # In our case, we want to fall back to the legacy name "swatch-tally-db".  Eventually, we
+        # In our case, we want to fall back to the legacy name "swatch-tally".  Eventually, we
         # will rename the secret to swatch-database-db but that will be a subsequent step so that
         # we don't incur an outage
-        name: swatch-tally-db
+        name: swatch-tally
         version: 13


### PR DESCRIPTION
Jira issue: SWATCH-2820

## Description
Clowder allows a fallback name for the database.  With the deployment of
swatch-database we want to fall back to our old database name initially
and then change the name in RDS in the future.  This process will allow
us to avoid any outage.  I was not sure if the fallback name would be
"swatch-tally-db" or "swatch-tally".  The former did not work, so this
commit tries the latter.
