### PR TITLE
SWATCH-3754: Update default ports on Quarkus and Spring services

### DIFF
--- a/src/main/resources/application-wiremock.yaml
+++ b/src/main/resources/application-wiremock.yaml
@@ -1,4 +1,4 @@
 # This profile needs to be activated as long as other profiles in the last order
 # For example: SPRING_PROFILES_ACTIVE=worker,api,kafka-queue,wiremock
-SERVER_PORT: 8005
-METRICS_SERVER_PORT: 9005
+SERVER_PORT: 8010
+METRICS_SERVER_PORT: 9010

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -32,6 +32,8 @@ KAFKA_BILLABLE_USAGE_PARTITIONS=1
 %ephemeral.KSTREAM_BILLABLE_USAGE_AGGREGATION_GRACE_DURATION=0s
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8012
+%dev.QUARKUS_MANAGEMENT_PORT=9012
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
@@ -43,8 +45,8 @@ KAFKA_BILLABLE_USAGE_PARTITIONS=1
 %dev.CORS_ORIGINS=/.*/
 
 #dev wiremock specific profile defaults; these can still be overridden by env var
-%wiremock.SERVER_PORT=8002
-%wiremock.QUARKUS_MANAGEMENT_PORT=9002
+%wiremock.SERVER_PORT=${%dev.SERVER_PORT}
+%wiremock.QUARKUS_MANAGEMENT_PORT=${%dev.QUARKUS_MANAGEMENT_PORT}
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -27,6 +27,8 @@ SPLUNK_HEC_RETRY_COUNT=3
 SPLUNK_HEC_INCLUDE_EX=false
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8011
+%dev.QUARKUS_MANAGEMENT_PORT=9011
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
@@ -39,8 +41,8 @@ SPLUNK_HEC_INCLUDE_EX=false
 
 
 #dev wiremock specific profile defaults; these can still be overridden by env var
-%wiremock.SERVER_PORT=8001
-%wiremock.QUARKUS_MANAGEMENT_PORT=9001
+%wiremock.SERVER_PORT=${%dev.SERVER_PORT}
+%wiremock.QUARKUS_MANAGEMENT_PORT=${%dev.QUARKUS_MANAGEMENT_PORT}
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -20,6 +20,8 @@ SERVICE_INSTANCE_INGRESS_TOPIC=platform.rhsm-subscriptions.service-instance-ingr
 HBI_HOST_EVENT_TOPIC=platform.inventory.events
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8015
+%dev.QUARKUS_MANAGEMENT_PORT=9015
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false

--- a/swatch-metrics/src/main/resources/application.properties
+++ b/swatch-metrics/src/main/resources/application.properties
@@ -19,6 +19,8 @@ METERING_TASK_TOPIC=platform.rhsm-subscriptions.metering-tasks
 SERVICE_INSTANCE_INGRESS_TOPIC=platform.rhsm-subscriptions.service-instance-ingress
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8016
+%dev.QUARKUS_MANAGEMENT_PORT=9016
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
@@ -30,8 +32,8 @@ SERVICE_INSTANCE_INGRESS_TOPIC=platform.rhsm-subscriptions.service-instance-ingr
 %dev.CORS_ORIGINS=/.*/
 
 #dev wiremock specific profile defaults; these can still be overridden by env var
-%wiremock.SERVER_PORT=8016
-%wiremock.QUARKUS_MANAGEMENT_PORT=9016
+%wiremock.SERVER_PORT=${%dev.SERVER_PORT}
+%wiremock.QUARKUS_MANAGEMENT_PORT=${%dev.QUARKUS_MANAGEMENT_PORT}
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -32,8 +32,8 @@ DISABLE_OTEL=true
 %ephemeral.AWS_MARKETPLACE_ENDPOINT_URL=${WIREMOCK_ENDPOINT}/mock/aws
 
 # wiremock specifics
-%wiremock.SERVER_PORT=8003
-%wiremock.QUARKUS_MANAGEMENT_PORT=9003
+%wiremock.SERVER_PORT=${%dev.SERVER_PORT}
+%wiremock.QUARKUS_MANAGEMENT_PORT=${%dev.QUARKUS_MANAGEMENT_PORT}
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
@@ -51,6 +51,8 @@ DISABLE_OTEL=true
 %wiremock.SWATCH_CONTRACTS_ENDPOINT=${WIREMOCK_ENDPOINT}/mock/contractApi
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8013
+%dev.QUARKUS_MANAGEMENT_PORT=9013
 %dev,wiremock.SWATCH_SELF_PSK=placeholder
 %dev,wiremock.ENABLE_SPLUNK_HEC=false
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -37,6 +37,8 @@ AZURE_MARKETPLACE_API_VERSION=2018-08-31
 AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 
 # dev-specific defaults; these can still be overridden by env var
+%dev.SERVER_PORT=8014
+%dev.QUARKUS_MANAGEMENT_PORT=9014
 %dev.LOGGING_LEVEL_COM_REDHAT_SWATCH=DEBUG
 %dev.SWATCH_SELF_PSK=placeholder
 %dev.ENABLE_SPLUNK_HEC=false
@@ -49,8 +51,8 @@ AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 %dev.CORS_ORIGINS=/.*/
 
 #dev wiremock specific profile defaults; these can still be overridden by env var
-%wiremock.SERVER_PORT=8004
-%wiremock.QUARKUS_MANAGEMENT_PORT=9004
+%wiremock.SERVER_PORT=${%dev.SERVER_PORT}
+%wiremock.QUARKUS_MANAGEMENT_PORT=${%dev.QUARKUS_MANAGEMENT_PORT}
 %wiremock.quarkus.management.enabled=false
 %wiremock.LOGGING_LEVEL_COM_REDHAT_SWATCH=${%dev.LOGGING_LEVEL_COM_REDHAT_SWATCH}
 %wiremock.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3754

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

By default, the Quarks services use 8000 on a local instance. The Nginx service uses that port when the Podman containers are started, which leads to a conflict. This would start the services on unique ports by default.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. Start the containers
 ```podman -compose up -d```
2. Run the liqubase update
```./mvnw -f swatch-database/pom.xml exec:java```

### Steps
<!-- Enter each step of the test below -->
1. Start any of the Quarkus services, e.g.
``` ./mvnw -pl swatch-contracts quarkus:dev```
4. Run against the URL with the expected port
```http GET :8011/api/swatch-contracts/internal/offerings/MCT2342/product_tags```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. You will get the correct response on the port
```
HTTP/1.1 404 Not Found
Content-Type: application/json
content-length: 83
traceresponse: 00-00000000000000000000000000000000-0000000000000000-00

{
    "code": "CONTRACTS3003",
    "status": "404",
    "title": "Sku MCT2342 not found in Offering"
}
```

