### PR TITLE
SWATCH-3424: Configure sonar to exclude generated sources

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -30,6 +30,10 @@
                 <dataFileInclude>**/jacoco.exec</dataFileInclude>
               </dataFileIncludes>
               <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+              <excludes>
+                <exclude>**/*Test*.class</exclude>
+                <exclude>**/test/**</exclude>
+              </excludes>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <sonar.branch.target>main</sonar.branch.target>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.java.binaries>${project.build.directory}</sonar.java.binaries>
+    <sonar.coverage.exclusions>**/generated-sources/**,**/*Test*.java,**/test/**</sonar.coverage.exclusions>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Jira issue: SWATCH-3424

## Description
The Jacoco plugin is not excluding the generated sources from the openapi or the jsonschema plugins. Also, we can't configure this using the Jacoco Maven plugin.

However, since we're going to pull the code coverage to sonar, we can exclude the generated sources and tests using the Sonar Maven plugin which involves much lesser changes than renaming the Java packages.

## Testing
Regression testing only.
Check the sonar code coverage is 74% now.