### PR TITLE
SWATCH-4792: Added new org_utilization_preference table in swatch-utilization

### DIFF
--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -81,6 +81,14 @@ variable (defaults to 5%).
 over-usage detection entirely for that product. This is useful for products that shouldn't generate
 over-usage alerts.
 
+**Organization-level preferences (database)**: The service uses the shared Subscription Watch
+PostgreSQL database (via Clowder) with table `org_utilization_preference`. Each row
+stores optional per-organization settings: `org_id` (primary key), `custom_threshold` (integer
+percentage points, e.g. 5 for 5%), and `last_updated`. Schema is owned by Liquibase;
+the `OrgUtilizationPreferenceRepository` exposes persistence through Hibernate Panache.
+Application code can later read this table to override product defaults per org without
+redeploying configuration.
+
 ### Granularity Filtering
 The service processes utilization summaries regardless of their granularity (HOURLY, DAILY, MONTHLY).
 All granularities are checked for over-usage, allowing the service to detect capacity issues at

--- a/swatch-utilization/ct/README.md
+++ b/swatch-utilization/ct/README.md
@@ -7,7 +7,7 @@
 Start the required local services using Docker Compose:
 
 ```bash
-podman compose up -d kafka kafka-bridge kafka-setup unleash
+podman compose up -d kafka kafka-bridge kafka-setup unleash db
 ```
 
 This will start all necessary dependencies (databases, Kafka, etc.) required for the component tests.
@@ -27,7 +27,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-util
 Deploy only the necessary dependencies for a specific service. For example, for `swatch-utilization` (which only requires wiremock and kafka bridge, as Kafka comes by default):
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-utilization --remove-dependencies swatch-utilization --component swatch-kafka-bridge
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-utilization --remove-dependencies swatch-utilization/swatch-contracts --component swatch-kafka-bridge
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -71,6 +71,21 @@ parameters:
     value: token
   - name: CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT
     value: '5.0'
+  - name: LOGGING_SHOW_SQL_QUERIES
+    value: 'false'
+  # allow overriding to support independent deploy with bonfire
+  - name: DB_POD
+    value: swatch-database
+  # Using a value of 'select 1' makes this job a no-op by default.
+  # When needed bump DB_CHANGELOG_CLEANUP_RUN_NUMBER, set DB_CHANGELOG_CLEANUP_SQL to 'delete from databasechangeloglock_swatch_utilization'
+  - name: DB_CHANGELOG_CLEANUP_RUN_NUMBER
+    value: '1'
+  - name: DB_CHANGELOG_CLEANUP_SQL
+    value: 'select 1'
+  - name: EGRESS_IMAGE
+    value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
+  - name: EGRESS_IMAGE_TAG
+    value: latest
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -81,7 +96,10 @@ objects:
       prometheus: quarkus
   spec:
     envName: ${ENV_NAME}
+    database:
+      sharedDbAppName: ${DB_POD}
     dependencies:
+      - ${DB_POD}
       - swatch-contracts
 
     kafkaTopics:
@@ -181,6 +199,33 @@ objects:
               value: ${OTEL_DISABLED}
             - name: CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT
               value: ${CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT}
+            - name: LOGGING_SHOW_SQL_QUERIES
+              value: ${LOGGING_SHOW_SQL_QUERIES}
+            - name: DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${DB_POD}-db
+                  key: db.host
+            - name: DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${DB_POD}-db
+                  key: db.port
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${DB_POD}-db
+                  key: db.user
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${DB_POD}-db
+                  key: db.password
+            - name: DATABASE_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: ${DB_POD}-db
+                  key: db.name
           volumeMounts:
             - name: logs
               mountPath: /logs
@@ -206,6 +251,73 @@ objects:
           volumes:
             - name: logs
               emptyDir:
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: swatch-utilization-db-cleanup
+  spec:
+    envName: ${ENV_NAME}
+
+    database:
+      sharedDbAppName: ${DB_POD}
+
+    dependencies:
+      - ${DB_POD}
+
+    pullSecrets:
+      name: ${IMAGE_PULL_SECRET}
+
+    kafkaTopics: [ ]
+    deployments: [ ]
+    jobs:
+    - name: changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+      restartPolicy: Never
+      podSpec:
+        image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
+        name: db-changelog-cleanup
+        command: [ "/bin/sh", "-c" ]
+        args:
+          - psql -h $POSTGRESQL_SERVICE_HOST -U $POSTGRESQL_USER $POSTGRESQL_DATABASE -c "$DB_CHANGELOG_CLEANUP_SQL"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        env:
+          - name: POSTGRESQL_SERVICE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: ${DB_POD}-db
+                key: db.host
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${DB_POD}-db
+                key: db.user
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: ${DB_POD}-db
+                key: db.name
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${DB_POD}-db
+                key: db.password
+          - name: DB_CHANGELOG_CLEANUP_SQL
+            value: ${DB_CHANGELOG_CLEANUP_SQL}
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: utilization-db-changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+  spec:
+    appName: swatch-utilization-db-cleanup
+    jobs:
+      - changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
 
 - apiVersion: v1
   kind: Secret

--- a/swatch-utilization/pom.xml
+++ b/swatch-utilization/pom.xml
@@ -45,6 +45,18 @@
       <artifactId>quarkus-messaging-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-liquibase</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-panache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.unleash</groupId>
       <artifactId>quarkus-unleash</artifactId>
     </dependency>
@@ -84,6 +96,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceEntity.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceEntity.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.data;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "org_utilization_preference")
+public class OrgUtilizationPreferenceEntity implements Serializable {
+
+  @Id
+  @Column(name = "org_id", nullable = false, length = 32)
+  private String orgId;
+
+  /** Over-usage threshold margin as a whole-number percentage (e.g. 5 means 5%). */
+  @Column(name = "custom_threshold", nullable = false)
+  private int customThreshold;
+
+  @Column(name = "last_updated", nullable = false)
+  private OffsetDateTime lastUpdated;
+
+  @PrePersist
+  @PreUpdate
+  public void setLastUpdated() {
+    this.lastUpdated = OffsetDateTime.now(ZoneOffset.UTC);
+  }
+}

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceRepository.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.data;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class OrgUtilizationPreferenceRepository
+    implements PanacheRepositoryBase<OrgUtilizationPreferenceEntity, String> {}

--- a/swatch-utilization/src/main/resources/application.properties
+++ b/swatch-utilization/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 SERVER_PORT=${clowder.endpoints.swatch-utilization.port:8000}
 LOGGING_LEVEL_COM_REDHAT_SWATCH=INFO
 LOGGING_LEVEL_ROOT=INFO
+LOGGING_SHOW_SQL_QUERIES=false
 ENABLE_SPLUNK_HEC=true
 SPLUNK_HEC_URL=https://splunk-hec.redhat.com:8088/
 SPLUNK_SOURCE=${quarkus.application.name}
@@ -11,6 +12,12 @@ SPLUNK_HEC_RETRY_COUNT=3
 SPLUNK_HEC_INCLUDE_EX=true
 CORS_ORIGINS=/.+\\\\.redhat\\\\.com/
 OTEL_DISABLED=true
+
+DATABASE_HOST=${clowder.database.hostname:localhost}
+DATABASE_PORT=${clowder.database.port:5432}
+DATABASE_DATABASE=${clowder.database.name:rhsm-subscriptions}
+DATABASE_USERNAME=${clowder.database.username:rhsm-subscriptions}
+DATABASE_PASSWORD=${clowder.database.password:rhsm-subscriptions}
 
 # Customer over-usage detection threshold (percentage)
 CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT=5.0
@@ -51,6 +58,25 @@ quarkus.http.cors.origins=${CORS_ORIGINS}
 quarkus.management.enabled=true
 quarkus.management.root-path=/
 quarkus.management.test-port=0
+
+quarkus.liquibase.database-change-log-lock-table-name=DATABASECHANGELOGLOCK_SWATCH_UTILIZATION
+quarkus.liquibase.database-change-log-table-name=DATABASECHANGELOG_SWATCH_UTILIZATION
+quarkus.liquibase.change-log=db/changelog.xml
+quarkus.liquibase.migrate-at-start=true
+
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=${DATABASE_USERNAME}
+quarkus.datasource.password=${DATABASE_PASSWORD}
+quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-utilization}
+quarkus.datasource.metrics.enabled=true
+quarkus.hibernate-orm.schema-management.strategy=validate
+quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}
+quarkus.hibernate-orm.mapping.timezone.default-storage=normalize-utc
+
+%test.quarkus.datasource.db-kind=h2
+%test.quarkus.datasource.jdbc.url=jdbc:h2:mem:swatch_utilization;DB_CLOSE_DELAY=-1
+%test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
+%test.quarkus.hibernate-orm.schema-management.strategy=none
 
 # expose swagger-ui and openapi JSON/YAML on turnpike-friendly paths
 quarkus.smallrye-openapi.path=/api/${quarkus.application.name}/internal/openapi

--- a/swatch-utilization/src/main/resources/db/202604161200-create-organization-utilization-preference-table.xml
+++ b/swatch-utilization/src/main/resources/db/202604161200-create-organization-utilization-preference-table.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202604161200-001" author="jcarvaja">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="org_utilization_preference"/>
+      </not>
+    </preConditions>
+
+    <comment>Store per-organization utilization notification preferences</comment>
+    <createTable tableName="org_utilization_preference">
+      <column name="org_id" type="VARCHAR(32)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="org_utilization_preference_pkey"/>
+      </column>
+      <column name="custom_threshold" type="INTEGER">
+        <constraints nullable="false"/>
+      </column>
+      <column name="last_updated" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <rollback>
+      <dropTable tableName="org_utilization_preference"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/swatch-utilization/src/main/resources/db/changelog.xml
+++ b/swatch-utilization/src/main/resources/db/changelog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <include file="/db/202604161200-create-organization-utilization-preference-table.xml"/>
+
+</databaseChangeLog>

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceRepositoryTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/data/OrgUtilizationPreferenceRepositoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@Transactional
+@QuarkusTest
+class OrgUtilizationPreferenceRepositoryTest {
+
+  private static final String ORG_ID = "org-1";
+  private static final int CUSTOM_THRESHOLD = 5;
+
+  @Inject OrgUtilizationPreferenceRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void whenSavePreference_thenFindReturnsPersistedValues() {
+    whenSavePreference(ORG_ID, CUSTOM_THRESHOLD);
+    thenPreferenceIsFound(ORG_ID, CUSTOM_THRESHOLD);
+  }
+
+  private void whenSavePreference(String orgId, int thresholdPercent) {
+    var entity = new OrgUtilizationPreferenceEntity();
+    entity.setOrgId(orgId);
+    entity.setCustomThreshold(thresholdPercent);
+    repository.persist(entity);
+  }
+
+  private void thenPreferenceIsFound(String orgId, int thresholdPercent) {
+    Optional<OrgUtilizationPreferenceEntity> found = repository.findByIdOptional(orgId);
+    assertTrue(found.isPresent());
+    assertEquals(orgId, found.get().getOrgId());
+    assertEquals(thresholdPercent, found.get().getCustomThreshold());
+    assertNotNull(found.get().getLastUpdated());
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-4792

## Description
Adds a shared PostgreSQL table and persistence layer in swatch-utilization for per-organization utilization preferences (org_utilization_preference: org_id, custom_threshold as a non-null int percentage, last_updated, is_enabled).

Changes:
- Quarkus: JDBC PostgreSQL, Liquibase, Panache; H2 + Liquibase for tests.
- Liquibase: single changelog creating org_utilization_preference with service-specific changelog table names.
- Clowder: database + swatch-database dependency, DB env from secrets; optional Liquibase lock cleanup job (swatch-utilization-db-cleanup + ClowdJobInvocation) mirroring swatch-billable-usage.
- Code: OrgUtilizationPreferenceEntity, OrgUtilizationPreferenceRepository; compact OrgUtilizationPreferenceRepositoryTest (given/when/then helpers, no Thread.sleep).

Note that I will create a separate JIRA ticket for the floorish work. 

## Testing
mvn -pl swatch-utilization test (includes repository tests against H2).