### PR TITLE
Fixes AttributeError: 'Application' object has no attribute 'curiosity'

### DIFF
--- a/deploy/stage-internal-test-job.yaml
+++ b/deploy/stage-internal-test-job.yaml
@@ -110,7 +110,7 @@ parameters:
   from: "[a-z0-9]{6}"
 - name: IQE_IMAGE
   description: "container image path for the iqe plugin"
-  value: quay.io/cloudservices/iqe-tests:rhsm-subscriptions
+  value: quay.io/cloudservices/iqe-tests:curiosity
 - name: ENV_FOR_DYNACONF
   value: stage_proxy
 - name: IQE_PLUGINS


### PR DESCRIPTION
jira issue: SWATCH-4037 and SWATCH-4029

## Description
The iqe-tests: curiosity image has both the rhsm-subscriptions plugin and the rhsm-curiosity plugin.
Switching to use it for the stage tests for access to curiosity.

To be considered:
https://issues.redhat.com/browse/SWATCH-3463 enhances this change by ensuring the curiosity image is built more often.  Until that is complete, a new iqe-tests:curiosity image is only built when a change is made to the iqe-curiosity repo.

## Testing
Current stage pipelines should no longer get the error message _AttributeError: 'Application' object has no attribute 'curiosity'_
