### PR TITLE
Move DebugClientLogger into swatch-common-resteasy-client

### DIFF
--- a/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/DebugClientLogger.java
+++ b/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/DebugClientLogger.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.contract.config;
+package com.redhat.swatch.resteasy.client;
 
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
@@ -42,14 +42,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Slf4j
 public class DebugClientLogger implements ClientRequestFilter, ClientResponseFilter {
 
-  protected static final String URI_FILTER_PROPERTY = "rest-client-debug-logging.uri-filter";
-  protected static final String LOG_RESPONSES_PROPERTY = "rest-client-debug-logging.log-responses";
-  protected static final String LOG_HEADERS_PROPERTY = "rest-client-debug-logging.log-headers";
+  public static final String URI_FILTER_PROPERTY = "rest-client-debug-logging.uri-filter";
+  public static final String LOG_RESPONSES_PROPERTY = "rest-client-debug-logging.log-responses";
+  public static final String LOG_HEADERS_PROPERTY = "rest-client-debug-logging.log-headers";
 
   private static final String EMPTY_BODY = "(empty)";
   private static final String OMIT_BODY = "(omit)";
 
-  @ConfigProperty(name = URI_FILTER_PROPERTY)
+  @ConfigProperty(name = URI_FILTER_PROPERTY, defaultValue = ".*")
   Pattern uriFilterPattern;
 
   @ConfigProperty(name = LOG_RESPONSES_PROPERTY, defaultValue = "false")

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -168,12 +168,12 @@ quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".scope=jakarta.enterprise.context.ApplicationScoped
-quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
+quarkus.rest-client."com.redhat.swatch.clients.rh.partner.gateway.api.resources.PartnerApi".providers=com.redhat.swatch.resteasy.client.DebugClientLogger
 
 # rest-client debug logging
 # NOTE: all of uri-filter-regex, log category level, and logging.scope need to be set for a request/response to be logged.
 rest-client-debug-logging.uri-filter=.*(partnerSubscriptions|search|products|export).*
-quarkus.log.category."com.redhat.swatch.contract.config.DebugClientLogger".level=DEBUG
+quarkus.log.category."com.redhat.swatch.resteasy.client.DebugClientLogger".level=DEBUG
 %test.quarkus.rest-client.logging.scope=request-response
 %dev.quarkus.rest-client.logging.scope=request-response
 %ephemeral.quarkus.rest-client.logging.scope=request-response
@@ -186,7 +186,7 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".scope=jakarta.enterprise.context.ApplicationScoped
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".connection-pool-size=${SUBSCRIPTION_MAX_CONNECTIONS}
-quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
+quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".providers=com.redhat.swatch.resteasy.client.DebugClientLogger
 # Setting up the timeout to 2 minutes instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.SearchApi".read-timeout=120000
 
@@ -198,7 +198,7 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store-password=${TRUSTSTORE_PASSWORD:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".scope=jakarta.enterprise.context.ApplicationScoped
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".providers=com.redhat.swatch.contract.config.DebugClientLogger
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".providers=com.redhat.swatch.resteasy.client.DebugClientLogger
 # Setting up the timeout to 60 seconds instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=90000
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
@@ -20,8 +20,8 @@
  */
 package com.redhat.swatch.contract.config;
 
-import static com.redhat.swatch.contract.config.DebugClientLogger.LOG_RESPONSES_PROPERTY;
-import static com.redhat.swatch.contract.config.DebugClientLogger.URI_FILTER_PROPERTY;
+import static com.redhat.swatch.resteasy.client.DebugClientLogger.LOG_RESPONSES_PROPERTY;
+import static com.redhat.swatch.resteasy.client.DebugClientLogger.URI_FILTER_PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +33,7 @@ import com.redhat.swatch.clients.subscription.api.resources.ApiException;
 import com.redhat.swatch.clients.subscription.api.resources.SearchApi;
 import com.redhat.swatch.contract.test.resources.InjectWireMock;
 import com.redhat.swatch.contract.test.resources.WireMockResource;
+import com.redhat.swatch.resteasy.client.DebugClientLogger;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;

--- a/swatch-metrics/src/main/resources/application.properties
+++ b/swatch-metrics/src/main/resources/application.properties
@@ -91,10 +91,19 @@ quarkus.log.category."io.quarkus.http.access-log".handlers=ACCESS_LOG
 quarkus.log.category."io.quarkus.http.access-log".use-parent-handlers=false
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
 
+# rest-client debug logging
+# NOTE: all of uri-filter-regex, log category level, and logging.scope need to be set for a request/response to be logged.
+quarkus.log.category."com.redhat.swatch.resteasy.client.DebugClientLogger".level=DEBUG
+%test.quarkus.rest-client.logging.scope=request-response
+%dev.quarkus.rest-client.logging.scope=request-response
+%ephemeral.quarkus.rest-client.logging.scope=request-response
+
 quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryApi".url=${rhsm-subscriptions.metering.prometheus.client.url}
 quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryApi".scope=jakarta.enterprise.context.ApplicationScoped
+quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryApi".providers=com.redhat.swatch.resteasy.client.DebugClientLogger
 quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryRangeApi".url=${rhsm-subscriptions.metering.prometheus.client.url}
 quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryRangeApi".scope=jakarta.enterprise.context.ApplicationScoped
+quarkus.rest-client."com.redhat.swatch.clients.prometheus.api.resources.QueryRangeApi".providers=com.redhat.swatch.resteasy.client.DebugClientLogger
 
 # Kafka security configuration.  These properties must be present so that
 # clowder-quarkus-config-source will populate them from the Clowder provided configuration JSON.
@@ -148,7 +157,6 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 # By default, the openapi and swagger ui endpoints are exposed on the management port, so we need to disable it
 # to expose it on the server port 8000:
 quarkus.smallrye-openapi.management.enabled=false
-quarkus.smallrye-openapi.sdk.disabled=${DISABLE_OTEL}
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
 


### PR DESCRIPTION
## Description
The DebugClientLogger is incredibly helpful to troubleshoot rest-client errors, but at the moment, it's only defined in swatch-contracts.
Let's move it to swatch-common-resteasy-client to be used by all our swatch services.

## Testing
Regression testing only.