### PR TITLE
SWATCH-3663: Disable all DEV services

### DIFF
--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -156,7 +156,6 @@ mp.messaging.incoming.tally-summary.failure-strategy=ignore
 mp.messaging.incoming.tally-summary.fail-on-deserialization-failure=false
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
-quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -144,7 +144,6 @@ quarkus.management.port=9000
 quarkus.management.root-path=/
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
-quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
@@ -412,5 +411,5 @@ rhsm-subscriptions.subscription-sync-enabled=${SUBSCRIPTION_SYNC_ENABLED:true}
 # Enable Kafka metrics
 smallrye.messaging.observation.enabled=true
 
-# Disable Keycloak DEV services
-quarkus.keycloak.devservices.enabled=false
+# Disable ALL dev services
+quarkus.devservices.enabled=false

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -29,6 +29,9 @@ HBI_HOST_EVENT_TOPIC=platform.inventory.events
 %dev.SPLUNK_HEC_INCLUDE_EX=true
 %dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
+%dev.quarkus.log.file.enable=true
+%dev.quarkus.log.file.path=/tmp/swatch-metrics-hbi-application.log
+%dev.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
@@ -87,7 +90,6 @@ mp.messaging.outgoing.swatch-events-out.value.serializer=io.quarkus.kafka.client
 mp.messaging.outgoing.swatch-events-out.max-inflight-messages=128
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
-quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
@@ -137,8 +139,5 @@ quarkus.liquibase.database-change-log-table-name=DATABASECHANGELOG_SWATCH_METRIC
 quarkus.liquibase.change-log=db/changelog.xml
 quarkus.liquibase.migrate-at-start=true
 
-
-# Enable logging to file
-%dev.quarkus.log.file.enable=true
-%dev.quarkus.log.file.path=/tmp/swatch-metrics-hbi-application.log
-%dev.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
+# Disable ALL dev services
+quarkus.devservices.enabled=false

--- a/swatch-metrics/src/main/resources/application.properties
+++ b/swatch-metrics/src/main/resources/application.properties
@@ -55,7 +55,6 @@ quarkus.management.port=9000
 quarkus.management.root-path=/
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
-quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}
@@ -160,6 +159,9 @@ quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
 quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+
+# Disable ALL dev services
+quarkus.devservices.enabled=false
 
 rhsm-subscriptions.prometheus-latency-duration=${PROMETHEUS_LATENCY_DURATION:0h}
 rhsm-subscriptions.enable-synchronous-operations=${ENABLE_SYNCHRONOUS_OPERATIONS:false}

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -162,7 +162,6 @@ quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultAp
 quarkus.rest-client."com.redhat.swatch.clients.contracts.api.resources.DefaultApi".read-timeout=120000
 
 quarkus.log.handler.splunk.enabled=${ENABLE_SPLUNK_HEC:false}
-quarkus.log.handler.splunk.devservices.enabled=false
 quarkus.log.handler.splunk.url=${SPLUNK_HEC_URL:https://splunk-hec.redhat.com:8088/}
 quarkus.log.handler.splunk.disable-certificate-validation=${SPLUNK_DISABLE_CERTIFICATE_VALIDATION:false}
 quarkus.log.handler.splunk.token=${SPLUNK_HEC_TOKEN:replaceme}


### PR DESCRIPTION
Jira issue: SWATCH-3663

## Description
The Quarkus services are randomly failing when starting the Splunk dev service which we have it disabled using the following property:
```
quarkus.log.handler.splunk.devservices.enabled=false
```

Yet, sometimes the splunk container was trying to start.

Checking the source code of the splunk Quarkus extension, this property is checked when the dev service is executed which might cause inconsistencies.

On the other hand, if we disable all the DEV services using `quarkus.devservices.enabled`, the Splunk Dev Service should not be executed at all.

Note that I've verified that all the Quarkus services worked fine in DEV mode with these changes.

## Testing
Regression testing.