### PR TITLE
Adjust how the Makefile activates Spring profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SHELL=/bin/bash
 #
 # Add the wiremock profile automatically
 override PROFILES+=wiremock
+QUARKUS_PARENT_PROFILE?=dev
 
 # See section 8.1 of the make manual
 comma:=,
@@ -29,17 +30,37 @@ endef
 
 # $1 is the directory with the application to start.
 # $2 is the port number to start on.  The management port will be $2 + 1000
+# The QUARKUS_CONFIG_PROFILE_PARENT setting is a little different from the
+# SPRING_PROFILES_INCLUDE option that we use in the SPRING_PROXY define.
+# QUARKUS_CONFIG_PROFILE_PARENT sets a fallback profile that will be consulted if
+# the profiles set in QUARKUS_PROFILE do not have a property.  The quarkus:dev
+# command is meant to use the dev profile by default, so it seems appropriate
+# to set it as a fallback (and sparing users the annoyance of constantly adding
+# PROFILES=dev to their make commands) while still providing some flexibility
+# for additional profile manipulations.  If a dev absolutely doesn't want the dev
+# profile loaded, they can unset the parent like so
+# make swatch-metrics-hbi QUARKUS_PARENT_PROFILE=
+# See https://quarkus.io/guides/config-reference#profiles
 define QUARKUS_PROXY
     $(call BUILD,$(1))
 	QUARKUS_HTTP_PORT=$(2) QUARKUS_MANAGEMENT_PORT=$(shell echo $$((1000 + $(2)))) \
 	QUARKUS_HTTP_HOST=0.0.0.0 QUARKUS_PROFILE=$(subst $(space),$(comma),$(PROFILES)) \
+	QUARKUS_CONFIG_PROFILE_PARENT=$(QUARKUS_PARENT_PROFILE) \
 	./mvnw -pl $(1) quarkus:dev
 endef
 
+# Take note that we're using SPRING_PROFILES_INCLUDE rather that
+# SPRING_PROFILES_ACTIVE The INCLUDE directive will take the specified profiles
+# and add them to the list of profiles in use.  In other words, it is additive
+# to other methods of giving profiles such as through definitions in
+# applications.properties.  The ACTIVE directive defines the totality of
+# profiles that will be in use.  Our Spring profile organization is so complex
+# that I don't want to force developers to have to remember the full listing
+# of profiles they want to use.
 define SPRING_PROXY
     $(call BUILD,$(1))
 	SERVER_PORT=$(2) MANAGEMENT_SERVER_PORT=$(shell echo $$((1000 + $(2)))) \
-	SPRING_PROFILES_ACTIVE=$(subst $(space),$(comma),$(PROFILES)) \
+	SPRING_PROFILES_INCLUDE=$(subst $(space),$(comma),$(PROFILES)) \
 	./mvnw -pl $(1) spring-boot:run
 endef
 


### PR DESCRIPTION
Jira issue: none

## Description
Rather than force developers to remember the complete list of profiles they wish to use during Spring application deployments, just add the "wiremock" profile to the list.  See [docs](https://docs.spring.io/spring-boot/reference/features/profiles.html#features.profiles.adding-active-profiles) for more information.

## Testing

### Steps
1. `make swatch-tally`

### Verification
1. Check the logs.  You'll see all the normal profiles listed in the startup messages along with `wiremock`.