### PR TITLE
SWATCH-3545: Use org_id as message key when creating events via tally API

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventConflictResolver.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventConflictResolver.java
@@ -116,7 +116,7 @@ public class EventConflictResolver {
 
                   if (!amendmentRequired(event, conflictingEvent, conflictKey.getMetricId())) {
                     log.debug(
-                        "The incoming event does require amendments for {}: {}",
+                        "The incoming event does not require amendments for {}: {}",
                         conflictKey.getMetricId(),
                         event);
                     return;

--- a/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/admin/InternalTallyResource.java
@@ -240,7 +240,7 @@ public class InternalTallyResource implements InternalTallyApi {
             .forEach(
                 event -> {
                   try {
-                    eventKafkaTemplate.send(this.eventTopic, event);
+                    eventKafkaTemplate.send(this.eventTopic, event.getOrgId(), event);
                   } catch (Exception e) {
                     messages.append(e.getMessage());
                   }

--- a/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/admin/InternalTallyResourceTest.java
@@ -132,7 +132,8 @@ class InternalTallyResourceTest {
             + "  \"metering_batch_id\": \"f39d1d22-eb72-4597-b722-5bee34abd78d\","
             + "  \"billing_account_id\": \"381492115198\""
             + " }]");
-    verify(kafkaTemplate, times(1)).send(eq(taskQueueProperties.getTopic()), any(Event.class));
+    verify(kafkaTemplate, times(1))
+        .send(eq(taskQueueProperties.getTopic()), eq("11091977"), any(Event.class));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-3545

## Description
While investigating bug SWATCH-3545, I noticed that we are not setting the org_id as the message key when creating events via the internal tally API. This is critical in ensuring that all events are processed in order for a given org_id.

**NOTE:** This was discovered while investigating this issue. The patch should not be considered as a 'fix' for the bug as we are still unable to reliably reproduce this issue.

## Testing
1. After deploying the main branch, create an event using the admin API.
```bash
$ ./mvnw -f swatch-database/pom.xml exec:java
$ MANAGEMENT_SERVER_PORT=9002 SERVER_PORT=8002 DEV_MODE=true ./mvnw -pl swatch-tally spring-boot:run
```
```
$ curl -s "http://localhost:8002/api/rhsm-subscriptions/v1/internal/rpc/tally/events"  -H "Content-Type: application/json"  -H "x-rh-swatch-psk: placeholder"  -d '[
   {
     "org_id": "123456",
     "instance_id": "i-123456",
     "timestamp": "2025-07-21T17:00:00Z",
     "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
     "event_source": "rhelemeter",
     "measurements": [
       {
         "metric_id": "vCPUs",
         "value": 1.0
       }
     ],
     "product_tag": ["rhel-for-x86-els-payg"],
     "service_type": "RHEL System",
     "display_name": "test.redhat.com-1",
     "sla": "Premium",
     "usage": "Production",
     "billing_provider": "aws",
     "billing_account_id": "444444444"
   }
 ]'
```

2. Check the kafka topic browser and see that the message key is 'null'.
```
http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/data/table
```

3. Deploy the PR branch and create an event using the admin API.
```
$ curl -s "http://localhost:8002/api/rhsm-subscriptions/v1/internal/rpc/tally/events"  -H "Content-Type: application/json"  -H "x-rh-swatch-psk: placeholder"  -d '[
   {
     "org_id": "123456",
     "instance_id": "i-123456",
     "timestamp": "2025-07-21T17:00:00Z",
     "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
     "event_source": "rhelemeter",
     "measurements": [
       {
         "metric_id": "vCPUs",
         "value": 1.0
       }
     ],
     "product_tag": ["rhel-for-x86-els-payg"],
     "service_type": "RHEL System",
     "display_name": "test.redhat.com-1",
     "sla": "Premium",
     "usage": "Production",
     "billing_provider": "aws",
     "billing_account_id": "444444444"
   }
 ]'
```

4. Check the kafka topic browser and see that the message key is the org_id of '123456'.
```
http://localhost:3030/#/cluster/default/topic/n/platform.rhsm-subscriptions.service-instance-ingress/data/table
```

