### PR TITLE
chore: Remove unused dev properties of swatch-metrics-hbi

### DIFF
--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -29,9 +29,6 @@ HBI_HOST_EVENT_TOPIC=platform.inventory.events
 %dev.SPLUNK_HEC_INCLUDE_EX=true
 %dev.SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
-%dev.quarkus.log.file.enable=true
-%dev.quarkus.log.file.path=/tmp/swatch-metrics-hbi-application.log
-%dev.quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) %s%e%n
 
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR proposes to remove unused dev properties os swatch-metrics-hbi service. The log file set is not used and the service is the only one configuring it. It is confusing.
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
The log file is created in `tmp` and it's not used. Regular log are not affected.
