### PR TITLE
SWATCH-3778: Implement POST /api/swatch-metrics-hbi/internal/outbox

### DIFF
--- a/swatch-metrics-hbi/pom.xml
+++ b/swatch-metrics-hbi/pom.xml
@@ -115,6 +115,14 @@
       <artifactId>quarkus-liquibase</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct-processor</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
@@ -133,6 +141,10 @@
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-messaging-in-memory</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
@@ -193,6 +205,16 @@
                 -->
                 <additionalProperty>disableMultipart=true</additionalProperty>
               </additionalProperties>
+              <importMappings>
+                <importMapping>
+                  Event=org.candlepin.subscriptions.json.Event
+                </importMapping>¡
+              </importMappings>
+              <typeMappings>
+                <typeMapping>
+                  string+Event=Event
+                </typeMapping>
+              </typeMappings>
             </configuration>
           </execution>
         </executions>
@@ -210,6 +232,10 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/model/OutboxRecordMapper.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/model/OutboxRecordMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.model;
+
+import com.redhat.swatch.hbi.events.repository.HbiEventOutbox;
+import com.redhat.swatch.hbi.model.OutboxRecord;
+import org.mapstruct.Builder;
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper(
+    componentModel = "cdi",
+    collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED,
+    builder = @Builder(disableBuilder = true))
+public interface OutboxRecordMapper {
+
+  OutboxRecord entityToDto(HbiEventOutbox entity);
+}

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutbox.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/HbiEventOutbox.java
@@ -20,20 +20,24 @@
  */
 package com.redhat.swatch.hbi.events.repository;
 
+import com.redhat.swatch.hbi.events.repository.converters.EventConverter;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.candlepin.subscriptions.json.Event;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -55,9 +59,11 @@ public class HbiEventOutbox extends PanacheEntityBase {
   @Column(name = "created_on", nullable = false)
   private OffsetDateTime createdOn;
 
+  @Valid
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "swatch_event_json", columnDefinition = "jsonb", nullable = false)
-  private String swatchEventJson;
+  @Convert(converter = EventConverter.class)
+  private Event swatchEventJson;
 
   @PrePersist
   public void onCreate() {

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/converters/EventConverter.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/repository/converters/EventConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.repository.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.json.Event;
+
+/** JPA AttributeConverter which uses Jackson to map to/from Event JSON. */
+@ApplicationScoped
+@AllArgsConstructor
+@Converter
+public class EventConverter implements AttributeConverter<Event, String> {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public String convertToDatabaseColumn(Event attribute) {
+    try {
+      return objectMapper.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error serializing event", e);
+    }
+  }
+
+  @Override
+  public Event convertToEntityAttribute(String dbData) {
+    try {
+      return objectMapper.readValue(dbData, Event.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Error parsing event", e);
+    }
+  }
+}

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/resources/InternalResource.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/resources/InternalResource.java
@@ -18,20 +18,25 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.hbi.resources;
+package com.redhat.swatch.hbi.events.resources;
 
 import com.redhat.swatch.hbi.api.DefaultApi;
+import com.redhat.swatch.hbi.events.services.HbiEventOutboxService;
 import com.redhat.swatch.hbi.model.FlushResponse;
 import com.redhat.swatch.hbi.model.OutboxRecord;
-import com.redhat.swatch.hbi.model.OutboxRecordRequest;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
+import org.candlepin.subscriptions.json.Event;
 
 @ApplicationScoped
 public class InternalResource implements DefaultApi {
+
+  @Inject HbiEventOutboxService outboxService;
 
   @Override
   public List<OutboxRecord> fetchAllOutboxRecords() {
@@ -44,8 +49,8 @@ public class InternalResource implements DefaultApi {
   }
 
   @Override
-  public OutboxRecord createOutboxRecord(OutboxRecordRequest outboxRecordRequest) {
-    throw new WebApplicationException(Response.Status.NOT_IMPLEMENTED);
+  public OutboxRecord createOutboxRecord(@Valid Event event) {
+    return outboxService.createOutboxRecord(event);
   }
 
   @Override

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventOutboxService.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventOutboxService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.services;
+
+import com.redhat.swatch.hbi.events.model.OutboxRecordMapper;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutbox;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutboxRepository;
+import com.redhat.swatch.hbi.model.OutboxRecord;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.json.Event;
+
+@AllArgsConstructor
+@ApplicationScoped
+public class HbiEventOutboxService {
+
+  private final HbiEventOutboxRepository repository;
+  private final OutboxRecordMapper mapper;
+
+  @Transactional
+  public OutboxRecord createOutboxRecord(Event event) {
+    HbiEventOutbox entity = new HbiEventOutbox();
+    entity.setOrgId(event.getOrgId());
+    entity.setSwatchEventJson(event);
+    repository.persistAndFlush(entity);
+    return mapper.entityToDto(entity);
+  }
+}

--- a/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
@@ -29,7 +29,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OutboxRecordRequest'
+              $ref: '#/components/schemas/Event'
       responses:
         '201':
           description: "Outbox record created successfully"
@@ -136,10 +136,11 @@ components:
     OutboxRecord:
       type: object
       required:
-        - uuid
+        - id
         - org_id
+        - swatch_event_json
       properties:
-        uuid:
+        id:
           type: string
           format: uuid
           description: "Unique identifier for the outbox record"
@@ -148,16 +149,13 @@ components:
           type: string
           description: "Organization ID associated with the record"
           example: "org123"
+        swatch_event_json:
+          $ref: '#/components/schemas/Event'
 
-    OutboxRecordRequest:
-      type: object
-      required:
-        - org_id
-      properties:
-        org_id:
-          type: string
-          description: "Organization ID associated with the record"
-          example: "org123"
+    Event:
+      type: string
+      format: Event
+      description: "Swatch Event payload"
 
     FlushResponse:
       type: object
@@ -178,6 +176,5 @@ components:
         ```
         c9a98753-2092-4617-b226-5c2653330b3d
         ```
-
 security:
-  - PskIdentity: [] 
+  - PskIdentity: []

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/resources/InternalResourceTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/resources/InternalResourceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.resources;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.hbi.events.services.HbiEventOutboxService;
+import com.redhat.swatch.hbi.model.OutboxRecord;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import java.time.OffsetDateTime;
+import org.apache.http.HttpStatus;
+import org.candlepin.subscriptions.json.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class InternalResourceTest {
+
+  @InjectMock HbiEventOutboxService outboxService;
+
+  @BeforeEach
+  public void setup() {
+    when(outboxService.createOutboxRecord(any())).thenReturn(new OutboxRecord());
+  }
+
+  @Test
+  void testCreateOutboxRecordWhenRequestDoesNotHaveOrgIdThenReturnsBadRequest() {
+    Event request = new Event();
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when()
+        .post("/api/swatch-metrics-hbi/internal/outbox")
+        .then()
+        .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+    verifyNoInteractions(outboxService);
+  }
+
+  @Test
+  void testCreateOutboxRecordInvokesService() {
+    Event request = new Event();
+    request.setOrgId("org123");
+    request.setEventSource("HBI_HOST");
+    request.setInstanceId("test-instance-id");
+    request.setEventType("test");
+    request.setServiceType("RHEL System");
+    request.setTimestamp(OffsetDateTime.now());
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when()
+        .post("/api/swatch-metrics-hbi/internal/outbox")
+        .then()
+        .statusCode(HttpStatus.SC_OK);
+
+    verify(outboxService, times(1)).createOutboxRecord(any());
+  }
+}

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/services/HbiEventOutboxServiceTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/services/HbiEventOutboxServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.swatch.hbi.events.repository.HbiEventOutboxRepository;
+import com.redhat.swatch.hbi.model.OutboxRecord;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import org.candlepin.subscriptions.json.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class HbiEventOutboxServiceTest {
+
+  @Inject HbiEventOutboxService service;
+  @Inject HbiEventOutboxRepository repository;
+
+  @BeforeEach
+  @Transactional
+  void clean() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testCreateOutboxRecordPersistsAndReturnsDto() {
+    Event event = new Event();
+    event.setOrgId("org123");
+    event.setEventSource("HBI_HOST");
+    event.setInstanceId("test-instance-id");
+    event.setEventType("test");
+    event.setServiceType("RHEL System");
+    event.setTimestamp(OffsetDateTime.now());
+
+    OutboxRecord result = service.createOutboxRecord(event);
+
+    assertNotNull(result.getId());
+    assertEquals("org123", result.getOrgId());
+    assertEquals(event, result.getSwatchEventJson());
+    assertEquals(1L, repository.count());
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-3778

## Description
Changes:
- Added service and test security schemas following the same pattern as in swatch-contracts.
- Followed the controller->service->repository pattern to implement this endpoint.
- Added "swatch_event_json" property in the request what was initially missing.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1307
Added JUnit tests to cover these changes.