### PR TITLE
SWATCH-3663: Disable splunk DEV services to avoid random failures at start up

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -156,6 +156,7 @@ mp.messaging.incoming.tally-summary.failure-strategy=ignore
 mp.messaging.incoming.tally-summary.fail-on-deserialization-failure=false
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -121,6 +121,7 @@ quarkus.management.port=9000
 quarkus.management.root-path=/
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -87,6 +87,7 @@ mp.messaging.outgoing.swatch-events-out.value.serializer=io.quarkus.kafka.client
 mp.messaging.outgoing.swatch-events-out.max-inflight-messages=128
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-metrics/src/main/resources/application.properties
+++ b/swatch-metrics/src/main/resources/application.properties
@@ -55,6 +55,7 @@ quarkus.management.port=9000
 quarkus.management.root-path=/
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -140,6 +140,7 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -141,6 +141,7 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
+quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}


### PR DESCRIPTION
Jira issue: SWATCH-3663

## Description
Since we don't need splunk when running the service in DEV mode, we can disable it and at the same time, we avoid the linked issue reported by SWATCH-3663.

## Testing
1.- podman compose -f docker-compose.yml up -d
2.- run migrations: `mvn -f swatch-database/pom.xml exec:java`
3.- run swatch contracts: `SERVER_PORT=8001 ./mvnw -pl swatch-contracts quarkus:dev`

It should now work consistently. 