### PR TITLE
Update to okhttp dependency version handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
     <swagger-ui.version>5.32.2</swagger-ui.version>
     <splunk-otel-javaagent.version>2.26.1</splunk-otel-javaagent.version>
     <insights-notification-schemas-java.version>1.1.0</insights-notification-schemas-java.version>
-    <okhttp.version>4.12.0</okhttp.version>
     <rest-assured.version>6.0.0</rest-assured.version>
 
     <!-- Plugins -->
@@ -264,6 +263,14 @@
         <artifactId>splunk-library-javalogging</artifactId>
         <version>1.11.10</version>
       </dependency>
+      <!-- There is a conflict with splunk-library-javalogging and kubernetes-httpclient-okhttp having transitive dependencies
+            on different versions of okhttp. This explicit declaration is required to resolve the conflict where
+            splunk-library-javalogging is used -->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>4.12.0</version>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -313,11 +320,6 @@
         <groupId>com.redhat.cloud.common</groupId>
         <artifactId>insights-notification-schemas-java</artifactId>
         <version>${insights-notification-schemas-java.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The initial dependency update to the okhttp package version in the pom file left it open to updates from the package bot.

 In this case, we need swatch-tally and swatch-api to be locked into version 4.12.0 of okhttp3. The splunk-library-javalogging's transitive dependency on the okhttp3 package is not compatible with the most current okhttp3 version of 5.3.2.

The package kubernetes-httpclient-okhttp we use has a transitive dependency on okhttp3 version 5.3.2, which causes a conflict.

The explicit dependency definition should keep the version okhttp3  in place where it is needed. 
 
### Verification
<!-- Enter the steps needed to verify the test passed -->
CI runs should show the Ephemeral instances start successfully.
