### PR TITLE
Enable unleash in swatch-tally

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -127,11 +127,11 @@
             "createdAt": "2024-01-10T20:20:42.531Z"
         },
         {
-            "name": "rhsm-subscriptions.enable-primary-row-searches",
+            "name": "swatch.swatch-tally.enable-primary-row-searches",
             "description": "Enable the use of the primary row search for snapshots and buckets.",
             "type": "operational",
             "project": "default",
-            "enabled": true,
+            "enabled": false,
             "stale": false,
             "strategies": [
                 {

--- a/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationConfiguration.java
@@ -35,6 +35,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.candlepin.subscriptions.actuator.CertInfoContributor;
 import org.candlepin.subscriptions.clowder.KafkaSslBeanPostProcessor;
 import org.candlepin.subscriptions.clowder.RdsSslBeanPostProcessor;
+import org.candlepin.subscriptions.configuration.UnleashConfiguration;
 import org.candlepin.subscriptions.db.RhsmSubscriptionsDataSourceConfiguration;
 import org.candlepin.subscriptions.resource.ApiConfiguration;
 import org.candlepin.subscriptions.security.AuthProperties;
@@ -64,6 +65,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
   RhsmSubscriptionsDataSourceConfiguration.class,
   LiquibaseUpdateOnlyConfiguration.class,
   UtilConfiguration.class,
+  UnleashConfiguration.class,
 })
 public class ApplicationConfiguration implements WebMvcConfigurer {
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -120,9 +120,6 @@ public class ApplicationProperties {
   /** If enabled, will allow synchronous operations when requested. */
   private boolean enableSynchronousOperations = false;
 
-  /** When enabled, it will use the primary row search for tallying. */
-  private boolean enablePrimaryRowSearches = false;
-
   /** Sets a hard limit on the size of accounts that HBI-based tally will attempt to process. */
   private int tallyMaxHbiAccountSize;
 

--- a/src/main/java/org/candlepin/subscriptions/configuration/FeatureFlags.java
+++ b/src/main/java/org/candlepin/subscriptions/configuration/FeatureFlags.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.configuration;
+
+import io.getunleash.Unleash;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Feature flags service for managing Unleash feature toggles in the Spring Boot application.
+ *
+ * <p>This class provides methods to check feature flag status using Unleash. Feature flags allow
+ * runtime control of application features without redeployment.
+ */
+@Slf4j
+public class FeatureFlags {
+
+  // Feature flag names
+  public static final String ENABLE_PRIMARY_ROW_SEARCHES =
+      "swatch.swatch-tally.enable-primary-row-searches";
+
+  private final Unleash unleash;
+
+  public FeatureFlags(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
+  /**
+   * Check if primary row searches are enabled.
+   *
+   * @return true if primary row searches feature flag is enabled
+   */
+  public boolean isPrimaryRowSearchesEnabled() {
+    if (unleash == null) {
+      return false; // Default to disabled when Unleash is not available
+    }
+    return unleash.isEnabled(ENABLE_PRIMARY_ROW_SEARCHES);
+  }
+
+  /**
+   * Check if a feature flag is enabled by name.
+   *
+   * @param featureName the feature flag name
+   * @return true if the feature flag is enabled
+   */
+  public boolean isEnabled(String featureName) {
+    return unleash.isEnabled(featureName);
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/configuration/UnleashConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/configuration/UnleashConfiguration.java
@@ -18,27 +18,25 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package api;
+package org.candlepin.subscriptions.configuration;
 
-import com.redhat.swatch.component.tests.api.UnleashService;
-import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import io.getunleash.Unleash;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-public class TallyUnleashService extends UnleashService {
-  private static final String ENABLE_PRIMARY_ROW_SEARCHES =
-      "swatch.swatch-tally.enable-primary-row-searches";
+/** Configuration class for Unleash feature flags. */
+@Configuration
+public class UnleashConfiguration {
 
-  public void enablePrimaryRowSearches() {
-    enableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
-    waitForFlagToBe(true);
-  }
-
-  public void disablePrimaryRowSearches() {
-    disableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
-    waitForFlagToBe(false);
-  }
-
-  private void waitForFlagToBe(boolean expectedState) {
-    AwaitilityUtils.until(
-        () -> isFlagEnabled(ENABLE_PRIMARY_ROW_SEARCHES), enabled -> enabled == expectedState);
+  /**
+   * Creates the FeatureFlags bean for managing feature toggles.
+   *
+   * @param unleash the Unleash client instance (optional)
+   * @return FeatureFlags service
+   */
+  @Bean
+  public FeatureFlags featureFlags(@Autowired(required = false) Unleash unleash) {
+    return new FeatureFlags(unleash);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.clock.ApplicationClock;
-import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.contracts.ContractsCapacityController;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
@@ -91,7 +91,7 @@ public class TallyResource implements TallyApi {
   private final PageLinkCreator pageLinkCreator;
   private final ApplicationClock clock;
   private final ContractsCapacityController capacityController;
-  private final ApplicationProperties applicationProperties;
+  private final FeatureFlags featureFlags;
 
   @Context private UriInfo uriInfo;
 
@@ -102,13 +102,13 @@ public class TallyResource implements TallyApi {
       PageLinkCreator pageLinkCreator,
       ApplicationClock clock,
       ContractsCapacityController capacityController,
-      ApplicationProperties applicationProperties) {
+      FeatureFlags featureFlags) {
     this.mapper = mapper;
     this.repository = repository;
     this.pageLinkCreator = pageLinkCreator;
     this.clock = clock;
     this.capacityController = capacityController;
-    this.applicationProperties = applicationProperties;
+    this.featureFlags = featureFlags;
   }
 
   @Override
@@ -168,7 +168,7 @@ public class TallyResource implements TallyApi {
 
     List<TallyMeasurement> measurements;
     Page<? extends TallyMeasurement> page;
-    if (applicationProperties.isEnablePrimaryRowSearches()) {
+    if (featureFlags.isPrimaryRowSearchesEnabled()) {
       HardwareMeasurementType hardwareMeasurementType = HardwareMeasurementType.TOTAL;
       if (Objects.nonNull(reportCriteria.getReportCategory())) {
         hardwareMeasurementType =

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -5,3 +5,6 @@ METRICS_SERVER_PORT: 9010
 ENABLE_SYNCHRONOUS_OPERATIONS: true
 DEV_MODE: true
 RHSM_CONTRACTS_URL: http://localhost:8011
+UNLEASH_ENVIRONMENT: development
+UNLEASH_API_URL: http://localhost:4242/api
+UNLEASH_API_TOKEN: default:development.unleash-insecure-api-token

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,7 +25,14 @@ rhsm-subscriptions:
   hourly-tally-offset: ${HOURLY_TALLY_OFFSET:60m}
   metric-lookup-range-duration: ${METRIC_LOOKUP_RANGE:1h}
   enable-synchronous-operations: ${ENABLE_SYNCHRONOUS_OPERATIONS:false}
-  enable-primary-row-searches: ${ENABLE_PRIMARY_ROW_SEARCHES:true}
+
+io:
+  getunleash:
+    app-name: ${UNLEASH_APP_NAME:swatch-tally}
+    instance-id: ${UNLEASH_INSTANCE_ID:swatch-tally}
+    environment: ${UNLEASH_ENVIRONMENT:production}
+    api-url: ${UNLEASH_API_URL:http://localhost:4242/api}
+    api-token: ${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
 management:
   health:
     jms:

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
@@ -51,7 +51,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.candlepin.clock.ApplicationClock;
-import org.candlepin.subscriptions.ApplicationProperties;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.contracts.ContractsCapacityController;
 import org.candlepin.subscriptions.db.OrgConfigRepository;
 import org.candlepin.subscriptions.db.TallySnapshotRepository;
@@ -76,7 +76,6 @@ import org.candlepin.subscriptions.utilization.api.v1.model.TallyReportData;
 import org.candlepin.subscriptions.utilization.api.v1.model.TallyReportDataPoint;
 import org.candlepin.subscriptions.utilization.api.v1.model.TallyReportTotalMonthly;
 import org.candlepin.subscriptions.utilization.api.v1.model.UsageType;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -89,7 +88,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("linelength")
 @SpringBootTest
@@ -107,13 +105,12 @@ class TallyResourceTest {
       ProductId.fromString("OpenShift-dedicated-metrics");
   public static final ProductId RHEL_FOR_X86 = RHEL_PRODUCT_ID;
   private static final MetricId METRIC_ID_CORES = MetricIdUtils.getCores();
-  public Object originalApplicationProperites = null;
 
   @MockitoBean TallySnapshotRepository repository;
   @MockitoBean PageLinkCreator pageLinkCreator;
   @MockitoBean OrgConfigRepository orgConfigRepository;
   @MockitoBean ContractsCapacityController capacityController;
-  @MockitoBean ApplicationProperties applicationProperties;
+  @MockitoBean FeatureFlags featureFlags;
   @Autowired TallyResource resource;
   @Autowired ApplicationClock applicationClock;
 
@@ -129,16 +126,7 @@ class TallyResourceTest {
   class WithPrimaryRowSearchesEnabled {
     @BeforeEach
     void setup() {
-      when(applicationProperties.isEnablePrimaryRowSearches()).thenReturn(true);
-      originalApplicationProperites =
-          ReflectionTestUtils.getField(resource, "applicationProperties");
-      ReflectionTestUtils.setField(resource, "applicationProperties", applicationProperties);
-    }
-
-    @AfterEach
-    void tearDown() {
-      ReflectionTestUtils.setField(
-          resource, "applicationProperties", originalApplicationProperites);
+      when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(true);
     }
 
     @Test
@@ -880,16 +868,7 @@ class TallyResourceTest {
   class WithPrimaryRowSearchesDisabled {
     @BeforeEach
     void setup() {
-      when(applicationProperties.isEnablePrimaryRowSearches()).thenReturn(false);
-      originalApplicationProperites =
-          ReflectionTestUtils.getField(resource, "applicationProperties");
-      ReflectionTestUtils.setField(resource, "applicationProperties", applicationProperties);
-    }
-
-    @AfterEach
-    void tearDown() {
-      ReflectionTestUtils.setField(
-          resource, "applicationProperties", originalApplicationProperites);
+      when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
     }
 
     @Test

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySource.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySource.java
@@ -78,6 +78,7 @@ public class ClowderJsonPropertySource extends PropertySource<ClowderJson>
   private static final String KAFKA_TOPICS = "kafka.topics";
   private static final String ENDPOINTS = "endpoints";
   private static final String PRIVATE_ENDPOINTS = "privateEndpoints";
+  private static final String FEATURE_FLAGS = "featureFlags";
   private static final String ENDPOINT_TLS_PORT_PROPERTY = "tlsPort";
   private static final Integer PORT_NOT_SET = 0;
 
@@ -126,7 +127,9 @@ public class ClowderJsonPropertySource extends PropertySource<ClowderJson>
           ENDPOINTS,
           this::getEndpointProperty,
           PRIVATE_ENDPOINTS,
-          this::getEndpointProperty);
+          this::getEndpointProperty,
+          FEATURE_FLAGS,
+          this::getFeatureFlagProperty);
 
   private static final String SERVLET_ENVIRONMENT_CLASS =
       "org.springframework.web.context.support.StandardServletEnvironment";
@@ -253,6 +256,21 @@ public class ClowderJsonPropertySource extends PropertySource<ClowderJson>
       if (name.endsWith(entry.getKey())) {
         return determineEndpointConfig(name, entry.getValue());
       }
+    }
+
+    return null;
+  }
+
+  private Object getFeatureFlagProperty(String name) {
+    String featureFlagProperty = name.substring(FEATURE_FLAGS.length());
+
+    // Handle feature flags configuration from clowder
+    // clowder.featureFlags.hostname -> featureFlags.hostname
+    // clowder.featureFlags.port -> featureFlags.port
+    // clowder.featureFlags.clientAccessToken -> featureFlags.clientAccessToken
+    var value = source.getNode(FEATURE_FLAGS + featureFlagProperty);
+    if (value != null) {
+      return value.asText();
     }
 
     return null;

--- a/swatch-tally/ct/java/tests/TallyReportFiltersTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportFiltersTest.java
@@ -51,9 +51,8 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.json.Event;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TallyReportFiltersTest extends BaseTallyComponentTest {
 
@@ -66,14 +65,23 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
   private static final String TEST_BILLING_ACCOUNT_ID =
       String.valueOf(100000000000L + (long) (Math.random() * 900000000000L));
 
-  @BeforeAll
-  static void enablePrimaryRowSearchesFlag() {
-    unleash.enablePrimaryRowSearches();
-  }
+  private void setupFeatureFlagAndWaitForServiceSync(boolean enablePrimaryRowSearches) {
+    // Toggle the Unleash flag
+    if (enablePrimaryRowSearches) {
+      unleash.enablePrimaryRowSearches();
+    } else {
+      unleash.disablePrimaryRowSearches();
+    }
 
-  @AfterAll
-  static void disablePrimaryRowSearchesFlag() {
-    unleash.disablePrimaryRowSearches();
+    // Wait for the swatch-tally service to poll Unleash and pick up the change
+    // Unleash SDK client typically polls every 10-15 seconds by default
+    // We wait at least 5 seconds to allow the service to pick up the flag change
+    long startTime = System.currentTimeMillis();
+    AwaitilityUtils.until(
+        () -> System.currentTimeMillis() - startTime,
+        elapsed -> elapsed >= 5000, // Wait at least 5 seconds
+        com.redhat.swatch.component.tests.utils.AwaitilitySettings.usingTimeout(
+            java.time.Duration.ofSeconds(10)));
   }
 
   private void givenTwoEventsPublished(
@@ -161,9 +169,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     return response.getMeta();
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC001")
-  public void shouldReturnDailyReportWithAllFilters() {
+  public void shouldReturnDailyReportWithAllFilters(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and daily granularity query parameters with all filters
     service.createOptInConfig(orgId);
 
@@ -204,9 +216,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Billing account ID should match request");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC002")
-  public void shouldFilterHourlyReportBySla() {
+  public void shouldFilterHourlyReportBySla(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different SLAs (PREMIUM and STANDARD)
     service.createOptInConfig(orgId);
 
@@ -229,9 +245,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     thenResponseContainsOnlyValue(response, 20.0, "Should only include STANDARD SLA event value");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC003")
-  public void shouldFilterHourlyReportByUsage() {
+  public void shouldFilterHourlyReportByUsage(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different usage types (PRODUCTION and DEVELOPMENT)
     service.createOptInConfig(orgId);
 
@@ -254,9 +274,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 10.0, "Should only include PRODUCTION usage event value");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC004")
-  public void shouldFilterHourlyReportByBillingProvider() {
+  public void shouldFilterHourlyReportByBillingProvider(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different billing providers (AWS and AZURE)
     service.createOptInConfig(orgId);
 
@@ -286,9 +310,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 20.0, "Should only include AZURE billing provider event value");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC005")
-  public void shouldFilterHourlyReportByBillingAccountId() {
+  public void shouldFilterHourlyReportByBillingAccountId(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different billing account IDs
     service.createOptInConfig(orgId);
 
@@ -317,9 +345,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 20.0, "Should only include account2 billing account event value");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC006")
-  public void shouldReturnDailyReportWithPartialFilters() {
+  public void shouldReturnDailyReportWithPartialFilters(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and daily granularity query parameters with partial filters
     service.createOptInConfig(orgId);
 
@@ -359,9 +391,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     assertNull(meta.getBillingAcountId(), "Billing account ID should not be present");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC007")
-  public void shouldReturnHourlyReportWithAllFilters() {
+  public void shouldReturnHourlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and hourly granularity query parameters with all filters
     service.createOptInConfig(orgId);
 
@@ -402,9 +438,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Billing account ID should match request");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC008")
-  public void shouldReturnBadRequestWithoutGranularity() {
+  public void shouldReturnBadRequestWithoutGranularity(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and query parameters missing granularity
     service.createOptInConfig(orgId);
 
@@ -428,9 +468,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Error message should indicate granularity is required");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC009")
-  public void shouldAggregateMultipleEventsWithSameFilters() {
+  public void shouldAggregateMultipleEventsWithSameFilters(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Multiple events with the same filter values in the same hour
     service.createOptInConfig(orgId);
 
@@ -492,9 +536,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 50.0, "Should aggregate all three PREMIUM SLA event values (15+25+10)");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC010")
-  public void shouldFilterWithThreeDistinctSlaValues() {
+  public void shouldFilterWithThreeDistinctSlaValues(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with three different SLA values in the same hour
     service.createOptInConfig(orgId);
 
@@ -558,9 +606,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 30.0, "Should only include SELF_SUPPORT SLA event value");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC016")
-  public void shouldReturnAllDataWhenNoOptionalFiltersApplied() {
+  public void shouldReturnAllDataWhenNoOptionalFiltersApplied(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different filter attributes in the same hour
     service.createOptInConfig(orgId);
 
@@ -627,9 +679,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 60.0, "Should aggregate all events when no filters applied (10+20+30)");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC017")
-  public void shouldFilterDailyReportBySlaAfterNightlyTally() {
+  public void shouldFilterDailyReportBySlaAfterNightlyTally(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different SLAs processed through hourly then nightly tally
     service.createOptInConfig(orgId);
 
@@ -703,9 +759,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 20.0, "Should only include STANDARD SLA event value from daily snapshot");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC018")
-  public void shouldFilterDailyReportByUsageAfterNightlyTally() {
+  public void shouldFilterDailyReportByUsageAfterNightlyTally(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different usage types processed through hourly then nightly tally
     service.createOptInConfig(orgId);
 
@@ -771,9 +831,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         response, 10.0, "Should only include PRODUCTION usage event value from daily snapshot");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC019")
-  public void shouldFilterDailyReportByBillingProviderAfterNightlyTally() {
+  public void shouldFilterDailyByBillingProviderAfterNightly(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different billing providers processed through hourly then nightly tally
     service.createOptInConfig(orgId);
 
@@ -845,9 +909,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Should only include AZURE billing provider event value from daily snapshot");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC020")
-  public void shouldFilterDailyReportByBillingAccountIdAfterNightlyTally() {
+  public void shouldFilterDailyByBillingAccountAfterNightly(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: Events with different billing account IDs processed through hourly then nightly tally
     service.createOptInConfig(orgId);
 
@@ -922,9 +990,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Should only include daily-account-456 billing account event value from daily snapshot");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC011")
-  public void shouldReturnBadRequestWithoutBeginning() {
+  public void shouldReturnBadRequestWithoutBeginning(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and query parameters missing beginning timestamp
     service.createOptInConfig(orgId);
 
@@ -945,9 +1017,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Error message should indicate beginning is required");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC012")
-  public void shouldReturnBadRequestWithoutEnding() {
+  public void shouldReturnBadRequestWithoutEnding(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and query parameters missing ending timestamp
     service.createOptInConfig(orgId);
 
@@ -968,9 +1044,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Error message should indicate ending is required");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC013")
-  public void shouldReturnNullMetadataWhenFiltersOmitted() {
+  public void shouldReturnNullMetadataWhenFiltersOmitted(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and query with only required parameters
     service.createOptInConfig(orgId);
 
@@ -999,9 +1079,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     assertEquals(TEST_METRIC_ID, meta.getMetricId(), "Metric ID should match request");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC014")
-  public void shouldReflectEmptyFilterInMetadata() {
+  public void shouldReflectEmptyFilterInMetadata(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and query with EMPTY filter value
     service.createOptInConfig(orgId);
 
@@ -1034,9 +1118,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     assertNull(meta.getBillingProvider(), "Billing provider should be null when not filtered");
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC015")
-  public void shouldIndicateDataGapsWithHasDataField() {
+  public void shouldIndicateDataGapsWithHasDataField(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with events only in specific hours within a multi-hour range
     service.createOptInConfig(orgId);
 
@@ -1107,9 +1195,10 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     // This test verifies the field is present and populated
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC021")
-  public void shouldReturnMonthlyReportWithAllFilters() {
+  public void shouldReturnMonthlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     OffsetDateTime beginning =
         OffsetDateTime.now(ZoneOffset.UTC)
             .minusMonths(2)
@@ -1121,9 +1210,10 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Monthly", GranularityType.MONTHLY, beginning, ending);
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC022")
-  public void shouldReturnQuarterlyReportWithAllFilters() {
+  public void shouldReturnQuarterlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     OffsetDateTime beginning = calculateQuarterStart();
     OffsetDateTime ending = beginning.plusMonths(3).minusNanos(1);
 
@@ -1131,9 +1221,10 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
         "Quarterly", GranularityType.QUARTERLY, beginning, ending);
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC023")
-  public void shouldReturnYearlyReportWithAllFilters() {
+  public void shouldReturnYearlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     OffsetDateTime beginning =
         OffsetDateTime.now(ZoneOffset.UTC)
             .minusYears(1)
@@ -1144,9 +1235,13 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     thenGranularityReportWithAllFiltersIsValid("Yearly", GranularityType.YEARLY, beginning, ending);
   }
 
-  @Test
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC024")
-  public void shouldTrackBillingAccountChangeForSameInstance() {
+  public void shouldTrackBillingAccountChangeForSameInstance(boolean enablePrimaryRowSearches) {
+    // Setup feature flag and wait for service to pick up the change
+    setupFeatureFlagAndWaitForServiceSync(enablePrimaryRowSearches);
+
     // Given: An org with opt-in config and an instance that will change billing accounts
     service.createOptInConfig(orgId);
     String instanceId = UUID.randomUUID().toString();
@@ -1163,6 +1258,7 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     AwaitilityUtils.untilAsserted(
         () -> {
           service.performHourlyTallyForOrg(orgId);
+          service.tallyOrg(orgId); // Run nightly tally to create daily snapshots
           assertAll(
               () -> thenDailyReportContainsValue(beginning, ending, billingAccount1, 5.0),
               () -> thenDailyReportContainsValue(beginning, ending, null, 5.0));
@@ -1175,6 +1271,7 @@ public class TallyReportFiltersTest extends BaseTallyComponentTest {
     AwaitilityUtils.untilAsserted(
         () -> {
           service.performHourlyTallyForOrg(orgId);
+          service.tallyOrg(orgId); // Run nightly tally to create daily snapshots
           assertAll(
               () -> thenDailyReportContainsValue(beginning, ending, billingAccount1, 5.0),
               () -> thenDailyReportContainsValue(beginning, ending, billingAccount2, 8.0),

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -388,6 +388,8 @@ objects:
     testing:
       iqePlugin: rhsm-subscriptions
 
+    featureFlags: true
+
     kafkaTopics:
       - replicas: ${{KAFKA_TALLY_REPLICAS}}
         partitions: ${{KAFKA_TALLY_PARTITIONS}}

--- a/swatch-tally/pom.xml
+++ b/swatch-tally/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.getunleash</groupId>
+      <artifactId>springboot-unleash-starter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4734

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The previous branch for using the is_primary searches was not complete for Unleash functionality. This will complete what is needed.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

<!--
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
-->

### Setup
<!-- Add any steps required to set up the test case -->
1. ```podman compose up -d```
2. ```SERVER_PORT=8010 ./mvnw -pl swatch-tally spring-boot:run  -Dspring-boot.run.arguments="--logging.level.org.hibernate.SQL=DEBUG"```
3. 2. import data from prod [swatch-support-scripts]
```python import-from-gabi.py --tallies --org-id 6340056```
4. open the webpage that views the Unleash parameter that has been created
```http://localhost:4242/projects/default/features/swatch.swatch-tally.enable-primary-row-searches``` 

### Steps
<!-- Enter each step of the test below -->
1. run the report to get data for the current day [may need to opt in]
```http ':8010/api/rhsm-subscriptions/v1/tally/products/rosa/CORES' x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"6340056"}}}' | base64 -w0) granularity==HOURLY beginning=='2026-03-17T00:00Z' ending=='2026-03-17T23:59Z'```
2. change the toggle in the UI for the "development" project so that it is enabled.
3. run the same report again 

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. When disabled, you will see this SQL in the swatch-tally log
```select distinct ts1_0.id,ts1_0.billing_account_id,ts1_0.billing_provider,ts1_0.granularity,ts1_0.is_primary,ts1_0.last_modified,ts1_0.org_id,ts1_0.product_id,ts1_0.sla,ts1_0.snapshot_date,tm1_0.snapshot_id,tm1_0.measurement_type,tm1_0.metric_id,tm1_0.value,ts1_0.usage from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id where ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.sla=? and ts1_0.usage=? and ts1_0.billing_provider=? and ts1_0.billing_account_id=? and ts1_0.snapshot_date between ? and ? order by ts1_0.snapshot_date```
2. When enabled, you will see this SQL in the swatch-tally log
```select distinct ts1_0.snapshot_date,tm1_0.measurement_type,tm1_0.metric_id,sum(tm1_0.value) from tally_snapshots ts1_0 left join tally_measurements tm1_0 on ts1_0.id=tm1_0.snapshot_id where ts1_0.is_primary=? and ts1_0.org_id=? and ts1_0.product_id=? and ts1_0.granularity=? and ts1_0.snapshot_date between ? and ? and tm1_0.metric_id=? and tm1_0.measurement_type=? group by 1,2,3```