### PR TITLE
SWATCH-3802: PK on swatch-metrics-hbi Liquibase table

### DIFF
--- a/swatch-metrics-hbi/src/main/resources/db/202507231327_primary_key_on_changelog_table.xml
+++ b/swatch-metrics-hbi/src/main/resources/db/202507231327_primary_key_on_changelog_table.xml
@@ -1,0 +1,46 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <!--
+  These changeSets are only for PostgreSQL because the primary keys we're adding are just to satisfy
+  PostgreSQL's requirements for logical replication.  See
+  https://www.postgresql.org/docs/16/logical-replication-publication.html
+
+  Consequently, these keys aren't mapped in JPA so we don't need to worry about them during
+  in-memory DB tests.
+  -->
+  <changeSet id="202507231327-01" author="awood" dbms="postgresql">
+    <!--
+    Creating an extension requires superuser permissions.  But in some environments, we don't
+    have those permissions.  We have to create the extension in an out-of-band migration.
+
+    The creation command checks permissions before it checks the extensions existence, so even an
+    invocation that would have no effect will cause the changeset to fail.  Accordingly, we have to
+    have a pre-condition to check if we should even attempt to create the extension.  That way we
+    can use the same changeset everywhere.
+    -->
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT count(1) FROM pg_extension WHERE extname = 'uuid-ossp';
+      </sqlCheck>
+    </preConditions>
+    <sql>
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    </sql>
+    <!--
+    I am intentionally not providing a rollback because we have multiple change logs.  Rolling back
+    the extension in one changelog could adversely affect the operations of the other changelog.
+    -->
+  </changeSet>
+
+  <changeSet id="202507231327-02" author="awood" dbms="postgresql">
+    <addColumn tableName="databasechangelog_swatch_metrics_hbi">
+      <column name="uuid" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-metrics-hbi/src/main/resources/db/changelog.xml
+++ b/swatch-metrics-hbi/src/main/resources/db/changelog.xml
@@ -7,5 +7,5 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <include file="/db/202411041305_create_hypervisor_relations_tables.xml"/>
-
+  <include file="db/202507231327_primary_key_on_changelog_table.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Jira issue: SWATCH-3802

## Description
Postgresql logical replication documentation recommends that tables that
are to be replicated have a primary key.  Since we use logical
replication to do our blue-green deployments, we should add a primary
key to the Liquibase table.

## Testing

### Setup
1. Run `./mvnw -pl swatch-metrics-hbi quarkus:dev` on `main` to run the current
  migrations

### Steps
<!-- Enter each step of the test below -->
1. Run `./mvnw -pl swatch-metrics-hbi quarkus:dev` on this branch to create the
   PK.

### Verification
1 `psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "\d
databasechangelog_swatch_metrics_hbi"`
1. Verify the PK is there.
