### PR TITLE
SWATCH-3977: Update default nginx-otel tag

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -70,7 +70,7 @@ parameters:
   - name: NGINX_OTEL_IMAGE
     value: quay.io/cloudservices/nginx-otel
   - name: NGINX_OTEL_IMAGE_TAG
-    value: '1df2c89'
+    value: '58f1545'
   - name: OTEL_ENABLED
     value: 'off'
   - name: OTEL_JAVAAGENT_ENABLED


### PR DESCRIPTION
Jira issue: SWATCH-3977

## Description
We want to enable OTEL reporting for our Nginx proxy.  We actually already had
all this set up; it just wasn't turned on.  App Interface MR #159442 turns OTEL
reporting on in production.  This PR just updates the version of the Nginx
container we use in the ephemeral environments.

## Testing
These steps will test that Nginx sends OTEL data.  It's not a perfect test
because we're mocking the entire receiving side of the process but it
demonstrates that our configuration settings are correct.

### Setup
1. Apply the following patch.  It will turn OTEL reporting on, create a
   [Jaeger](https://www.jaegertracing.io/docs/1.22/getting-started/) pod to
   receive the messages, and create a service to allow network communication
   between the pods.
    ```patch
    diff --git a/swatch-api/deploy/clowdapp.yaml b/swatch-api/deploy/clowdapp.yaml
    index 5dbc78d9c..230eeb1c4 100644
    --- a/swatch-api/deploy/clowdapp.yaml
    +++ b/swatch-api/deploy/clowdapp.yaml
    @@ -72,11 +72,11 @@ parameters:
       - name: NGINX_OTEL_IMAGE_TAG
         value: '58f1545'
       - name: OTEL_ENABLED
    -    value: 'off'
    +    value: 'on'
       - name: OTEL_JAVAAGENT_ENABLED
         value: 'false'
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
    -    value: 'http://localhost:4317'
    +    value: 'http://jaeger:4317'
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
         value: 'grpc'
       - name: DB_POD
    @@ -103,6 +103,44 @@ objects:
             sharedDbAppName: ${DB_POD}

           deployments:
    +        - name: jaeger
    +          replicas: 1
    +          webServices:
    +            public:
    +              enabled: true
    +          podSpec:
    +            image: quay.io/awood/all-in-one:1.60
    +            env:
    +              - name: COLLECTOR_ZIPKIN_HOST_PORT
    +                value: ':9411'
    +            resources:
    +              requests:
    +                cpu: ${CPU_REQUEST}
    +                memory: ${MEMORY_REQUEST}
    +              limits:
    +                cpu: ${CPU_LIMIT}
    +                memory: ${MEMORY_LIMIT}
    +            livenessProbe:
    +              failureThreshold: 3
    +              httpGet:
    +                path: /search
    +                port: 16686
    +                scheme: HTTP
    +              initialDelaySeconds: 160
    +              periodSeconds: 20
    +              successThreshold: 1
    +              timeoutSeconds: 5
    +            readinessProbe:
    +              failureThreshold: 3
    +              httpGet:
    +                path: /search
    +                port: 16686
    +                scheme: HTTP
    +              initialDelaySeconds: 160
    +              periodSeconds: 20
    +              successThreshold: 1
    +              timeoutSeconds: 5
    +
             - name: service
               replicas: ${{REPLICAS}}
               webServices:
    @@ -302,6 +340,54 @@ objects:
           selector:
             pod: swatch-api-nginx-proxy

    +  - kind: Service
    +    apiVersion: v1
    +    metadata:
    +      name: jaeger
    +    spec:
    +      ports:
    +        - port: 6831
    +          name: "6831"
    +          protocol: UDP
    +          targetPort: 6831
    +        - port: 6832
    +          name: "6832"
    +          protocol: UDP
    +          targetPort: 6832
    +        - port: 5778
    +          name: "5778"
    +          protocol: TCP
    +          targetPort: 5778
    +        - port: 16686
    +          name: "16686"
    +          protocol: TCP
    +          targetPort: 16686
    +        - port: 4317
    +          name: "4317"
    +          protocol: TCP
    +          targetPort: 4317
    +        - port: 4318
    +          name: "4318"
    +          protocol: TCP
    +          targetPort: 4318
    +        - port: 14250
    +          name: "14250"
    +          protocol: TCP
    +          targetPort: 14250
    +        - port: 14268
    +          name: "14268"
    +          protocol: TCP
    +          targetPort: 14268
    +        - port: 14269
    +          name: "14269"
    +          protocol: TCP
    +          targetPort: 14269
    +        - port: 9411
    +          name: "9411"
    +          protocol: TCP
    +          targetPort: 9411
    +      selector:
    +        pod: swatch-api-jaeger

       - apiVersion: v1
         kind: ConfigMap
    ```
1.  Perform a standard EE deployment.  I myself run `bin/build-images.sh` and us
    the command below:
    ```shell
    VER=$(git rev-parse --short=7 HEAD) ; \
    REPO=$(podman login quay.io --get-login) ; \
    bonfire deploy rhsm \
    --source=appsre \
    --ref-env insights-production \
    --optional-deps-method none \
    --frontends false \
    --no-remove-resources app:rhsm \
    --timeout 1000 \
    -i quay.io/$REPO/swatch-metrics=$VER \
    -i quay.io/$REPO/swatch-metrics-hbi=$VER \
    -i quay.io/$REPO/rhsm-subscriptions=$VER \
    -i quay.io/$REPO/swatch-producer-aws=$VER \
    -i quay.io/$REPO/swatch-producer-azure=$VER \
    -i quay.io/$REPO/swatch-system-conduit=$VER \
    -i quay.io/$REPO/swatch-billable-usage=$VER \
    -i quay.io/$REPO/swatch-database=$VER \
    -i quay.io/$REPO/swatch-contracts=$VER \
    -p swatch-metrics/IMAGE=quay.io/$REPO/swatch-metrics \
    -p swatch-metrics-hbi/IMAGE=quay.io/$REPO/swatch-metrics-hbi \
    -p swatch-tally/IMAGE=quay.io/$REPO/rhsm-subscriptions \
    -p swatch-api/IMAGE=quay.io/$REPO/rhsm-subscriptions \
    -p swatch-database/IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-contracts/IMAGE=quay.io/$REPO/swatch-contracts \
    -p swatch-producer-aws/IMAGE=quay.io/$REPO/swatch-producer-aws \
    -p swatch-producer-azure/IMAGE=quay.io/$REPO/swatch-producer-azure \
    -p swatch-billable-usage/IMAGE=quay.io/$REPO/swatch-billable-usage \
    -p swatch-system-conduit/IMAGE=quay.io/$REPO/swatch-system-conduit \
    -p swatch-api/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-tally/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-billable-usage/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-database/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-metrics-hbi/MIGRATION_IMAGE=quay.io/$REPO/swatch-database \
    -p swatch-contracts/MIGRATION_IMAGE=quay.io/$REPO/swatch-database
    ```
1. Port-forward the Jaeger web UI and the http port for the proxy:
    ```shell
    oc port-forward $(oc get pods | grep swatch-api-jaeger | cut -f1 -d' ')
    16686:16686 &
    oc port-forward $(oc get pods | grep swatch-api-nginx | cut -f1 -d' ') 8888:8000 &
    ```
1. Tail the logs for the proxy
    ```
    oc logs -f $(oc get pods | grep swatch-api-nginx | cut -f1 -d' ')
    ```

### Steps
1. Make a bunch of calls to the proxy.  I use the `perf` package to do this.
    ```
    perf stat -r 500 curl -v http://localhost:8888/api/rhsm-subscriptions/v1/version
    ```
1. Make sure the calls are logged in the log you are tailing.

### Verification
1. Open a browser and go to http://localhost:16686.  You should see
   `swatch-api-nginx-proxy` in the "Service" drop down on the left.  If you
   select it, you will see some results are returned.
