### PR TITLE
SWATCH-3777: Define and generate an internal REST API for the swatch-metrics-hbi outbox records.

### DIFF
--- a/swatch-metrics-hbi/pom.xml
+++ b/swatch-metrics-hbi/pom.xml
@@ -36,6 +36,14 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jackson</artifactId>
     </dependency>
     <dependency>
@@ -145,6 +153,51 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.openapitools</groupId>
+        <artifactId>openapi-generator-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${project.basedir}/src/main/resources/META-INF/openapi.yaml</inputSpec>
+              <generatorName>java</generatorName>
+              <modelPackage>com.redhat.swatch.hbi.model</modelPackage>
+              <apiPackage>com.redhat.swatch.hbi.api</apiPackage>
+              <invokerPackage>com.redhat.swatch.hbi</invokerPackage>
+              <groupId>com.redhat.swatch.hbi</groupId>
+              <output>${project.build.directory}/generated-sources</output>
+              <generateApiTests>false</generateApiTests>
+              <generateModelTests>false</generateModelTests>
+              <configOptions>
+                <interfaceOnly>true</interfaceOnly>
+                <library>microprofile</library>
+                <java8>true</java8>
+                <dateLibrary>java8</dateLibrary>
+                <serializationLibrary>jackson</serializationLibrary>
+                <useBeanValidation>true</useBeanValidation>
+                <microprofileRestClientVersion>3.0</microprofileRestClientVersion>
+                <useJakartaEE>true</useJakartaEE>
+              </configOptions>
+              <additionalProperties>
+                <!--
+                see https://github.com/OpenAPITools/openapi-generator/pull/4713#issuecomment-633906581
+                microprofile doesn't support the standard useJakartaEE=true
+                -->
+                <additionalProperty>disableMultipart=true</additionalProperty>
+              </additionalProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/resources/InternalResource.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/resources/InternalResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.resources;
+
+import com.redhat.swatch.hbi.api.DefaultApi;
+import com.redhat.swatch.hbi.model.FlushResponse;
+import com.redhat.swatch.hbi.model.OutboxRecord;
+import com.redhat.swatch.hbi.model.OutboxRecordRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationScoped
+public class InternalResource implements DefaultApi {
+
+  @Override
+  public List<OutboxRecord> fetchAllOutboxRecords() {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public List<OutboxRecord> fetchOutboxRecordsByOrgId(String orgId) {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public OutboxRecord createOutboxRecord(OutboxRecordRequest outboxRecordRequest) {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public OutboxRecord updateOutboxRecord(OutboxRecord outboxRecord) {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public void deleteOutboxRecord(UUID uuid) {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public FlushResponse flushOutbox(Boolean async) {
+    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  }
+}

--- a/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
@@ -1,0 +1,183 @@
+---
+openapi: "3.0.2"
+info:
+  title: Swatch Metrics HBI Internal API
+  version: 1.0.0
+  description: Internal API for Swatch Metrics HBI service outbox operations
+
+paths:
+  /api/swatch-metrics-hbi/internal/outbox:
+    get:
+      operationId: fetchAllOutboxRecords
+      summary: "Fetch all outbox records"
+      description: "Retrieve all outbox records from the system"
+      responses:
+        '200':
+          description: "Successfully retrieved all outbox records"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OutboxRecord'
+    post:
+      operationId: createOutboxRecord
+      summary: "Create a new outbox record"
+      description: "Create a new outbox record in the system"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OutboxRecordRequest'
+      responses:
+        '201':
+          description: "Outbox record created successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutboxRecord'
+        '400':
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/BadRequest"
+    put:
+      operationId: updateOutboxRecord
+      summary: "Update an existing outbox record"
+      description: "Update an existing outbox record in the system"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OutboxRecord'
+      responses:
+        '200':
+          description: "Outbox record updated successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OutboxRecord'
+        '400':
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/BadRequest"
+        '404':
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+
+  /api/swatch-metrics-hbi/internal/outbox/{org_id}:
+    get:
+      operationId: fetchOutboxRecordsByOrgId
+      summary: "Fetch outbox records by organization ID"
+      description: "Retrieve all outbox records for the specified organization ID"
+      parameters:
+        - name: org_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "The organization ID to filter outbox records"
+      responses:
+        '200':
+          description: "Successfully retrieved outbox records for the organization"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OutboxRecord'
+        '400':
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/BadRequest"
+
+  /api/swatch-metrics-hbi/internal/outbox/{uuid}:
+    delete:
+      operationId: deleteOutboxRecord
+      summary: "Delete an outbox record"
+      description: "Delete an existing outbox record by UUID"
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: "The UUID of the outbox record to delete"
+      responses:
+        '204':
+          description: "Outbox record deleted successfully"
+        '404':
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/ResourceNotFound"
+
+  /api/swatch-metrics-hbi/internal/rpc/outbox/flush:
+    put:
+      operationId: flushOutbox
+      summary: "Trigger outbox flush logic"
+      description: "Trigger the outbox-flush logic either asynchronously or synchronously based on query parameter"
+      parameters:
+        - name: async
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+          description: "Whether to execute the flush asynchronously (default: true) or synchronously (false)"
+      responses:
+        '200':
+          description: "Outbox flush completed successfully"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlushResponse'
+        '202':
+          description: "Outbox flush initiated asynchronously"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlushResponse'
+
+components:
+  schemas:
+    OutboxRecord:
+      type: object
+      required:
+        - uuid
+        - org_id
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: "Unique identifier for the outbox record"
+          example: "123e4567-e89b-12d3-a456-426614174000"
+        org_id:
+          type: string
+          description: "Organization ID associated with the record"
+          example: "org123"
+
+    OutboxRecordRequest:
+      type: object
+      required:
+        - org_id
+      properties:
+        org_id:
+          type: string
+          description: "Organization ID associated with the record"
+          example: "org123"
+
+    FlushResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          description: "Status of the flush operation"
+          example: "SUCCESS"
+
+  securitySchemes:
+    PskIdentity:
+      type: apiKey
+      in: header
+      name: x-rh-swatch-psk
+      description: |
+        Psk header containing Pre Shared Key. Contains an
+        UUID string:
+        ```
+        c9a98753-2092-4617-b226-5c2653330b3d
+        ```
+
+security:
+  - PskIdentity: [] 

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -116,6 +116,14 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://splunk-
 # Metrics and logging are not yet supported - 30 Jul 2024
 quarkus.otel.exporter.otlp.traces.protocol=${OTEL_EXPORTER_OTLP_PROTOCOL:grpc}
 
+# expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
+quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi
+# By default, the openapi and swagger ui endpoints are exposed on the management port, so we need to disable it
+# to expose it on the server port:
+quarkus.smallrye-openapi.management.enabled=false
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
+
 # Disable the service in the test environment so that we can
 # mock the service.
 %test.quarkus.unleash.active=false


### PR DESCRIPTION
Jira issue: SWATCH-3777

## Description
Create an openapi schema that defines the API and generate the interface and DTO during the build process. A stubbed out resource implementation should be created to allow all endpoint implementation cards to be worked on in parallel.

The schema should include the following endpoints:

 
||Endpoint||Description||
|GET /api/swatch-metrics-hbi/internal/outbox|Fetch all outbox records.|
|GET /api/swatch-metrics-hbi/internal/outbox/\{org_id}|Fetch all outbox records for the specified org_id.|
|POST /api/swatch-metrics-hbi/internal/outbox|Create a new outbox record.|
|PUT /api/swatch-metrics-hbi/internal/outbox/|Update an existing outbox record.|
|DELETE /api/swatch-metrics-hbi/internal/outbox/\{uuid}|Delete an existing outbox record|
|PUT /api/swatch-metrics-hbi/internal/rpc/outbox/flush?async=[true\\|false]|Trigger the outbox-flush logic either asynchronously or synchronously based on query parameter (default to async).|

 

*Acceptance Criteria*
 * An openapi.yaml schema file exists and defines the endpoints for the API.
 * The build process generates the API's interfaces and DTO classes.
 * A stub resource implementation is created, returned 501 Not Implemented http code.

## Testing
IQE Test MR: <!-- IQE MR link here -->

### Setup
1. podman compose up -d
2. make build swatch-metrics-hbi

### Verification
1. New API is in: http://localhost:8015/api/swatch-metrics-hbi/internal/swagger-ui/#/
