### PR TITLE
SWATCH-3895: Add Liquibase preconditions to tables controlled by swatch-contracts

### DIFF
--- a/bin/oc-db
+++ b/bin/oc-db
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# If you put this file (or symlink it) to somewhere in your path, the `oc`
+# command will find it and delegate to it.  You can then just run `oc db`
+
+PORT_FORWARD_PID=""
+
+# Cleanup function
+cleanup() {
+    if [ -n "$PORT_FORWARD_PID" ]; then
+        echo "Cleaning up port-forward (PID: $PORT_FORWARD_PID)..."
+        kill $PORT_FORWARD_PID 2>/dev/null
+    fi
+}
+
+# Set trap to cleanup on various signals
+trap cleanup INT TERM ERR EXIT
+
+# Find and port-forward the swatch-database-db pod
+POD=$(oc get pods --no-headers | grep "^swatch-database-db" | awk '{print $1}' | head -1)
+
+if [ -z "$POD" ]; then
+    echo "No pod found starting with 'swatch-database-db'"
+    exit 1
+fi
+
+echo "Found pod: $POD"
+echo "Setting up port-forward..."
+
+# Start port-forward in background
+oc port-forward "$POD" 5433:5432 &
+PORT_FORWARD_PID=$!
+
+# Give port-forward time to establish
+sleep 3
+
+# Get username from secret
+USERNAME=$(oc get secret swatch-database-db -o json | jq -r '.data.username' | base64 -d)
+
+if [ -z "$USERNAME" ]; then
+    echo "Failed to get username from secret"
+    exit 1
+fi
+
+echo "Connecting to database as user: $USERNAME"
+
+# Connect to database
+psql -U "$USERNAME" -p 5433 -h localhost rhsm "$@"

--- a/swatch-database-migrations/src/main/resources/db/202509021332-assume-ownership-of-offerings-and-subscriptions.xml
+++ b/swatch-database-migrations/src/main/resources/db/202509021332-assume-ownership-of-offerings-and-subscriptions.xml
@@ -161,12 +161,8 @@
     </createIndex>
   </changeSet>
 
-  <changeSet id="202509021332-7" author="awood" dbms="postgresql">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <viewExists viewName="subscription_capacity_view"/>
-      </not>
-    </preConditions>
+  <changeSet id="202509021332-7" author="awood" dbms="postgresql" runOnChange="true">
+    <dropView viewName="subscription_capacity_view" ifExists="true"/>
     <createView replaceIfExists="true" viewName="subscription_capacity_view">
     <![CDATA[
     with active_subscriptions as (

--- a/swatch-database-migrations/src/main/resources/liquibase/202012181510-add-offering-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202012181510-add-offering-table.xml
@@ -6,6 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202012181511-1" author="jharriso">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <tableExists tableName="offering"/>
+          </not>
+        </preConditions>
+
         <comment>Create the offerings table</comment>
         <createTable tableName="offering">
             <column name="sku" type="VARCHAR(255)"/>
@@ -24,6 +30,12 @@
     </changeSet>
 
     <changeSet id="202012181511-2" author="jharriso">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <tableExists tableName="sku_child_sku"/>
+          </not>
+        </preConditions>
+
         <comment>Create the sku to child sku table</comment>
         <createTable tableName="sku_child_sku">
             <column name="sku" type="VARCHAR(255)"/>
@@ -35,6 +47,12 @@
     </changeSet>
 
     <changeSet id="202012181511-3" author="jharriso">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <tableExists tableName="sku_oid"/>
+          </not>
+        </preConditions>
+
         <comment>Create the sku to oid table</comment>
         <createTable tableName="sku_oid">
             <column name="sku" type="VARCHAR(255)"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202101081600-tweak-offering.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202101081600-tweak-offering.xml
@@ -4,6 +4,9 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202001081600-1" author="khowell">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="offering" columnName="entitlement_quantity"/>
+        </preConditions>
         <comment>Drop entitlement_quantity column</comment>
         <dropColumn tableName="offering" columnName="entitlement_quantity"/>
     </changeSet>

--- a/swatch-database-migrations/src/main/resources/liquibase/202101121122-add-subscription-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202101121122-add-subscription-table.xml
@@ -6,6 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202101121122-1" author="jharriso">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <tableExists tableName="subscription"/>
+          </not>
+        </preConditions>
+
         <comment>Create the subscription table</comment>
         <createTable tableName="subscription">
             <column name="sku" type="VARCHAR(255)"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202102031030-update-subscription-pkey.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202102031030-update-subscription-pkey.xml
@@ -4,6 +4,31 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202101081600-1" author="jharriso">
+        <preConditions onFail="MARK_RAN">
+            <!-- The expectedResult is a little counter-intuitive.  Basically it means, if the
+            result of the SQL matches the expectedResult, run the changeset.
+
+            In this case, we only want to try to create the composite primary key if it doesn't
+            already exist.  I.e. the query does not find a matching constraint in the
+            table_constraints table.
+            -->
+            <sqlCheck expectedResult="0">
+                SELECT CASE
+                    WHEN COUNT(*) = 1 THEN 1
+                    ELSE 0
+                END
+                FROM (
+                    SELECT tc.constraint_name
+                    FROM information_schema.table_constraints tc
+                    JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+                    WHERE tc.table_name = 'subscription'
+                    AND tc.constraint_type = 'PRIMARY KEY'
+                    AND kcu.column_name IN ('subscription_id', 'start_date')
+                    GROUP BY tc.constraint_name
+                    HAVING COUNT(kcu.column_name) = 2
+                )
+            </sqlCheck>
+        </preConditions>
         <comment>Change primary key</comment>
         <dropPrimaryKey tableName="subscription" />
         <addPrimaryKey tableName="subscription" columnNames="subscription_id,start_date" />

--- a/swatch-database-migrations/src/main/resources/liquibase/202102261751-add-marketplace-subscription-id.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202102261751-add-marketplace-subscription-id.xml
@@ -7,6 +7,14 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="202102261751-1" author="awood">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <and>
+              <columnExists tableName="subscription" columnName="marketplace_subscription_id"/>
+              <columnExists tableName="subscription" columnName="account_number"/>
+            </and>
+          </not>
+        </preConditions>
         <addColumn tableName="subscription">
             <column name="marketplace_subscription_id" type="VARCHAR(255)"/>
             <column name="account_number" type="VARCHAR(255)"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202104091791-insert-openshift-skus.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202104091791-insert-openshift-skus.xml
@@ -6,6 +6,17 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202104091791-1" author="khowell">
+        <preConditions onFail="MARK_RAN">
+          <and>
+            <sqlCheck expectedResult="0">
+              SELECT COUNT(1) FROM offering WHERE sku = 'MW01485'
+            </sqlCheck>
+            <columnExists tableName="offering" columnName="physical_cores"/>
+            <columnExists tableName="offering" columnName="physical_sockets"/>
+            <columnExists tableName="offering" columnName="virtual_cores"/>
+            <columnExists tableName="offering" columnName="virtual_sockets"/>
+          </and>
+        </preConditions>
         <insert tableName="offering">
             <column name="sku" value="MW01485"/>
             <column name="product_name" value="OpenShift Container Platform"/>
@@ -29,5 +40,41 @@
             <column name="virtual_sockets" value="0"/>
         </insert>
     </changeSet>
+
+  <changeSet id="202104091791-2" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <sqlCheck expectedResult="0">
+          SELECT COUNT(1) FROM offering WHERE sku = 'MW01485'
+        </sqlCheck>
+        <columnExists tableName="offering" columnName="cores"/>
+        <columnExists tableName="offering" columnName="sockets"/>
+        <columnExists tableName="offering" columnName="hypervisor_cores"/>
+        <columnExists tableName="offering" columnName="hypervisor_sockets"/>
+      </and>
+    </preConditions>
+    <insert tableName="offering">
+      <column name="sku" value="MW01485"/>
+      <column name="product_name" value="OpenShift Container Platform"/>
+      <column name="role" value="ocp"/>
+      <column name="sla" value="Premium"/>
+      <column name="usage" value="Production"/>
+      <column name="cores" value="0"/>
+      <column name="sockets" value="0"/>
+      <column name="hypervisor_cores" value="0"/>
+      <column name="hypervisor_sockets" value="0"/>
+    </insert>
+    <insert tableName="offering">
+      <column name="sku" value="MW01484"/>
+      <column name="product_name" value="OpenShift Dedicated"/>
+      <column name="role" value="osd"/>
+      <column name="sla" value="Premium"/>
+      <column name="usage" value="Production"/>
+      <column name="cores" value="0"/>
+      <column name="sockets" value="0"/>
+      <column name="hypervisor_cores" value="0"/>
+      <column name="hypervisor_sockets" value="0"/>
+    </insert>
+  </changeSet>
 
 </databaseChangeLog>

--- a/swatch-database-migrations/src/main/resources/liquibase/202107121534-add-subscription-number-to-subscription.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202107121534-add-subscription-number-to-subscription.xml
@@ -7,6 +7,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="202107121408-2" author="sgunta">
+      <preConditions onFail="MARK_RAN">
+        <not>
+          <columnExists tableName="subscription" columnName="subscription_number"/>
+        </not>
+      </preConditions>
         <comment>Add subscription_number column to subscription table</comment>
         <addColumn tableName="subscription">
             <column name="subscription_number" type="VARCHAR(255)" />

--- a/swatch-database-migrations/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202110211313-add-rhosak-offering.xml
@@ -6,9 +6,16 @@
 
   <changeSet id="202110211313-1" author="mstead">
     <preConditions onFail="MARK_RAN">
-      <sqlCheck expectedResult="0">
-        SELECT COUNT(1) FROM offering WHERE sku = 'MW01882'
-      </sqlCheck>
+      <and>
+        <sqlCheck expectedResult="0">
+          SELECT COUNT(1) FROM offering WHERE sku = 'MW01882'
+        </sqlCheck>
+
+        <columnExists tableName="offering" columnName="physical_cores"/>
+        <columnExists tableName="offering" columnName="physical_sockets"/>
+        <columnExists tableName="offering" columnName="virtual_cores"/>
+        <columnExists tableName="offering" columnName="virtual_sockets"/>
+      </and>
     </preConditions>
     <comment>Add offering for RHOSAK SKU</comment>
     <insert tableName="offering">
@@ -24,4 +31,30 @@
     </insert>
   </changeSet>
 
+  <changeSet id="202110211313-2" author="mstead">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <sqlCheck expectedResult="0">
+          SELECT COUNT(1) FROM offering WHERE sku = 'MW01882'
+        </sqlCheck>
+
+        <columnExists tableName="offering" columnName="cores"/>
+        <columnExists tableName="offering" columnName="sockets"/>
+        <columnExists tableName="offering" columnName="hypervisor_cores"/>
+        <columnExists tableName="offering" columnName="hypervisor_sockets"/>
+      </and>
+    </preConditions>
+    <comment>Add offering for RHOSAK SKU</comment>
+    <insert tableName="offering">
+      <column name="sku" value="MW01882"/>
+      <column name="product_name" value="OpenShift Streams for Apache Kafka"/>
+      <column name="role" value="rhosak"/>
+      <column name="sla" value="Premium"/>
+      <column name="usage" value="Production"/>
+      <column name="cores" value="0"/>
+      <column name="sockets" value="0"/>
+      <column name="hypervisor_cores" value="0"/>
+      <column name="hypervisor_sockets" value="0"/>
+    </insert>
+  </changeSet>
 </databaseChangeLog>

--- a/swatch-database-migrations/src/main/resources/liquibase/202110211314-add-description-column-to-offering.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202110211314-add-description-column-to-offering.xml
@@ -7,6 +7,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202110211010-1" author="mstead">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="offering" columnName="description"/>
+      </not>
+    </preConditions>
     <comment>Add description column to offering table</comment>
     <addColumn tableName="offering">
       <column name="description" type="VARCHAR(255)" />

--- a/swatch-database-migrations/src/main/resources/liquibase/202112171721-add-subscription-indexes.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202112171721-add-subscription-indexes.xml
@@ -5,6 +5,13 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202112171721-1"  author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <and>
+        <columnExists tableName="subscription" columnName="sku"/>
+        <columnExists tableName="subscription" columnName="account_number"/>
+        <columnExists tableName="subscription" columnName="owner_id"/>
+      </and>
+    </preConditions>
     <comment>Add indexes to subscription table</comment>
     <createIndex tableName="subscription" indexName="subscription_sku_idx">
       <column name="sku"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202202041415-add-unlimited-usage-column-to-offering-table.xml
@@ -5,6 +5,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202202041415-1"  author="kflahert">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="offering" columnName="has_unlimited_usage"/>
+      </not>
+    </preConditions>
     <comment>Add has_unlimited_usage column to offering table</comment>
     <addColumn tableName="offering">
       <column name="has_unlimited_usage" type="BOOLEAN" />

--- a/swatch-database-migrations/src/main/resources/liquibase/202202211433-add-billing-provider-column-to-subscription-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202202211433-add-billing-provider-column-to-subscription-table.xml
@@ -1,21 +1,33 @@
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet id="202202211433-1"  author="ksynvrit">
-        <comment>Add billing_provider column to subscription table</comment>
-        <addColumn tableName="subscription">
-            <column name="billing_provider" type="VARCHAR(255)" />
-        </addColumn>
-    </changeSet>
+  <changeSet id="202202211433-1" author="ksynvrit">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="subscription" columnName="billing_provider"/>
+      </not>
+    </preConditions>
+    <comment>Add billing_provider column to subscription table</comment>
+    <addColumn tableName="subscription">
+      <column name="billing_provider" type="VARCHAR(255)"/>
+    </addColumn>
+  </changeSet>
 
-    <changeSet id="202202211433-2"  author="ksynvrit">
-        <comment>Rename marketplace_subscription_id column to billing_provider_id in subscription table</comment>
-        <renameColumn  newColumnName="billing_provider_id"
-                       oldColumnName="marketplace_subscription_id"
-                       tableName="subscription"/>
-    </changeSet>
+  <changeSet id="202202211433-2" author="ksynvrit">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="subscription" columnName="billing_provider_id"/>
+      </not>
+    </preConditions>
+    <comment>Rename marketplace_subscription_id column to billing_provider_id in subscription
+      table
+    </comment>
+    <renameColumn newColumnName="billing_provider_id"
+      oldColumnName="marketplace_subscription_id"
+      tableName="subscription"/>
+  </changeSet>
 
 </databaseChangeLog>

--- a/swatch-database-migrations/src/main/resources/liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202204081020-add-billing-account-id-column-to-subscriptions.xml
@@ -5,6 +5,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="202204081020-1" author="kflahert">
+      <preConditions onFail="MARK_RAN">
+        <not>
+          <columnExists tableName="subscription" columnName="billing_account_id"/>
+        </not>
+      </preConditions>
         <comment>Add column for billing account id to subscription table</comment>
         <addColumn tableName="subscription">
             <column name="billing_account_id" type="VARCHAR(255)" />

--- a/swatch-database-migrations/src/main/resources/liquibase/202210281140-rename-owner-id-to-org-id.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202210281140-rename-owner-id-to-org-id.xml
@@ -7,6 +7,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202210281140-1"  author="kflahert">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="subscription" columnName="org_id"/>
+      </not>
+    </preConditions>
     <comment>Rename owner_id column to org_id in subscription table</comment>
     <renameColumn  newColumnName="org_id"
       oldColumnName="owner_id"

--- a/swatch-database-migrations/src/main/resources/liquibase/202211091649-rename-physical-virtual-cores-sockets-columns.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202211091649-rename-physical-virtual-cores-sockets-columns.xml
@@ -15,6 +15,16 @@
   </changeSet>
 
   <changeSet id="202211091649-2" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <and>
+          <columnExists tableName="offering" columnName="sockets"/>
+          <columnExists tableName="offering" columnName="hypervisor_sockets"/>
+          <columnExists tableName="offering" columnName="cores"/>
+          <columnExists tableName="offering" columnName="hypervisor_cores"/>
+        </and>
+      </not>
+    </preConditions>
     <comment>Rename sockets/cores columns in the offering table.</comment>
     <renameColumn tableName="offering" oldColumnName="physical_sockets" newColumnName="sockets"/>
     <renameColumn tableName="offering" oldColumnName="virtual_sockets" newColumnName="hypervisor_sockets"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202212161446-add-derived-sku-to-offering.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202212161446-add-derived-sku-to-offering.xml
@@ -6,6 +6,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202212161446-1" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="offering" columnName="derived_sku"/>
+      </not>
+    </preConditions>
     <comment>
       Add derived SKU column to offering, so that we can easily detect changes in derived SKUs.
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202305031403-create-subscription-measurements-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202305031403-create-subscription-measurements-table.xml
@@ -17,6 +17,12 @@
     SET subscription.has_unlimited_usage = subscription_capacity.has_unlimited_usage"/>
 
   <changeSet id="202305031403-01" author="awood">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="subscription_measurements"/>
+      </not>
+    </preConditions>
+
     <createTable tableName="subscription_measurements">
       <column name="subscription_id" type="VARCHAR(255)"/>
       <column name="start_date" type="TIMESTAMP WITH TIME ZONE"/>
@@ -35,6 +41,11 @@
   </changeSet>
 
   <changeSet id="202305031403-02" author="awood">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="subscription" columnName="has_unlimited_usage"/>
+      </not>
+    </preConditions>
     <addColumn tableName="subscription">
       <column name="has_unlimited_usage" type="BOOLEAN"/>
     </addColumn>

--- a/swatch-database-migrations/src/main/resources/liquibase/202306151541-add-sku-foreign-key-to-subscription.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202306151541-add-sku-foreign-key-to-subscription.xml
@@ -7,6 +7,12 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="202306151541-01" author="awood">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <foreignKeyConstraintExists foreignKeyName="subscription_sku_fkey"
+              foreignKeyTableName="subscription"/>
+          </not>
+        </preConditions>
         <addForeignKeyConstraint constraintName="subscription_sku_fkey"
             baseTableName="subscription" baseColumnNames="sku"
             referencedTableName="offering" referencedColumnNames="sku"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202306201611-add-subscription-id-index-for-measurements.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202306201611-add-subscription-id-index-for-measurements.xml
@@ -7,6 +7,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="202306201611-1" author="karshah">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <indexExists tableName="subscription_measurements" indexName="subscription_id_idx"/>
+          </not>
+        </preConditions>
         <comment>Add an index on subscription_id column in the subscription_measurements table</comment>
         <createIndex indexName="subscription_id_idx" tableName="subscription_measurements"
                      unique="false">

--- a/swatch-database-migrations/src/main/resources/liquibase/202310131200-remove-account-config.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202310131200-remove-account-config.xml
@@ -7,6 +7,9 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202310031000-02" author="vbusch">
+    <preConditions onFail="MARK_RAN">
+      <columnExists tableName="subscription" columnName="account_number"/>
+    </preConditions>
     <comment>Drop account_number column from subscription table</comment>
     <dropColumn tableName="subscription" columnName="account_number"/>
 

--- a/swatch-database-migrations/src/main/resources/liquibase/202312200751-add-metered-column-for-offering-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202312200751-add-metered-column-for-offering-table.xml
@@ -5,6 +5,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202312200751-01" author="jcarvaja">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="offering" columnName="metered"/>
+      </not>
+    </preConditions>
     <comment>Add column for metered column to the offering table</comment>
     <addColumn tableName="offering">
       <column name="metered" type="BOOLEAN"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202402151211-add-sku-product-tag-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202402151211-add-sku-product-tag-table.xml
@@ -6,6 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
     <changeSet id="202402151211-1" author="karshah">
+        <preConditions onFail="MARK_RAN">
+          <not>
+            <tableExists tableName="sku_product_tag"/>
+          </not>
+        </preConditions>
+
         <comment>Create the table relation sku to product tag from offering</comment>
         <createTable tableName="sku_product_tag">
             <column name="sku" type="VARCHAR(255)"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202404080930-add-special_pricing_flag-to-offering.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202404080930-add-special_pricing_flag-to-offering.xml
@@ -7,6 +7,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <changeSet id="202404080930-1" author="jcarvaja">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="offering" columnName="special_pricing_flag"/>
+      </not>
+    </preConditions>
     <addColumn tableName="offering">
       <column name="special_pricing_flag" type="VARCHAR(255)"/>
     </addColumn>

--- a/swatch-database-migrations/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
@@ -4,12 +4,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
-  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <viewExists viewName="subscription_capacity_view"/>
-      </not>
-    </preConditions>
+  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql" ignore="true">
+    <!-- View controlled by swatch-contracts -->
     <comment>
       Add subscription_capacity_view that aggregates all the capacities by sku
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202405160950-add-subscription-capacity-view.xml
@@ -5,6 +5,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="subscription_capacity_view"/>
+      </not>
+    </preConditions>
     <comment>
       Add subscription_capacity_view that aggregates all the capacities by sku
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
@@ -4,12 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
-  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <viewExists viewName="subscription_capacity_view"/>
-      </not>
-    </preConditions>
+  <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql" runOnChange="true"
+    ignore="true">
+    <!-- View controlled by swatch-contracts -->
     <comment>
       Add subscription_capacity_view that aggregates all the capacities by sku
     </comment>
@@ -88,7 +85,8 @@
     </rollback>
   </changeSet>
 
-  <changeSet id="202405160950-02" author="jcarvaja" dbms="hsqldb" runOnChange="true">
+  <changeSet id="202405160950-02" author="jcarvaja" dbms="hsqldb" runOnChange="true" ignore="true">
+    <!-- View controlled by swatch-contracts -->
     <comment>
       Add subscription_capacity_view that aggregates all the capacities by sku (test version)
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202406120950-update-subscription-capacity-view.xml
@@ -5,6 +5,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202405160950-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="subscription_capacity_view"/>
+      </not>
+    </preConditions>
     <comment>
       Add subscription_capacity_view that aggregates all the capacities by sku
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202406240700-add-subscription-number-index.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202406240700-add-subscription-number-index.xml
@@ -6,6 +6,11 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
   <changeSet id="202406240700-1" author="bcourt">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists tableName="subscription" indexName="subscription_subscription_number_idx"/>
+      </not>
+    </preConditions>
     <comment>Create an index on subscription_number for subscription</comment>
     <createIndex indexName="subscription_subscription_number_idx" tableName="subscription"
                  unique="false">

--- a/swatch-database-migrations/src/main/resources/liquibase/202407030751-add-level-column-for-offering-table.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202407030751-add-level-column-for-offering-table.xml
@@ -5,6 +5,14 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202407030751-01" author="karshah">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <and>
+          <columnExists tableName="offering" columnName="level_1"/>
+          <columnExists tableName="offering" columnName="level_2"/>
+        </and>
+      </not>
+    </preConditions>
     <comment>Add level_1 and level_2 columns to the OFFERING table</comment>
     <addColumn tableName="offering">
       <column name="level_1" type="text"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202407231110-subscription-capacity-index.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202407231110-subscription-capacity-index.xml
@@ -5,6 +5,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202407231110-01" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <indexExists indexName="subscription_sku_idx" tableName="subscription"/>
+    </preConditions>
     <dropIndex indexName="subscription_sku_idx" tableName="subscription"/>
     <rollback>
       <createIndex tableName="subscription" indexName="subscription_sku_idx">
@@ -13,6 +16,11 @@
     </rollback>
   </changeSet>
   <changeSet id="202407231110-02" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists tableName="subscription" indexName="subscription_sku_subs_id_start_date_idx"/>
+      </not>
+    </preConditions>
     <createIndex tableName="subscription" indexName="subscription_sku_subs_id_start_date_idx">
       <column name="sku"/>
       <column name="subscription_id"/>
@@ -21,6 +29,12 @@
     <!-- rollback automatically generated -->
   </changeSet>
   <changeSet id="202407231110-03" author="khowell">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists tableName="subscription"
+          indexName="subscription_sku_sub_number_start_date_idx"/>
+      </not>
+    </preConditions>
     <createIndex tableName="subscription" indexName="subscription_sku_sub_number_start_date_idx">
       <column name="sku"/>
       <column name="subscription_number"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
@@ -4,12 +4,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
-  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <viewExists viewName="subscription_capacity_view"/>
-      </not>
-    </preConditions>
+  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true" ignore="true">
+    <!-- View controlled by swatch-contracts -->
     <comment>
       Update subscription_capacity_view to filter by org_id
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202409251400-update-subscription-capacity-view-org-id.xml
@@ -5,6 +5,11 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="subscription_capacity_view"/>
+      </not>
+    </preConditions>
     <comment>
       Update subscription_capacity_view to filter by org_id
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202412041537-primary-keys-on-all-tables.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202412041537-primary-keys-on-all-tables.xml
@@ -47,6 +47,11 @@
   </changeSet>
 
   <changeSet id="202412041537-03" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="sku_child_sku" columnName="id"/>
+      </not>
+    </preConditions>
     <addColumn tableName="sku_child_sku">
       <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
         <constraints primaryKey="true" nullable="false"/>
@@ -55,6 +60,11 @@
   </changeSet>
 
   <changeSet id="202412041537-04" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="sku_oid" columnName="id"/>
+      </not>
+    </preConditions>
     <addColumn tableName="sku_oid">
       <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
         <constraints primaryKey="true" nullable="false"/>
@@ -63,6 +73,11 @@
   </changeSet>
 
   <changeSet id="202412041537-05" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="sku_product_tag" columnName="id"/>
+      </not>
+    </preConditions>
     <addColumn tableName="sku_product_tag">
       <column name="id" type="uuid" defaultValueComputed="uuid_generate_v4()">
         <constraints primaryKey="true" nullable="false"/>

--- a/swatch-database-migrations/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
@@ -4,13 +4,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
-  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+  <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true" ignore="true">
     <!-- View controlled by swatch-contracts -->
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <viewExists viewName="subscription_capacity_view"/>
-      </not>
-    </preConditions>
     <comment>
       Update subscription_capacity_view to filter measurements by subscription ID plus start date
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml
@@ -5,6 +5,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
   <changeSet id="202409251400-01" author="jcarvaja" dbms="postgresql" runOnChange="true">
+    <!-- View controlled by swatch-contracts -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="subscription_capacity_view"/>
+      </not>
+    </preConditions>
     <comment>
       Update subscription_capacity_view to filter measurements by subscription ID plus start date
     </comment>

--- a/swatch-database-migrations/src/main/resources/liquibase/changelog.xml
+++ b/swatch-database-migrations/src/main/resources/liquibase/changelog.xml
@@ -181,7 +181,7 @@
     <include file="liquibase/202504291554-add-updated-at-column-to-billable-usage-remittance.xml"/>
     <include file="liquibase/202505131100-update-subscription-capacity-view-to-filter-start-date.xml"/>
     <include file="liquibase/202506191100-add-host-service-type-table.xml"/>
-    <!-- From this point forward, the following tables are now managed under swatch-contracts:
+    <!-- From this point forward, the following tables and views are managed under swatch-contracts:
       * offering
       * sku_child_sku
       * sku_oid
@@ -190,7 +190,7 @@
       * subscription_measurements
       * subscription_capacity_view
 
-      Perform any changes to these tables in the swatch-contracts migrations
+      Perform any changes to these tables or views in the swatch-contracts migrations
     -->
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-database/src/main/java/org/candlepin/subscriptions/liquibase/cli/MigrationService.java
+++ b/swatch-database/src/main/java/org/candlepin/subscriptions/liquibase/cli/MigrationService.java
@@ -154,7 +154,7 @@ public class MigrationService {
               + "environment variables and properties files.",
           contexts);
       log.info(
-          "If you wish to provide arguments via a `gradlew run` use `--args=` and specify "
+          "If you wish to provide arguments via a `mvnw exec:java` use `-Dexec.args=` and specify "
               + "the context as the first argument followed by Liquibase commands and arguments");
       invocationArgs = new String[] {"update"};
     }


### PR DESCRIPTION
Jira issue: SWATCH-3895 (this is a fix for a bug in this card's code reported in Slack)

## Description
PR #4919 introduced a bug where Liquibase would not run correctly in a swatch database where the changesets had previously been executed.  The run failed with an error that the `offering` table already exists.  I thought I had addressed this issue by making sure the "contracts" changesets would run before the "tally" changesets.  I didn't apply a `precondition` to the legacy changesets because I thought it would alter the checksums and dealing with altered checksums in Liquibase can be a headache.  After the bug report, I realized the `precondition` is necessary and much to my surprise, they can be added without altering the checksum.

## Testing

### Setup
1. Create the following aliases
    ```shell
    $ alias recreate="dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && createdb -h localhost -U postgres -O rhsm-subscriptions rhsm-subscriptions && echo 'done'"
    $ alias compile="./mvnw -pl swatch-database -am clean install"
    $ alias contracts="./mvnw -pl swatch-database exec:java -Dexec.args='contracts update'"
    $ alias core="./mvnw -pl swatch-database -am -DskipTests install && ./mvnw -pl swatch-database exec:java -Dexec.args='core update'"
    ```

### Steps
**These steps will drop your database!  Make a back-up or use a scratch database**
1. Simulate the current ephemeral setup
    ```shell
    $ recreate && compile && contracts && core
    ```
1. Simulate the ephemeral setup in an alternate order
    ```shell
    $ recreate && compile && core && contracts
    ```
1. Simulate the current production setup
    ```shell
   # Commit prior to the merge of #4919
    $ git checkout 7c605fa7d50adf352f9b6e96c8eb3352d9d09e53
    $ recreate && compile && core && contracts
    $ git switch -t origin/awood/liquibase-fixup
    # #4919 changed the default order that migrations are run in when both sets are run together
    # Note there is no recreate performed here
    $ compile && contracts && core
    # Simulate subsequent runs
    $ contracts && core
    $ core && contracts
    ```
1. Simulate production with different ordering
    ```shell
   # Commit prior to the merge of #4919
    $ git checkout 7c605fa7d50adf352f9b6e96c8eb3352d9d09e53
    $ recreate && compile && core && contracts
    $ git switch -t origin/awood/liquibase-fixup
    # The default order isn't guaranteed because some ClowdApps only run one set of migrations
    # Note there is no recreate performed here
    $ compile && core && contracts
    $ contracts && core
    $ core && contracts
    ```

## Ephemeral Testing

### Setup
1. Run `bin/build-images.sh` on `main`
1. Deploy
    ```shell
    VER=$(git rev-parse --short=7 HEAD) ; \
    REPO=$(podman login quay.io --get-login) ; \
    bonfire deploy rhsm \
    --source=appsre \
    --ref-env insights-production \
    --optional-deps-method none \
    --frontends false \
    --no-remove-resources app:rhsm \
    --timeout 1000 \
    -i quay.io/$REPO/swatch-metrics=$VER \
    -i quay.io/$REPO/swatch-metrics-hbi=$VER \
    -i quay.io/$REPO/rhsm-subscriptions=$VER \
    -i quay.io/$REPO/swatch-producer-aws=$VER \
    -i quay.io/$REPO/swatch-producer-azure=$VER \
    -i quay.io/$REPO/swatch-system-conduit=$VER \
    -i quay.io/$REPO/swatch-billable-usage=$VER \
    -i quay.io/$REPO/swatch-database=$VER \
    -i quay.io/$REPO/swatch-contracts=$VER \
    -p swatch-metrics/IMAGE=quay.io/$REPO/swatch-metrics \
    -p swatch-metrics-hbi/IMAGE=quay.io/$REPO/swatch-metrics-hbi \
    -p swatch-tally/IMAGE=quay.io/$REPO/rhsm-subscriptions \
    -p swatch-api/IMAGE=quay.io/$REPO/rhsm-subscriptions \
    -p swatch-database/IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-contracts/IMAGE=quay.io/$REPO/swatch-contracts \
    -p swatch-producer-aws/IMAGE=quay.io/$REPO/swatch-producer-aws \
    -p swatch-producer-azure/IMAGE=quay.io/$REPO/swatch-producer-azure \
    -p swatch-billable-usage/IMAGE=quay.io/$REPO/swatch-billable-usage \
    -p swatch-system-conduit/IMAGE=quay.io/$REPO/swatch-system-conduit \
    -p swatch-api/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-tally/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-billable-usage/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-database/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-metrics-hbi/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-contracts/MIGRATION_IMAGE=quay.io/$REPO/swatch-database
   ```
1. Deployment will fail due to conflict on the `offering` table

### Steps
1.  Check out this branch.
1.  Delete existing ClowdApps
    ```shell
    oc delete app swatch-api swatch-contracts swatch-metrics swatch-metrics-rhel swatch-producer-aws swatch-subscription-sync swatch-system-conduit swatch-tally swatch-db-changelog-cleanup swatch-producer-azure rhsm swatch-billable-usage swatch-database swatch-metrics-hbi ingress rbac puptoo host-inventory export-service storage-broker
    ```
1.  Run `bin/build-images.sh`
1. Deploy with the same command as above.

### Verification
1.  All the init containers start successfully.
