### PR TITLE
SWATCH-3994: Introduce the MIGRATION_IMAGE_TAG parameter

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -93,6 +93,10 @@ spec:
       type: string
       description: Secret name to take the token from.
       default: "swatch-ibutsu-token"
+    - name: MIGRATION_IMAGE
+      type: string
+      description: The container image to use for the migration tasks
+      default: "quay.io/redhat-user-workloads/rh-subs-watch-tenant/rhsm-subscriptions/swatch-database@sha256"
   workspaces:
     - name: shared-workspace
       description: A workspace to share data between tasks
@@ -123,6 +127,56 @@ spec:
           - name: pathInRepo
             value: tasks/teardown.yaml
   tasks:
+    - name: set-extra-deploy-args
+      params:
+        - name: SNAPSHOT
+          value: "$(params.SNAPSHOT)"
+        - name: MIGRATION_IMAGE
+          value: "$(params.MIGRATION_IMAGE)"
+        - name: EXTRA_DEPLOY_ARGS
+          value: "$(params.EXTRA_DEPLOY_ARGS)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+            type: string
+          - name: EXTRA_DEPLOY_ARGS
+            type: string
+          - name: MIGRATION_IMAGE
+            type: string
+        results:
+          - name: EXTRA_DEPLOY_ARGS
+            description: Populate extra deploy args needed for our components
+        steps:
+          - name: extract
+            image: quay.io/konflux-ci/appstudio-utils:latest
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              
+              # Keep the existing extra deploy args
+              extra_deploy_args="$(params.EXTRA_DEPLOY_ARGS)"
+              
+              # Check if swatch-database component exists first
+              if echo '$(params.SNAPSHOT)' | jq -e '.components[] | select(.name=="swatch-database")' > /dev/null; then
+                # Extract the image tag from the swatch-database component
+                migration_image="$(params.MIGRATION_IMAGE)"
+                migration_image_tag=$(echo '$(params.SNAPSHOT)' | jq -r '.components[] | select(.name=="swatch-database") | .containerImage | split("@sha256:")[1]')
+                
+                if [ -z "$migration_image_tag" ] || [ "$migration_image_tag" == "null" ]; then
+                  echo "Warning: swatch-database component found but no SHA available"
+                else                
+                  # Add the MIGRATION_IMAGE_TAG parameter for the required components
+                  components_with_db=("swatch-tally" "swatch-contracts" "swatch-billable-usage")
+                  for component in "${components_with_db[@]}"; do
+                    extra_deploy_args="$extra_deploy_args --set-parameter $component/MIGRATION_IMAGE=$migration_image --set-parameter $component/MIGRATION_IMAGE_TAG=$migration_image_tag"
+                  done
+                fi
+              else
+                echo "Info: swatch-database component not found in SNAPSHOT - skipping migration parameters"
+              fi
+              
+              printf "%s" "$extra_deploy_args" > $(results.EXTRA_DEPLOY_ARGS.path)
+
     - name: reserve-namespace
       params:
         - name: NS_REQUESTER
@@ -131,6 +185,8 @@ spec:
           value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"
+      runAfter:
+        - set-extra-deploy-args
       taskRef:
         resolver: git
         params:
@@ -161,7 +217,7 @@ spec:
         - name: COMPONENTS_W_RESOURCES
           value: "$(params.COMPONENTS_W_RESOURCES)"
         - name: EXTRA_DEPLOY_ARGS
-          value: "$(params.EXTRA_DEPLOY_ARGS)"
+          value: "$(tasks.set-extra-deploy-args.results.EXTRA_DEPLOY_ARGS)"
         - name: DEPLOY_FRONTENDS
           value: "$(params.DEPLOY_FRONTENDS)"
         - name: DEPLOY_TIMEOUT

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -21,6 +21,9 @@ parameters:
     value: '1'
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
+  - name: MIGRATION_IMAGE_TAG
+    description: The tag of the migration image to use (only for component-testing purposes)
+    value: ${IMAGE_TAG}
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -144,7 +147,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
+            - image: ${MIGRATION_IMAGE}:${MIGRATION_IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["core", "update"]
               inheritEnv: true

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -133,7 +133,6 @@ objects:
         sharedDbAppName: ${DB_POD}
       dependencies:
         - ${DB_POD}
-        - swatch-tally
         - rbac
         - export-service
 

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -21,6 +21,9 @@ parameters:
     value: 1500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
+  - name: MIGRATION_IMAGE_TAG
+    description: The tag of the migration image to use (only for component-testing purposes)
+    value: ${IMAGE_TAG}
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -160,7 +163,7 @@ objects:
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             initContainers:
-              - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
+              - image: ${MIGRATION_IMAGE}:${MIGRATION_IMAGE_TAG}
                 command: ["/opt/jboss/container/java/run/run-java.sh"]
                 args: ["contracts", "update"]
                 inheritEnv: true

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -49,6 +49,9 @@ parameters:
     value: 1500m
   - name: MIGRATION_IMAGE
     value: quay.io/cloudservices/swatch-database
+  - name: MIGRATION_IMAGE_TAG
+    description: The tag of the migration image to use (only for component-testing purposes)
+    value: ${IMAGE_TAG}
   - name: MIGRATION_MEMORY_REQUEST
     value: 256Mi
   - name: MIGRATION_MEMORY_LIMIT
@@ -299,7 +302,7 @@ objects:
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           initContainers:
-            - image: ${MIGRATION_IMAGE}:${IMAGE_TAG}
+            - image: ${MIGRATION_IMAGE}:${MIGRATION_IMAGE_TAG}
               command: ["/opt/jboss/container/java/run/run-java.sh"]
               args: ["core", "update"]
               inheritEnv: true


### PR DESCRIPTION
Jira issue: SWATCH-3994

## Description
This new parameter defaults to IMAGE_TAG when MIGRATION_IMAGE_TAG is not set.

The idea is to only set MIGRATION_IMAGE_TAG when running the component tests because when Konflux executes the integration test, the snapshot contains a different image tag for each component.

## Testing
CI is green.