### PR TITLE
SWATCH-3571: Adjust the min interval to view the PAYG metrics

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml
@@ -171,6 +171,7 @@ data:
             "y": 1
           },
           "id": 3,
+          "interval": "$interval",
           "options": {
             "legend": {
               "calcs": [],
@@ -351,6 +352,7 @@ data:
                 "y": 2
               },
               "id": 5,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -442,6 +444,7 @@ data:
                 "y": 2
               },
               "id": 6,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -533,6 +536,7 @@ data:
                 "y": 10
               },
               "id": 7,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -624,6 +628,7 @@ data:
                 "y": 10
               },
               "id": 8,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -715,6 +720,7 @@ data:
                 "y": 18
               },
               "id": 9,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -806,6 +812,7 @@ data:
                 "y": 18
               },
               "id": 15,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -897,6 +904,7 @@ data:
                 "y": 26
               },
               "id": 10,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -993,6 +1001,7 @@ data:
                 "y": 90
               },
               "id": 79,
+              "interval": "$interval",
               "options": {
                 "legend": {
                   "calcs": [],
@@ -1146,7 +1155,7 @@ data:
           {
             "auto": false,
             "auto_count": 30,
-            "auto_min": "10s",
+            "auto_min": "1h",
             "current": {
               "selected": true,
               "text": "1d",


### PR DESCRIPTION
Jira issue: SWATCH-3571

## Description
These changes set the min interval to view the metrics. Without these changes, the min interval is auto-calculated by grafana regardless of the interval value we set in the filter (which in most of the cases, it uses 10 seconds).

## Testing
Extract the new dashboard json using `oc extract -f .rhcicd/grafana/grafana-dashboard-subscription-watch-payg-metrics.configmap.yaml --confirm`

Once you extract it from the .yaml that's checked into this repo, you can import it into the stage instance of grafana by going to `Dashboards -> +Import` from the left nav.

## Verification

After importing the dashboard, if you change the "Interval" filter, you should see all the plots are updated accordingly. 
