### PR TITLE
SWATCH-3690: Enable UMB service for local testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         run: ./mvnw clean install -DskipTests
 
       - name: Start components
-        run: docker compose up -d db kafka kafka-setup
+        run: docker compose up -d db kafka kafka-setup amqp
 
       - name: Run database migrations
         run: make run-migrations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,14 @@ services:
       swatch-network:
         aliases:
           - prometheus
+  amqp:
+    extends:
+      file: config/artemis/docker-compose.yml
+      service: artemis
+    networks:
+      swatch-network:
+        aliases:
+          - amqp
   db:
     # Use the same version as in https://gitlab.cee.redhat.com/service/app-interface/-/blob/ff61d457898da76ebd4abf21fe3ce7b5c74c87a5/data/services/insights/rhsm/namespaces/rhsm-prod.yml#L179
     # When updating the image, remember to also update the following locations:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -229,6 +229,7 @@ SWATCH_CONTRACT_PRODUCER_ENABLED = false
 
 UMB_ENABLED=false
 %ephemeral.UMB_ENABLED=true
+%dev.UMB_ENABLED=true
 %test.UMB_ENABLED=true
 %stage.UMB_ENABLED=true
 %prod.UMB_ENABLED=true
@@ -240,7 +241,6 @@ UMB_HOSTNAME=localhost
 %prod.UMB_HOSTNAME=umb.api.redhat.com
 
 UMB_PORT=5672
-%ephemeral.UMB_PORT=5672
 %stage.UMB_PORT=5671
 %prod.UMB_PORT=5671
 


### PR DESCRIPTION
Jira issue: SWATCH-3690

## Description
Changes:
- Set Up the AMQP container for local testing
- Enable UMB in swatch contracts

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1289

### Setup
1. podman compose up -d
2. make run-migrations
3. make swatch-contracts

### Verification
1. Run the test test_umb_product_sync_topic that should be working now.