### PR TITLE
SWATCH-4034: Remove activeDeadlineSeconds property and increase the memory requests/limits for jobs

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -269,7 +269,6 @@ objects:
     jobs:
       - name: sync
         schedule: ${AGGREGATE_FLUSH_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -295,7 +294,6 @@ objects:
 
       - name: purge-remittances
         schedule: ${PURGE_REMITTANCE_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -66,9 +66,9 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 10Mi
+    value: 50Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 20Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
     value: 100m
   - name: CURL_CRON_CPU_LIMIT

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -356,7 +356,6 @@ objects:
       jobs:
         - name: subscription-sync
           schedule: ${SUBSCRIPTION_SYNC_SCHEDULE}
-          activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2
           restartPolicy: Never
           podSpec:
@@ -382,7 +381,6 @@ objects:
 
         - name: offering-sync
           schedule: ${OFFERING_SYNC_SCHEDULE}
-          activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2
           restartPolicy: Never
           podSpec:

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -103,9 +103,9 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 10Mi
+    value: 50Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 20Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
     value: 100m
   - name: CURL_CRON_CPU_LIMIT

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -320,7 +320,6 @@ objects:
       jobs:
         - name: sync
           schedule: ${METERING_SCHEDULE}
-          activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2
           restartPolicy: Never
           podSpec:
@@ -522,7 +521,6 @@ objects:
       jobs:
         - name: sync
           schedule: ${RHEL_METERING_SCHEDULE}
-          activeDeadlineSeconds: 1800
           successfulJobsHistoryLimit: 2
           restartPolicy: Never
           podSpec:

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -26,9 +26,9 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 10Mi
+    value: 50Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 20Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
     value: 100m
   - name: CURL_CRON_CPU_LIMIT

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -83,9 +83,9 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 10Mi
+    value: 50Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 20Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
     value: 100m
   - name: CURL_CRON_CPU_LIMIT

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -334,7 +334,6 @@ objects:
     jobs:
       - name: sync
         schedule: ${ORG_SYNC_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -210,9 +210,9 @@ parameters:
   - name: CURL_CRON_IMAGE_TAG
     value: latest
   - name: CURL_CRON_MEMORY_REQUEST
-    value: 10Mi
+    value: 50Mi
   - name: CURL_CRON_MEMORY_LIMIT
-    value: 20Mi
+    value: 50Mi
   - name: CURL_CRON_CPU_REQUEST
     value: 100m
   - name: CURL_CRON_CPU_LIMIT

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -535,7 +535,6 @@ objects:
     jobs:
       - name: tally
         schedule: ${CAPTURE_SNAPSHOT_SCHEDULE}
-        activeDeadlineSeconds: 4200
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -564,7 +563,6 @@ objects:
 
       - name: hourly
         schedule: ${CAPTURE_HOURLY_SNAPSHOT_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -593,7 +591,6 @@ objects:
 
       - name: purge
         schedule: ${PURGE_SNAPSHOT_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:
@@ -619,7 +616,6 @@ objects:
 
       - name: purge-events
         schedule: ${PURGE_EVENTS_SCHEDULE}
-        activeDeadlineSeconds: 1800
         successfulJobsHistoryLimit: 2
         restartPolicy: Never
         podSpec:


### PR DESCRIPTION
Jira issue: SWATCH-4034

## Description
The IT team asked us to increase the memory limit for these jobs, and also configure it so the limits and the requests have the same constraint.

Apart from these changes, remove activeDeadlineSeconds which might be causing containers to be killed

## Testing
No new pods triggered for jobs should be in error in Stage. 
We cannot test the changes in EE or local. 