### PR TITLE
Add swatch-common-security.include-rbac for inclusion of RbacRolesAugmentor

### DIFF
--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RbacRolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RbacRolesAugmentor.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.common.security;
 import com.redhat.swatch.clients.rbac.api.model.Access;
 import com.redhat.swatch.clients.rbac.api.resources.AccessApi;
 import com.redhat.swatch.clients.rbac.api.resources.ApiException;
+import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
@@ -42,6 +43,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 /** Component that adds roles from RBAC service to customer and service account principals. */
 @Slf4j
 @ApplicationScoped
+@IfBuildProperty(name = "swatch-common-security.include-rbac", stringValue = "true")
 public class RbacRolesAugmentor implements SecurityIdentityAugmentor {
 
   private static final String RBAC_APP_NAME = "subscriptions";

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -3,6 +3,9 @@
 %test.SWATCH_SELF_PSK=${%dev.SWATCH_SELF_PSK}
 # stage/prod values come from clowdapp.yaml for individual services
 
+# Controls whether RbacRolesAugmentor is included at build time via @IfBuildProperty (requires rebuild to change)
+swatch-common-security.include-rbac=true
+
 SWATCH_TEST_APIS_ENABLED=true
 %prod.SWATCH_TEST_APIS_ENABLED=false
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
To avoid loading this Augmentor when not in use. The augmentor load is causing the RBAC configuration to be exercised, which leads to other issues. As the augmentor is not needed in all scenarios, this is the simplest solution.
