### PR TITLE
SWATCH-3774: Bump prometheus image to use internal /import API

### DIFF
--- a/config/prometheus/docker-compose.yml
+++ b/config/prometheus/docker-compose.yml
@@ -2,7 +2,10 @@
 version: '3.8'
 services:
   prometheus:
-    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/prometheus:eac5c45
+    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/prometheus:d426e7d
     container_name: prometheus
     ports:
       - "127.0.0.1:9090:8000"
+      - "127.0.0.1:9091:9000"
+    volumes:
+      - /tmp/prometheus-data:/var/lib/prometheus:Z


### PR DESCRIPTION
Jira issue: SWATCH-3774

## Description
Created new API to import prometheus files in https://github.com/RedHatInsights/prometheus-consoledot/pull/12

These changes use this API to connect with Prometheus. So, now, local and ephemeral environments will use the same logic.


## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1260

### Steps
1. podman compose up -d
2. make run-migrations
3. make build swatch-metrics

### Verification

Run all the tests within the file test_mock_event_via_prometheus.py