### PR TITLE
Remove unnecessary delete method and its use

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
+++ b/src/main/java/org/candlepin/subscriptions/retention/TallyRetentionController.java
@@ -78,24 +78,11 @@ public class TallyRetentionController {
               orgId, granularity, cutoffDate);
 
       if (countSnapshots > 0) {
-        purgeMeasurementsByOrgAndGranularity(orgId, granularity, cutoffDate);
         purgeSnapshotsByOrgAndGranularity(countSnapshots, orgId, granularity, cutoffDate);
       }
     }
 
     LogUtils.clearOrgIdFromMdc();
-  }
-
-  private void purgeMeasurementsByOrgAndGranularity(
-      String orgId, Granularity granularity, OffsetDateTime cutoffDate) {
-    long count =
-        tallySnapshotRepository.countMeasurementsByGranularityAndSnapshotDateBefore(
-            orgId, granularity.name(), cutoffDate);
-    while (count > 0) {
-      tallySnapshotRepository.deleteMeasurementsByGranularityAndSnapshotDateBefore(
-          orgId, granularity.name(), cutoffDate, policy.getSnapshotsToDeleteInBatches());
-      count -= policy.getSnapshotsToDeleteInBatches();
-    }
   }
 
   private void purgeSnapshotsByOrgAndGranularity(

--- a/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/retention/TallyRetentionControllerTest.java
@@ -105,28 +105,6 @@ class TallyRetentionControllerTest {
   }
 
   @Test
-  void retentionControllerShouldRemoveMeasurementsForGranularitiesConfigured() {
-    givenOrganization(ORG_ID);
-    OffsetDateTime cutoff = givenCutoffDateForGranularity(Granularity.DAILY);
-    // given 9 existing measurements
-    givenExistingSnapshotsFor(Granularity.DAILY, cutoff, 1);
-    givenExistingMeasurementsFor(Granularity.DAILY, cutoff, 9);
-    controller.purgeSnapshotsAsync();
-    verify(repository, times(1))
-        .deleteMeasurementsByGranularityAndSnapshotDateBefore(
-            ORG_ID, Granularity.DAILY.name(), cutoff, policy.getSnapshotsToDeleteInBatches());
-
-    reset(repository);
-    // given 11 existing measurements, then we expect 2 iterations because the limit is 10.
-    givenExistingSnapshotsFor(Granularity.DAILY, cutoff, 1);
-    givenExistingMeasurementsFor(Granularity.DAILY, cutoff, 11);
-    controller.purgeSnapshotsAsync();
-    verify(repository, times(2))
-        .deleteMeasurementsByGranularityAndSnapshotDateBefore(
-            ORG_ID, Granularity.DAILY.name(), cutoff, policy.getSnapshotsToDeleteInBatches());
-  }
-
-  @Test
   void retentionControllerShouldIgnoreGranularityWithoutCutoff() {
     when(policy.getCutoffDate(any())).thenReturn(null);
     controller.purgeSnapshotsAsync();
@@ -145,13 +123,6 @@ class TallyRetentionControllerTest {
     // expected 4 invocations: 1 for each organization (because the limit in the test is 1),
     // plus the last one that will retrieve empty results and hence will stop the loop.
     verify(orgConfigRepository, times(4)).findAll(any(Pageable.class));
-  }
-
-  private void givenExistingMeasurementsFor(
-      Granularity granularity, OffsetDateTime cutoff, long expected) {
-    when(repository.countMeasurementsByGranularityAndSnapshotDateBefore(
-            ORG_ID, granularity.name(), cutoff))
-        .thenReturn(expected);
   }
 
   private void givenExistingSnapshotsFor(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallySnapshotRepository.java
@@ -87,37 +87,6 @@ public interface TallySnapshotRepository extends JpaRepository<TallySnapshot, UU
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   @Query(
-      nativeQuery = true,
-      value =
-          "select count(*) FROM tally_measurements m inner join tally_snapshots ts on m.snapshot_id=ts.id where ts.org_id=:orgId and ts.granularity=:granularity and ts.snapshot_date < :cutoffDate")
-  long countMeasurementsByGranularityAndSnapshotDateBefore(
-      @Param("orgId") String orgId,
-      @Param("granularity") String granularity,
-      @Param("cutoffDate") OffsetDateTime cutoffDate);
-
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  @Modifying
-  @Query(
-      nativeQuery = true,
-      value =
-          """
-    delete from tally_measurements
-    where (snapshot_id, measurement_type, metric_id) in (
-        select m.snapshot_id, m.measurement_type, m.metric_id
-        from tally_measurements m
-        inner join tally_snapshots ts on m.snapshot_id=ts.id
-        where ts.org_id=:orgId and ts.granularity=:granularity and ts.snapshot_date < :cutoffDate
-        limit :limit
-    )
-""")
-  void deleteMeasurementsByGranularityAndSnapshotDateBefore(
-      @Param("orgId") String orgId,
-      @Param("granularity") String granularity,
-      @Param("cutoffDate") OffsetDateTime cutoffDate,
-      @Param("limit") long limit);
-
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  @Query(
       value =
           "select count(*) from TallySnapshot where orgId=:orgId and granularity=:granularity and snapshotDate < :cutoffDate")
   long countAllByGranularityAndSnapshotDateBefore(


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3962

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
A query is causing a timeout daily for the process of removing old snapshots

- The deletion of tally_measurements entries method is unnecessary as there is a delete cascade from the tally_snapshots table.
- The only use of this method was called immediately preceeding the tally_snapshot delete which removes the measurements also.
- The lookup for the joined tables is expensive. A count query based on the join times out every day on prod for an org with about a million snapshots.


## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Regression only

