### PR TITLE
hotfix to replace swatch-database :latest image tag

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -37,8 +37,6 @@ parameters:
     value: 300m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -113,7 +111,7 @@ objects:
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             initContainers:
-              - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+              - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
                 command: ["/opt/jboss/container/java/run/run-java.sh"]
                 args: ["core", "update"]
                 inheritEnv: true

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -21,8 +21,6 @@ parameters:
     value: '1'
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -146,7 +144,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["core", "update"]
               inheritEnv: true

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -21,8 +21,6 @@ parameters:
     value: 1500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -162,7 +160,7 @@ objects:
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             initContainers:
-              - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+              - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
                 command: ["/opt/jboss/container/java/run/run-java.sh"]
                 args: ["contracts", "update"]
                 inheritEnv: true

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -21,8 +21,6 @@ parameters:
     value: 1500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -112,7 +110,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["metrics_hbi", "update"]
               inheritEnv: true

--- a/swatch-subscription-sync/deploy/clowdapp.yaml
+++ b/swatch-subscription-sync/deploy/clowdapp.yaml
@@ -43,8 +43,6 @@ parameters:
     value: 500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -175,7 +173,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["core", "update"]
               inheritEnv: true

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -49,8 +49,6 @@ parameters:
     value: 1500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
-  - name: MIGRATION_TAG
-    value: latest
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -303,7 +301,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${MIGRATION_TAG}
+            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["core", "update"]
               inheritEnv: true


### PR DESCRIPTION
Relates to: SWATCH-3735

https://redhat-internal.slack.com/archives/C09BCH0GRT7/p1759382029073089

Using the `:latest` tag for the swatch-database image in production caused unpredictable component rollouts.

This led to a critical incident where a Liquibase lock was held by a terminated pod during a rollout. As a result, all services are currently blocked from applying new migrations because they are waiting on a lock that no longer exists.

This commit replaces the `:latest` tag with a specific, stable version to ensure predictable deployments. This aligns the production environment with the configuration that has been stable in stage for some time.

