### PR TITLE
SWATCH-3619: Update postgresql image to quay.io/sclorg/postgresql-13-c9s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           curl -Ls https://sh.jbang.dev | bash -s - app install --fresh --force yamlpath@yaml-path/jbang
 
       - name: Setup PostgreSQL DB
-        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/centos7/postgresql-13-centos7:centos7
+        run: docker run -d -v ./init_dbs.sh:/usr/share/container-scripts/postgresql/start/set_passwords.sh:z -p 5432:5432 -e POSTGRESQL_ADMIN_PASSWORD=admin quay.io/sclorg/postgresql-13-c9s:c9s
 
       - name: Setup PostgreSQL client
         run: sudo apt-get install -y postgresql-client

--- a/deploy/dev-clowdenv.yaml
+++ b/deploy/dev-clowdenv.yaml
@@ -44,7 +44,7 @@ objects:
         mode: local
 
       db:
-        image: quay.io/centos7/postgresql-13-centos7:centos7
+        image: quay.io/sclorg/postgresql-13-c9s:c9s
         mode: local
 
       logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     # When updating the image, remember to also update the following locations:
     # - SwatchPostgreSQLContainer.POSTGRESQL_IMAGE
     # - .github/workflows/pr.yaml (step "Setup Postgresql Database")
-    image: quay.io/centos7/postgresql-13-centos7:centos7
+    image: quay.io/sclorg/postgresql-13-c9s:c9s
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRESQL_MAX_CONNECTIONS=5000

--- a/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
+++ b/swatch-common-testcontainers/src/main/java/org/candlepin/testcontainers/SwatchPostgreSQLContainer.java
@@ -35,7 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @EqualsAndHashCode(callSuper = true)
 public class SwatchPostgreSQLContainer extends PostgreSQLContainer<SwatchPostgreSQLContainer> {
-  private static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-13-centos7:centos7";
+  private static final String POSTGRESQL_IMAGE = "quay.io/sclorg/postgresql-13-c9s:c9s";
 
   public SwatchPostgreSQLContainer(String database) {
     super(DockerImageName.parse(POSTGRESQL_IMAGE).asCompatibleSubstituteFor("postgres"));


### PR DESCRIPTION
Jira issue: SWATCH-3619

## Description
Our podman compose and test containers use unsupported Postgress 13 image based on CentOS7. We should use supported image from https://github.com/sclorg/postgresql-container?tab=readme-ov-file#versions:
- CentOS Stream 9 - quay.io/sclorg/postgresql-13-c9s

Additionally, most of these images (except CentOS 8) are multiarch, which would make it easier for running on MacOS.