### PR TITLE
SWATCH-3895: remove swatch-tally dependency from swatch-contracts

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -130,7 +130,6 @@ objects:
         sharedDbAppName: ${DB_POD}
       dependencies:
         - ${DB_POD}
-        - swatch-tally
         - rbac
         - export-service
 


### PR DESCRIPTION
Jira issue: SWATCH-3895

## Description
We can deploy swatch-contracts independently from swatch-tally, so we can remove this dependency from the clowder.yaml file in swatch-contracts.

## Testing
CI is green.