### PR TITLE
SWATCH-3661: Validate data schema when starting the Quarkus services

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -85,7 +85,7 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-billable-usage}
-quarkus.hibernate-orm.database.generation=validate
+quarkus.hibernate-orm.schema-management.strategy=validate
 quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
 
 %test.quarkus.datasource.db-kind=h2

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
@@ -94,7 +94,7 @@ public class SubscriptionCapacityView implements Serializable {
   @Column(name = "quantity")
   private long quantity;
 
-  @Column(name = "metrics", insertable = false, updatable = false)
+  @Column(name = "metrics", insertable = false, updatable = false, columnDefinition = "jsonb")
   @Convert(converter = SubscriptionCapacityViewMetricConverter.class)
   private Set<SubscriptionCapacityViewMetric> metrics = new HashSet<>();
 }

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -41,8 +41,6 @@ SPLUNK_HEC_INCLUDE_EX=false
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
 %test.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}
 %test.HOST_NAME=unit_tests
-%test.quarkus.liquibase.database-change-log-lock-table-name=DATABASECHANGELOGLOCK_SWATCH_CONTRACTS
-%test.quarkus.liquibase.database-change-log-table-name=DATABASECHANGELOG_SWATCH_CONTRACTS
 %test.quarkus.liquibase.change-log=db/changelog.xml
 %test.quarkus.liquibase.migrate-at-start=true
 
@@ -104,6 +102,10 @@ quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/
 %test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 %dev.LOGGING_SHOW_SQL_QUERIES=true
 %test.LOGGING_SHOW_SQL_QUERIES=true
+quarkus.hibernate-orm.schema-management.strategy=validate
+# We only run the migrations for the contracts data model,
+# so we can't validate the schema at tests
+%test.quarkus.hibernate-orm.schema-management.strategy=none
 quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
 quarkus.hibernate-orm.mapping.timezone.default-storage=normalize-utc
 %dev.quarkus.hibernate-orm.log.bind-parameters=true

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -129,7 +129,7 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-metrics-hbi}
-quarkus.hibernate-orm.database.generation=validate
+quarkus.hibernate-orm.schema-management.strategy=validate
 quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
 
 %test.quarkus.liquibase.database-change-log-lock-table-name=DATABASECHANGELOGLOCK_SWATCH_METRICS_HBI


### PR DESCRIPTION
Jira issue: SWATCH-3661

## Description
Replace the property to validate the schema from:
```
quarkus.hibernate-orm.database.generation=validate
```

To:
```
quarkus.hibernate-orm.schema-management.strategy=validate
```

Moreover, disabling schema validation when running the tests in swatch-contracts.
Note that the Spring Boot services are already validating the schema. 

## Testing
Regression testing only.