### PR TITLE
SWATCH-4003: Build image and deploy the swatch-utilization in EE

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -26,11 +26,6 @@ git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
 git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 
 for service in $SERVICES; do
-  # Skip swatch-utilization image until SWATCH-4003 is done
-  if [ "${service}" = "swatch-utilization" ]; then
-    continue
-  fi
-
   IMAGE_NAME="quay.io/cloudservices/${service}"
   DOCKERFILE=$(get_dockerfile "$service")
   docker build --ulimit nofile=2048:2048 \

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -50,10 +50,6 @@ IMAGES=""
 export COMPONENT_NAME="rhsm"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 # prebuild artifacts for quarkus builds
 for service in $SERVICES; do
-  # Skip swatch-utilization deployment until SWATCH-4003 is done
-  if [ "$service" = "swatch-utilization" ]; then
-    continue
-  fi
   export IMAGE="quay.io/cloudservices/$service"  # the image location on quay
   export DOCKERFILE="$(get_dockerfile $service)"
 
@@ -86,11 +82,6 @@ export COMPONENTS_W_RESOURCES="app:rhsm app:export-service"
 # NOTE: this ensures that all of the other services end up deployed with the latest template
 export EXTRA_COMPONENTS="rhsm swatch-kafka-bridge $(find -name clowdapp.yaml -exec dirname {} \; | cut -d'/' -f2 | xargs)"
 for EXTRA_COMPONENT_NAME in $EXTRA_COMPONENTS; do
-  # Skip swatch-utilization deployment until SWATCH-4003 is done
-  if [ "${EXTRA_COMPONENT_NAME}" = "swatch-utilization" ]; then
-    continue
-  fi
-
   export EXTRA_DEPLOY_ARGS="${EXTRA_DEPLOY_ARGS} --set-template-ref ${EXTRA_COMPONENT_NAME}=${GIT_COMMIT}"
 done
 

--- a/swatch-utilization/src/main/resources/application.properties
+++ b/swatch-utilization/src/main/resources/application.properties
@@ -47,7 +47,7 @@ quarkus.http.cors.origins=${CORS_ORIGINS}
 # Exposing the health checks and metrics on :9000.
 quarkus.management.enabled=true
 quarkus.management.root-path=/
-quarkus.management.test-port=${QUARKUS_MANAGEMENT_PORT}
+quarkus.management.test-port=${QUARKUS_MANAGEMENT_PORT:9000}
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi


### PR DESCRIPTION
Jira issue: SWATCH-4003

## Description
Uncommit some TODO tasks to build the container for swatch-utilization and deploy it.
Additionally, I fixed a config issue that was causing the swatch-utilization service not to deploy.

## Testing

CI is green
and running `bonfire deploy rhsm --source=appsre --ref-env insights-stage --component swatch-utilization --remove-dependencies swatch-utilization --component swatch-kafka-bridge` should work using the image tag generated as part of this pull request