### PR TITLE
SWATCH-3631: Create required topic in local Kafka instance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.inventory.host-ingress
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.inventory.events
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.notifications.ingress
+        bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.rhsm-subscriptions.service-instance-ingress
       "
     depends_on:
       kafka:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: [SWATCH-3631](https://issues.redhat.com/browse/SWATCH-3631)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
This PR proposes to add a command for creating a new topic during Kafka local instance startup.
This is done inside `docker-compose.yml` used for local testing.
It is necessary because the topic in question, contrary to what happens in ephemeral environment, is not created by default.
With this change we can locally run tests that require `SwatchMetricsHbiTestHelper` (helper that connects to the queue).

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Pull changes
2. Add the following code to `iqe-rhsm-subscriptions-plugin/iqe_rhsm_subscriptions/tests/component/swatch_metrics_hbi/test_hbi_delete_events.py`
 ```
@pytest.mark.ephemeral
@pytest.mark.ephemeral_only
    def test_hbi_kafka(helpers):
    assert True
```
3. Set up IQE for local testing
4. Start the cluster with `podman compose up -d`

### Steps
<!-- Enter each step of the test below -->
1. Run the dummy test with:
`iqe tests plugin rhsm_subscriptions -k test_hbi_kafka`

#### To assess the fix run the same test without pulling the changes in this PR.
