### PR TITLE
fix: CreateUpdateHostHandlerTest test

### DIFF
--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/TestingApplicationConfiguration.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/TestingApplicationConfiguration.java
@@ -56,7 +56,7 @@ public class TestingApplicationConfiguration extends ApplicationConfiguration {
     return fixedClock();
   }
 
-  private ApplicationClock fixedClock() {
+  public static ApplicationClock fixedClock() {
     ZoneId utc = ZoneId.of("UTC");
     LocalDateTime reference = LocalDateTime.of(2025, 5, 12, 12, 25, 0, 0);
     ZonedDateTime timeUtc = reference.atZone(utc);

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/processing/handlers/CreateUpdateHostHandlerTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/processing/handlers/CreateUpdateHostHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.hbi.events.TestingApplicationConfiguration;
 import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostCreateUpdateEvent;
 import com.redhat.swatch.hbi.events.normalization.NormalizedEventType;
 import com.redhat.swatch.hbi.events.normalization.facts.RhsmFacts;
@@ -65,7 +66,7 @@ class CreateUpdateHostHandlerTest {
   @Inject SwatchEventTestHelper swatchEventHelper;
 
   static Stream<Arguments> skipEventTestArgs() {
-    ApplicationClock clock = new ApplicationClock();
+    ApplicationClock clock = TestingApplicationConfiguration.fixedClock();
     OffsetDateTime notStale = clock.now().plusMonths(1);
     OffsetDateTime stale = clock.now().minusMonths(2);
     return Stream.of(


### PR DESCRIPTION
## Description
The problem is that the clock used by the service was the fixed one, instead of the default one, what was causing the host not being considered stale.

## Testing
Regression testing only.