### PR TITLE
SWATCH-3626: Enable wiremock profile for swatch tally for local component testing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,19 +9,20 @@ http {
             add_header Content-Type text/plain;
         }
 
-
         location /api/swatch-contracts/ {
             proxy_pass http://host.containers.internal:8001;
         }
-
 
         location /api/swatch-billable-usage/ {
             proxy_pass http://host.containers.internal:8002;
         }
 
-
         location /api/swatch-producer-aws/ {
             proxy_pass http://host.containers.internal:8003;
+        }
+
+        location /api/rhsm-subscriptions/ {
+            proxy_pass http://host.containers.internal:8005;
         }
     }
 }

--- a/src/main/resources/application-wiremock.yaml
+++ b/src/main/resources/application-wiremock.yaml
@@ -1,0 +1,4 @@
+# This profile needs to be activated as long as other profiles in the last order
+# For example: SPRING_PROFILES_ACTIVE=worker,api,kafka-queue,wiremock
+SERVER_PORT: 8005
+METRICS_SERVER_PORT: 9005


### PR DESCRIPTION
Jira issue: SWATCH-3626

## Description
The objective is to extend this capability to all services. This card focuses on enabling local testing for the swatch tally using the Wiremock profile.

## Testing
IQE Test MR: 

### Steps
1.- podman compose -f docker-compose.yml up -d
2.- mvn clean install -Prun-migrations
3.- Pycharm add env file that is located at iqe-rhsm-subscriptions-plugin/iqe_rhsm_subscriptions/conf/iqe_env
4.- DEV_MODE=true SPRING_PROFILES_ACTIVE=worker,api,kafka-queue,wiremock ./mvnw -pl swatch-tally spring-boot:run
5.- And run the test_verify_tally_snapshot_produced_matched_with_kakfa_topic test in pycharm

The test should work as it is. 