### PR TITLE
SWATCH-3597: Restrict billing providers for /internal/rpc/tally/event…

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -236,6 +236,7 @@ public class InternalTallyResource implements InternalTallyApi {
       try {
         List<Event> events = objectMapper.readValue(jsonListOfEvents, new TypeReference<>() {});
         events.stream()
+            .filter(this::isBillingProviderAllowed)
             .forEach(
                 event -> {
                   try {
@@ -332,6 +333,30 @@ public class InternalTallyResource implements InternalTallyApi {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Validates that the billing provider is allowed for the /internal/rpc/tally/events endpoint.
+   * Only AWS and Azure are currently supported.
+   *
+   * @param event the event to validate
+   * @return true if the billing provider is allowed, false otherwise
+   */
+  private boolean isBillingProviderAllowed(Event event) {
+    if (event.getBillingProvider() == null) {
+      return true; // Allow null billing providers
+    }
+
+    String billingProvider = event.getBillingProvider().value();
+    boolean isAllowed = "aws".equals(billingProvider) || "azure".equals(billingProvider);
+
+    if (!isAllowed) {
+      log.warn(
+          "Billing provider '{}' is not supported for /internal/rpc/tally/events endpoint. Event will be filtered out.",
+          billingProvider);
+    }
+
+    return isAllowed;
   }
 
   @NotNull

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -132,6 +133,18 @@ class InternalTallyResourceTest {
             + "  \"billing_account_id\": \"381492115198\""
             + " }]");
     verify(kafkaTemplate, times(1)).send(eq(taskQueueProperties.getTopic()), any(Event.class));
+  }
+
+  @Test
+  void testSaveEventsShouldOnlyAcceptAwsOrAzure() {
+    when(properties.isDevMode()).thenReturn(true);
+    resource.saveEvents(
+        "[{"
+            + "  \"sla\": \"Premium\","
+            + "  \"service_type\": \"rosa Instance\","
+            + "  \"billing_provider\": \"gcp\""
+            + " }]");
+    verifyNoInteractions(kafkaTemplate);
   }
 
   @Test


### PR DESCRIPTION
…s endpoint

- Add validation to filter out unsupported billing providers in REST endpoint
- Only allow 'aws' and 'azure' billing providers for /internal/rpc/tally/events
- Events with 'red hat', 'oracle', or 'gcp' billing providers will be filtered out
- Existing database records are unaffected (no database changes required)
- Logs warning when unsupported billing providers are encountered

This change specifically targets the /internal/rpc/tally/events REST endpoint and does not modify the core BillingProvider enum or other parts of the system.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3597
