### PR TITLE
SWATCH-4011: Allow debugging SWATCH services when running component tests in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endef
 default: format install
 
 format:
-	./mvnw spotless:apply
+	./mvnw spotless:apply -Pbuild -Pcomponent-tests -Pcomponent-tests-by-service
 
 install:
 	./mvnw clean install -DskipTests

--- a/docs/component-tests.md
+++ b/docs/component-tests.md
@@ -77,5 +77,6 @@ The key difference is the addition of the `-Dswatch.component-tests.global.targe
 The component tests can be configured using system properties:
 
 - `swatch.component-tests.global.target`: Set to `openshift` to run against OpenShift deployment, or omit for local execution
+- `swatch.component-tests.services.all.debug`: Enable debug mode for all the services
 - Additional configuration options may be available per service
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/configuration/ServiceConfiguration.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/configuration/ServiceConfiguration.java
@@ -68,4 +68,10 @@ public @interface ServiceConfiguration {
    * Tune the log level for the current service. Possible values in {@link java.util.logging.Level}.
    */
   String logLevel() default "INFO";
+
+  /**
+   * Enable the debug mode for the current service only when the test starts. Fallback service
+   * property: "swatch.component-tests.services.SERVICE NAME.debug".
+   */
+  boolean debug() default true;
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/configuration/ServiceConfiguration.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/configuration/ServiceConfiguration.java
@@ -32,6 +32,7 @@ public final class ServiceConfiguration {
   private Duration startupTimeout = Duration.ofMinutes(5);
   private Duration startupCheckPollInterval = Duration.ofSeconds(2);
   private Double factorTimeout = 1.0;
+  private boolean debug = false;
   private boolean logEnabled = true;
   private boolean logEnabledOnTestStarted = true;
   private int portRangeMin = 1100;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/configuration/ServiceConfigurationBuilder.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/configuration/ServiceConfigurationBuilder.java
@@ -35,6 +35,7 @@ public class ServiceConfigurationBuilder
   private static final String LOG_ENABLED = "log.enabled";
   private static final String LOG_ENABLED_ON_TEST_STARTED = "log.enabled.on-test-started";
   private static final String LOG_LEVEL = "log.level";
+  private static final String DEBUG = "debug";
 
   @Override
   public ServiceConfiguration build() {
@@ -47,6 +48,7 @@ public class ServiceConfigurationBuilder
     loadBoolean(LOG_ENABLED_ON_TEST_STARTED, a -> a.logEnabledOnTestStarted())
         .ifPresent(config::setLogEnabledOnTestStarted);
     loadString(LOG_LEVEL, a -> a.logLevel()).map(Level::parse).ifPresent(config::setLogLevel);
+    loadBoolean(DEBUG, a -> a.debug()).ifPresent(config::setDebug);
     return config;
   }
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServiceContext.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServiceContext.java
@@ -27,6 +27,7 @@ import com.redhat.swatch.component.tests.configuration.ServiceConfigurationBuild
 import com.redhat.swatch.component.tests.configuration.ServiceConfigurationLoader;
 import com.redhat.swatch.component.tests.utils.OutputUtils;
 import java.lang.annotation.Annotation;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +37,8 @@ import lombok.Getter;
 
 @Getter
 public final class ServiceContext {
+
+  private static final String JDWP = "jdwp=";
 
   private final Service owner;
   private final ComponentTestContext componentTestContext;
@@ -95,5 +98,24 @@ public final class ServiceContext {
 
     customConfiguration.add(
         ServiceConfigurationLoader.load(owner.getName(), componentTestContext, builder));
+  }
+
+  /**
+   * @return if the service starts in debug mode.
+   */
+  public boolean isDebug() {
+    // if enabled from the properties
+    if (getConfiguration().isDebug()) {
+      return true;
+    }
+
+    // or when starting a test in debug mode from intellij, the property jdwt is automatically set
+    for (String arg : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
+      if (arg.contains(JDWP) && arg.contains("suspend=y")) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ContainerLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ContainerLoggingHandler.java
@@ -24,7 +24,7 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Frame;
-import com.redhat.swatch.component.tests.api.Service;
+import com.redhat.swatch.component.tests.core.ServiceContext;
 import org.testcontainers.DockerClientFactory;
 
 public class ContainerLoggingHandler extends ServiceLoggingHandler {
@@ -32,7 +32,7 @@ public class ContainerLoggingHandler extends ServiceLoggingHandler {
   private final Container container;
   private String oldLogs;
 
-  public ContainerLoggingHandler(Service service, Container container) {
+  public ContainerLoggingHandler(ServiceContext service, Container container) {
     super(service);
 
     this.container = container;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/FileServiceLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/FileServiceLoggingHandler.java
@@ -20,7 +20,7 @@
  */
 package com.redhat.swatch.component.tests.logging;
 
-import com.redhat.swatch.component.tests.api.Service;
+import com.redhat.swatch.component.tests.core.ServiceContext;
 import com.redhat.swatch.component.tests.utils.FileUtils;
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +33,7 @@ public class FileServiceLoggingHandler extends ServiceLoggingHandler {
   private final File file;
   private String printedContent;
 
-  public FileServiceLoggingHandler(Service context, File input) {
+  public FileServiceLoggingHandler(ServiceContext context, File input) {
     super(context);
     this.file = input;
   }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
@@ -36,7 +36,7 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
 
   public OpenShiftLoggingHandler(
       Map<String, String> podLabels, String containerName, ServiceContext context) {
-    super(context.getOwner());
+    super(context);
 
     this.podLabels = podLabels;
     this.containerName = containerName;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
@@ -20,15 +20,15 @@
  */
 package com.redhat.swatch.component.tests.logging;
 
-import com.redhat.swatch.component.tests.api.Service;
+import com.redhat.swatch.component.tests.core.ServiceContext;
 
 public abstract class ServiceLoggingHandler extends LoggingHandler {
 
-  private final Service service;
+  private final ServiceContext service;
 
   private boolean isTestStarted = false;
 
-  public ServiceLoggingHandler(Service service) {
+  public ServiceLoggingHandler(ServiceContext service) {
     this.service = service;
   }
 
@@ -48,13 +48,17 @@ public abstract class ServiceLoggingHandler extends LoggingHandler {
 
   @Override
   protected void logInfo(String line) {
-    Log.info(service, line);
+    Log.info(service.getOwner(), line);
   }
 
   @Override
   protected boolean isLogEnabled() {
     if (!service.getConfiguration().isLogEnabled()) {
       return false;
+    }
+
+    if (service.isDebug()) {
+      return true;
     }
 
     return !service.getConfiguration().isLogEnabledOnTestStarted() || isTestStarted;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/LocalContainerManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/LocalContainerManagedResource.java
@@ -46,7 +46,7 @@ public class LocalContainerManagedResource extends ManagedResource {
     }
 
     container = findContainerByName(context.getOwner(), containerName);
-    loggingHandler = new ContainerLoggingHandler(context.getOwner(), container);
+    loggingHandler = new ContainerLoggingHandler(context, container);
     loggingHandler.startWatching();
   }
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
@@ -36,6 +36,8 @@ import com.redhat.swatch.component.tests.utils.SocketUtils;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,6 +67,7 @@ public class LocalQuarkusManagedResource extends ManagedResource {
   private Process process;
   private LoggingHandler loggingHandler;
   private int assignedHttpPort;
+  private Integer assignedDebugPort;
   private Map<Integer, Integer> assignedCustomPorts;
 
   private final File location;
@@ -94,7 +97,7 @@ public class LocalQuarkusManagedResource extends ManagedResource {
 
       process = pb.start();
 
-      loggingHandler = new FileServiceLoggingHandler(context.getOwner(), logOutputFile);
+      loggingHandler = new FileServiceLoggingHandler(context, logOutputFile);
       loggingHandler.startWatching();
 
     } catch (Exception e) {
@@ -167,11 +170,21 @@ public class LocalQuarkusManagedResource extends ManagedResource {
     List<String> command = new LinkedList<>();
     command.add("./mvnw");
     command.addAll(systemProperties);
+    command.addAll(getDebugProperties());
     command.add("-pl");
     command.add(service);
     command.add("quarkus:dev");
 
     return command;
+  }
+
+  protected Collection<String> getDebugProperties() {
+    if (context.isDebug()) {
+      assignedDebugPort = SocketUtils.findAvailablePort(context.getOwner());
+      return Arrays.asList("-Ddebug=" + assignedDebugPort, "-Dsuspend");
+    }
+
+    return Collections.emptyList();
   }
 
   protected Map<Integer, Integer> assignCustomPorts() {


### PR DESCRIPTION
Jira ticket: [SWATCH-4011](https://issues.redhat.com/browse/SWATCH-4011)

## Description
Allow attaching the debugger when running the component tests from:
- Intellij using debug mode
- from command line using "-Dswatch.component-tests.services.all.debug=true"

Note that this will only work when running the component tests locally. In the future, we can make it compatible when running the tests against an ephemeral environment. 

When running the tests in debug mode, all the logs will be printed even when the service has not started yet.

## Testing
See video demostration here: 

https://github.com/user-attachments/assets/9f791a18-6339-425f-93d9-1a29ae43044f

