### PR TITLE
SWATCH-3628: Enable wiremock profile for swatch-metrics for local component testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ config/*
 !config/export-service
 !config/wiremock
 !config/moto
+!config/prometheus
 config/export-service/tmp
 
 #VS Code

--- a/config/prometheus/docker-compose.yml
+++ b/config/prometheus/docker-compose.yml
@@ -1,0 +1,8 @@
+---
+version: '3.8'
+services:
+  prometheus:
+    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/prometheus:eac5c45
+    container_name: prometheus
+    ports:
+      - "127.0.0.1:9090:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@ services:
       swatch-network:
         aliases:
           - wiremock
+  prometheus:
+    extends:
+      file: config/prometheus/docker-compose.yml
+      service: prometheus
+    networks:
+      swatch-network:
+        aliases:
+          - prometheus
   db:
     # Use the same version as in https://gitlab.cee.redhat.com/service/app-interface/-/blob/ff61d457898da76ebd4abf21fe3ce7b5c74c87a5/data/services/insights/rhsm/namespaces/rhsm-prod.yml#L179
     # When updating the image, remember to also update the following locations:
@@ -129,7 +137,6 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-
   inventory:
     image: quay.io/cloudservices/insights-inventory
     entrypoint: /bin/bash -c

--- a/swatch-metrics/src/main/resources/application.properties
+++ b/swatch-metrics/src/main/resources/application.properties
@@ -23,11 +23,26 @@ SERVICE_INSTANCE_INGRESS_TOPIC=platform.rhsm-subscriptions.service-instance-ingr
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
 %dev.SPLUNK_HEC_URL=https://splunk-hec.prod.utility-us-east-2.redhat.com:8088/
-%dev".HOST_NAME=${USER}@${HOSTNAME}
+%dev.HOST_NAME=${USER}@${HOSTNAME}
 %dev.SPLUNKMETA_namespace=local
 %dev.SPLUNK_HEC_INCLUDE_EX=true
 %dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
+
+#dev wiremock specific profile defaults; these can still be overridden by env var
+%wiremock.SERVER_PORT=8016
+%wiremock.QUARKUS_MANAGEMENT_PORT=9016
+%wiremock.quarkus.management.enabled=false
+%wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
+%wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
+%wiremock.ENABLE_SPLUNK_HEC=${%dev.ENABLE_SPLUNK_HEC}
+%wiremock.SPLUNK_HEC_URL=${%dev.SPLUNK_HEC_URL}
+%wiremock.HOST_NAME=${%dev.HOST_NAME}
+%wiremock.SPLUNKMETA_namespace=${%dev.SPLUNKMETA_namespace}
+%wiremock.SPLUNK_HEC_INCLUDE_EX=${%dev.SPLUNK_HEC_INCLUDE_EX}
+%wiremock.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=${%dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION}
+%wiremock.CORS_ORIGINS=${%dev.CORS_ORIGINS}
+%wiremock.PROM_URL=http://localhost:9090/api/v1
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}


### PR DESCRIPTION
Jira issue: SWATCH-3628

## Description
This card focuses on enabling local testing for the swatch metrics using the Wiremock profile.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1259

### Steps
1. podman compose up -d
2. make run-migrations
3. make build swatch-metrics

### Verification

Run all the tests within the file test_mock_event_via_prometheus.py
