### PR TITLE
Move RBAC configuration into swatch-common-security

### DIFF
--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -2,3 +2,13 @@
 %dev.SWATCH_SELF_PSK=placeholder
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
 # stage/prod values come from clowdapp.yaml for individual services
+
+RBAC_ENABLED=true
+RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
+%dev.RBAC_ENDPOINT=http://localhost:8080
+%test.RBAC_ENDPOINT=http://localhost:8080
+# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-type=${clowder.endpoints.rbac-service.trust-store-type}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -203,18 +203,6 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 # Setting up the timeout to 60 seconds instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=90000
 
-# rbac service configuration
-RBAC_ENABLED=true
-%dev.RBAC_ENABLED=false
-RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
-%dev.RBAC_ENDPOINT=http://localhost:8080
-%test.RBAC_ENDPOINT=http://localhost:8080
-# Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
-quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
-quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
-quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}
-quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-type=${clowder.endpoints.rbac-service.trust-store-type}
-
 quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".url=${clowder.private-endpoints.export-service-service.url:http://localhost:10000}
 quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store=${clowder.private-endpoints.export-service-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store-password=${clowder.private-endpoints.export-service-service.trust-store-password}


### PR DESCRIPTION
Required for Jira issue: SWATCH-3862

## Description
This config belongs at the library level and allows for overridding at the application config level.

Always set the RBAC_ENABLED env var to True since
it is only ever used in testing and is forced to
False only in specific unit test cases. By default,
Quarkus security will disable the role augmenters
in development mode, so enabling RBAC all the
time is Ok.
