### PR TITLE
SWATCH-3664: Support instances to be mapped to different products/servide types

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerTest.java
@@ -226,7 +226,9 @@ class TallySnapshotControllerTest implements ExtendWithEmbeddedKafka {
         instance1.getMonthlyTotal(
             InstanceMonthlyTotalKey.formatMonthId(instance1Event1.getTimestamp()),
             MetricIdUtils.getCores()));
-    assertEquals(instance1.getLastAppliedEventRecordDate(), instance1Event2.getRecordDate());
+    assertEquals(
+        instance1.getLastAppliedEventRecordDate(instance1Event2.getEvent().getServiceType()),
+        instance1Event2.getRecordDate());
 
     Host instance2 = hosts.get(instance2Event1.getInstanceId());
     assertEquals(
@@ -234,7 +236,9 @@ class TallySnapshotControllerTest implements ExtendWithEmbeddedKafka {
         instance2.getMonthlyTotal(
             InstanceMonthlyTotalKey.formatMonthId(instance2Event1.getTimestamp()),
             MetricIdUtils.getCores()));
-    assertEquals(instance2.getLastAppliedEventRecordDate(), instance2Event1.getRecordDate());
+    assertEquals(
+        instance2.getLastAppliedEventRecordDate(instance2Event1.getEvent().getServiceType()),
+        instance2Event1.getRecordDate());
 
     List<TallySnapshot> createdSnapshots = snapshotCaptor.getAllValues();
     // 48 is from:

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -149,8 +149,13 @@ public class Host implements Serializable {
    * Used to track the last Event that was applied to the monthly totals. The expected value will be
    * Event.recordDate.
    */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(
+      name = "host_tally_service_type",
+      joinColumns = @JoinColumn(name = "host_id", referencedColumnName = "id"))
+  @MapKeyColumn(name = "service_type")
   @Column(name = "last_applied_event_record_date")
-  private OffsetDateTime lastAppliedEventRecordDate;
+  private Map<String, OffsetDateTime> lastAppliedEventRecordDateByServiceType = new HashMap<>();
 
   public Host() {}
 
@@ -276,6 +281,14 @@ public class Host implements Serializable {
     keys.stream()
         .filter(key -> Objects.equals(key.getMonth(), monthIdentifier))
         .forEach(key -> monthlyTotals.put(key, 0.0));
+  }
+
+  public OffsetDateTime getLastAppliedEventRecordDate(String serviceType) {
+    return lastAppliedEventRecordDateByServiceType.get(serviceType);
+  }
+
+  public void setLastAppliedEventRecordDate(String serviceType, OffsetDateTime recordDate) {
+    lastAppliedEventRecordDateByServiceType.put(serviceType, recordDate);
   }
 
   @Override

--- a/swatch-database-migrations/src/main/resources/liquibase/202506191100-add-host-service-type-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202506191100-add-host-service-type-table.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202506191100-01" author="jcarvaja">
+    <comment>Add table for host service type mapping.</comment>
+    <createTable tableName="host_tally_service_type">
+      <column name="host_id" type="uuid">
+        <constraints referencedTableName="hosts" referencedColumnNames="id"
+          nullable="false" foreignKeyName="host_id_service_type_fk" deleteCascade="true"/>
+      </column>
+      <column name="service_type" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="last_applied_event_record_date" type="TIMESTAMP WITH TIME ZONE"/>
+    </createTable>
+    <addPrimaryKey constraintName="host_tally_service_type_pkey"
+      tableName="host_tally_service_type"
+      columnNames="host_id,service_type"/>
+  </changeSet>
+
+  <changeSet id="202506191100-02" author="jcarvaja" dbms="postgresql">
+    <comment>
+      Update last_applied_event_record_date from tally_instance_view
+    </comment>
+    <dropView viewName="tally_instance_non_payg_view" />
+    <dropView viewName="tally_instance_payg_view" />
+    <dropView viewName="tally_instance_view" />
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      select distinct h.org_id,
+                      h.id,
+                      h.instance_id as instance_id,
+                      h.display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      h.last_seen,
+                      mhstd.max_last_applied_event_record_date AS last_applied_event_record_date,
+                      coalesce(h.num_of_guests, 0) AS num_of_guests,
+                      b.product_id,
+                      b.sla,
+                      b.usage,
+                      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                      b.sockets,
+                      b.cores,
+                      h.subscription_manager_id,
+                      h.inventory_id,
+                      h.hypervisor_uuid
+      from hosts h
+      join host_tally_buckets b on h.id = b.host_id
+      left join lateral (
+        SELECT MAX(last_applied_event_record_date) AS max_last_applied_event_record_date
+        FROM host_tally_service_type
+        WHERE host_id = h.id
+      ) mhstd ON true
+    </createView>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_non_payg_view">
+      select distinct v.*,
+                      jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+      from tally_instance_view v
+             left outer join instance_measurements m on v.id = m.host_id
+      group by v.org_id,
+               v.id,
+               v.instance_id,
+               v.display_name,
+               v.host_billing_provider,
+               v.host_billing_account_id,
+               v.bucket_billing_provider,
+               v.bucket_billing_account_id,
+               v.last_seen,
+               v.last_applied_event_record_date,
+               v.num_of_guests,
+               v.product_id,
+               v.sla,
+               v."usage",
+               v.measurement_type,
+               v.sockets,
+               v.cores,
+               v.subscription_manager_id,
+               v.inventory_id,
+               v.hypervisor_uuid
+    </createView>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_payg_view">
+      select distinct v.*,
+                      m."month",
+                      jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+      from tally_instance_view v
+             left outer join instance_monthly_totals m on v.id = m.host_id
+      group by v.org_id,
+               v.id,
+               v.instance_id,
+               v.display_name,
+               v.host_billing_provider,
+               v.host_billing_account_id,
+               v.bucket_billing_provider,
+               v.bucket_billing_account_id,
+               v.last_seen,
+               v.last_applied_event_record_date,
+               v.num_of_guests,
+               v.product_id,
+               v.sla,
+               v."usage",
+               v.measurement_type,
+               v.sockets,
+               v.cores,
+               v.subscription_manager_id,
+               v.inventory_id,
+               v.hypervisor_uuid,
+               m."month"
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_non_payg_view" />
+      <dropView viewName="tally_instance_payg_view" />
+      <dropView viewName="tally_instance_view" />
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_view">
+        select distinct h.org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        h.last_applied_event_record_date,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id,
+        h.hypervisor_uuid
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+      </createView>
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_non_payg_view">
+        select distinct v.*,
+        jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+        from tally_instance_view v
+        left outer join instance_measurements m on v.id = m.host_id
+        group by v.org_id,
+        v.id,
+        v.instance_id,
+        v.display_name,
+        v.host_billing_provider,
+        v.host_billing_account_id,
+        v.bucket_billing_provider,
+        v.bucket_billing_account_id,
+        v.last_seen,
+        v.last_applied_event_record_date,
+        v.num_of_guests,
+        v.product_id,
+        v.sla,
+        v."usage",
+        v.measurement_type,
+        v.sockets,
+        v.cores,
+        v.subscription_manager_id,
+        v.inventory_id
+      </createView>
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_payg_view">
+        select distinct v.*,
+        m."month",
+        jsonb_agg(jsonb_build_object('metric_id',m.metric_id,'value',m.value)) as metrics
+        from tally_instance_view v
+        left outer join instance_monthly_totals m on v.id = m.host_id
+        group by v.org_id,
+        v.id,
+        v.instance_id,
+        v.display_name,
+        v.host_billing_provider,
+        v.host_billing_account_id,
+        v.bucket_billing_provider,
+        v.bucket_billing_account_id,
+        v.last_seen,
+        v.last_applied_event_record_date,
+        v.num_of_guests,
+        v.product_id,
+        v.sla,
+        v."usage",
+        v.measurement_type,
+        v.sockets,
+        v.cores,
+        v.subscription_manager_id,
+        v.inventory_id,
+        m."month"
+      </createView>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202506191100-03" author="jcarvaja" dbms="hsqldb">
+    <comment>
+      Update last_applied_event_record_date from tally_instance_view
+    </comment>
+    <dropView viewName="tally_instance_non_payg_view" />
+    <dropView viewName="tally_instance_payg_view" />
+    <dropView viewName="tally_instance_view" />
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_view">
+      WITH MaxHostServiceTypeDate AS (
+        SELECT host_id,
+               MAX(last_applied_event_record_date) AS max_last_applied_event_record_date
+        FROM host_tally_service_type
+        GROUP BY host_id
+      )
+      select distinct h.org_id,
+                      h.id,
+                      h.instance_id as instance_id,
+                      h.display_name,
+                      h.billing_provider as host_billing_provider,
+                      h.billing_account_id as host_billing_account_id,
+                      b.billing_provider as bucket_billing_provider,
+                      b.billing_account_id as bucket_billing_account_id,
+                      h.last_seen,
+                      mhstd.max_last_applied_event_record_date AS last_applied_event_record_date,
+                      coalesce(h.num_of_guests, 0) AS num_of_guests,
+                      b.product_id,
+                      b.sla,
+                      b.usage,
+                      coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+                      b.sockets,
+                      b.cores,
+                      h.subscription_manager_id,
+                      h.inventory_id,
+                      h.hypervisor_uuid
+      from hosts h
+             join host_tally_buckets b on h.id = b.host_id
+             inner join MaxHostServiceTypeDate mhstd ON h.id = mhstd.host_id
+    </createView>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_non_payg_view">
+      select distinct v.*,
+                      CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+      from tally_instance_view v
+             left outer join instance_measurements m on v.id = m.host_id
+    </createView>
+    <createView
+      replaceIfExists="true"
+      viewName="tally_instance_payg_view">
+      select distinct v.*,
+                      m.month,
+                      CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+      from tally_instance_view v
+             left outer join instance_monthly_totals m on v.id = m.host_id
+    </createView>
+    <rollback>
+      <dropView viewName="tally_instance_non_payg_view" />
+      <dropView viewName="tally_instance_payg_view" />
+      <dropView viewName="tally_instance_view" />
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_view">
+        select distinct h.org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        h.last_applied_event_record_date,
+        coalesce(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        coalesce(b.measurement_type, 'EMPTY') AS measurement_type,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id,
+        h.hypervisor_uuid
+        from hosts h
+        join host_tally_buckets b on h.id = b.host_id
+      </createView>
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_non_payg_view">
+        select distinct v.*,
+        CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+        from tally_instance_view v
+        left outer join instance_measurements m on v.id = m.host_id
+      </createView>
+      <createView
+        replaceIfExists="true"
+        viewName="tally_instance_payg_view">
+        select distinct v.*,
+        m.month,
+        CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') as metrics
+        from tally_instance_view v
+        left outer join instance_monthly_totals m on v.id = m.host_id
+      </createView>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202506191100-04" author="jcarvaja">
+    <comment>Populate hosts to host_tally_service_type.</comment>
+    <sql>
+      insert into host_tally_service_type(host_id, service_type, last_applied_event_record_date)
+      select id, instance_type, last_applied_event_record_date
+      from hosts
+      where last_applied_event_record_date is not null;
+    </sql>
+    <dropColumn tableName="hosts" columnName="last_applied_event_record_date"/>
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-database-migrations/src/main/resources/liquibase/changelog.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/changelog.xml
@@ -180,5 +180,6 @@
     <include file="liquibase/202412091327-drop-hardware-measurement-type-from-billable-usage-remittance.xml"/>
     <include file="liquibase/202504291554-add-updated-at-column-to-billable-usage-remittance.xml"/>
     <include file="liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml"/>
+    <include file="liquibase/202506191100-add-host-service-type-table.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-3664

## Description
Before these changes, when we ingested events into the tally buckets table for different products like rosa and rhacs, we were only processing the events for one product.

After these changes, we need to refactor the solution, so one instance can be mapped to different products.

For doing this:
- Create new table "host_tally_service_type" to store the service_type and the last_applied_event_record_date (in the future, we could drop the instance_type from the hosts table which is replaced by this mapping now).
- Only delete buckets when the buckets belong to the same event service type.
- Check whether the last_applied_event_record_date from the new table host_tally_service_type.

## Testing
Added an integration test that reproduces the issue and confirmed the fix.

MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1221

## Manual Verification
1. podman compose -f docker-compose.yml up -d
2. ./mvnw clean install -DskipTests
3. mvn -f swatch-database/pom.xml exec:java
4. import the data from [here](https://privatebin.corp.redhat.com/?9b574872a25d9d62#2JEUNATLxi1KesJ3VZjusg9ucN198eS2fRiSTxNtUfFB).
5. run the tally service: `INVENTORY_DATABASE_SCHEMA=hbi SERVER_PORT=8001 DEV_MODE=true ./mvnw -pl swatch-tally spring-boot:run`
6. run hourly tally: `http POST ":8001/api/rhsm-subscriptions/v1/internal/tally/hourly?org=15324659" x-rh-swatch-psk:placeholder Origin:console.redhat.com`
7. Then, query the "host_tally_buckets" table and confirm that the buckets for the rosa and rhacm products do exist.
8. Using the Instance API:

opt in:
```
curl -X 'PUT' \
  'http://localhost:8001/api/rhsm-subscriptions/v1/internal/rpc/tally/opt-in?org_id=15324659' \
  -H 'accept: application/vnd.api+json' \
  -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNTMyNDY1OSJ9fX0='
```

instances API for rosa:
```
http GET ":8001/api/rhsm-subscriptions/v1/instances/products/rosa" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNTMyNDY1OSJ9fX0= | jq
```

instances API for rhacm:
```
http GET ":8001/api/rhsm-subscriptions/v1/instances/products/rhacm" x-rh-identity:eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxNTMyNDY1OSJ9fX0= | jq
```