### PR TITLE
SWATCH-3862: Configure swatch-common-security in swatch-metrics-hbi

### DIFF
--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/PskHeaderAuthenticationMechanism.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/PskHeaderAuthenticationMechanism.java
@@ -45,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 @Priority(1)
 @ApplicationScoped
 public class PskHeaderAuthenticationMechanism implements HttpAuthenticationMechanism {
-  private static final String PSK_HEADER = "x-rh-swatch-psk";
+  public static final String PSK_HEADER = "x-rh-swatch-psk";
 
   @Override
   public Uni<SecurityIdentity> authenticate(

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
@@ -26,11 +26,11 @@ import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Component that adds roles to principals as needed.
@@ -41,15 +41,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Slf4j
 @ApplicationScoped
 public class RolesAugmentor implements SecurityIdentityAugmentor {
-  @ConfigProperty(name = "SWATCH_TEST_APIS_ENABLED", defaultValue = "false")
-  boolean testApisEnabled;
+  @Inject SecurityConfiguration configuration;
 
   @Override
   public Uni<SecurityIdentity> augment(
       SecurityIdentity identity, AuthenticationRequestContext context) {
     Principal principal = identity.getPrincipal();
     Set<String> roles = new HashSet<>();
-    if (!identity.isAnonymous() && testApisEnabled) {
+    if (!identity.isAnonymous() && configuration.isTestApisEnabled()) {
       roles.add("test");
     }
     if (principal instanceof RhIdentityPrincipal) {

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/SecurityConfiguration.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/SecurityConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class SecurityConfiguration {
+  @ConfigProperty(name = "SWATCH_TEST_APIS_ENABLED", defaultValue = "false")
+  boolean testApisEnabled;
+
+  public boolean isTestApisEnabled() {
+    return testApisEnabled;
+  }
+}

--- a/swatch-metrics-hbi/pom.xml
+++ b/swatch-metrics-hbi/pom.xml
@@ -36,6 +36,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
@@ -85,6 +89,10 @@
     <dependency>
       <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-common-models</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-security</artifactId>
     </dependency>
     <dependency>
       <groupId>com.redhat.swatch</groupId>

--- a/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/resources/InternalResource.java
+++ b/swatch-metrics-hbi/src/main/java/com/redhat/swatch/hbi/events/resources/InternalResource.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.hbi.api.DefaultApi;
 import com.redhat.swatch.hbi.events.services.HbiEventOutboxService;
 import com.redhat.swatch.hbi.model.FlushResponse;
 import com.redhat.swatch.hbi.model.OutboxRecord;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -49,6 +50,7 @@ public class InternalResource implements DefaultApi {
   }
 
   @Override
+  @RolesAllowed({"test"})
   public OutboxRecord createOutboxRecord(@Valid Event event) {
     return outboxService.createOutboxRecord(event);
   }

--- a/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-metrics-hbi/src/main/resources/META-INF/openapi.yaml
@@ -39,6 +39,8 @@ paths:
                 $ref: '#/components/schemas/OutboxRecord'
         '400':
           $ref: "../../../../../spec/error-responses.yaml#/$defs/BadRequest"
+      security:
+        - test: [ ]
     put:
       operationId: updateOutboxRecord
       summary: "Update an existing outbox record"
@@ -166,15 +168,14 @@ components:
           example: "SUCCESS"
 
   securitySchemes:
-    PskIdentity:
+    service:
       type: apiKey
-      in: header
+      description: API is available for services
       name: x-rh-swatch-psk
-      description: |
-        Psk header containing Pre Shared Key. Contains an
-        UUID string:
-        ```
-        c9a98753-2092-4617-b226-5c2653330b3d
-        ```
-security:
-  - PskIdentity: []
+      in: header
+    test:
+      type: apiKey
+      description: API is available for testing purposes (pre-production environments
+        only)
+      name: x-rh-swatch-psk
+      in: header

--- a/swatch-metrics-hbi/src/main/resources/application.properties
+++ b/swatch-metrics-hbi/src/main/resources/application.properties
@@ -60,6 +60,9 @@ quarkus.management.enabled=true
 quarkus.management.port=9000
 quarkus.management.root-path=/
 
+# Disable role checking in dev mode. Use QUARKUS_SECURITY_AUTH_ENABLED_IN_DEV_MODE=true to override.
+quarkus.security.auth.enabled-in-dev-mode=false
+
 #clowder quarkus config takes care of setting the common kafka settings
 kafka.bootstrap.servers=localhost:9092
 
@@ -155,3 +158,6 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 
 # Disable ALL dev services
 quarkus.devservices.enabled=false
+
+# Do not include RbacRolesAugmentor
+swatch-common-security.include-rbac=false


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3862

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Enable the createOutboxRecord endpoint for the role 'test' only

## Testing
<!--
When possible, please use commands that a developer can directly paste or modify
-->
IQE Test MR: No new tests needed
Run the tests locally in ```iqe_rhsm_subscriptions/tests/component/swatch_metrics_hbi/test_internal_api.py```
They will pass unless the SWATCH_TEST_APIS_ENABLED variable is set to false on the local swatch-metrics-hbi application, as is described below.

### Setup
<!-- Add any steps required to set up the test case -->
1.  ```podman-compose up -d```
2.  ```QUARKUS_SECURITY_AUTH_ENABLED_IN_DEV_MODE=true make build swatch-metrics-hbi```

### Steps
<!-- Enter each step of the test below -->
1. ```
    http POST :8015/api/swatch-metrics-hbi/internal/outbox --raw '{
        "event_source": "HBI_HOST",
        "event_type": "test",
        "org_id": "org123",
        "instance_id": "test-instance-id",
        "service_type": "RHEL System",
        "timestamp": 1756912842.587640403,
        "conversion": false,
        "isHypervisor": false,
        "isVirtual": false,
        "isUnmappedGuest": false
    }'
    ```
2. ``` 
    http POST :8015/api/swatch-metrics-hbi/internal/outbox x-rh-swatch-psk:placeholder --raw '{
            "event_source": "HBI_HOST",
            "event_type": "test",
            "org_id": "org123",
            "instance_id": "test-instance-id",
            "service_type": "RHEL System",
            "timestamp": 1756912842.587640403,
            "conversion": false,
            "isHypervisor": false,
            "isVirtual": false,
            "isUnmappedGuest": false
    }'
    ```


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. An empty header will result in a 401, even in test mode
2. A psk header will result in a 200 and a response of the event JSON
3. If you start swatch-metrics-hbi with 'SWATCH_TEST_APIS_ENABLED=false', then the requests above will be rejected (403 with a valid header and 401 with no header)
