### PR TITLE
Revert Fixes AttributeError: 'Application' object has no attribute 'curiosity'

### DIFF
--- a/deploy/stage-internal-test-job.yaml
+++ b/deploy/stage-internal-test-job.yaml
@@ -110,7 +110,7 @@ parameters:
   from: "[a-z0-9]{6}"
 - name: IQE_IMAGE
   description: "container image path for the iqe plugin"
-  value: quay.io/cloudservices/iqe-tests:curiosity
+  value: quay.io/cloudservices/iqe-tests:rhsm-subscriptions
 - name: ENV_FOR_DYNACONF
   value: stage_proxy
 - name: IQE_PLUGINS


### PR DESCRIPTION
This reverts commit 83de898c753b29a298543360445e84a2b410446d.

Jira issue: SWATCH-4029

## Description
Using the iqe-tests:curiosity to run the iqe-rhsm-subscriptions tests doesn't work.  Both plugins are there but now rhsm-subscriptions tests fail with: AttributeError: 'Application' object has no attribute 'rhsm_subscriptions'

## Going forward
A new issue will be created to split the post-deploy job into 2.  One for curiosity and one for rhsm-subscriptions.