### PR TITLE
SWATCH-3776: Create an outbox record table, entity, and a repository supporting CRUD operations

### DIFF
--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutbox.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutbox.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.repository;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@EqualsAndHashCode(callSuper = false)
+@Entity
+@Table(name = "hbi_event_outbox")
+@Data
+@NoArgsConstructor
+public class HbiEventOutbox extends PanacheEntityBase {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(name = "id", nullable = false)
+  private UUID id;
+
+  @Column(name = "org_id", nullable = false)
+  private String orgId;
+
+  @Column(name = "created_on", nullable = false)
+  private OffsetDateTime createdOn;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "swatch_event_json", columnDefinition = "jsonb", nullable = false)
+  private String swatchEventJson;
+
+  @PrePersist
+  public void onCreate() {
+    this.createdOn = OffsetDateTime.now(ZoneId.of("UTC"));
+  }
+}

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutboxRepository.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutboxRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.repository;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationScoped
+public class HbiEventOutboxRepository implements PanacheRepositoryBase<HbiEventOutbox, UUID> {
+
+  public List<HbiEventOutbox> findByOrgId(String orgId) {
+    return list("orgId", orgId);
+  }
+
+  public long deleteByOrgId(String orgId) {
+    return delete("orgId", orgId);
+  }
+}

--- a/swatch-metrics-hbi/src/main/resources/db/202508010700_create_outbox_table.xml
+++ b/swatch-metrics-hbi/src/main/resources/db/202508010700_create_outbox_table.xml
@@ -1,0 +1,30 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <property name="json_type" dbms="h2" value="json"/>
+  <property name="json_type" dbms="postgresql" value="jsonb"/>
+
+  <changeSet id="202508010700-01" author="jcarvaja">
+    <createTable tableName="hbi_event_outbox">
+      <column name="id" type="UUID">
+        <constraints nullable="false" primaryKey="true" />
+      </column>
+      <column name="org_id" type="VARCHAR">
+        <constraints nullable="false"/>
+      </column>
+      <column name="created_on" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false"/>
+      </column>
+      <column name="swatch_event_json" type="${json_type}">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createIndex tableName="hbi_event_outbox" indexName="hbi_event_outbox_org_id_idx">
+      <column name="org_id"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog> 

--- a/swatch-metrics-hbi/src/main/resources/db/changelog.xml
+++ b/swatch-metrics-hbi/src/main/resources/db/changelog.xml
@@ -8,4 +8,5 @@
 
   <include file="/db/202411041305_create_hypervisor_relations_tables.xml"/>
   <include file="db/202507231327_primary_key_on_changelog_table.xml"/>
+  <include file="db/202508010700_create_outbox_table.xml"/>
 </databaseChangeLog>

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/repository/HbiEventOutboxRepositoryTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/repository/HbiEventOutboxRepositoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class HbiEventOutboxRepositoryTest {
+
+  @Inject HbiEventOutboxRepository repository;
+
+  @BeforeEach
+  @Transactional
+  public void setUp() {
+    repository.deleteAll();
+  }
+
+  @Test
+  @Transactional
+  void testFindByIdReturnsCorrectResult() {
+    HbiEventOutbox existing = givenExistingHbiEventOutbox();
+    Optional<HbiEventOutbox> found = repository.findByIdOptional(existing.getId());
+    assertTrue(found.isPresent());
+    assertHbiEventOutboxEquals(existing, found.get());
+  }
+
+  @Test
+  @Transactional
+  void testFindByOrgIdReturnsCorrectResults() {
+    givenExistingHbiEventOutbox("org1");
+    List<HbiEventOutbox> foundRecords = repository.findByOrgId("org1");
+    assertEquals(1, foundRecords.size());
+
+    givenExistingHbiEventOutbox("org2");
+    List<HbiEventOutbox> foundRecordsForOrg2 = repository.findByOrgId("org2");
+    assertEquals(1, foundRecordsForOrg2.size());
+  }
+
+  @Test
+  @Transactional
+  void testFindByOrgIdReturnsEmptyListForUnknownOrg() {
+    List<HbiEventOutbox> foundRecords = repository.findByOrgId("unknown_org");
+    assertTrue(foundRecords.isEmpty());
+  }
+
+  @Test
+  @Transactional
+  void testPersistAndRetrieve() {
+    HbiEventOutbox existing = givenExistingHbiEventOutbox();
+
+    Optional<HbiEventOutbox> retrieved = repository.findByIdOptional(existing.getId());
+    assertTrue(retrieved.isPresent());
+    assertHbiEventOutboxEquals(existing, retrieved.get());
+  }
+
+  @Test
+  @Transactional
+  void testDeleteByOrgId() {
+    HbiEventOutbox existing = givenExistingHbiEventOutbox();
+    long deletedCount = repository.deleteByOrgId(existing.getOrgId());
+    assertEquals(1L, deletedCount);
+
+    List<HbiEventOutbox> remainingRecords = repository.findByOrgId(existing.getOrgId());
+    assertTrue(remainingRecords.isEmpty());
+  }
+
+  @Test
+  @Transactional
+  void testUpdateRecord() {
+    HbiEventOutbox existing = givenExistingHbiEventOutbox();
+
+    String newEventJson =
+        "{\"event_source\":\"updated\",\"event_type\":\"updated\",\"org_id\":\"org1\",\"instance_id\":\"updated\",\"service_type\":\"updated\",\"timestamp\":\"2024-01-20T12:00:00Z\"}";
+    existing.setSwatchEventJson(newEventJson);
+    repository.persistAndFlush(existing);
+
+    Optional<HbiEventOutbox> updated = repository.findByIdOptional(existing.getId());
+    assertTrue(updated.isPresent());
+    assertEquals(newEventJson, updated.get().getSwatchEventJson());
+  }
+
+  private HbiEventOutbox givenExistingHbiEventOutbox() {
+    return givenExistingHbiEventOutbox("org1");
+  }
+
+  private HbiEventOutbox givenExistingHbiEventOutbox(String orgId) {
+    HbiEventOutbox entity = new HbiEventOutbox();
+    entity.setOrgId(orgId);
+    entity.setSwatchEventJson(
+        "{\"event_source\":\"HBI_HOST\",\"event_type\":\"test\",\"org_id\":\"org1\",\"instance_id\":\"instance1\",\"service_type\":\"RHEL System\",\"timestamp\":\"2024-01-20T10:00:00Z\"}");
+    repository.persistAndFlush(entity);
+    return entity;
+  }
+
+  private void assertHbiEventOutboxEquals(HbiEventOutbox expected, HbiEventOutbox actual) {
+    assertEquals(expected.getId(), actual.getId());
+    assertEquals(expected.getOrgId(), actual.getOrgId());
+    assertEquals(expected.getCreatedOn(), actual.getCreatedOn());
+    assertEquals(expected.getSwatchEventJson(), actual.getSwatchEventJson());
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3776

## Description
Created an outbox record the following schema:
||Column Name||Type||Description||
|id|UUID| A unique ID for the outbox record.|
|org_id|varchar|The org_id for the associated event.|
|created_on|timestamp with timezone|The timestamp at which this record was created.|
|swatch_event_json|JSONB|The JSON string representation of an outgoing SWatch event adhering to our event schema.|
|org_id_index|index|An index on org_id to facilitate look ups by org_id via the API|

The table name is "hbi_event_outbox".

## Testing
Only unit tests covering repository CRUD operations.