### PR TITLE
Use fixed version for the moto component

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -222,7 +222,7 @@ objects:
       spec:
         containers:
           - name: moto
-            image: 'motoserver/moto:latest'
+            image: 'motoserver/moto:5.1.8'
             env:
               - name: MOTO_PORT
                 value: '5000'


### PR DESCRIPTION

## Description
The 5.1.9 release (latest) includes some breaking changes in the API that makes our tests to fail: https://github.com/getmoto/moto/blob/master/CHANGELOG.md#519

## Testing
CI is passing.