### PR TITLE
Remove kafka port binding in docker compose that was causing conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       start_period: 10s
     ports:
       - "127.0.0.1:9092:9092"
-      - "[::1]:9092:9092"
       # Port 9093 is used by the Kraft configuration
       - "127.0.0.1:9094:9094"
       - "127.0.0.1:29092:29092"


### PR DESCRIPTION
## Description
The port 9092 was already binded by the previous line.