### PR TITLE
SWATCH-4780: Implement the IT Partner Gateway Kafka Consumer

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -113,3 +113,17 @@ objects:
     data:
       # dummy-token for testing purposes only
       token: ZHVtbXktdG9rZW4=
+
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: swatch-managed-kafka
+    type: Opaque
+    data:
+      ## dummy credentials for testing purposes only
+      # dummy-username
+      username: ZHVtbXktdXNlcm5hbWU=
+      # dummy-password
+      password: ZHVtbXktcGFzc3dvcmQ=
+      # dummy-web-name:dummy-web-client:13345
+      servers: ZHVtbXktd2ViLW5hbWU6ZHVtbXktd2ViLWNsaWVudDoxMzM0NQ==

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -106,6 +106,10 @@ parameters:
     value: '3'
   - name: KAFKA_UTILIZATION_PARTITIONS
     value: '3'
+  - name: KAFKA_PARTNER_GATEWAY_REPLICAS
+    value: '3'
+  - name: KAFKA_PARTNER_GATEWAY_PARTITIONS
+    value: '3'
   - name: CURL_CRON_IMAGE
     value: registry.access.redhat.com/ubi8/ubi-minimal
   - name: CURL_CRON_IMAGE_TAG
@@ -177,6 +181,12 @@ objects:
         - replicas: ${{KAFKA_UTILIZATION_REPLICAS}}
           partitions: ${{KAFKA_UTILIZATION_PARTITIONS}}
           topicName: platform.rhsm-subscriptions.utilization
+        - replicas: ${{KAFKA_PARTNER_GATEWAY_REPLICAS}}
+          partitions: ${{KAFKA_PARTNER_GATEWAY_PARTITIONS}}
+          topicName: partner-integration.entitlement-gateway.partner-entitlement.protected
+        - replicas: ${{KAFKA_PARTNER_GATEWAY_REPLICAS}}
+          partitions: ${{KAFKA_PARTNER_GATEWAY_PARTITIONS}}
+          topicName: stage.partner-integration.entitlement-gateway.partner-entitlement.protected
 
       deployments:
         - name: service

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -184,9 +184,6 @@ objects:
         - replicas: ${{KAFKA_PARTNER_GATEWAY_REPLICAS}}
           partitions: ${{KAFKA_PARTNER_GATEWAY_PARTITIONS}}
           topicName: partner-integration.entitlement-gateway.partner-entitlement.protected
-        - replicas: ${{KAFKA_PARTNER_GATEWAY_REPLICAS}}
-          partitions: ${{KAFKA_PARTNER_GATEWAY_PARTITIONS}}
-          topicName: stage.partner-integration.entitlement-gateway.partner-entitlement.protected
 
       deployments:
         - name: service
@@ -353,6 +350,21 @@ objects:
                   secretKeyRef:
                     name: tls
                     key: keystore_password
+              - name: IT_MANAGED_KAFKA_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-managed-kafka
+                    key: username
+              - name: IT_MANAGED_KAFKA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-managed-kafka
+                    key: password
+              - name: IT_MANAGED_KAFKA_SERVERS
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-managed-kafka
+                    key: servers
               - name: SUBSCRIPTION_SYNC_ENABLED
                 value: ${SUBSCRIPTION_SYNC_ENABLED}
               - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
@@ -24,6 +24,7 @@ public final class Channels {
 
   public static final String CAPACITY_RECONCILE = "capacity-reconcile";
   public static final String CAPACITY_RECONCILE_TASK = "capacity-reconcile-task";
+  public static final String CONTRACTS_FROM_GATEWAY = "contracts-from-gateway";
   public static final String ENABLED_ORGS = "enabled-orgs";
   public static final String SUBSCRIPTION_SYNC_TASK_TOPIC = "subscription-sync-task";
   public static final String SUBSCRIPTION_SYNC_TASK_UMB = "subscription-sync-umb";

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource;
+
+import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+@Slf4j
+public class ContractsPartnerEntitlementMessageConsumer {
+
+  @Inject ObjectMapper mapper;
+
+  @Blocking
+  @Incoming(CONTRACTS_FROM_GATEWAY)
+  public void consumeMessage(String dtoContract) {
+    log.debug("IT Partner Kafka consumer was called");
+    if (dtoContract == null) {
+      return;
+    }
+
+    consumeContract(dtoContract);
+  }
+
+  public void consumeContract(String dtoContract) {
+    log.info(dtoContract);
+
+    try {
+      PartnerEntitlementContract contract =
+          mapper.readValue(dtoContract, PartnerEntitlementContract.class);
+
+      String awsCustomerAccountId = null;
+      String productCode = null;
+      String azureResourceId = null;
+
+      if (contract.getCloudIdentifiers() != null) {
+        awsCustomerAccountId = contract.getCloudIdentifiers().getAwsCustomerAccountId();
+        productCode = contract.getCloudIdentifiers().getProductCode();
+        azureResourceId = contract.getCloudIdentifiers().getAzureResourceId();
+      }
+
+      log.info(
+          "IT Partner message consumed: source=kafka, action={}, "
+              + "awsCustomerAccountId={}, productCode={}, azureResourceId={}, "
+              + "redHatSubscriptionNumber={}",
+          contract.getAction(),
+          awsCustomerAccountId,
+          productCode,
+          azureResourceId,
+          contract.getRedHatSubscriptionNumber());
+
+    } catch (Exception e) {
+      log.warn("Unable to read IT Partner Kafka message from JSON.", e);
+    }
+  }
+}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -203,7 +203,6 @@ UMB_ENABLED=false
 %stage.UMB_ENABLED=true
 %prod.UMB_ENABLED=true
 
-
 UMB_HOSTNAME=localhost
 %ephemeral.UMB_HOSTNAME=artemis-amqp-service
 %stage.UMB_HOSTNAME=umb.stage.api.redhat.com
@@ -266,6 +265,12 @@ mp.messaging.outgoing.contractstest.client-options-name=umb
 mp.messaging.incoming.contracts-from-gateway.connector=smallrye-kafka
 %test.mp.messaging.incoming.contracts-from-gateway.connector=smallrye-in-memory
 mp.messaging.incoming.contracts-from-gateway.topic=${IT_PARTNER_KAFKA_TOPIC}
+%stage,prod.mp.messaging.incoming.contracts-from-gateway.bootstrap.servers=${IT_MANAGED_KAFKA_SERVERS}
+%stage,prod.mp.messaging.incoming.contracts-from-gateway.security.protocol=SASL_SSL
+%stage,prod.mp.messaging.incoming.contracts-from-gateway.sasl.mechanism=SCRAM-SHA-512
+%stage,prod.mp.messaging.incoming.contracts-from-gateway.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+    username="${IT_MANAGED_KAFKA_USERNAME}" \
+    password="${IT_MANAGED_KAFKA_PASSWORD}";
 mp.messaging.incoming.contracts-from-gateway.group.id=it-partner-kafka-worker
 mp.messaging.incoming.contracts-from-gateway.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.contracts-from-gateway.failure-strategy=ignore

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -220,6 +220,10 @@ CONTRACT_UMB_QUEUE=VirtualTopic.services.partner-entitlement-gateway
 OFFERING_UMB_SERVICE_QUEUE=VirtualTopic.services.productservice.Product
 SUBSCRIPTION_UMB_QUEUE=VirtualTopic.canonical.subscription
 
+IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitlement.protected
+%stage.IT_PARTNER_KAFKA_TOPIC=stage.partner-integration.entitlement-gateway.partner-entitlement.protected
+%prod.IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitlement.protected
+
 %ephemeral.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm-ephemeral
 %stage.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm
 %prod.UMB_SERVICE_ACCOUNT_NAME=insightsrhsm
@@ -258,6 +262,13 @@ mp.messaging.incoming.contracts.failure-strategy=accept
 mp.messaging.outgoing.contractstest.connector=smallrye-in-memory
 mp.messaging.outgoing.contractstest.address=${CONTRACT_UMB_QUEUE}
 mp.messaging.outgoing.contractstest.client-options-name=umb
+
+mp.messaging.incoming.contracts-from-gateway.connector=smallrye-kafka
+%test.mp.messaging.incoming.contracts-from-gateway.connector=smallrye-in-memory
+mp.messaging.incoming.contracts-from-gateway.topic=${IT_PARTNER_KAFKA_TOPIC}
+mp.messaging.incoming.contracts-from-gateway.group.id=it-partner-kafka-worker
+mp.messaging.incoming.contracts-from-gateway.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.contracts-from-gateway.failure-strategy=ignore
 
 mp.messaging.incoming.subscription-sync-task.connector=smallrye-kafka
 %test.mp.messaging.incoming.subscription-sync-task.connector=smallrye-in-memory

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource;
+
+import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ContractsPartnerEntitlementMessageConsumerTest {
+
+  private static final String VALID_JSON_MESSAGE =
+      """
+        {
+          "action": "contract-updated",
+          "redHatSubscriptionNumber": "12345678",
+          "cloudIdentifiers": {
+            "awsCustomerAccountId": "795061427196",
+            "productCode": "test-product-code",
+            "azureResourceId": "azure-resource-123"
+          },
+          "currentDimensions": [{
+            "dimensionName": "test-dimension",
+            "dimensionValue": "10"
+          }]
+        }
+        """;
+
+  @Inject @Any InMemoryConnector connector;
+
+  @InjectSpy ContractsPartnerEntitlementMessageConsumer consumer;
+
+  private InMemorySource<Object> contractsKafkaChannel;
+
+  @BeforeEach
+  void setUp() {
+    contractsKafkaChannel = connector.source(CONTRACTS_FROM_GATEWAY);
+  }
+
+  @Test
+  void shouldProcessStringMessage() {
+    whenSendMessage(VALID_JSON_MESSAGE);
+    assertMessageIsProcessed();
+  }
+
+  private void whenSendMessage(String message) {
+    contractsKafkaChannel.send(message);
+  }
+
+  private void assertMessageIsProcessed() {
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(() -> verify(consumer).consumeContract(anyString()));
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-4780

## Description
This PR creates the IT Partner Kafka Consumer as part of the umb to kafkamigration, and also configures the consumer to use a different Kafka Instance (the IT Managed Kafka instance). Details in SWATCH-4894. 

The idea is that in ephemeral, it will use the Kafka instance that is started within the environment. But in stage and prod, it will use the IT Managed Kafka instance which secret was already added in app-interface. 

## Testing
./mvnw test -Dtest=PartnerEntitlementKafkaMessageConsumerTest -pl swatch-contracts
All tests should pass.

## Verification

I verified that the connection works fine for stage and prod, so this should work as expected after merged. 