### PR TITLE
SWATCH-3785: Store SWatch events produced by SMHBI in outbox table

### DIFF
--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/processing/handlers/CreateUpdateHostHandler.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/processing/handlers/CreateUpdateHostHandler.java
@@ -25,7 +25,6 @@ import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostCreateUpdateEvent;
 import com.redhat.swatch.hbi.events.normalization.Host;
 import com.redhat.swatch.hbi.events.normalization.facts.RhsmFacts;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -59,7 +58,6 @@ public class CreateUpdateHostHandler implements HbiEventHandler<HbiHostCreateUpd
   }
 
   @Override
-  @Transactional
   public List<Event> handleEvent(HbiHostCreateUpdateEvent hbiHostEvent) {
     log.debug("Handling HBI host created/updated event {}", hbiHostEvent);
 

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/processing/handlers/DeleteHostHandler.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/processing/handlers/DeleteHostHandler.java
@@ -24,7 +24,6 @@ import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostDeleteEvent;
 import com.redhat.swatch.hbi.events.normalization.NormalizedEventType;
 import com.redhat.swatch.hbi.events.repository.HbiHostRelationship;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +56,6 @@ public class DeleteHostHandler implements HbiEventHandler<HbiHostDeleteEvent> {
    *     deletion of the HBI host.
    */
   @Override
-  @Transactional
   public List<Event> handleEvent(HbiHostDeleteEvent deleteEvent) {
     log.debug("Handling hbi host delete event: {}", deleteEvent);
     Optional<HbiHostRelationship> deleted =

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventConsumer.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/services/HbiEventConsumer.java
@@ -21,7 +21,6 @@
 package com.redhat.swatch.hbi.events.services;
 
 import static com.redhat.swatch.hbi.events.configuration.Channels.HBI_HOST_EVENTS_IN;
-import static com.redhat.swatch.hbi.events.configuration.Channels.SWATCH_EVENTS_OUT;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,19 +29,17 @@ import com.redhat.swatch.hbi.events.dtos.hbi.HbiEvent;
 import com.redhat.swatch.hbi.events.exception.UnrecoverableMessageProcessingException;
 import com.redhat.swatch.hbi.events.processing.HbiEventProcessor;
 import com.redhat.swatch.hbi.events.processing.UnsupportedHbiEventException;
-import com.redhat.swatch.kafka.EmitterService;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutbox;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutboxRepository;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.json.Event;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.Message;
 
 @Slf4j
 @ApplicationScoped
@@ -55,25 +52,22 @@ public class HbiEventConsumer {
   public static final String COUNTER_EVENTS_METRIC = EVENTS_METRIC + ".counter";
 
   private final FeatureFlags flags;
-
-  @SuppressWarnings("java:S1068")
-  private final EmitterService<Event> emitter;
-
   private final HbiEventProcessor hbiEventProcessor;
   private final ObjectMapper objectMapper;
   private final MeterRegistry meterRegistry;
+  private final HbiEventOutboxRepository outboxRepository;
 
   public HbiEventConsumer(
-      @Channel(SWATCH_EVENTS_OUT) Emitter<Event> emitter,
       FeatureFlags flags,
       HbiEventProcessor hbiEventProcessor,
       ObjectMapper objectMapper,
-      MeterRegistry meterRegistry) {
-    this.emitter = new EmitterService<>(emitter);
+      MeterRegistry meterRegistry,
+      HbiEventOutboxRepository outboxRepository) {
     this.flags = flags;
     this.hbiEventProcessor = hbiEventProcessor;
     this.objectMapper = objectMapper;
     this.meterRegistry = meterRegistry;
+    this.outboxRepository = outboxRepository;
   }
 
   @Timed(TIMED_EVENTS_METRIC)
@@ -83,24 +77,16 @@ public class HbiEventConsumer {
       delay = "${SWATCH_EVENT_PRODUCER_BACK_OFF_INITIAL_INTERVAL:1s}",
       maxDelay = "${SWATCH_EVENT_PRODUCER_BACK_OFF_MAX_INTERVAL:60s}",
       factor = "${SWATCH_EVENT_PRODUCER_BACK_OFF_MULTIPLIER:2}")
+  @Transactional
   public void consume(HbiEvent hbiEvent) {
     logHbiEvent(hbiEvent);
     try {
-      List<Event> toSend = hbiEventProcessor.process(hbiEvent);
-      if (flags.emitEvents()) {
-        log.info("Emitting {} HBI events to swatch! {}", toSend.size(), toSend);
-        toSend.forEach(
-            eventToSend ->
-                emitter.send(
-                    Message.of(eventToSend)
-                        .addMetadata(
-                            OutgoingKafkaRecordMetadata.builder()
-                                .withKey(eventToSend.getOrgId())
-                                .build())));
+      List<Event> toPersist = hbiEventProcessor.process(hbiEvent);
+      if (!toPersist.isEmpty()) {
+        log.info("Persisting {} SWatch events into outbox.", toPersist.size());
+        toPersist.forEach(this::persistOutboxRecord);
       } else {
-        log.info(
-            "Emitting HBI events to swatch is disabled. Not sending {} events.", toSend.size());
-        toSend.forEach(eventToSend -> log.info("EVENT: {}", eventToSend));
+        log.info("No SWatch events produced to persist.");
       }
       incrementCounter(hbiEvent.getType());
     } catch (UnsupportedHbiEventException unsupportedException) {
@@ -112,6 +98,13 @@ public class HbiEventConsumer {
           e);
       incrementCounterWithError(hbiEvent.getType(), e.getMessage());
     }
+  }
+
+  private void persistOutboxRecord(Event eventToPersist) {
+    HbiEventOutbox entity = new HbiEventOutbox();
+    entity.setOrgId(eventToPersist.getOrgId());
+    entity.setSwatchEventJson(eventToPersist);
+    outboxRepository.persist(entity);
   }
 
   private void logHbiEvent(HbiEvent hbiEvent) {

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/processing/HbiEventProcessorTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/processing/HbiEventProcessorTest.java
@@ -34,6 +34,7 @@ import com.redhat.swatch.hbi.events.test.helpers.HbiEventTestData;
 import com.redhat.swatch.hbi.events.test.helpers.HbiEventTestHelper;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,7 @@ class HbiEventProcessorTest {
   }
 
   @Test
+  @Transactional
   void testCreateUpdateEventIsSupported() {
     HbiHostCreateUpdateEvent event =
         hbiEventHelper.createTemplatedGuestCreatedEvent(
@@ -64,6 +66,7 @@ class HbiEventProcessorTest {
   }
 
   @Test
+  @Transactional
   void testDeleteEventIsSupported() {
     HbiHostDeleteEvent event =
         hbiEventHelper.createHostDeleteEvent("org123", UUID.randomUUID(), OffsetDateTime.now());

--- a/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/services/HbiEventConsumerTransactionBoundaryTest.java
+++ b/swatch-metrics-hbi/src/test/java/com/redhat/swatch/hbi/events/services/HbiEventConsumerTransactionBoundaryTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.hbi.events.services;
+
+import static com.redhat.swatch.hbi.events.configuration.Channels.HBI_HOST_EVENTS_IN;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.redhat.swatch.hbi.events.dtos.hbi.HbiEvent;
+import com.redhat.swatch.hbi.events.dtos.hbi.HbiHostCreateUpdateEvent;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutbox;
+import com.redhat.swatch.hbi.events.repository.HbiEventOutboxRepository;
+import com.redhat.swatch.hbi.events.repository.HbiHostRelationship;
+import com.redhat.swatch.hbi.events.repository.HbiHostRelationshipRepository;
+import com.redhat.swatch.hbi.events.test.helpers.HbiEventTestData;
+import com.redhat.swatch.hbi.events.test.helpers.HbiEventTestHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import jakarta.persistence.PersistenceException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class HbiEventConsumerTransactionBoundaryTest {
+  @Inject @Any InMemoryConnector connector;
+  @InjectSpy HbiHostRelationshipRepository repo;
+  @InjectSpy HbiEventOutboxRepository outboxRepository;
+  @Inject HbiEventTestHelper hbiEventTestHelper;
+  @Inject TransactionSynchronizationRegistry tsr;
+  private InMemorySource<HbiEvent> hbiEventsIn;
+
+  private HbiHostCreateUpdateEvent hbiEvent;
+  private HbiHostRelationship expectedRelationship;
+
+  @Transactional
+  @BeforeEach
+  void setup() {
+    hbiEventsIn = connector.source(HBI_HOST_EVENTS_IN);
+    repo.deleteAll();
+    outboxRepository.deleteAll();
+
+    hbiEvent =
+        hbiEventTestHelper.getCreateUpdateEvent(HbiEventTestData.getPhysicalRhelHostCreatedEvent());
+    expectedRelationship = hbiEventTestHelper.relationshipFromHbiEvent(hbiEvent);
+  }
+
+  @Test
+  void testHbiHostRelationshipNotPersistedIfOutboxRecordFailsToPersist() {
+    doThrow(
+            new PersistenceException(
+                "FORCED: Ensure that the database transaction is rolled back on failure."))
+        .when(outboxRepository)
+        .persist(any(HbiEventOutbox.class));
+
+    hbiEventsIn.send(hbiEvent);
+
+    // Wait for the event to be processed. The outbox repository persist call must happen.
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              verify(repo, times(1)).persist(any(HbiHostRelationship.class));
+              verify(outboxRepository, times(1)).persist(any(HbiEventOutbox.class));
+            });
+
+    // If the outbox record could not be persisted, the relationship change should have
+    // been rolled back.
+    assertTrue(
+        repo.findByOrgIdAndInventoryId(
+                expectedRelationship.getOrgId(), expectedRelationship.getInventoryId())
+            .isEmpty());
+    assertTrue(outboxRepository.findByOrgId(expectedRelationship.getOrgId()).isEmpty());
+  }
+
+  @Test
+  void testNothingPersistedIfDatabaseTransactionFails() {
+    // After the real persist, schedule the transaction to roll back at commit time.
+    doAnswer(
+            inv -> {
+              inv.callRealMethod();
+              tsr.registerInterposedSynchronization(
+                  new Synchronization() {
+                    @Override
+                    public void beforeCompletion() {
+                      // Force the enclosing @Transactional method's commit to roll back
+                      tsr.setRollbackOnly();
+                    }
+
+                    @Override
+                    public void afterCompletion(int status) {}
+                  });
+              return null;
+            })
+        .when(outboxRepository)
+        .persist(any(HbiEventOutbox.class));
+
+    // Send the event and await persist invocation
+    hbiEventsIn.send(hbiEvent);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              verify(repo, atLeastOnce()).persist(any(HbiHostRelationship.class));
+              verify(outboxRepository, atLeastOnce()).persist(any(HbiEventOutbox.class));
+            });
+
+    // Make sure that the relationship is not found (transaction rolled back on commit)
+    assertTrue(
+        repo.findByOrgIdAndInventoryId(
+                expectedRelationship.getOrgId(), expectedRelationship.getInventoryId())
+            .isEmpty());
+    assertTrue(outboxRepository.findByOrgId(expectedRelationship.getOrgId()).isEmpty());
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3785

## Description
When swatch-metrics-hbi processes an HBI event, the resulting SWatch events are stored as JSON in persisted outbox records.

If an outbox record fails to persist, the DB transaction should get rolled back and the HBI event will be retried.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1321

### Setup
Create the following test JSON files.

***NOTE:***
* Make sure that the stale_timestamp of the facts is not in the past, otherwise, these facts will not be considered during normalization.
* Make sure that the SYNC_TIMESTAMP of the **rhsm** facts less than 24h ago, otherwise the rhsm facts will not be considered and will not apply RHEL specific rules to the measurement (they will be normalized as is without considering unmapped guest rules).

#### rhel_hypervisor.json
```bash
cat > rhel_hypervisor.json <<EOF
$(jq -n --arg ts "$(date -u -d "$((RANDOM % 86400)) seconds ago" +%Y-%m-%dT%H:%M:%S.%NZ)" '{
  records: [{
    key: "12345678",
    value: {
      type: "created",
      host: {
        id: "18ebb8c0-a597-41b6-85d2-62003ebaacd3",
        display_name: "testhost.example.com",
        ansible_host: null,
        account: null,
        org_id: "12345678",
        insights_id: "4a6a184e-6204-47d9-b888-26db9b5e8c81",
        subscription_manager_id: "6bfc8a3d-464f-4853-a301-4b1715480799",
        satellite_id: null,
        fqdn: "testhost.example.com",
        ip_addresses: null,
        mac_addresses: null,
        facts: [{
          namespace: "rhsm",
          facts: {
            orgId: "12345678",
            MEMORY: 1,
            RH_PROD: ["69"],
            IS_VIRTUAL: false,
            ARCHITECTURE: "x86_64",
            SYNC_TIMESTAMP: $ts,
            SYSPURPOSE_SLA: "Self-Support",
            SYSPURPOSE_USAGE: "Development/Test"
          }
        }],
        provider_id: null,
        provider_type: null,
        created: "2024-10-18T16:22:14.086713+00:00",
        updated: "2024-10-18T16:42:28.857787+00:00",
        stale_timestamp: "2025-10-19T21:42:28.857787+00:00",
        stale_warning_timestamp: "2025-10-25T16:42:28.857787+00:00",
        culled_timestamp: "",
        reporter: "rhsm-conduit",
        tags: [],
        system_profile: {
          arch: "x86_64",
          owner_id: "6bfc8a3d-464f-4853-a301-4b1715480799",
          conversions: { activity: false },
          is_marketplace: false,
          cores_per_socket: 1,
          number_of_sockets: 2,
          infrastructure_type: "physical",
          system_memory_bytes: 5120
        }
      },
      timestamp: "2024-10-18T16:42:29.134663+00:00",
      platform_metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
      },
      metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e5"
      }
    }
  }]
}')
EOF
```

#### rhel_guest.json
```bash
cat > rhel_guest.json <<EOF
$(jq -n --arg ts "$(date -u -d "$((RANDOM % 86400)) seconds ago" +%Y-%m-%dT%H:%M:%S.%NZ)" '{
  records: [{
    key: "12345678",
    value: {
      type: "created",
      host: {
        id: "18ebb8c0-a597-41b6-85d2-62003ebaacd4",
        display_name: "virtual.testhost.example.com",
        ansible_host: null,
        account: null,
        org_id: "12345678",
        insights_id: "4a6a184e-6204-47d9-b888-26db9b5e8c82",
        subscription_manager_id: "6bfc8a3d-464f-4853-a301-4b1715480800",
        satellite_id: null,
        fqdn: "virtual.testhost.example.com",
        ip_addresses: null,
        mac_addresses: null,
        facts: [{
          namespace: "rhsm",
          facts: {
            orgId: "12345678",
            MEMORY: 1,
            RH_PROD: ["69"],
            IS_VIRTUAL: true,
            ARCHITECTURE: "x86_64",
            SYNC_TIMESTAMP: $ts,
            SYSPURPOSE_SLA: "Self-Support",
            SYSPURPOSE_USAGE: "Development/Test"
          }
        }],
        provider_id: null,
        provider_type: null,
        created: "2024-10-18T15:22:14.086713+00:00",
        updated: "2024-10-18T15:42:28.857787+00:00",
        stale_timestamp: "2025-10-19T21:42:28.857787+00:00",
        stale_warning_timestamp: "2025-10-25T16:42:28.857787+00:00",
        culled_timestamp: "2024-11-01T16:42:28.857787+00:00",
        reporter: "rhsm-conduit",
        tags: [],
        system_profile: {
          arch: "x86_64",
          owner_id: "6bfc8a3d-464f-4853-a301-4b1715480800",
          conversions: { activity: false },
          is_marketplace: false,
          cores_per_socket: 1,
          number_of_sockets: 3,
          infrastructure_type: "virtual",
          virtual_host_uuid: "6bfc8a3d-464f-4853-a301-4b1715480799",
          system_memory_bytes: 5120
        }
      },
      timestamp: "2024-10-18T15:42:29.134663+00:00",
      platform_metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e6"
      },
      metadata: {
        request_id: "8f752a10-3ed0-48b0-b55f-7d26e4ea50e6"
      }
    }
  }]
}')
EOF
```

#### guest_deleted.json
```
cat > guest_deleted.json <<EOF
$(jq -n --arg ts "$(date -u -d "$((RANDOM % 86400)) seconds ago" +%Y-%m-%dT%H:%M:%S.%NZ)" '{
	records: [
	  {
		key: "12345678",
		value: {
			"id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4",
			"timestamp": $ts,
			"type": "delete",
			"org_id": "12345678",
			"insights_id": "4a6a184e-6204-47d9-b888-26db9b5e8c82",
		}
	  }
	]
}')
EOF
```

### Deploy swatch-metrics-hbi and its dependant services
```
$ podman compose up -d
$ make run-migrations
$ make swatch-metrics-hbi
```
To reset the DB tables for this PR you can run:
```
$ psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions -c "truncate hbi_host_relationship; truncate hbi_event_outbox"
```

Send an HBI event to simulate a RHEL guest was reported.
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json \
Accept:application/vnd.kafka.v2+json \
< rhel_guest.json
```

Verify that a relationship and an outbox record was created by the service after processing the event.
```
$ psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions \
-c "select org_id, subscription_manager_id, hypervisor_uuid, is_unmapped_guest, creation_date, last_updated from hbi_host_relationship;"
  org_id  |       subscription_manager_id        |           hypervisor_uuid            | is_unmapped_guest |         creation_date         |         last_updated          
----------+--------------------------------------+--------------------------------------+-------------------+-------------------------------+-------------------------------
 12345678 | 6bfc8a3d-464f-4853-a301-4b1715480800 | 6bfc8a3d-464f-4853-a301-4b1715480799 | t                 | 2025-03-26 18:35:11.120375+00 | 2025-03-26 18:35:11.120375+00
(1 row)
```

Validate that the outbox record's swatch_event_json contains the following fields:
* Swatch event is sent for the guest.
	* eventType=INSTANCE_CREATED
	* isHypervisor=false
	* isVirtual=true
	* isUnmappedGuest=true (since its hypervisor is unknown)
	* productIds=[69]
	* productTag=[RHEL for x86]
	* measurements:
		* 2 cores
		* 1 sockets
```
$ psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions \
-c "select * from hbi_event_outbox where org_id='12345678' and swatch_event_json->>'instance_id' = '18ebb8c0-a597-41b6-85d2-62003ebaacd4'"

id   |  org_id  |   created_on  |  swatch_event_json
 996cd852-304a-4196-bd63-8571bdd53983 | 12345678 | 2025-08-27 15:35:56.117255+00 | {"sla": "Self-Support", "usage": "Development/Test", "org_id": "12345678", "lastSeen": "2024-10-18T15
:42:28.857787Z", "isVirtual": true, "timestamp": "2024-10-18T15:00:00Z", "conversion": false, "event_type": "INSTANCE_CREATED", "expiration": "2024-10-18T16:00:00Z", "insights_id": "4a
6a184e-6204-47d9-b888-26db9b5e8c82", "instance_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "product_ids": ["69"], "product_tag": ["RHEL for x86"], "display_name": "virtual.testhost.ex
ample.com", "event_source": "HBI_EVENT", "inventory_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "isHypervisor": false, "measurements": [{"value": 2.0, "metric_id": "cores"}, {"value":
 1.0, "metric_id": "sockets"}], "service_type": "HBI_HOST", "hardware_type": "Virtual", "hypervisor_uuid": "6bfc8a3d-464f-4853-a301-4b1715480799", "isUnmappedGuest": true, "subscriptio
n_manager_id": "6bfc8a3d-464f-4853-a301-4b1715480800"}

```

Send an HBI event to simulate a RHEL Hypervisor was reported for the previous unmapped guest.
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json \
Accept:application/vnd.kafka.v2+json \
< rhel_hypervisor.json
```

Validate that a relationship was created for the new hypervisor and the guest's relationship was updated and is_unmapped_guest was set to FALSE.

```
$ psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions \
-c "select org_id, subscription_manager_id, hypervisor_uuid, is_unmapped_guest, creation_date, last_updated from hbi_host_relationship;"
  org_id  |       subscription_manager_id        |           hypervisor_uuid            | is_unmapped_guest |         creation_date         |         last_updated          
----------+--------------------------------------+--------------------------------------+-------------------+-------------------------------+-------------------------------
 12345678 | 6bfc8a3d-464f-4853-a301-4b1715480799 |                                      | f                 | 2025-08-27 15:44:54.776242+00 | 2025-08-27 15:44:54.776242+00
 12345678 | 6bfc8a3d-464f-4853-a301-4b1715480800 | 6bfc8a3d-464f-4853-a301-4b1715480799 | f                 | 2025-08-27 15:35:56.116777+00 | 2025-08-27 15:44:54.782529+00

(2 rows)
```

Verify that an outbox record was created for the new hypervisor. The JSON should contain the following:
  * eventType=INSTANCE_CREATED
  * isHypervisor=true
  * isVirtual=false
  * isUnmappedGuest=false
  * productIds=[69]
  * productTag=[RHEL for x86]
  * measurements:
	  * cores: 2
	  * sockets: 2

```
psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions \
-c "select * from hbi_event_outbox where org_id='12345678' and swatch_event_json->>'instance_id' = '18ebb8c0-a597-41b6-85d2-62003ebaacd3'"

id   |  org_id  |   created_on  |  swatch_event_json
 9100dfbc-0319-4d36-bb07-e33afe955348 | 12345678 | 2025-08-27 15:44:54.782797+00 | {"sla": "Self-Support", "usage": "Development/Test", "org_id": "12345678", "lastSeen": "2024-10-18T16
:42:28.857787Z", "isVirtual": false, "timestamp": "2024-10-18T16:00:00Z", "conversion": false, "event_type": "INSTANCE_CREATED", "expiration": "2024-10-18T17:00:00Z", "insights_id": "4
a6a184e-6204-47d9-b888-26db9b5e8c81", "instance_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd3", "product_ids": ["69"], "product_tag": ["RHEL for x86"], "display_name": "testhost.example.c
om", "event_source": "HBI_EVENT", "inventory_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd3", "isHypervisor": true, "measurements": [{"value": 2.0, "metric_id": "cores"}, {"value": 2.0, "m
etric_id": "sockets"}], "service_type": "HBI_HOST", "hardware_type": "Physical", "hypervisor_uuid": null, "isUnmappedGuest": false, "subscription_manager_id": "6bfc8a3d-464f-4853-a301-
4b1715480799"}
(1 row)
```

Two records should now exist for the guest.
```
psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions -c "select count(*) from hbi_event_outbox where org_id='12345678' and swatch_event_json->>'instance_id' = '18ebb8c0-a597-41b6-85d2-62003ebaacd4'"
 count 
-------
     2
(1 row
```

Verify that an additional outbox record was created for the guest update since it went from unmapped to mapped. Its measurements should have also been updated. The JSON should include:
* eventType=INSTANCE_UPDATED
* isHypervisor=false
* isVirtual=true
* isUnmappedGuest=false (since its hypervisor is known)
* productIds=[69]
* productTag=[RHEL for x86]
* measurements:
	* 2 cores
	* 3 sockets
```
psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions -c "select * from hbi_event_outbox where org_id='12345678' and swatch_event_json->>'instance_id' = '18ebb8c0-a597-41b6-85d2-62003ebaacd4' order by created_on desc limit 1"

id | org_id | created_on | swatch_event_json

 c4d650f8-1ae0-48ab-96b0-ad40cc91cd6c | 12345678 | 2025-08-27 15:44:54.783217+00 | {"sla": "Self-Support", "usage": "Development/Test", "org_id": "12345678", "lastSeen": "2024-10-18T15
:42:28.857787Z", "isVirtual": true, "timestamp": "2024-10-18T16:00:00Z", "conversion": false, "event_type": "INSTANCE_UPDATED", "expiration": "2024-10-18T17:00:00Z", "insights_id": "4a
6a184e-6204-47d9-b888-26db9b5e8c82", "instance_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "product_ids": ["69"], "product_tag": ["RHEL for x86"], "display_name": "virtual.testhost.ex
ample.com", "event_source": "HBI_EVENT", "inventory_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "isHypervisor": false, "measurements": [{"value": 2.0, "metric_id": "cores"}, {"value":
 3.0, "metric_id": "sockets"}], "service_type": "HBI_HOST", "hardware_type": "Virtual", "hypervisor_uuid": "6bfc8a3d-464f-4853-a301-4b1715480799", "isUnmappedGuest": false, "subscripti
on_manager_id": "6bfc8a3d-464f-4853-a301-4b1715480800"}
(1 row)
```

Send an HBI event to signal that the guest was deleted.
```
http :9080/topics/platform.inventory.events \
Content-Type:application/vnd.kafka.json.v2+json \
Accept:application/vnd.kafka.v2+json \
< guest_deleted.json
```

Verify that the guest relationship was deleted.
```
$ psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions \
-c "select org_id, subscription_manager_id, hypervisor_uuid, is_unmapped_guest, creation_date, last_updated from hbi_host_relationship;"

  org_id  |       subscription_manager_id        | hypervisor_uuid | is_unmapped_guest |         creation_date         |         last_updated          
----------+--------------------------------------+-----------------+-------------------+-------------------------------+-------------------------------
 12345678 | 6bfc8a3d-464f-4853-a301-4b1715480799 |                 | f                 | 2025-08-27 15:44:54.776242+00 | 2025-08-27 18:04:10.941949+00
(1 row)
```

Verify an outbox record exists that contains an INSTANCE_DELETED swatch event and that it contains the same host information as last known by the relationship. This should be the same as the last outbox record above.
```
psql -p 5432 -h localhost rhsm-subscriptions rhsm-subscriptions -c "select * from hbi_event_outbox where org_id='12345678' and swatch_event_json->>'instance_id' = '18ebb8c0-a597-41b6-85d2-62003ebaacd4' order by created_on desc limit 1"

id | org_id | created_on | swatch_event_json
 e628c5d0-8e96-4e8c-8cb8-99825ac51ea9 | 12345678 | 2025-08-27 18:04:10.942325+00 | {"sla": "Self-Support", "usage": "Development/Test", "org_id": "12345678", "lastSeen": "2024-10-18T15
:42:28.857787Z", "isVirtual": true, "timestamp": "2025-08-27T17:00:00Z", "conversion": false, "event_type": "INSTANCE_DELETED", "expiration": "2025-08-27T18:00:00Z", "insights_id": "4a
6a184e-6204-47d9-b888-26db9b5e8c82", "instance_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "product_ids": ["69"], "product_tag": ["RHEL for x86"], "display_name": "virtual.testhost.ex
ample.com", "event_source": "HBI_EVENT", "inventory_id": "18ebb8c0-a597-41b6-85d2-62003ebaacd4", "isHypervisor": false, "measurements": [{"value": 2.0, "metric_id": "cores"}, {"value":
 3.0, "metric_id": "sockets"}], "service_type": "HBI_HOST", "hardware_type": "Virtual", "hypervisor_uuid": "6bfc8a3d-464f-4853-a301-4b1715480799", "isUnmappedGuest": false, "subscripti
on_manager_id": "6bfc8a3d-464f-4853-a301-4b1715480800"}
(1 row)
```