### PR TITLE
SWATCH-3345: Mark X509 authed users with service role

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/RolesAugmentor.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/security/RolesAugmentor.java
@@ -52,9 +52,13 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
     if (!identity.isAnonymous() && testApisEnabled) {
       roles.add("test");
     }
-    if (principal instanceof RhIdentityPrincipal
-        && ((RhIdentityPrincipal) principal).isAssociate()) {
-      roles.add("support");
+    if (principal instanceof RhIdentityPrincipal) {
+      if (((RhIdentityPrincipal) principal).isAssociate()) {
+        roles.add("support");
+      }
+      if ("X509".equals(((RhIdentityPrincipal) principal).getIdentity().getType())) {
+        roles.add("service");
+      }
     }
     if (principal instanceof PskPrincipal) {
       roles.add("service");


### PR DESCRIPTION
Jira issue: SWATCH-3345

## Description
We want to move our tests to use X509 based authentication rather than a PSK.
However, the swatch-contracts code doesn't give an X509 authed user the
"service" role like PSK auth does.

## Testing
Unit test
