### PR TITLE
SWATCH-3978: Fix component tests dependency issue (shows coupling problem)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,7 @@
         <!-- Dependencies -->
         <module>swatch-quarkus-parent</module>
         <module>swatch-model-billable-usage</module>
+        <module>swatch-metrics-hbi</module>
         <!-- Test framework module -->
         <module>swatch-test-framework</module>
         <!-- Services with component tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -598,9 +598,27 @@
         <!-- Dependencies -->
         <module>swatch-quarkus-parent</module>
         <module>swatch-model-billable-usage</module>
-        <module>swatch-metrics-hbi</module>
         <!-- Test framework module -->
         <module>swatch-test-framework</module>
+        <!-- Common modules needed by swatch-metrics-hbi -->
+        <module>swatch-common-clock</module>
+        <module>swatch-common-export</module>
+        <module>swatch-common-config-workaround</module>
+        <module>swatch-common-resteasy</module>
+        <module>swatch-common-resteasy-client</module>
+        <module>swatch-common-panache</module>
+        <module>swatch-common-kafka</module>
+        <module>swatch-common-smallrye-fault-tolerance</module>
+        <module>swatch-common-splunk</module>
+        <module>swatch-common-trace-response</module>
+        <module>swatch-common-security</module>
+        <module>swatch-common-health</module>
+        <module>swatch-common-models</module>
+        <module>swatch-common-testcontainers</module>
+        <module>swatch-model-events</module>
+        <module>swatch-product-configuration</module>
+        <!-- Main modules needed by component tests -->
+        <module>swatch-metrics-hbi</module>
         <!-- Services with component tests -->
         <module>swatch-producer-azure/ct</module>
         <module>swatch-tally/ct</module>


### PR DESCRIPTION
Jira issue: SWATCH-3978

## Description

**⚠️ This PR demonstrates the COUPLING PROBLEM with the band-aid approach ⚠️**

This PR shows the original fix for the swatch-metrics-hbi component tests dependency issue. While it solves the immediate build problem, it creates significant architectural concerns by adding 16+ heavy modules to the component-tests profile.

### What This PR Does

Adds all swatch-metrics-hbi dependencies to the component-tests Maven profile to fix the build error:
```
Could not find artifact com.redhat.swatch:swatch-metrics-hbi:jar:1.1.0-SNAPSHOT
```

### Modules Added to Component-Tests Profile

This approach requires adding **16+ heavy modules**:
- `swatch-common-clock`
- `swatch-common-export`  
- `swatch-common-config-workaround`
- `swatch-common-resteasy`
- `swatch-common-resteasy-client`
- `swatch-common-panache`
- `swatch-common-kafka`
- `swatch-common-smallrye-fault-tolerance`
- `swatch-common-splunk`
- `swatch-common-trace-response`
- `swatch-common-security`
- `swatch-common-health`
- `swatch-common-models`
- `swatch-common-testcontainers`
- `swatch-model-events`
- `swatch-product-configuration`
- `swatch-metrics-hbi` (main module)

## ⚠️ Architectural Concerns

### Massive Coupling
- **Before**: 3 lightweight modules in component-tests profile
- **After**: 19+ modules including heavy service dependencies
- **Impact**: Makes 16+ service modules available to ALL component tests

### Problems Created
- ❌ **Violates separation of concerns** - test framework now coupled to service modules
- ❌ **Increases build complexity** - much larger dependency graph
- ❌ **Goes against service isolation** - component tests should be lightweight
- ❌ **Makes modules available everywhere** - other component tests can now accidentally import from swatch-metrics-hbi

### Analysis Document
See `component-tests-architecture-concerns.md` for detailed analysis and team discussion points.

## Testing

### Validation Steps
1. Checkout this branch
1. Clear cache: `rm -rf ~/.m2/repository/com/redhat/swatch/`
1. Run: `./mvnw clean install -P component-tests -DskipTests`

### Results
✅ Build succeeds (fixes immediate problem)  
⚠️ But creates architectural coupling concerns

## Recommendation

**This PR should NOT be merged.** It demonstrates why the band-aid approach is problematic. 

See the companion PR with the **architectural solution** that creates a lightweight shared module approach instead: [PR for V2 solution to be created]

This PR is useful for:
- Understanding the scope of the dependency problem
- Seeing why this approach creates coupling concerns  
- Comparison with the cleaner architectural solution