### PR TITLE
Update the unleash fetch-toggles-interval in swatch-metrics-hbi

### DIFF
--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -29,14 +29,19 @@ HBI_HOST_EVENT_TOPIC=platform.inventory.events
 %dev.SPLUNK_HEC_INCLUDE_EX=true
 %dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
+
 %dev.quarkus.log.file.enable=true
 %dev.quarkus.log.file.path=/tmp/swatch-metrics-hbi-application.log
 %dev.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+%dev.quarkus.unleash.fetch-toggles-interval=1
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
 %test.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}
 %test.HOST_NAME=unit_tests
+
+# Ephemeral environment specific overrides
+%ephemeral.quarkus.unleash.fetch-toggles-interval=1
 
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode
@@ -120,7 +125,7 @@ quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
 quarkus.unleash.url=${UNLEASH_URL:http://localhost:4242/api}
 quarkus.unleash.token=${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
 quarkus.unleash.name-prefix=swatch
-%ephemeral.quarkus.unleash.fetch-toggles-interval=1
+
 
 swatch-metrics-hbi.culling-offset=${CULLING_OFFSET:14d}
 swatch-metrics-hbi.host-last-sync-threshold=${HOST_LAST_SYNC_THRESHOLD:24h}


### PR DESCRIPTION
Relates to Jira issue: SWATCH-3630

## Description
In order to avoid flaky IQE tests when testing against the local environment, the quarkus.unleash.fetch-toggles-interval configuration variable was updated to be 1 second for the dev environment. This is similar to what was done for the EE.