### PR TITLE
SWATCH-3791:Update swatch-tally to emit tally summaries with granularities HOURLY and DAILY

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyController.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.validator.Uuid;
 import org.slf4j.Logger;
@@ -62,7 +63,7 @@ public class MarketplaceResendTallyController {
     log.info("Resending tally snapshots for {} messages", snapshots.size());
     Map<String, List<TallySnapshot>> totalSnapshots =
         snapshots.stream().collect(Collectors.groupingBy(TallySnapshot::getOrgId));
-    summaryProducer.produceTallySummaryMessages(totalSnapshots);
+    summaryProducer.produceTallySummaryMessages(totalSnapshots, List.of(Granularity.HOURLY, Granularity.DAILY));
     return snapshots.size();
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MaxSeenSnapshotStrategy.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.tally.roller.BaseSnapshotRoller;
 import org.candlepin.subscriptions.tally.roller.DailySnapshotRoller;
@@ -80,7 +81,8 @@ public class MaxSeenSnapshotStrategy {
             .map(roller -> roller.rollSnapshots(accountCalc))
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
-    summaryProducer.produceTallySummaryMessages(Map.of(orgId, newAndUpdatedSnapshots));
+    summaryProducer.produceTallySummaryMessages(
+        Map.of(orgId, newAndUpdatedSnapshots), List.of(Granularity.HOURLY, Granularity.DAILY));
     log.info("Finished producing snapshots for orgId={}", orgId);
     return newAndUpdatedSnapshots;
   }

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySnapshotController.java
@@ -187,7 +187,7 @@ public class TallySnapshotController {
 
           tallyStateRepository.update(currentState);
           recordTallyCount(totalSnapshots.values().stream().flatMap(Collection::stream).toList());
-          summaryProducer.produceTallySummaryMessages(totalSnapshots);
+          summaryProducer.produceTallySummaryMessages(totalSnapshots, List.of(Granularity.HOURLY));
         }
 
         log.info("Finished producing {} hourly snapshots for orgId {}", serviceType, orgId);

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -99,7 +99,7 @@ public class TallySummaryMapper {
     return snapshotRepository.sumMeasurementValueForPeriod(
         snapshot.getOrgId(),
         snapshot.getProductId(),
-        Granularity.HOURLY,
+        snapshot.getGranularity(),
         snapshot.getServiceLevel(),
         snapshot.getUsage(),
         snapshot.getBillingProvider(),

--- a/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MarketplaceResendTallyControllerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
+import org.candlepin.subscriptions.db.model.Granularity;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,6 +64,6 @@ class MarketplaceResendTallyControllerTest {
     assertEquals(3, count);
 
     var summaryMap = Map.of("1", tallyList);
-    verify(summaryProducer, times(1)).produceTallySummaryMessages(summaryMap);
+    verify(summaryProducer, times(1)).produceTallySummaryMessages(summaryMap, List.of(Granularity.HOURLY, Granularity.DAILY));
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
In addition to the current emission of the hourly summaries, we need to send daily ones

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: This is waiting on the new platform for testing. A new card was created to make the tests for this change.


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Regression for HOURLY 
2. The unit tests have been adjusted to test for both

Note: The changes on the Billable Usage end should be complete before this is merged. Otherwise, the new Daily summaries can cause a problem.
