### PR TITLE
SWATCH-4000: use set-parameter instead of set-image-tag when deploying the services to ephemeral

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -57,7 +57,16 @@ for service in $SERVICES; do
   APP_ROOT=$(get_approot $service)
   source $CICD_ROOT/build.sh
 
-  IMAGES=" ${IMAGES} -i ${IMAGE}=${IMAGE_TAG} "
+  # Special case: rhsm-subscriptions image is really the swatch-api and swatch-tally services:
+  if [ "$service" = "rhsm-subscriptions" ]; then
+    IMAGES=" ${IMAGES} -p swatch-api/IMAGE=${IMAGE} -p swatch-api/IMAGE_TAG=${IMAGE_TAG} "
+    IMAGES=" ${IMAGES} -p swatch-tally/IMAGE=${IMAGE} -p swatch-tally/IMAGE_TAG=${IMAGE_TAG} "
+  elif [ "$service" = "swatch-unleash-import" ]; then
+    IMAGES=" ${IMAGES} -i ${IMAGE}=${IMAGE_TAG} "
+  else
+    # Add parameters for the current service
+    IMAGES=" ${IMAGES} -p ${service}/IMAGE=${IMAGE} -p ${service}/IMAGE_TAG=${IMAGE_TAG} "
+  fi
 done
 
 APP_ROOT=$PWD


### PR DESCRIPTION
Jira issue: SWATCH-4000

## Description
Instead of using the option -i (set image-tag), we can use -p (set parameter). For example, from: "-i quay.io/cloudservices/swatch-unleash-import=pr-4996-06e5cdf" to "-p swatch-database/IMAGE=quay.io/cloudservices/swatch-database -p swatch-database/IMAGE_TAG=pr-4996-06e5cdf".

Note that these changes also fix that the init container image for swatch-database use the correct tag instead of "latest". 

## Testing
CI is passing.