### PR TITLE
Change generated folder for the openapi plugins

### DIFF
--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -26,27 +26,4 @@
     <module>subscription-client</module>
     <module>quarkus</module>
   </modules>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/swatch-billable-usage/pom.xml
+++ b/swatch-billable-usage/pom.xml
@@ -195,7 +195,7 @@
               <apiPackage>com.redhat.swatch.billable.usage.openapi.resource</apiPackage>
               <invokerPackage>com.redhat.swatch.billable.usage.openapi</invokerPackage>
               <groupId>com.redhat.swatch.billable.usage</groupId>
-              <output>${project.build.directory}/generated</output>
+              <output>${project.build.directory}/generated-sources</output>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
               <configOptions>
@@ -238,7 +238,7 @@
             <sourcePath>tally_summary.yaml</sourcePath>
           </sourcePaths>
           <targetPackage>com.redhat.swatch.billable.usage.model</targetPackage>
-          <outputDirectory>${project.build.directory}/generated/src/gen/java</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
           <includeAdditionalProperties>false</includeAdditionalProperties>
           <includeJsr303Annotations>true</includeJsr303Annotations>
           <initializeCollections>false</initializeCollections>
@@ -249,25 +249,6 @@
           <includeSetters>true</includeSetters>
           <useJakartaValidation>true</useJakartaValidation>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -248,7 +248,7 @@
               <apiPackage>com.redhat.swatch.contract.openapi.resource</apiPackage>
               <invokerPackage>com.redhat.swatch.contract.openapi</invokerPackage>
               <groupId>com.redhat.swatch.contract</groupId>
-              <output>${project.build.directory}/generated</output>
+              <output>${project.build.directory}/generated-sources</output>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
               <configOptions>
@@ -298,7 +298,7 @@
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <configuration>
           <targetPackage>com.redhat.swatch.contract.model</targetPackage>
-          <outputDirectory>${project.build.directory}/generated/src/gen/java</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
           <includeAdditionalProperties>false</includeAdditionalProperties>
           <includeJsr303Annotations>true</includeJsr303Annotations>
           <initializeCollections>false</initializeCollections>

--- a/swatch-metrics/pom.xml
+++ b/swatch-metrics/pom.xml
@@ -156,7 +156,7 @@
               <apiPackage>com.redhat.swatch.metrics.admin.api</apiPackage>
               <invokerPackage>com.redhat.swatch.metrics</invokerPackage>
               <groupId>com.redhat.swatch.metrics</groupId>
-              <output>${project.build.directory}/generated</output>
+              <output>${project.build.directory}/generated-sources</output>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
               <configOptions>
@@ -186,7 +186,7 @@
         <artifactId>jsonschema2pojo-maven-plugin</artifactId>
         <configuration>
           <targetPackage>com.redhat.swatch.metrics.model</targetPackage>
-          <outputDirectory>${project.build.directory}/generated/src/gen/java</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
           <includeAdditionalProperties>false</includeAdditionalProperties>
           <includeJsr303Annotations>true</includeJsr303Annotations>
           <initializeCollections>false</initializeCollections>
@@ -197,25 +197,6 @@
           <includeSetters>true</includeSetters>
           <useJakartaValidation>true</useJakartaValidation>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/swatch-model-billable-usage/pom.xml
+++ b/swatch-model-billable-usage/pom.xml
@@ -49,7 +49,7 @@
             <sourcePath>billable_usage.yaml</sourcePath>
           </sourcePaths>
           <targetPackage>org.candlepin.subscriptions.billable.usage</targetPackage>
-          <outputDirectory>${project.build.directory}/generated/src/gen/java</outputDirectory>
+          <outputDirectory>${project.build.directory}/generated-sources/src/main/java</outputDirectory>
           <includeAdditionalProperties>false</includeAdditionalProperties>
           <includeJsr303Annotations>true</includeJsr303Annotations>
           <initializeCollections>false</initializeCollections>
@@ -60,25 +60,6 @@
           <includeSetters>true</includeSetters>
           <useJakartaValidation>true</useJakartaValidation>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/swatch-producer-aws/pom.xml
+++ b/swatch-producer-aws/pom.xml
@@ -163,7 +163,7 @@
               <apiPackage>com.redhat.swatch.aws.openapi.resource</apiPackage>
               <invokerPackage>com.redhat.swatch.aws.openapi</invokerPackage>
               <groupId>com.redhat.swatch.aws</groupId>
-              <output>${project.build.directory}/generated</output>
+              <output>${project.build.directory}/generated-sources</output>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
               <configOptions>
@@ -188,25 +188,6 @@
                   BillableUsage=org.candlepin.subscriptions.billable.usage.BillableUsage
                 </importMapping>
               </importMappings>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
             </configuration>
           </execution>
         </executions>

--- a/swatch-producer-azure/pom.xml
+++ b/swatch-producer-azure/pom.xml
@@ -177,7 +177,7 @@
               <apiPackage>com.redhat.swatch.azure.openapi.resource</apiPackage>
               <invokerPackage>com.redhat.swatch.azure.openapi</invokerPackage>
               <groupId>com.redhat.swatch.azure</groupId>
-              <output>${project.build.directory}/generated</output>
+              <output>${project.build.directory}/generated-sources</output>
               <generateApiTests>false</generateApiTests>
               <generateModelTests>false</generateModelTests>
               <configOptions>
@@ -202,25 +202,6 @@
                   BillableUsage=org.candlepin.subscriptions.billable.usage.BillableUsage
                 </importMapping>
               </importMappings>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated/src/gen/java</source>
-              </sources>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Description
Before these changes we used `<output>${project.build.directory}/generated</output>` plus the `build-helper-maven-plugin` plugin to "register" this path, so Maven can use the generated sources.

However, IntelliJ does not take into account this generated path if the plugin `build-helper-maven-plugin` is not properly configured (this is what was happening in the swatch-contracts module).

To avoid missing to configure the `build-helper-maven-plugin` plugin, let's replace `<output>${project.build.directory}/generated</output>` by using the standard generated sources folder `<output>${project.build.directory}/generated-sources</output>`, so it works fine from command line and intellij without needing to use the `build-helper-maven-plugin`.


## Testing
Regression testing only.