### PR TITLE
SWATCH-3691: Fix mapping rules in nginx for local testing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,8 +9,29 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # Create an alias for swatch-tally to /api/rhsm-subscriptions
-        # since that's the name used in openshift deployments
+        # Swatch Contracts mappings
+        location /api/rhsm-subscriptions/v1/subscriptions/billing_account_ids {
+            rewrite ^/api/rhsm-subscriptions/v1/subscriptions/billing_account_ids$ /api/swatch-contracts/v1/subscriptions/billing_account_ids break;
+            proxy_pass http://host.containers.internal:8011;
+        }
+
+        location /api/rhsm-subscriptions/v1/subscriptions/products {
+            proxy_pass http://host.containers.internal:8011;
+        }
+
+        location /api/rhsm-subscriptions/v2/subscriptions/products {
+            proxy_pass http://host.containers.internal:8011;
+        }
+
+        location /api/rhsm-subscriptions/v1/capacity/products {
+            proxy_pass http://host.containers.internal:8011;
+        }
+
+        location /api/swatch-contracts/ {
+            proxy_pass http://host.containers.internal:8011;
+        }
+
+        # Swatch Tally/API mappings
         location /api/rhsm-subscriptions/ {
             proxy_pass http://host.containers.internal:8010;
         }
@@ -19,26 +40,27 @@ http {
             proxy_pass http://host.containers.internal:8010;
         }
 
-        location /api/swatch-contracts/ {
-            proxy_pass http://host.containers.internal:8011;
-        }
-
+        # Swatch Billable Usage mappings
         location /api/swatch-billable-usage/ {
             proxy_pass http://host.containers.internal:8012;
         }
 
+        # Swatch Producer AWS mappings
         location /api/swatch-producer-aws/ {
             proxy_pass http://host.containers.internal:8013;
         }
 
+        # Swatch Producer Azure mappings
         location /api/swatch-producer-azure/ {
             proxy_pass http://host.containers.internal:8014;
         }
 
+        # Swatch Metrics HBI mappings
         location /api/swatch-metrics-hbi/ {
             proxy_pass http://host.containers.internal:8015;
         }
 
+        # Swatch Metrics mappings
         location /api/swatch-metrics/ {
             proxy_pass http://host.containers.internal:8016;
         }


### PR DESCRIPTION
Jira issue: SWATCH-3691

## Description
The new nginx configuration replicates what the SWATCH API (nginx service) does in production.


## Testing
1.- podman compose up -d
2.- make run-migrations
3.- make swatch-contracts

Then, run the tests:
- test_subscription_table_api_subscription_type_contracts
- test_subscription_table_api_subscription_type_contracts_v2

Both should work fine using the changes from this branch. In main, both failed.