### PR TITLE
SWATCH-2844: Update nginx routing send capacity queries directly to s…

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -341,6 +341,18 @@ objects:
               rewrite ^/api/rhsm-subscriptions/v1/subscriptions/billing_account_ids$ /api/swatch-contracts/v1/subscriptions/billing_account_ids break;
               proxy_pass http://swatch-contracts;
             }
+        
+            location /api/rhsm-subscriptions/v1/subscriptions/products {
+              proxy_pass http://swatch-contracts;
+            }
+    
+            location /api/rhsm-subscriptions/v2/subscriptions/products {
+              proxy_pass http://swatch-contracts;
+            }
+    
+            location /api/rhsm-subscriptions/v1/capacity/products {
+              proxy_pass http://swatch-contracts;
+            }
 
             location ^~/ {
               proxy_pass http://swatch-api;


### PR DESCRIPTION
Jira issue: SWATCH-2844

## Description
Endpoints to route:
- /api/rhsm-subscriptions/v1/subscriptions/billing_account_ids            ->  /api/swatch-contracts/v1/subscriptions/billing_account_ids
- /api/rhsm-subscriptions/v1/subscriptions/products/{product_id}          ->  /api/rhsm-subscriptions/v1/subscriptions/products/{product_id}
- /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}   ->  /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}
- /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}          ->  /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}

## Testing
Regression testing.
In stage, the test `test_validate_usage_filters_count_for_rhel_capacity` should keep working. 

### Manual Testing

1. Deploy EE project using these changes
2. Run the iqe test "test_subscription_table_api_subscription_type"

### Verify empty query params

1. Run `docker compose -f docker-compose.yaml up -d`
2. Run migrations `./gradlew --no-daemon :swatch-database:run`
3. Start swatch contracts service: `LOGGING_SHOW_SQL_QUERIES=true SERVER_PORT=8001 QUARKUS_MANAGEMENT_PORT=9001 ./gradlew :swatch-contracts:quarkusDev`
4. Call the API without the usage query param: `http GET ':8001/api/rhsm-subscriptions/v1/capacity/products/RHEL for x86/Sockets' x-rh-identity:eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxODkzOTU3OCIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxODkzOTU3OCJ9fX0K  granularity==DAILY beginning=='2025-03-27T08:22:08.776843+00:00' ending=='2025-03-28T08:22:33.604106+00:00'`

Expected output: 
```
HTTP/1.1 200 OK
Content-Type: application/vnd.api+json
content-length: 276
traceresponse: 00-00000000000000000000000000000000-0000000000000000-00

{
    "data": [
        {
            "date": "2025-03-27T00:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        },
        {
            "date": "2025-03-28T00:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        }
    ],
    "meta": {
        "count": 2,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86"
    }
}
```

5.- Call the API with an empty usage query param: `http GET ':8001/api/rhsm-subscriptions/v1/capacity/products/RHEL for x86/Sockets' x-rh-identity:eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxODkzOTU3OCIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxODkzOTU3OCJ9fX0K  granularity==DAILY beginning=='2025-03-27T08:22:08.776843+00:00' ending=='2025-03-28T08:22:33.604106+00:00' usage==`

Expected output:

```
HTTP/1.1 200 OK
Content-Type: application/vnd.api+json
content-length: 287
traceresponse: 00-00000000000000000000000000000000-0000000000000000-00

{
    "data": [
        {
            "date": "2025-03-27T00:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        },
        {
            "date": "2025-03-28T00:00:00Z",
            "has_data": false,
            "has_infinite_quantity": false,
            "value": 0
        }
    ],
    "meta": {
        "count": 2,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86",
        "usage": ""
    }
}
```

Note the `usage`="" is used. Before the migration to resteasy, the usage was always null when using an empty query param.