### PR TITLE
Correct configuration property used for live-reload container builds

### DIFF
--- a/bin/dev-argfile.conf
+++ b/bin/dev-argfile.conf
@@ -1,2 +1,2 @@
 # Tell Quarkus to build a mutable jar which allows for hot reloading.
-MAVEN_BUILD_ARGS=-Dquarkus.package.type=mutable-jar
+MAVEN_BUILD_ARGS=-Dquarkus.package.jar.type=mutable-jar


### PR DESCRIPTION
Jira issue: None

## Description
The name of this configuration property changed at some point.

## Testing
Run `bin/build-images.sh` and do an EE deployment.  Prior to this patch, Quarkus
apps would throw a ClassCastException complaining about
HibernateOrmDevIntegrator.
