### PR TITLE
SWATCH Metrics HBI: change the json deserialization strategy to not fail on unknown types

### DIFF
--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiEvent.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiEvent.java
@@ -34,10 +34,15 @@ import lombok.ToString;
 @ToString
 @Getter
 @Setter
-@JsonTypeInfo(use = Id.DEDUCTION)
+@JsonTypeInfo(
+    use = Id.NAME,
+    property = "type",
+    defaultImpl = HbiHostUnknownEvent.class,
+    visible = true)
 @JsonSubTypes({
-  @Type(value = HbiHostDeleteEvent.class, name = "HbiHostDeleteEvent"),
-  @Type(value = HbiHostCreateUpdateEvent.class, name = "HbiHostCreateUpdateEvent"),
+  @Type(value = HbiHostDeleteEvent.class, name = "delete"),
+  @Type(value = HbiHostCreateUpdateEvent.class, name = "created"),
+  @Type(value = HbiHostCreateUpdateEvent.class, name = "updated"),
 })
 public abstract class HbiEvent {
 

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostUnknownEvent.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/dtos/hbi/HbiHostUnknownEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.dtos.hbi;
+
+public class HbiHostUnknownEvent extends HbiEvent {}

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/HbiEventDeserializationTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/HbiEventDeserializationTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiEvent;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostCreateUpdateEvent;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostDeleteEvent;
+import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostUnknownEvent;
 import com.redhat.swatch.hbi.events.kafka.InMemoryMessageBrokerKafkaResource;
 import com.redhat.swatch.hbi.events.test.helpers.HbiEventTestData;
 import com.redhat.swatch.hbi.events.test.resources.PostgresResource;
@@ -48,6 +49,11 @@ class HbiEventDeserializationTest {
   private static Stream<Arguments> eventTypeDeserializationParams() {
     return Stream.of(
         Arguments.of(HbiEventTestData.getHostDeletedEvent(), "delete", HbiHostDeleteEvent.class),
+        Arguments.of(HbiEventTestData.getHostUnknownEvent(), "unknown", HbiHostUnknownEvent.class),
+        Arguments.of(
+            HbiEventTestData.getPhysicalRhelHostUpdatedEvent(),
+            "updated",
+            HbiHostCreateUpdateEvent.class),
         Arguments.of(
             HbiEventTestData.getPhysicalRhelHostCreatedEvent(),
             "created",

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/test/helpers/HbiEventTestData.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/test/helpers/HbiEventTestData.java
@@ -44,6 +44,10 @@ public class HbiEventTestData {
     return loadEventFileAsString("data/hbi_physical_rhel_host_created_event.json");
   }
 
+  public static String getPhysicalRhelHostUpdatedEvent() {
+    return loadEventFileAsString("data/hbi_physical_rhel_host_updated_event.json");
+  }
+
   public static String getVirtualRhelHostCreatedEvent() {
     return loadEventFileAsString("data/hbi_virtual_rhel_host_created_event.json");
   }
@@ -54,6 +58,10 @@ public class HbiEventTestData {
 
   public static String getHostDeletedEvent() {
     return loadEventFileAsString("data/hbi_physical_rhel_host_deleted_event.json");
+  }
+
+  public static String getHostUnknownEvent() {
+    return loadEventFileAsString("data/hbi_unknown_event.json");
   }
 
   public static String getHostDeletedTemplate() {

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/test/helpers/HbiEventTestHelper.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/test/helpers/HbiEventTestHelper.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.hbi.events.test.helpers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.hbi.events.configuration.ApplicationConfiguration;
+import com.redhat.swatch.hbi.events.dtos.hbi.HbiEvent;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostCreateUpdateEvent;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostDeleteEvent;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostFacts;
@@ -56,6 +57,14 @@ public class HbiEventTestHelper {
     // Override the syncTimestamp fact so that it aligns with the current time
     // and is within the configured 'hostLastSyncThreshold'.
     setRhsmSyncTimestamp(event, clock.now().minusHours(5));
+    return event;
+  }
+
+  public HbiEvent createEventOfTypeUnknown() {
+    // we use the create/update event template on purpose to ensure
+    // we don't deduct the type by the json schema.
+    var event = getCreateUpdateEvent(HbiEventTestData.getPhysicalRhelHostCreatedEvent());
+    event.setType("unknown");
     return event;
   }
 

--- a/swatch-metrics-hbi/src/test/resources/data/hbi_physical_rhel_host_updated_event.json
+++ b/swatch-metrics-hbi/src/test/resources/data/hbi_physical_rhel_host_updated_event.json
@@ -1,0 +1,78 @@
+{
+  "type": "updated",
+  "host": {
+    "id": "18ebb8c0-a597-41b6-85d2-62003ebaacd3",
+    "display_name": "testhost.example.com",
+    "ansible_host": null,
+    "account": null,
+    "org_id": "12345678",
+    "insights_id": "4a6a184e-6204-47d9-b888-26db9b5e8c81",
+    "subscription_manager_id": "6bfc8a3d-464f-4853-a301-4b1715480799",
+    "satellite_id": null,
+    "fqdn": "testhost.example.com",
+    "ip_addresses": null,
+    "mac_addresses": null,
+    "facts": [
+      {
+        "namespace": "rhsm",
+        "facts": {
+          "orgId": "12345678",
+          "MEMORY": 1,
+          "RH_PROD": [
+            "69"
+          ],
+          "IS_VIRTUAL": false,
+          "ARCHITECTURE": "x86_64",
+          "SYNC_TIMESTAMP": "2024-10-18T16:42:27.185484784Z",
+          "SYSPURPOSE_SLA": "Self-Support",
+          "SYSPURPOSE_USAGE": "Development/Test"
+        }
+      }
+    ],
+    "provider_id": null,
+    "provider_type": null,
+    "created": "2024-10-18T16:22:14.086713+00:00",
+    "updated": "2024-10-18T16:42:28.857787+00:00",
+    "stale_timestamp": "2024-10-19T21:42:28.857787+00:00",
+    "stale_warning_timestamp": "2024-10-25T16:42:28.857787+00:00",
+    "culled_timestamp": "2024-11-01T16:42:28.857787+00:00",
+    "reporter": "rhsm-conduit",
+    "tags": [],
+    "system_profile": {
+      "arch": "x86_64",
+      "owner_id": "6bfc8a3d-464f-4853-a301-4b1715480799",
+      "conversions": {
+        "activity": false
+      },
+      "is_marketplace": false,
+      "cores_per_socket": 1,
+      "number_of_sockets": 2,
+      "infrastructure_type": "physical",
+      "system_memory_bytes": 5120
+    },
+    "per_reporter_staleness": {
+      "rhsm-conduit": {
+        "last_check_in": "2024-10-18T16:42:28.821635+00:00",
+        "stale_timestamp": "2024-10-19T21:42:28.821635+00:00",
+        "check_in_succeeded": true,
+        "stale_warning_timestamp": "2024-10-25T16:42:28.821635+00:00",
+        "culled_timestamp": "2024-11-01T16:42:28.821635+00:00"
+      },
+      "rhsm-system-profile-bridge": {
+        "last_check_in": "2024-10-18T16:22:14.065333+00:00",
+        "stale_timestamp": "2024-10-19T21:22:14.065333+00:00",
+        "check_in_succeeded": true,
+        "stale_warning_timestamp": "2024-10-25T16:22:14.065333+00:00",
+        "culled_timestamp": "2024-11-01T16:22:14.065333+00:00"
+      }
+    },
+    "groups": []
+  },
+  "timestamp": "2024-10-18T16:42:29.134663+00:00",
+  "platform_metadata": {
+    "request_id": "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
+  },
+  "metadata": {
+    "request_id": "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
+  }
+}

--- a/swatch-metrics-hbi/src/test/resources/data/hbi_unknown_event.json
+++ b/swatch-metrics-hbi/src/test/resources/data/hbi_unknown_event.json
@@ -1,0 +1,78 @@
+{
+  "type": "unknown",
+  "host": {
+    "id": "18ebb8c0-a597-41b6-85d2-62003ebaacd3",
+    "display_name": "testhost.example.com",
+    "ansible_host": null,
+    "account": null,
+    "org_id": "12345678",
+    "insights_id": "4a6a184e-6204-47d9-b888-26db9b5e8c81",
+    "subscription_manager_id": "6bfc8a3d-464f-4853-a301-4b1715480799",
+    "satellite_id": null,
+    "fqdn": "testhost.example.com",
+    "ip_addresses": null,
+    "mac_addresses": null,
+    "facts": [
+      {
+        "namespace": "rhsm",
+        "facts": {
+          "orgId": "12345678",
+          "MEMORY": 1,
+          "RH_PROD": [
+            "69"
+          ],
+          "IS_VIRTUAL": false,
+          "ARCHITECTURE": "x86_64",
+          "SYNC_TIMESTAMP": "2024-10-18T16:42:27.185484784Z",
+          "SYSPURPOSE_SLA": "Self-Support",
+          "SYSPURPOSE_USAGE": "Development/Test"
+        }
+      }
+    ],
+    "provider_id": null,
+    "provider_type": null,
+    "created": "2024-10-18T16:22:14.086713+00:00",
+    "updated": "2024-10-18T16:42:28.857787+00:00",
+    "stale_timestamp": "2024-10-19T21:42:28.857787+00:00",
+    "stale_warning_timestamp": "2024-10-25T16:42:28.857787+00:00",
+    "culled_timestamp": "2024-11-01T16:42:28.857787+00:00",
+    "reporter": "rhsm-conduit",
+    "tags": [],
+    "system_profile": {
+      "arch": "x86_64",
+      "owner_id": "6bfc8a3d-464f-4853-a301-4b1715480799",
+      "conversions": {
+        "activity": false
+      },
+      "is_marketplace": false,
+      "cores_per_socket": 1,
+      "number_of_sockets": 2,
+      "infrastructure_type": "physical",
+      "system_memory_bytes": 5120
+    },
+    "per_reporter_staleness": {
+      "rhsm-conduit": {
+        "last_check_in": "2024-10-18T16:42:28.821635+00:00",
+        "stale_timestamp": "2024-10-19T21:42:28.821635+00:00",
+        "check_in_succeeded": true,
+        "stale_warning_timestamp": "2024-10-25T16:42:28.821635+00:00",
+        "culled_timestamp": "2024-11-01T16:42:28.821635+00:00"
+      },
+      "rhsm-system-profile-bridge": {
+        "last_check_in": "2024-10-18T16:22:14.065333+00:00",
+        "stale_timestamp": "2024-10-19T21:22:14.065333+00:00",
+        "check_in_succeeded": true,
+        "stale_warning_timestamp": "2024-10-25T16:22:14.065333+00:00",
+        "culled_timestamp": "2024-11-01T16:22:14.065333+00:00"
+      }
+    },
+    "groups": []
+  },
+  "timestamp": "2024-10-18T16:42:29.134663+00:00",
+  "platform_metadata": {
+    "request_id": "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
+  },
+  "metadata": {
+    "request_id": "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
+  }
+}


### PR DESCRIPTION
## Description
I found an issue that when the event is not supported, we were still serializing to a create/update event which is wrong.
The logic should be based on the event type, not by deduction. 

## Testing

### Setup
1.- podman compose up -d
2.- mvn install -Prun-migrations
3.- mvn clean install -DskipTests
4.- SERVER_PORT=8005 QUARKUS_MANAGEMENT_PORT=9005 mvn -pl swatch-metrics-hbi quarkus:dev

### Verification

- Unsupported event

```
curl -X POST \
  http://localhost:9080/topics/platform.inventory.events \
  -H "Content-Type: application/vnd.kafka.json.v2+json" \
  -H "Accept: application/vnd.kafka.v2+json" \
  -d '{
        "records": [
            {
            "key": "12345678",
            "value": {
                "type": "unknown"
                }
            }
        ]
        }'
```

Then, you should see that the event is discarded because unknown is unsupported.

- Supported event by type

```
cat > rhel_guest.json <<EOF
$(jq -n --arg ts "$(date -u -d "$((RANDOM % 86400)) seconds ago" +%Y-%m-%dT%H:%M:%S.%NZ)" '{
  records: [{
    key: "12345678",
    value: {
      type: "created",
      host: {
        id: "18ebb8c0-a597-41b6-85d2-62003ebaacd4",
        display_name: "virtual.testhost.example.com",
        ansible_host: null,
        account: null,
        org_id: "12345678",
        insights_id: "4a6a184e-6204-47d9-b888-26db9b5e8c82",
        subscription_manager_id: "6bfc8a3d-464f-4853-a301-4b1715480800",
        satellite_id: null,
        fqdn: "virtual.testhost.example.com",
        ip_addresses: null,
        mac_addresses: null,
        facts: [{
          namespace: "rhsm",
          facts: {
            orgId: "12345678",
            MEMORY: 1,
            RH_PROD: ["69"],
            IS_VIRTUAL: true,
            ARCHITECTURE: "x86_64",
            SYNC_TIMESTAMP: $ts,
            SYSPURPOSE_SLA: "Self-Support",
            SYSPURPOSE_USAGE: "Development/Test"
          }
        }],
        provider_id: null,
        provider_type: null,
        created: "2024-10-18T15:22:14.086713+00:00",
        updated: "2024-10-18T15:42:28.857787+00:00",
        stale_timestamp: "2025-10-19T21:42:28.857787+00:00",
        stale_warning_timestamp: "2025-10-25T16:42:28.857787+00:00",
        culled_timestamp: "2024-11-01T16:42:28.857787+00:00",
        reporter: "rhsm-conduit",
        tags: [],
        system_profile: {
          arch: "x86_64",
          owner_id: "6bfc8a3d-464f-4853-a301-4b1715480800",
          conversions: { activity: false },
          is_marketplace: false,
          cores_per_socket: 1,
          number_of_sockets: 3,
          infrastructure_type: "virtual",
          virtual_host_uuid: "6bfc8a3d-464f-4853-a301-4b1715480799",
          system_memory_bytes: 5120
        }
      },
      timestamp: "2024-10-18T15:42:29.134663+00:00",
      platform_metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e6"
      },
      metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e6"
      }
    }
  }]
}')
EOF
```

```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json \
Accept:application/vnd.kafka.v2+json \
< rhel_guest.json
```

Now, this event should be handled because "created" is supported.