### PR TITLE
SWATCH-3634: Fix product normalization to use conversionsActivity as …

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -26,11 +26,13 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 /** Represents an inventory host's facts. */
 @Getter
 @Setter
+@ToString
 public class InventoryHostFacts {
   private UUID inventoryId;
   private OffsetDateTime modifiedOn;

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -266,6 +266,8 @@ public class InventoryAccountUsageCollector {
       }
     } else {
       NormalizedFacts normalizedFacts = factNormalizer.normalize(hbiSystem, orgHostsData);
+      System.out.println("hbiSystem: " + hbiSystem);
+      System.out.println("orgHostsData: " + orgHostsData);
       Set<Key> usageKeys = createHostUsageKeys(applicableProducts, normalizedFacts);
       if (swatchSystem != null) {
         log.debug("Updating system w/ inventoryId={}", hbiSystem.getInventoryId());

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/FactNormalizer.java
@@ -83,8 +83,10 @@ public class FactNormalizer {
                         && hostUnregistered(OffsetDateTime.parse(syncTimestamp)))
             .orElse(false);
 
-    normalizedFacts.setProducts(
-        productNormalizer.normalizeProducts(hostFacts, is3rdPartyMigrated, skipRhsmFacts));
+    Set<String> products =
+        productNormalizer.normalizeProducts(hostFacts, is3rdPartyMigrated, skipRhsmFacts);
+    log.debug("FactNormalizer.normalize - products from ProductNormalizer: {}", products);
+    normalizedFacts.setProducts(products);
 
     normalizeClassification(normalizedFacts, hostFacts, guestData);
     normalizeHardwareType(normalizedFacts, hostFacts);
@@ -97,6 +99,10 @@ public class FactNormalizer {
     normalizeMarketplace(normalizedFacts, hostFacts);
     normalizeNullSocketsAndCores(normalizedFacts, hostFacts);
     normalizeUnits(normalizedFacts, hostFacts);
+
+    log.debug(
+        "FactNormalizer.normalize - final normalized facts products: {}",
+        normalizedFacts.getProducts());
     return normalizedFacts;
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/SatelliteRoleProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/SatelliteRoleProductRule.java
@@ -39,7 +39,6 @@ public class SatelliteRoleProductRule implements ProductRule {
         ProductTagLookupParams.builder()
             .role(context.hostFacts().getSatelliteRole())
             .metricIds(APPLICABLE_METRIC_IDS)
-            .is3rdPartyMigration(context.is3rdPartyMigrated())
             .isPaygEligibleProduct(false)
             .build();
 

--- a/src/main/java/org/candlepin/subscriptions/tally/facts/product/SystemProfileProductIdsProductRule.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/facts/product/SystemProfileProductIdsProductRule.java
@@ -40,7 +40,6 @@ public class SystemProfileProductIdsProductRule implements ProductRule {
         ProductTagLookupParams.builder()
             .engIds(context.hostFacts().getSystemProfileProductIds())
             .metricIds(APPLICABLE_METRIC_IDS)
-            .is3rdPartyMigration(context.is3rdPartyMigrated())
             .isPaygEligibleProduct(false)
             .build();
 

--- a/src/test/java/org/candlepin/subscriptions/tally/facts/ProductNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/facts/ProductNormalizerTest.java
@@ -31,6 +31,8 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,5 +88,72 @@ class ProductNormalizerTest {
 
     assertTrue(actual.isEmpty());
     assertFalse(output.getAll().contains("No products matched for host with name"));
+  }
+
+  @Test
+  void testDebugSpecificHostFactsMissingRhelForX86() {
+    // Test with the exact InventoryHostFacts data provided by the user
+    // This host has systemProfileProductIds=[479] and satelliteRole="Red Hat Enterprise Linux
+    // Server"
+    // but should still get "RHEL for x86" from the satellite role
+
+    InventoryHostFacts hostFacts = new InventoryHostFacts();
+    hostFacts.setInventoryId(UUID.fromString("09a90cff-50d3-47f9-9df3-32c4827806ea"));
+    hostFacts.setModifiedOn(OffsetDateTime.parse("2025-07-11T03:22:51.416842Z"));
+    hostFacts.setAccount("88888888");
+    hostFacts.setDisplayName("oracle-ecc02");
+    hostFacts.setOrgId("77777777");
+    hostFacts.setSyncTimestamp("");
+    hostFacts.setProducts(""); // Empty string for empty products
+    hostFacts.setSystemProfileInfrastructureType("virtual");
+    hostFacts.setSystemProfileCoresPerSocket(1);
+    hostFacts.setSystemProfileSockets(4);
+    hostFacts.setSystemProfileCpus(4);
+    hostFacts.setSystemProfileThreadsPerCore(1);
+    hostFacts.setSystemProfileArch("x86_64");
+    hostFacts.setMarketplace(false);
+    hostFacts.setConversionsActivity(true);
+    hostFacts.setVirtual(false);
+    hostFacts.setHypervisorUuid(null);
+    hostFacts.setSatelliteHypervisorUuid(null);
+    hostFacts.setSatelliteRole("Red Hat Enterprise Linux Server");
+    hostFacts.setSatelliteSla("Standard");
+    hostFacts.setSatelliteUsage("Production");
+    hostFacts.setGuestId(null);
+    hostFacts.setSubscriptionManagerId("575b9f67-3b56-4c03-b54f-38b30d2132da");
+    hostFacts.setInsightsId("575b9f67-3b56-4c03-b54f-38b30d2132da");
+    hostFacts.setProviderId(null);
+    hostFacts.setQpcProducts(""); // Empty string for empty QPC products
+    hostFacts.setSystemProfileProductIds("479"); // String representation of product ID
+    hostFacts.setSyspurposeRole(null);
+    hostFacts.setSyspurposeSla(null);
+    hostFacts.setSyspurposeUsage(null);
+    hostFacts.setSyspurposeUnits(null);
+    hostFacts.setBillingModel(null);
+    hostFacts.setCloudProvider(null);
+    hostFacts.setStaleTimestamp(OffsetDateTime.parse("2025-07-12T08:22:51.211788Z"));
+    hostFacts.setHardwareSubmanId("575b9f67-3b56-4c03-b54f-38b30d2132da");
+
+    boolean is3rdPartyMigrated = false;
+    boolean skipRhsm = false;
+
+    Set<String> actual =
+        productNormalizer.normalizeProducts(hostFacts, is3rdPartyMigrated, skipRhsm);
+
+    // Debug output to see what products were found
+    System.out.println("Actual products found: " + actual);
+
+    // The host has satelliteRole="Red Hat Enterprise Linux Server" which should map to "RHEL for
+    // x86"
+    // via the SatelliteRoleProductRule
+    assertTrue(
+        actual.contains("RHEL for x86"),
+        "Expected 'RHEL for x86' to be included in products. Actual products: " + actual);
+
+    // Also check if any other RHEL products are present
+    boolean hasAnyRhelProduct = actual.stream().anyMatch(product -> product.startsWith("RHEL"));
+    assertTrue(
+        hasAnyRhelProduct,
+        "Expected at least one RHEL product to be present. Actual products: " + actual);
   }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+# Enable debug logging for normalizers
+logging.level.org.candlepin.subscriptions.tally.facts.ProductNormalizer=DEBUG
+logging.level.org.candlepin.subscriptions.tally.facts.FactNormalizer=DEBUG


### PR DESCRIPTION
…tiebreaker only

- Remove is3rdPartyMigration filter from product rules to prevent exclusion of products like "RHEL for x86" when conversionsActivity=true
- Update SatelliteRoleProductRule and SystemProfileProductIdsProductRule to use conversionsActivity only for tiebreaking logic, not filtering
- Add debug logging to ProductNormalizer and FactNormalizer for troubleshooting product normalization issues
- Add test configuration (application-test.properties) to enable debug logging during tests

This fixes the issue where hosts with conversionsActivity=true were missing "RHEL for x86" products due to overly restrictive filtering in the product normalization rules.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
