### PR TITLE
SWATCH-3824: Date Filtering Not Working for OpenShift Products Instances API

### DIFF
--- a/api/rhsm-subscriptions-api-v1-spec.yaml
+++ b/api/rhsm-subscriptions-api-v1-spec.yaml
@@ -516,18 +516,18 @@ paths:
           schema:
             type: string
             format: date-time
-          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+          description: "Include only hosts that have been tallied for in given month and year. Dates should be provided in ISO 8601
                      format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
-                     Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
+                     Only applicable for PAYG products"
         - name: ending
           in: query
           required: false
           schema:
             type: string
             format: date-time
-          description: "Defines the end of the report period. Dates should be provided in ISO 8601
+          description: "Include only hosts that have been tallied for in given month and year. Must be after beginning date. Dates should be provided in ISO 8601
                      format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z.
-                     Only applicable for OpenShift-dedicated-metrics and OpenShift-metrics products"
+                     Only applicable for PAYG products"
         - name: sort
           in: query
           schema:

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/registry/SubscriptionDefinition.java
@@ -358,7 +358,11 @@ public class SubscriptionDefinition {
 
   public boolean isPaygEligible() {
     return metrics.stream()
-        .anyMatch(metric -> metric.getRhmMetricId() != null || metric.getAwsDimension() != null);
+        .anyMatch(
+            metric ->
+                metric.getRhmMetricId() != null
+                    || metric.getAwsDimension() != null
+                    || metric.getAzureDimension() != null);
   }
 
   public static String getAwsDimension(String productTag, String metricId) {

--- a/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
+++ b/swatch-product-configuration/src/test/java/com/redhat/swatch/configuration/registry/SubscriptionDefinitionTest.java
@@ -399,4 +399,31 @@ class SubscriptionDefinitionTest {
         Arguments.of(lookupParams1, Set.of("ansible-aap-managed")),
         Arguments.of(lookupParams2, Set.of("ansible-aap-managed")));
   }
+
+  @Test
+  void testPaygEligibleAzure() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    Metric metric = new Metric();
+    metric.setAzureDimension("testAzureDimension");
+    testDef.setMetrics(Set.of(metric));
+    assertTrue(testDef.isPaygEligible());
+  }
+
+  @Test
+  void testPaygEligibleAws() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    Metric metric = new Metric();
+    metric.setAwsDimension("testAwsDimension");
+    testDef.setMetrics(Set.of(metric));
+    assertTrue(testDef.isPaygEligible());
+  }
+
+  @Test
+  void testPaygEligibleRhm() {
+    SubscriptionDefinition testDef = new SubscriptionDefinition();
+    Metric metric = new Metric();
+    metric.setRhmMetricId("testRhmDimension");
+    testDef.setMetrics(Set.of(metric));
+    assertTrue(testDef.isPaygEligible());
+  }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3824

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

~~Date filtering was failing for PAYG openshift products in the instance API. This was occurring because isPaygEligible() only checked for aws or azure metrics but these where rh marketplace only products. In order to properly check for payg eligibility I added a new field to explicitly set it per product.~~

This is working as expected but isPaygEligible was not including azureDimensions which is updated in this PR. No functional changes since all azure products are also on aws currently.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: [<!-- IQE MR link here -->] https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1295

### Setup
<!-- Add any steps required to set up the test case -->
1. Create snapshots for OpenShift-dedicated-metrics
2. Query instances API for date outside of snapshot_date month
3. No data should return
