### PR TITLE
chore: Update and pin Kafka bridge version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     depends_on:
       - kafka-rest
   kafka-bridge:
-    image: quay.io/strimzi/kafka-bridge:latest
+    image: quay.io/strimzi/kafka-bridge:0.31.2
     entrypoint: /opt/strimzi/bin/kafka_bridge_run.sh
     command: --config-file=config/application-kafka-bridge.properties
     ports:


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
With this change we propose to pin Kafka bridge  version in docker compose file.
This fixes a compatibility issue running local component test.
Also using latest is considered a bad practice.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
[Testing local deployment of billable usage service](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/blob/master/iqe_rhsm_subscriptions/tests/component/swatch_billable_usage/test_verify_ansible_usage.py#L19) resulted in an error during [consumer group creation](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/blob/master/iqe_rhsm_subscriptions/internal_apis/kafka_bridge.py#L21).
The error we got was `400 Validation error on: The format of the request body is not supported`.
After this change, redeploying locally Kafka bridge and the service, the test passes (hence creating the consumer group correctly)