### PR TITLE
CI: run migrations using a Maven profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,9 @@ jobs:
       - name: Setup PostgreSQL client
         run: sudo apt-get install -y postgresql-client
 
-      - name: Install Dependencies
-        id: install-dependencies
-        run: mvn install -DskipTests
-
       - name: Execute migrations
         id: run-migrations
-        run: mvn -f swatch-database/pom.xml exec:java
+        run: mvn install -Prun-migrations
 
       - name: Run FloorPlan Query Validation
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -91,43 +91,6 @@
     </repository>
   </repositories>
 
-  <modules>
-    <module>swatch-spring-parent</module>
-    <module>swatch-quarkus-parent</module>
-    <module>swatch-product-configuration</module>
-    <module>api</module>
-    <module>clients-core</module>
-    <module>clients</module>
-    <module>swatch-core</module>
-    <module>swatch-core-test</module>
-    <module>swatch-common-clock</module>
-    <module>swatch-common-export</module>
-    <module>swatch-common-config-workaround</module>
-    <module>swatch-common-resteasy</module>
-    <module>swatch-common-resteasy-client</module>
-    <module>swatch-common-panache</module>
-    <module>swatch-common-kafka</module>
-    <module>swatch-common-smallrye-fault-tolerance</module>
-    <module>swatch-common-splunk</module>
-    <module>swatch-common-trace-response</module>
-    <module>swatch-common-health</module>
-    <module>swatch-common-models</module>
-    <module>swatch-common-testcontainers</module>
-    <module>swatch-model-events</module>
-    <module>swatch-model-billable-usage</module>
-    <module>swatch-database-migrations</module>
-    <!-- Services -->
-    <module>swatch-database</module>
-    <module>swatch-tally</module>
-    <module>swatch-system-conduit</module>
-    <module>swatch-billable-usage</module>
-    <module>swatch-contracts</module>
-    <module>swatch-metrics</module>
-    <module>swatch-metrics-hbi</module>
-    <module>swatch-producer-aws</module>
-    <module>swatch-producer-azure</module>
-  </modules>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -481,6 +444,12 @@
           <artifactId>jandex-maven-plugin</artifactId>
           <version>3.3.1</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -564,6 +533,63 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>coverage</name>
+        </property>
+      </activation>
+      <modules>
+        <module>swatch-spring-parent</module>
+        <module>swatch-quarkus-parent</module>
+        <module>swatch-product-configuration</module>
+        <module>api</module>
+        <module>clients-core</module>
+        <module>clients</module>
+        <module>swatch-core</module>
+        <module>swatch-core-test</module>
+        <module>swatch-common-clock</module>
+        <module>swatch-common-export</module>
+        <module>swatch-common-config-workaround</module>
+        <module>swatch-common-resteasy</module>
+        <module>swatch-common-resteasy-client</module>
+        <module>swatch-common-panache</module>
+        <module>swatch-common-kafka</module>
+        <module>swatch-common-smallrye-fault-tolerance</module>
+        <module>swatch-common-splunk</module>
+        <module>swatch-common-trace-response</module>
+        <module>swatch-common-health</module>
+        <module>swatch-common-models</module>
+        <module>swatch-common-testcontainers</module>
+        <module>swatch-model-events</module>
+        <module>swatch-model-billable-usage</module>
+        <module>swatch-database-migrations</module>
+        <!-- Services -->
+        <module>swatch-database</module>
+        <module>swatch-tally</module>
+        <module>swatch-system-conduit</module>
+        <module>swatch-billable-usage</module>
+        <module>swatch-contracts</module>
+        <module>swatch-metrics</module>
+        <module>swatch-metrics-hbi</module>
+        <module>swatch-producer-aws</module>
+        <module>swatch-producer-azure</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>run-migrations</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>swatch-database-migrations</module>
+        <module>swatch-database</module>
+      </modules>
+    </profile>
+
     <profile>
       <id>coverage</id>
       <activation>

--- a/swatch-database/pom.xml
+++ b/swatch-database/pom.xml
@@ -92,11 +92,39 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>${exec-maven-plugin.version}</version>
         <configuration>
           <mainClass>${javaMainClass}</mainClass>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>run-migrations</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>run-migrations-exec</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <configuration>
+                  <mainClass>${javaMainClass}</mainClass>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Description
Before these changes, in order to run the migrations, we had to first install the swatch-database-migrations, and then run the following command `mvn -f swatch-database/pom.xml exec:java`.

After these changes, we don't need to install the swatch-database-migrations or remember the long maven command of exec:java. This is now replaced by simply `./mvnw install -Prun-migrations`.

## Testing
Regression testing only.