### PR TITLE
Add missing dev mode build flag

### DIFF
--- a/bin/dev-argfile.conf
+++ b/bin/dev-argfile.conf
@@ -1,8 +1,2 @@
 # Tell Quarkus to build a mutable jar which allows for hot reloading.
-GRADLE_BUILD_ARGS=-Dquarkus.package.type=mutable-jar
-# The 'snapshot' insures that we get a consistent version number.  Without this directive
-# the resultant JAR file has a git hash in it, meaning that if you do a git commit, the name
-# of the built JAR file will change and an oc rsync won't replace the JAR file in the image.
-# Instead rsync will just copy over the new JAR file alongside the old one which won't trigger a
-# hot reload.
-GRADLE_TASKS=snapshot assemble
+MAVEN_BUILD_ARGS=-Dquarkus.package.type=mutable-jar


### PR DESCRIPTION
Jira issue: None

## Description
The mutable JAR setting is needed when deploying Quarkus apps in a live
reload situation.  This setting was part of the Gradle configuration but
got missed when we migrated to Maven.

## Testing
Just run `bin/build-images.sh` to make sure everything still builds.  You can do
a full EE deployment if you like.  Without the mutable JAR setting, if you
attempt to deploy with live reload capability (`QUARKUS_LAUNCH_DEVMODE=true`),
the application will fail to start with an error message reading

```
Exception in thread "main" java.lang.reflect.UndeclaredThrowableException
at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:42)
Caused by: java.nio.file.NoSuchFileException: /deployments/lib/deployment/deployment-class-path.dat
```
