### PR TITLE
Improve caching during container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 RUN (cd /stage/swatch-tally && exec jar -xf ./target/*.jar)
 RUN ls -al /stage/swatch-tally

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,11 @@
 
   <profiles>
     <profile>
+      <!-- Profile with no modules so we can download the dependencies during container build -->
+      <id>download</id>
+    </profile>
+
+    <profile>
       <id>build</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -92,10 +92,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -91,10 +91,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-database/src/main/docker/Dockerfile.jvm
+++ b/swatch-database/src/main/docker/Dockerfile.jvm
@@ -93,10 +93,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -91,10 +91,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -93,10 +93,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -89,14 +89,17 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-# The commented out commands are used for quarkus offline as we need the subprojects to run at top level
-# Have to add too many files to have quarkus offline run
-# We can revist once we refactor the codebases a bit
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -93,10 +93,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN -- mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22-1.1749462971
 USER root

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -16,10 +16,13 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml ./
 
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-RUN ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw ${MAVEN_TASKS} -DskipTests ${MAVEN_BUILD_ARGS}
 
 # See https://stackoverflow.com/a/786515
 RUN (cd /stage/swatch-system-conduit && exec jar -xf ./target/*.jar)


### PR DESCRIPTION
Jira issue: None

## Description
The RUN command has an option to cache directories.  The directories persist between builder invocations without invalidating the instruction cache.  Additionally, we can improve build performance by downloading as many dependencies as possible into a layer prior to copying over the project source.

On my machine, these improvements result in about 80s savings to rebuild (i.e. the cache is getting used) an image for swatch-contracts.  Building all the images with the `bin/build-images.sh` script results in about a 40s savings.


## Testing

### Setup
1. Install the `perf` package.

### Steps
1. In the `bin/build-images.sh` script, add `--no-cache` to the `podman build` line.
1. Run `perf stat -B ./bin/build-images.sh` on `main`
1. Remove the `--no-cache` and rerun the command from step 1.
1. Repeat for steps 1-3 for this branch

| branch| `--no-cache` | using cache |
|---|---|---|
| main | 2923s | 750s |
| awood/faster-builds | 6600s | 709s |