### PR TITLE
SWATCH-3596: Remove any grafana dashboards related to monitoring for swatch-producer-red-hat-marketplace

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": 1026048,
+      "id": 1026286,
       "links": [],
       "panels": [
         {
@@ -300,7 +300,7 @@ data:
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 17
+                "y": 44
               },
               "id": 113,
               "options": {
@@ -400,7 +400,7 @@ data:
                 "h": 7,
                 "w": 6,
                 "x": 6,
-                "y": 17
+                "y": 44
               },
               "id": 115,
               "options": {
@@ -510,7 +510,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 0,
-                "y": 149
+                "y": 176
               },
               "id": 103,
               "options": {
@@ -608,7 +608,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 6,
-                "y": 149
+                "y": 176
               },
               "id": 76,
               "options": {
@@ -705,7 +705,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 12,
-                "y": 149
+                "y": 176
               },
               "id": 101,
               "options": {
@@ -815,7 +815,7 @@ data:
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 258
+                "y": 285
               },
               "id": 88,
               "options": {
@@ -922,7 +922,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 0,
-                "y": 259
+                "y": 286
               },
               "id": 47,
               "options": {
@@ -1059,7 +1059,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 6,
-                "y": 259
+                "y": 286
               },
               "id": 52,
               "options": {
@@ -1193,7 +1193,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 12,
-                "y": 259
+                "y": 286
               },
               "id": 54,
               "options": {
@@ -1374,7 +1374,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 18,
-                "y": 259
+                "y": 286
               },
               "id": 56,
               "options": {
@@ -1507,7 +1507,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 0,
-                "y": 268
+                "y": 295
               },
               "id": 92,
               "options": {
@@ -1610,7 +1610,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 0,
-                "y": 246
+                "y": 273
               },
               "id": 72,
               "options": {
@@ -1712,7 +1712,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 6,
-                "y": 246
+                "y": 273
               },
               "id": 40,
               "options": {
@@ -1842,7 +1842,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 12,
-                "y": 246
+                "y": 273
               },
               "id": 59,
               "options": {
@@ -1935,7 +1935,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 18,
-                "y": 246
+                "y": 273
               },
               "id": 4,
               "options": {
@@ -2028,7 +2028,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 0,
-                "y": 256
+                "y": 283
               },
               "id": 41,
               "options": {
@@ -2156,7 +2156,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 6,
-                "y": 256
+                "y": 283
               },
               "id": 8,
               "options": {
@@ -2248,7 +2248,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 12,
-                "y": 256
+                "y": 283
               },
               "id": 10,
               "options": {
@@ -2342,7 +2342,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 18,
-                "y": 256
+                "y": 283
               },
               "id": 96,
               "options": {
@@ -2455,7 +2455,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 0,
-                "y": 247
+                "y": 274
               },
               "id": 63,
               "options": {
@@ -2584,7 +2584,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 6,
-                "y": 247
+                "y": 274
               },
               "id": 64,
               "options": {
@@ -2712,7 +2712,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 12,
-                "y": 247
+                "y": 274
               },
               "id": 66,
               "options": {
@@ -2810,7 +2810,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 18,
-                "y": 247
+                "y": 274
               },
               "id": 68,
               "options": {
@@ -2903,7 +2903,7 @@ data:
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 255
+                "y": 282
               },
               "id": 94,
               "options": {
@@ -3320,7 +3320,7 @@ data:
                 "h": 11,
                 "w": 6,
                 "x": 0,
-                "y": 25
+                "y": 52
               },
               "id": 35,
               "options": {
@@ -3414,7 +3414,7 @@ data:
                 "h": 11,
                 "w": 6,
                 "x": 6,
-                "y": 25
+                "y": 52
               },
               "id": 36,
               "options": {
@@ -3510,7 +3510,7 @@ data:
                 "h": 11,
                 "w": 6,
                 "x": 12,
-                "y": 25
+                "y": 52
               },
               "id": 95,
               "options": {
@@ -3893,7 +3893,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 0,
-                "y": 18
+                "y": 45
               },
               "id": 20,
               "options": {
@@ -4000,7 +4000,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 6,
-                "y": 18
+                "y": 45
               },
               "id": 89,
               "options": {
@@ -4103,7 +4103,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 12,
-                "y": 18
+                "y": 45
               },
               "id": 90,
               "options": {
@@ -4200,7 +4200,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 0,
-                "y": 27
+                "y": 54
               },
               "id": 97,
               "options": {
@@ -4302,7 +4302,7 @@ data:
                 "h": 10,
                 "w": 6,
                 "x": 6,
-                "y": 27
+                "y": 54
               },
               "id": 118,
               "options": {
@@ -4369,7 +4369,7 @@ data:
                 "h": 10,
                 "w": 18,
                 "x": 0,
-                "y": 37
+                "y": 64
               },
               "id": 121,
               "options": {
@@ -4442,7 +4442,7 @@ data:
                 "h": 10,
                 "w": 18,
                 "x": 0,
-                "y": 47
+                "y": 74
               },
               "id": 122,
               "options": {
@@ -4564,7 +4564,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 0,
-                "y": 241
+                "y": 10
               },
               "id": 83,
               "options": {
@@ -4666,7 +4666,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 6,
-                "y": 241
+                "y": 10
               },
               "id": 120,
               "options": {
@@ -4739,6 +4739,103 @@ data:
                     "spanNulls": false,
                     "stacking": {
                       "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 6,
+                "x": 12,
+                "y": 10
+              },
+              "id": 107,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(kafka_consumergroup_group_lag{topic=~\".*platform.rhsm-subscriptions.billable-usage.status\"}) by (group, partition)",
+                  "legendFormat": "partition {{ partition }}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Billable Usage Status Task Lag",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
                       "mode": "none"
                     },
                     "thresholdsStyle": {
@@ -4768,7 +4865,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 18,
-                "y": 241
+                "y": 10
               },
               "id": 98,
               "options": {
@@ -4869,7 +4966,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 0,
-                "y": 250
+                "y": 19
               },
               "id": 78,
               "options": {
@@ -4966,7 +5063,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 6,
-                "y": 250
+                "y": 19
               },
               "id": 80,
               "options": {
@@ -5009,320 +5106,6 @@ data:
               },
               "fieldConfig": {
                 "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "normal"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 6,
-                "x": 12,
-                "y": 250
-              },
-              "id": 107,
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "11.6.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(kafka_consumergroup_group_lag{topic=~\".*platform.rhsm-subscriptions.billable-usage.status\"}) by (group, partition)",
-                  "legendFormat": "partition {{ partition }}",
-                  "range": true,
-                  "refId": "A"
-                }
-              ],
-              "title": "Billable Usage Status Task Lag",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "uid": "${datasource}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "options": {
-                        "match": "null",
-                        "result": {
-                          "text": "N/A"
-                        }
-                      },
-                      "type": "special"
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "rejected"
-                    },
-                    "properties": [
-                      {
-                        "id": "thresholds",
-                        "value": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 1
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 6,
-                "x": 0,
-                "y": 259
-              },
-              "id": 82,
-              "maxDataPoints": 100,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "mean"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "11.6.3",
-              "targets": [
-                {
-                  "expr": "sum(increase(rhsm_subscriptions_rh_marketplace_batch_accepted_total[$__range]))",
-                  "format": "time_series",
-                  "instant": true,
-                  "interval": "",
-                  "intervalFactor": 1,
-                  "legendFormat": "accepted",
-                  "refId": "A"
-                },
-                {
-                  "expr": "sum(increase(rhsm_subscriptions_rh_marketplace_batch_rejected_total[$__range]))",
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "rejected",
-                  "refId": "B"
-                },
-                {
-                  "expr": "sum(increase(rhsm_subscriptions_rh_marketplace_batch_unverified_total[$__range]))",
-                  "interval": "",
-                  "legendFormat": "unverified",
-                  "refId": "C"
-                }
-              ],
-              "title": "Red Hat Marketplace Batch Stats",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "mappings": [
-                    {
-                      "options": {
-                        "match": "null",
-                        "result": {
-                          "text": "N/A"
-                        }
-                      },
-                      "type": "special"
-                    }
-                  ],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "rejected"
-                    },
-                    "properties": [
-                      {
-                        "id": "thresholds",
-                        "value": {
-                          "mode": "absolute",
-                          "steps": [
-                            {
-                              "color": "green"
-                            },
-                            {
-                              "color": "red",
-                              "value": 1
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 6,
-                "x": 6,
-                "y": 259
-              },
-              "id": 99,
-              "maxDataPoints": 100,
-              "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "horizontal",
-                "percentChangeColorMode": "standard",
-                "reduceOptions": {
-                  "calcs": [
-                    "mean"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showPercentChange": false,
-                "textMode": "auto",
-                "wideLayout": true
-              },
-              "pluginVersion": "11.6.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(swatch_aws_marketplace_batch_accepted_total[$__range]))",
-                  "format": "time_series",
-                  "instant": true,
-                  "interval": "",
-                  "intervalFactor": 1,
-                  "legendFormat": "accepted",
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(swatch_aws_marketplace_batch_rejected_total[$__range]))",
-                  "instant": true,
-                  "interval": "",
-                  "legendFormat": "rejected",
-                  "refId": "B"
-                }
-              ],
-              "title": "AWS Marketplace Batch Stats",
-              "type": "stat"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${datasource}"
-              },
-              "fieldConfig": {
-                "defaults": {
                   "mappings": [
                     {
                       "options": {
@@ -5374,7 +5157,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 12,
-                "y": 259
+                "y": 19
               },
               "id": 119,
               "maxDataPoints": 100,
@@ -5440,9 +5223,120 @@ data:
               ],
               "title": "Azure Marketplace Batch Stats",
               "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "N/A"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "rejected"
+                    },
+                    "properties": [
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green"
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 6,
+                "x": 18,
+                "y": 19
+              },
+              "id": 99,
+              "maxDataPoints": 100,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(increase(swatch_aws_marketplace_batch_accepted_total[$__range]))",
+                  "format": "time_series",
+                  "instant": true,
+                  "interval": "",
+                  "intervalFactor": 1,
+                  "legendFormat": "accepted",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(increase(swatch_aws_marketplace_batch_rejected_total[$__range]))",
+                  "instant": true,
+                  "interval": "",
+                  "legendFormat": "rejected",
+                  "refId": "B"
+                }
+              ],
+              "title": "AWS Marketplace Batch Stats",
+              "type": "stat"
             }
           ],
-          "title": "Billing Provider Integration (swatch-producer-{aws})",
+          "title": "Billing Provider Integration (swatch-producer-{aws,azure})",
           "type": "row"
         }
       ],


### PR DESCRIPTION
Jira issue: SWATCH-3596

## Description
Changes:
- Delete Red Hat Marketplace Batch Stats
- Rename "Billing Provider Integration (swatch-producer- {aws} )" to "Billing Provider Integration (swatch-producer-{aws, azure})"
- Re-Order dashboards under the same panel

## Testing
To extract the JSON from the k8s configmap file:

```
oc extract -f .rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml --confirm
```

Once you extract it from the .yaml that's checked into this repo, you can import it into the stage instance of grafana by going to `Dashboards -> +Import` from the left nav.