### PR TITLE
ci: fix ClowderJsonPropertySourceTest in mac

### DIFF
--- a/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
@@ -119,7 +119,7 @@ class ClowderJsonPropertySourceTest {
         "clowder.kafka.brokers.cacert.type|PEM",
         "clowder.endpoints.rhsm-clowdapp-service.url|http://rhsm-clowdapp-service.rhsm.svc:8000",
         "clowder.endpoints.index-service.url|https://index.rhsm.svc:8800",
-        "clowder.endpoints.index-service.trust-store-path|file:/tmp/truststore.*.trust",
+        "clowder.endpoints.index-service.trust-store-path|file:/.*/truststore.*.trust",
         "clowder.endpoints.index-service.trust-store-password|.+",
         "clowder.endpoints.index-service.trust-store-type|PKCS12",
         "clowder.privateEndpoints.export-service-service.url|http://export-service-service.svc:10000",


### PR DESCRIPTION
## Description
In mac, the temporal folder is created at 'file:/var/folders/0b/_8m7gctd65x5kpqd4rpv_7w80000gn/T/truststore1231686984112883276.trust instead of file:/tmp/truststore.*.trust in Linux.

These changes will cause the test to pass in both systems.

## Testing
Regression testing only.