### PR TITLE
Correct reference to Checkstyle XPath suppressions

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -419,7 +419,8 @@
     </module>
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
-      <property name="file" value="config/checkstyle/checkstyle-xpath-suppressions.xml"/>
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+         default="checkstyle-xpath-suppressions.xml" />
     </module>
     <module name="SuppressWarningsHolder" />
     <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,9 @@
         <configuration>
           <configLocation>${maven.multiModuleProjectDirectory}/config/checkstyle/checkstyle.xml</configLocation>
           <suppressionsLocation>${maven.multiModuleProjectDirectory}/config/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+          <propertyExpansion>
+            org.checkstyle.google.suppressionxpathfilter.config=${maven.multiModuleProjectDirectory}/config/checkstyle/checkstyle-xpath-suppressions.xml
+          </propertyExpansion>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <sourceDirectories>


### PR DESCRIPTION
Jira issue: None

## Description
Correct the path reference to the Checkstyle XPath suppressions file.  This
patch defines a property with the location and then sets that property to the
proper location within the pom.xml.

## Testing

### Steps
```
cd clients-core
../mvnw install
```

### Verification
Build runs
