### PR TITLE
ci: automatically add labels in the PR for each service that changed

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,84 @@
+name: Add labels to Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  detect-and-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need to do git diff against the base branch
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update && sudo apt install -y gh
+      - name: Add labels to PR
+        id: add-labels
+        run: |
+          MVNW=$(pwd)/mvnw
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          SERVICES=("swatch-billable-usage" "swatch-contracts" "swatch-metrics" "swatch-metrics-hbi"  "swatch-producer-azure" "swatch-producer-aws" "swatch-tally" "swatch-system-conduit")
+          
+          echo "Removing all service labels from PR"
+          for LABEL in "${SERVICES[@]}"; do
+            # Remove the label, ignore errors if the PR doesn't have it
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "$LABEL" || true
+          done
+          
+          echo "Fetching base branch $BASE_BRANCH..."
+          git fetch origin "$BASE_BRANCH"
+          
+          # ================================
+          # Detect changed top-level Maven modules
+          # ================================
+          CHANGED=$(git diff --name-only "origin/$BASE_BRANCH...HEAD" | awk -F/ '{print $1}' | sort -u | xargs)
+          
+          if [ -z "$CHANGED" ]; then
+            echo ""
+            exit 0
+          fi
+        
+          echo "Changed modules: $CHANGED"
+          
+          for SERVICE in "${SERVICES[@]}"; do
+            # If the service itself changed, mark it as affected immediately
+            if [[ " $CHANGED " =~ " $SERVICE " ]]; then
+              gh pr edit ${{ github.event.pull_request.number }} --add-label "$SERVICE"
+              continue  # No need to check dependencies, already affected
+            fi
+        
+            GRAPH_FILE="$SERVICE/target/dep-graph.dot"
+          
+            echo "Generating dependency graph for $SERVICE..."
+            # Generate graph inside the service folder
+            (cd "$SERVICE" && $MVNW dependency:tree -DoutputType=dot -DappendOutput=true -DoutputFile=target/dep-graph.dot -q)
+          
+            DEPENDENCY_FOUND=false
+          
+            # Read the service's dependency graph line by line
+            while IFS= read -r line && [ "$DEPENDENCY_FOUND" = false ]; do
+              if [[ "$line" == *"->"* ]]; then
+                LEFT=$(echo "$line" | cut -d'"' -f2 | cut -d':' -f2)
+                RIGHT=$(echo "$line" | cut -d'"' -f4 | cut -d':' -f2)
+                
+                # Check if the service depends on any changed module
+                for MOD in $CHANGED; do
+                  if [ "$RIGHT" = "$MOD" ]; then
+                    gh pr edit ${{ github.event.pull_request.number }} --add-label "$SERVICE"
+                    DEPENDENCY_FOUND=true
+                    break  # Exit inner loop only; while will terminate automatically
+                  fi
+                done
+              fi
+            done < "$GRAPH_FILE"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ pytest_swatch/*
 
 # maven
 .mvn/wrapper/maven-wrapper.jar
+**/*.dot


### PR DESCRIPTION
Changes:
- Added a new github action to detect what SWATCH services are affected by the changes in the pull request
- The changes might be because one dependency changed or because the service's logic changed