### PR TITLE
SWATCH-3623: Enable wiremock profile for azure producer for local component testing

### DIFF
--- a/config/wiremock/__files/contract_service_response.json
+++ b/config/wiremock/__files/contract_service_response.json
@@ -1,0 +1,11 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "ANY",
+    "urlPattern": "/mock/contractApi/api/swatch-contracts/internal.*"
+  },
+  "response": {
+    "proxyBaseUrl": "http://localhost:8000",
+    "proxyUrlPrefixToRemove": "/mock/contractApi"
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,6 +21,10 @@ http {
             proxy_pass http://host.containers.internal:8003;
         }
 
+        location /api/swatch-producer-azure/ {
+            proxy_pass http://host.containers.internal:8004;
+        }
+
         location /api/rhsm-subscriptions/ {
             proxy_pass http://host.containers.internal:8005;
         }

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -48,6 +48,27 @@ AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 %dev.SWATCH_CONTRACTS_ENDPOINT=http://localhost:8101
 %dev.CORS_ORIGINS=/.*/
 
+#dev wiremock specific profile defaults; these can still be overridden by env var
+%wiremock.SERVER_PORT=8004
+%wiremock.QUARKUS_MANAGEMENT_PORT=9004
+%wiremock.quarkus.management.enabled=false
+%wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
+%wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
+%wiremock.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}
+%wiremock.SPLUNK_HEC_URL=${%dev.SPLUNK_HEC_URL}
+%wiremock.HOST_NAME=${%dev.HOST_NAME}
+%wiremock.SPLUNKMETA_namespace=${%dev.SPLUNKMETA_namespace}
+%wiremock.SPLUNK_HEC_INCLUDE_EX=${%dev.SPLUNK_HEC_INCLUDE_EX}
+%wiremock.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=${%dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION}
+%wiremock.WIREMOCK_ENDPOINT=http://localhost:8006
+%wiremock.CORS_ORIGINS=${%dev.CORS_ORIGINS}
+%wiremock.DISABLE_AZURE_OIDC=false
+%wiremock.ENABLE_AZURE_DRY_RUN=false
+%wiremock.AZURE_MANUAL_SUBMISSION_ENABLED=true
+%wiremock.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractApi
+%wiremock.AZURE_MARKETPLACE_BASE_URL=${WIREMOCK_ENDPOINT}/mock/azure
+%wiremock.AZURE_OAUTH_TOKEN_URL=${WIREMOCK_ENDPOINT}/mock/azure/[TenantIdPlaceholder]/oauth2/token
+
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
 %test.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}


### PR DESCRIPTION
Jira issue: SWATCH-3623

## Description
These changes focus on enabling local testing for the Azure Producer using the Wiremock profile.

## Testing
### Steps
1.- podman compose -f docker-compose.yml up -d
2.- mvn clean install -Prun-migrations
3.- Pycharm add env file that is located at iqe-rhsm-subscriptions-plugin/iqe_rhsm_subscriptions/conf/iqe_env
4.- QUARKUS_PROFILE=wiremock ./mvnw -pl swatch-producer-azure quarkus:dev
5.- And run all the tests from test_swatch_azure_producer.py

The tests should work as it is. 