### PR TITLE
Adjust .gitignore file to reflect new Maven working directory settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,23 +23,13 @@
 
 **/prometheumultiprocess
 
-# Spring Boot reads local configuration out of a directory named config.
-# However, Gradle also looks for project configurations - most notably
-# Checkstyle configuration - in the config directory.  This section hides
-# everything directly under the config directory except what Gradle is
-# going to use or files used for developer deployment (certificates and key)
-config/*
-!config/artemis
-!config/codestyle
-!config/checkstyle
-!config/kafka
-!config/otel
-!config/rabbitmq
-!config/splunk
-!config/export-service
-!config/wiremock
-!config/moto
-!config/prometheus
+# Spring Boot reads local configuration from application.properties out of the
+# "config" directory under the working directory for a Spring Boot project.
+# We set these to ignore so each developer can control application settings as
+# they see fit.
+swatch-tally/config/application.properties
+swatch-system-conduit/config/application.properties
+
 config/export-service/tmp
 
 #VS Code


### PR DESCRIPTION
Jira issue: none

## Description
When we were using Gradle, starting our Spring Boot applications
resulted in the repo's top directory being the working directory.  With
Maven, this is no longer the case.  The module's directory becomes the
working directory.  Consequently, we need to adjust our .gitignore
settings.  This also provides the chance to simplify our .gitignore file
since the root "config" directory no longer occupies a weird in-between
state of some files that should be checked in and some that shouldn't
be.

## Testing
### Steps
1. Create an `application.properties` file
    ```
    cat <<EOF > swatch-tally/config/application.properties
    logging.level.org.springframework.beans=DEBUG
    EOF
    ```
1. `make swatch-tally`

### Verification
1. You'll see a bunch of Spring bean debug messages indicating that the
   `application.properties` file you created is being read.
