### PR TITLE
SWATCH-4563: add nightly contracts sync all cron job

### DIFF
--- a/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/SwatchPskHeaderFilter.java
+++ b/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/SwatchPskHeaderFilter.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
- * Resteasy client filter that adds x-rh-swatch-psk to requests based on the value of the
+ * Resteasy client filter that adds {@link #SWATCH_PSK_HEADER} to requests based on the value of the
  * SWATCH_SELF_PSK property/environment variable.
  *
  * <p>Use by configuring as a provider on a rest client instance, e.g. <code>
@@ -42,11 +42,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class SwatchPskHeaderFilter implements ClientRequestFilter {
 
+  /** HTTP header name for Swatch service-to-service PSK authentication. */
+  public static final String SWATCH_PSK_HEADER = "x-rh-swatch-psk";
+
   @ConfigProperty(name = "SWATCH_SELF_PSK")
   String psk;
 
   @Override
   public void filter(ClientRequestContext requestContext) {
-    requestContext.getHeaders().add("x-rh-swatch-psk", psk);
+    requestContext.getHeaders().add(SWATCH_PSK_HEADER, psk);
   }
 }

--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -573,7 +573,7 @@ Test cases should be testable locally and in an ephemeral environment.
 **contracts-sync-TC003 - Sync all contracts across all organizations**  
 - **Description**: Verify syncAllContracts triggers sync for all orgs with contracts.  
 - **Setup**: Have multiple orgs with contracts.  
-- **Action**: POST `/internal/rpc/syncAllContracts`.  
+- **Action**: POST `/api/swatch-contracts/internal/rpc/contracts/sync`.  
 - **Verification**: Monitor sync progress.  
 - **Expected Result**:  
   - HTTP 200 OK
@@ -598,29 +598,29 @@ Test cases should be testable locally and in an ephemeral environment.
   - HTTP 204 No Content
   - No contracts remain for the org
 
-**contracts-sync-TC006 - Running the global sync twice does not create duplicate contracts**
-- **Description**: Verify that the global sync is idempotent.
+**contracts-sync-TC006 - Running contracts sync all twice does not create duplicate contracts**
+- **Description**: Verify that contracts sync all is idempotent.
 - **Setup**: An org has one contract created and stubbed upstream.
-- **Action**: POST `/internal/rpc/syncAllContracts` twice.
+- **Action**: POST `/api/swatch-contracts/internal/rpc/contracts/sync` twice.
 - **Verification**: Query contracts after each call.
 - **Expected Result**:
   - Contract count stays at 1 after both calls
   - Contract UUID is the same after both calls
   - Billing provider is unchanged
 
-**contracts-sync-TC007 - Global sync preserves all contracts for an org with multiple providers**
-- **Description**: Verify that when an org has both an AWS and an Azure contract, running the global sync leaves both intact.
+**contracts-sync-TC007 - Contracts sync all preserves all contracts for an org with multiple providers**
+- **Description**: Verify that when an org has both an AWS and an Azure contract, running contracts sync all leaves both intact.
 - **Setup**: An org has one AWS contract and one Azure contract.
-- **Action**: POST `/internal/rpc/syncAllContracts`.
+- **Action**: POST `/api/swatch-contracts/internal/rpc/contracts/sync`.
 - **Verification**: Query contracts for the org.
 - **Expected Result**:
   - Both the AWS and Azure contracts still exist
   - UUIDs of both contracts are unchanged
 
-**contracts-sync-TC008 - Global sync after a per-org sync does not add extra records**
-- **Description**: Verify that running the global sync on top of an already-synced org does not accumulate additional rows in any of the four related tables (contracts, contract metrics, subscriptions, subscription measurements).
+**contracts-sync-TC008 - Contracts sync all after a per-org sync does not add extra records**
+- **Description**: Verify that running contracts sync all on top of an already-synced org does not accumulate additional rows in any of the four related tables (contracts, contract metrics, subscriptions, subscription measurements).
 - **Setup**: An org is fully synced via the per-org endpoint; record counts and IDs across all four tables are captured as a baseline.
-- **Action**: POST `/internal/rpc/syncAllContracts`.
+- **Action**: POST `/api/swatch-contracts/internal/rpc/contracts/sync`.
 - **Verification**: Re-query all four tables.
 - **Expected Result**:
   - Contract count, UUID, and metric count are unchanged
@@ -653,7 +653,7 @@ Test cases should be testable locally and in an ephemeral environment.
 
 ## Contract Termination During Sync
 
-This section verifies the automatic contract termination behavior when contracts are missing from upstream during synchronization. Contracts are soft-deleted (endDate set to current timestamp) rather than hard-deleted to preserve historical records for audit and billing purposes. This behavior applies to both individual contract sync and global sync operations.
+This section verifies the automatic contract termination behavior when contracts are missing from upstream during synchronization. Contracts are soft-deleted (endDate set to current timestamp) rather than hard-deleted to preserve historical records for audit and billing purposes. This behavior applies to both individual contract sync and contracts sync all operations.
 
 **contracts-sync-TC011 - Contract missing from upstream is terminated (not deleted)**
 - **Description**: Verify that when a contract exists in SWATCH but is no longer returned by the upstream partner API during sync, it is terminated (endDate set) rather than deleted.

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -73,7 +73,7 @@ public class ContractsSwatchService extends SwatchService {
       ENDPOINT_PREFIX + "/subscriptions/terminate/{subscription_id}";
   private static final String SYNC_CONTRACTS_BY_ORG_ENDPOINT =
       ENDPOINT_PREFIX + "/rpc/sync/contracts/%s";
-  private static final String SYNC_ALL_CONTRACTS_ENDPOINT = "/internal/rpc/syncAllContracts";
+  private static final String SYNC_ALL_CONTRACTS_ENDPOINT = ENDPOINT_PREFIX + "/rpc/contracts/sync";
   private static final String SYNC_ALL_SUBSCRIPTIONS_ENDPOINT =
       ENDPOINT_PREFIX + "/rpc/subscriptions/sync";
   private static final String SUBSCRIPTIONS_UMB_ENDPOINT = ENDPOINT_PREFIX + "/subscriptions/umb";

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -22,8 +22,8 @@ package tests;
 
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContractsInOrgId;
 import static java.util.Collections.disjoint;
-import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,6 +34,7 @@ import static utils.DateUtils.assertDatesAreEqual;
 
 import api.PartnerApiStubs;
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.SkuCapacitySubscription;
 import domain.BillingProvider;
@@ -42,16 +43,14 @@ import io.restassured.response.Response;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 public class ContractsSyncComponentTest extends BaseContractComponentTest {
 
-  // Status message constants
   private static final String STATUS_SUCCESS = "SUCCESS";
-  private static final String STATUS_ALL_CONTRACTS_SYNCED = "All Contract are Synced";
+  private static final String STATUS_ENQUEUED_PREFIX = "Enqueued";
   private static final String STATUS_NO_CONTRACTS_FOUND = "No active contract found for the orgIds";
 
   @TestPlanName("contracts-sync-TC001")
@@ -156,7 +155,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     var initialSubscriptionIds =
         initialSkuCapacity.get().getSubscriptions().stream()
             .map(SkuCapacitySubscription::getId)
-            .collect(toSet());
+            .collect(Collectors.toSet());
 
     // Setup new upstream contracts (different from existing - same SKU, different provider)
     Contract newContract =
@@ -193,7 +192,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
       var remainingSubscriptionIds =
           finalSkuCapacity.get().getSubscriptions().stream()
               .map(SkuCapacitySubscription::getId)
-              .collect(toSet());
+              .collect(Collectors.toSet());
 
       // Verify none of the old AWS subscription IDs remain
       assertTrue(
@@ -238,27 +237,11 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     givenContractIsCreated(secondOrgContract);
 
     // When: Sync all contracts
-    Response syncResponse = service.syncAllContracts();
+    whenSyncAllContracts();
 
-    // Then: Verify sync succeeded
-    assertThat(
-        "Sync all contracts should succeed", syncResponse.statusCode(), is(HttpStatus.SC_OK));
-    syncResponse.then().body("status", equalTo(STATUS_ALL_CONTRACTS_SYNCED));
-
-    // Verify contracts still exist for both orgs after sync
-    var firstOrgContracts = service.getContractsByOrgId(firstOrg);
-    assertEquals(1, firstOrgContracts.size(), "First org should have one contract after sync");
-    assertEquals(
-        BillingProvider.AWS.toApiModel(),
-        firstOrgContracts.get(0).getBillingProvider(),
-        "First org contract should be AWS");
-
-    var secondOrgContracts = service.getContractsByOrgId(secondOrg);
-    assertEquals(1, secondOrgContracts.size(), "Second org should have one contract after sync");
-    assertEquals(
-        BillingProvider.AZURE.toApiModel(),
-        secondOrgContracts.get(0).getBillingProvider(),
-        "Second org contract should be Azure");
+    // Then: Verify contracts
+    thenOrgHasSingleContractWithProvider(firstOrg, BillingProvider.AWS);
+    thenOrgHasSingleContractWithProvider(secondOrg, BillingProvider.AZURE);
   }
 
   @TestPlanName("contracts-sync-TC004")
@@ -307,35 +290,21 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     var contractsBefore = service.getContractsByOrgId(orgId);
     assertEquals(1, contractsBefore.size(), "Should have exactly one contract before sync");
 
-    // When: Run syncAllContracts the first time
-    Response firstSync = service.syncAllContracts();
-    assertThat("First sync should succeed", firstSync.statusCode(), is(HttpStatus.SC_OK));
-    firstSync.then().body("status", equalTo(STATUS_ALL_CONTRACTS_SYNCED));
+    // When: Run syncAllContracts the first time (async)
+    whenSyncAllContracts();
 
-    var contractsAfterFirst = service.getContractsByOrgId(orgId);
-    assertEquals(
-        1, contractsAfterFirst.size(), "Should still have exactly one contract after first sync");
-    String uuidAfterFirst = contractsAfterFirst.get(0).getUuid();
+    // Wait for async processing, then capture state
+    String uuidAfterFirst =
+        AwaitilityUtils.until(
+                () -> service.getContractsByOrgId(orgId), contracts -> contracts.size() == 1)
+            .get(0)
+            .getUuid();
 
     // When: Run syncAllContracts a second time (same upstream data — idempotency check)
-    Response secondSync = service.syncAllContracts();
-    assertThat("Second sync should succeed", secondSync.statusCode(), is(HttpStatus.SC_OK));
-    secondSync.then().body("status", equalTo(STATUS_ALL_CONTRACTS_SYNCED));
+    whenSyncAllContracts();
 
-    // Then: No duplicate contracts created; record count is still exactly 1
-    var contractsAfterSecond = service.getContractsByOrgId(orgId);
-    assertEquals(1, contractsAfterSecond.size(), "Repeat sync must not create duplicate contracts");
-
-    // UUID must be stable — upsert finds the existing record and leaves it unchanged
-    String uuidAfterSecond = contractsAfterSecond.get(0).getUuid();
-    assertEquals(
-        uuidAfterFirst,
-        uuidAfterSecond,
-        "Contract UUID must remain stable across repeat syncAllContracts calls");
-    assertEquals(
-        contractsAfterFirst.get(0).getBillingProvider(),
-        contractsAfterSecond.get(0).getBillingProvider(),
-        "Billing provider must not change across repeat runs");
+    // Then: Wait for async processing and verify no duplicates
+    thenSingleContractHasStableUuid(uuidAfterFirst);
   }
 
   @TestPlanName("contracts-sync-TC007")
@@ -367,43 +336,16 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     var contractsBefore = service.getContractsByOrgId(orgId);
     assertEquals(2, contractsBefore.size(), "Should have two contracts before sync");
 
-    Set<String> uuidsBefore =
-        contractsBefore.stream()
-            .map(com.redhat.swatch.contract.test.model.Contract::getUuid)
-            .collect(Collectors.toSet());
+    String awsUuid = getContractUuidByProvider(orgId, BillingProvider.AWS);
+    String azureUuid = getContractUuidByProvider(orgId, BillingProvider.AZURE);
 
-    // When: syncAllContracts (will iterate this org twice since it has 2 contracts in DB)
-    Response syncResponse = service.syncAllContracts();
-    assertThat("Sync should succeed", syncResponse.statusCode(), is(HttpStatus.SC_OK));
-    syncResponse.then().body("status", equalTo(STATUS_ALL_CONTRACTS_SYNCED));
+    // When: syncAllContracts (async — enqueues one task for this org)
+    whenSyncAllContracts();
 
-    // Then: Both contracts still exist after the full loop
-    var contractsAfter = service.getContractsByOrgId(orgId);
-    assertEquals(
-        2,
-        contractsAfter.size(),
-        "Both AWS and Azure contracts must survive syncAllContracts loop iteration");
-
-    Set<String> providersAfter =
-        contractsAfter.stream()
-            .map(com.redhat.swatch.contract.test.model.Contract::getBillingProvider)
-            .collect(Collectors.toSet());
-    assertTrue(
-        providersAfter.contains(BillingProvider.AWS.toApiModel()),
-        "AWS contract must still exist after syncAllContracts");
-    assertTrue(
-        providersAfter.contains(BillingProvider.AZURE.toApiModel()),
-        "Azure contract must still exist after syncAllContracts");
-
-    // UUIDs should be stable — same records, not new UUIDs from re-creation
-    Set<String> uuidsAfter =
-        contractsAfter.stream()
-            .map(com.redhat.swatch.contract.test.model.Contract::getUuid)
-            .collect(Collectors.toSet());
-    assertEquals(
-        uuidsBefore,
-        uuidsAfter,
-        "Contract UUIDs must remain stable after syncAllContracts for multi-provider org");
+    // Then: both contracts survive and their UUIDs are stable
+    thenContractIsFound(awsUuid, BillingProvider.AWS);
+    thenContractIsFound(azureUuid, BillingProvider.AZURE);
+    thenContractsSizeAre(2);
   }
 
   @TestPlanName("contracts-sync-TC008")
@@ -426,35 +368,13 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     String subIdAfterOrgSync = subsAfterOrgSync.get(0).getSubscriptionId();
     int measurementCountAfterOrgSync = subsAfterOrgSync.get(0).getMetrics().size();
 
-    // When: Run syncAllContracts on top of the already-synced state
-    Response globalSync = service.syncAllContracts();
-    assertThat("Global sync should succeed", globalSync.statusCode(), is(HttpStatus.SC_OK));
-    globalSync.then().body("status", equalTo(STATUS_ALL_CONTRACTS_SYNCED));
+    // When: Run syncAllContracts on top of the already-synced state (async)
+    whenSyncAllContracts();
 
-    // Then: No additional records in any table
-    var contractsAfterGlobalSync = service.getContractsByOrgId(orgId);
-    assertEquals(
-        1, contractsAfterGlobalSync.size(), "contracts: no duplicate rows after global sync");
-    assertEquals(
-        uuidAfterOrgSync,
-        contractsAfterGlobalSync.get(0).getUuid(),
-        "contracts: UUID must be stable after global sync");
-    assertEquals(
-        metricsCountAfterOrgSync,
-        contractsAfterGlobalSync.get(0).getMetrics().size(),
-        "contract_metrics: row count must be stable after global sync");
-
-    var subsAfterGlobalSync = service.getSubscriptionsByOrgId(orgId);
-    assertEquals(
-        1, subsAfterGlobalSync.size(), "subscriptions: no duplicate rows after global sync");
-    assertEquals(
-        subIdAfterOrgSync,
-        subsAfterGlobalSync.get(0).getSubscriptionId(),
-        "subscriptions: subscription_id must be stable after global sync");
-    assertEquals(
-        measurementCountAfterOrgSync,
-        subsAfterGlobalSync.get(0).getMetrics().size(),
-        "subscription_measurements: row count must be stable after global sync");
+    // Then: Wait for async processing, no additional records in any table
+    thenSingleContractHasStableUuidAndMetrics(uuidAfterOrgSync, metricsCountAfterOrgSync);
+    thenSingleSubscriptionHasStableIdAndMeasurements(
+        subIdAfterOrgSync, measurementCountAfterOrgSync);
   }
 
   @TestPlanName("contracts-sync-TC009")
@@ -484,98 +404,24 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertEquals(1, contracts.size(), "Exactly one contract row must exist");
 
     var c = contracts.get(0);
-    assertNotNull(c.getUuid(), "contracts.uuid must be set");
-    assertEquals(orgId, c.getOrgId(), "contracts.org_id must match");
-    assertEquals(sku, c.getSku(), "contracts.sku must match");
-    assertEquals(
-        BillingProvider.AWS.toApiModel(), c.getBillingProvider(), "contracts.billing_provider");
-    assertNotNull(
-        c.getBillingProviderId(),
-        "contracts.billing_provider_id must be populated (pre-cleanup key)");
-    assertFalse(
-        c.getBillingProviderId().isBlank(), "contracts.billing_provider_id must not be blank");
-    assertNotNull(c.getBillingAccountId(), "contracts.billing_account_id must be set");
-    assertEquals(
-        contract.getBillingAccountId(),
-        c.getBillingAccountId(),
-        "contracts.billing_account_id must match upstream value");
-    assertNotNull(c.getStartDate(), "contracts.start_date must be set");
-    assertNotNull(c.getEndDate(), "contracts.end_date must be set");
-    assertEquals(
-        contract.getSubscriptionNumber(),
-        c.getSubscriptionNumber(),
-        "contracts.subscription_number must match upstream");
-    assertFalse(c.getProductTags().isEmpty(), "contracts.product_tags must not be empty");
-
-    // ── contract_metrics table ────────────────────────────────────────────
-    var metrics = c.getMetrics();
-    assertFalse(metrics.isEmpty(), "contract_metrics must have at least one row");
-
-    for (var metric : metrics) {
-      assertNotNull(metric.getMetricId(), "contract_metrics.metric_id must not be null");
-      assertFalse(metric.getMetricId().isBlank(), "contract_metrics.metric_id must not be blank");
-      assertNotNull(metric.getValue(), "contract_metrics.value must not be null");
-      assertTrue(metric.getValue() > 0, "contract_metrics.value must be positive");
-    }
-
-    // No duplicate metric_ids on the same contract
-    var metricIds =
-        metrics.stream()
-            .map(com.redhat.swatch.contract.test.model.Metric::getMetricId)
-            .collect(Collectors.toList());
-    assertEquals(
-        metricIds.size(),
-        metricIds.stream().distinct().count(),
-        "contract_metrics must not contain duplicate metric_id values for the same contract");
+    verifyContractFields(contract, c);
+    verifyContractMetricsAreValid(c.getMetrics());
 
     // ── subscriptions table ───────────────────────────────────────────────
     var subscriptions = service.getSubscriptionsByOrgId(orgId);
     assertEquals(1, subscriptions.size(), "Exactly one subscription row must exist");
 
     var sub = subscriptions.get(0);
-    assertNotNull(sub.getSubscriptionId(), "subscriptions.subscription_id must be set");
-    assertEquals(orgId, sub.getOrgId(), "subscriptions.org_id must match");
-    assertEquals(sku, sub.getSku(), "subscriptions.sku must match");
-    assertEquals(
-        BillingProvider.AWS.toApiModel(),
-        sub.getBillingProvider().toLowerCase(),
-        "subscriptions.billing_provider must match");
-    assertNotNull(
-        sub.getBillingProviderId(), "subscriptions.billing_provider_id must be populated");
-    assertNotNull(sub.getBillingAccountId(), "subscriptions.billing_account_id must be set");
-    assertNotNull(sub.getStartDate(), "subscriptions.start_date must be set");
-    assertNotNull(sub.getEndDate(), "subscriptions.end_date must be set");
-
-    // ── subscription_measurements table ───────────────────────────────────
-    var measurements = sub.getMetrics();
-    assertNotNull(measurements, "subscription_measurements must not be null");
-    assertFalse(measurements.isEmpty(), "subscription_measurements must have at least one row");
-
-    for (var m : measurements) {
-      assertNotNull(m.getMetricId(), "subscription_measurements.metric_id must not be null");
-      assertNotNull(m.getValue(), "subscription_measurements.value must not be null");
-      assertTrue(m.getValue() > 0, "subscription_measurements.value must be positive");
-      assertNotNull(
-          m.getMeasurementType(), "subscription_measurements.measurement_type must not be null");
-      assertFalse(
-          m.getMeasurementType().isBlank(),
-          "subscription_measurements.measurement_type must not be blank");
-    }
+    verifySubscriptionFields(contract, sub);
 
     // ── cross-table consistency ───────────────────────────────────────────
-    // contract.subscription_number == subscription.subscription_number
     assertEquals(
         c.getSubscriptionNumber(),
         sub.getSubscriptionNumber(),
         "contracts.subscription_number must equal subscriptions.subscription_number");
-
-    // Both tables must have the same number of distinct metric entries for this
-    // contract/subscription
-    // (contract_metrics and subscription_measurements use different ID representations — e.g.
-    // "four_vcpu_hour" vs "Cores" — so we compare counts, not names)
     assertEquals(
-        metrics.size(),
-        measurements.size(),
+        c.getMetrics().size(),
+        sub.getMetrics().size(),
         "contract_metrics and subscription_measurements must have the same number of metric entries");
   }
 
@@ -816,6 +662,186 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
         endDateBefore,
         contractsAfter.get(0).getEndDate(),
         "Azure contract end_date should be unchanged (not terminated)");
+  }
+
+  protected String getContractUuidByProvider(String orgId, BillingProvider provider) {
+    var contracts =
+        service.getContractsByOrgId(orgId).stream()
+            .filter(c -> c.getBillingProvider().equals(provider.toApiModel()))
+            .toList();
+    assertEquals(
+        1,
+        contracts.size(),
+        "Expected exactly one contract with provider " + provider + " for org " + orgId);
+    return contracts.get(0).getUuid();
+  }
+
+  protected void verifyContractFields(
+      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
+    assertNotNull(actual.getUuid(), "contracts.uuid must be set");
+    assertEquals(expected.getOrgId(), actual.getOrgId(), "contracts.org_id must match");
+    assertEquals(expected.getOffering().getSku(), actual.getSku(), "contracts.sku must match");
+    assertEquals(
+        expected.getBillingProvider().toApiModel(),
+        actual.getBillingProvider(),
+        "contracts.billing_provider");
+    assertNotNull(
+        actual.getBillingProviderId(),
+        "contracts.billing_provider_id must be populated (pre-cleanup key)");
+    assertFalse(
+        actual.getBillingProviderId().isBlank(), "contracts.billing_provider_id must not be blank");
+    assertNotNull(actual.getBillingAccountId(), "contracts.billing_account_id must be set");
+    assertEquals(
+        expected.getBillingAccountId(),
+        actual.getBillingAccountId(),
+        "contracts.billing_account_id must match upstream value");
+    assertNotNull(actual.getStartDate(), "contracts.start_date must be set");
+    assertNotNull(actual.getEndDate(), "contracts.end_date must be set");
+    assertEquals(
+        expected.getSubscriptionNumber(),
+        actual.getSubscriptionNumber(),
+        "contracts.subscription_number must match upstream");
+    assertFalse(actual.getProductTags().isEmpty(), "contracts.product_tags must not be empty");
+    assertNotNull(actual.getMetrics(), "contract_metrics must not be null");
+  }
+
+  protected void verifyContractMetricsAreValid(
+      List<com.redhat.swatch.contract.test.model.Metric> metrics) {
+    assertFalse(metrics.isEmpty(), "contract_metrics must have at least one row");
+    for (var metric : metrics) {
+      assertNotNull(metric.getMetricId(), "contract_metrics.metric_id must not be null");
+      assertFalse(metric.getMetricId().isBlank(), "contract_metrics.metric_id must not be blank");
+      assertNotNull(metric.getValue(), "contract_metrics.value must not be null");
+      assertTrue(metric.getValue() > 0, "contract_metrics.value must be positive");
+    }
+    long distinctCount =
+        metrics.stream()
+            .map(com.redhat.swatch.contract.test.model.Metric::getMetricId)
+            .distinct()
+            .count();
+    assertEquals(
+        (long) metrics.size(),
+        distinctCount,
+        "contract_metrics must not contain duplicate metric_id values for the same contract");
+  }
+
+  protected void verifySubscriptionFields(
+      Contract expected, com.redhat.swatch.contract.test.model.Subscription actual) {
+    assertNotNull(actual.getSubscriptionId(), "subscriptions.subscription_id must be set");
+    assertEquals(expected.getOrgId(), actual.getOrgId(), "subscriptions.org_id must match");
+    assertEquals(expected.getOffering().getSku(), actual.getSku(), "subscriptions.sku must match");
+    assertEquals(
+        expected.getBillingProvider().toApiModel(),
+        actual.getBillingProvider().toLowerCase(),
+        "subscriptions.billing_provider must match");
+    assertNotNull(
+        actual.getBillingProviderId(), "subscriptions.billing_provider_id must be populated");
+    assertNotNull(actual.getBillingAccountId(), "subscriptions.billing_account_id must be set");
+    assertNotNull(actual.getStartDate(), "subscriptions.start_date must be set");
+    assertNotNull(actual.getEndDate(), "subscriptions.end_date must be set");
+    var measurements = actual.getMetrics();
+    assertNotNull(measurements, "subscription_measurements must not be null");
+    assertFalse(measurements.isEmpty(), "subscription_measurements must have at least one row");
+    for (var m : measurements) {
+      assertNotNull(m.getMetricId(), "subscription_measurements.metric_id must not be null");
+      assertNotNull(m.getValue(), "subscription_measurements.value must not be null");
+      assertTrue(m.getValue() > 0, "subscription_measurements.value must be positive");
+      assertNotNull(
+          m.getMeasurementType(), "subscription_measurements.measurement_type must not be null");
+      assertFalse(
+          m.getMeasurementType().isBlank(),
+          "subscription_measurements.measurement_type must not be blank");
+    }
+  }
+
+  @FunctionalInterface
+  interface Condition {
+    void verify(List<com.redhat.swatch.contract.test.model.Contract> contracts);
+  }
+
+  private void whenSyncAllContracts() {
+    Response sync = service.syncAllContracts();
+    assertThat("Sync all contracts should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+    sync.then().body("status", containsString(STATUS_ENQUEUED_PREFIX));
+  }
+
+  private void thenAssertContractsForOrg(Condition condition) {
+    thenAssertContractsForOrg(orgId, condition);
+  }
+
+  private void thenAssertContractsForOrg(String orgId, Condition condition) {
+    AwaitilityUtils.untilAsserted(() -> condition.verify(service.getContractsByOrgId(orgId)));
+  }
+
+  private void thenContractIsFound(String contractUuid, BillingProvider provider) {
+    thenAssertContractsForOrg(
+        contracts -> {
+          boolean found =
+              contracts.stream()
+                  .anyMatch(
+                      c ->
+                          c.getUuid().equals(contractUuid)
+                              && c.getBillingProvider().equals(provider.toApiModel()));
+          assertTrue(
+              found,
+              "Expected contract uuid=" + contractUuid + " provider=" + provider + " to exist");
+        });
+  }
+
+  private void thenSingleContractHasStableUuid(String uuid) {
+    thenAssertContractsForOrg(
+        contracts -> {
+          assertEquals(1, contracts.size(), "contracts: no duplicate rows");
+          assertEquals(uuid, contracts.get(0).getUuid(), "contracts: UUID must be stable");
+        });
+  }
+
+  private void thenSingleContractHasStableUuidAndMetrics(String uuid, int expectedMetricsCount) {
+    thenAssertContractsForOrg(
+        contracts -> {
+          assertEquals(1, contracts.size(), "contracts: no duplicate rows");
+          assertEquals(uuid, contracts.get(0).getUuid(), "contracts: UUID must be stable");
+          assertEquals(
+              expectedMetricsCount,
+              contracts.get(0).getMetrics().size(),
+              "contract_metrics: row count must be stable");
+        });
+  }
+
+  private void thenSingleSubscriptionHasStableIdAndMeasurements(
+      String subId, int expectedMeasurementsCount) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          var subs = service.getSubscriptionsByOrgId(orgId);
+          assertEquals(1, subs.size(), "subscriptions: no duplicate rows");
+          assertEquals(
+              subId,
+              subs.get(0).getSubscriptionId(),
+              "subscriptions: subscription_id must be stable");
+          assertEquals(
+              expectedMeasurementsCount,
+              subs.get(0).getMetrics().size(),
+              "subscription_measurements: row count must be stable");
+        });
+  }
+
+  private void thenContractsSizeAre(int expected) {
+    thenAssertContractsForOrg(
+        contracts ->
+            assertEquals(
+                expected, contracts.size(), "Expected " + expected + " contract(s) for org"));
+  }
+
+  private void thenOrgHasSingleContractWithProvider(String orgId, BillingProvider provider) {
+    thenAssertContractsForOrg(
+        orgId,
+        contracts -> {
+          assertEquals(1, contracts.size(), "Org " + orgId + " should have exactly one contract");
+          assertEquals(
+              provider.toApiModel(),
+              contracts.get(0).getBillingProvider(),
+              "Contract billing provider should be " + provider);
+        });
   }
 
   private void givenRosaContractsAreStubbed(int count) {

--- a/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
@@ -27,9 +27,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -316,12 +317,17 @@ public class ContractsTerminationComponentTest extends BaseContractComponentTest
         nextEventDate.toLocalDate(),
         equalTo(tomorrow.toLocalDate()));
 
-    // Verify it's at the end of the day (allowing for timezone differences)
-    // The hour could be 22 or 23 depending on timezone conversion
+    // Verify it's at the end of the day (allowing for timezone and daylight saving time
+    // differences).
+    // Depending on offset conversions, this can be 21, 22, or 23.
     assertThat(
-        "next_event_date hour should be near end of day (22 or 23)",
+        "next_event_date hour should be near end of day (21, 22, or 23)",
         nextEventDate.getHour(),
-        is(greaterThan(21)));
+        is(greaterThanOrEqualTo(21)));
+    assertThat(
+        "next_event_date hour should not be after end of day",
+        nextEventDate.getHour(),
+        is(lessThanOrEqualTo(23)));
     assertThat("next_event_date minute should be 59", nextEventDate.getMinute(), equalTo(59));
     assertThat("next_event_date second should be 59", nextEventDate.getSecond(), equalTo(59));
   }

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -76,6 +76,10 @@ parameters:
     value: 'true'
   - name: OFFERING_SYNC_SCHEDULE
     value: 0 2 * * *
+  # Nightly sync of all contracts from IT Partner Gateway (POST .../internal/rpc/contracts/sync).
+  # Default 03:30 UTC — after offering-sync (02:00), before subscription-sync (10:00). Not overlapping hourly tally.
+  - name: CONTRACTS_SYNC_SCHEDULE
+    value: 30 3 * * *
   - name: SUBSCRIPTION_SYNC_SCHEDULE
     value: 0 10 * * *
   - name: KAFKA_ENABLED_ORGS_REPLICAS
@@ -89,6 +93,10 @@ parameters:
   - name: KAFKA_CAPACITY_RECONCILE_REPLICAS
     value: '3'
   - name: KAFKA_CAPACITY_RECONCILE_PARTITIONS
+    value: '3'
+  - name: KAFKA_CONTRACT_SYNC_REPLICAS
+    value: '3'
+  - name: KAFKA_CONTRACT_SYNC_PARTITIONS
     value: '3'
   - name: KAFKA_OFFERING_SYNC_REPLICAS
     value: '3'
@@ -166,6 +174,9 @@ objects:
         - replicas: ${{KAFKA_SUBSCRIPTION_SYNC_TASK_REPLICAS}}
           partitions: ${{KAFKA_SUBSCRIPTION_SYNC_TASK_PARTITIONS}}
           topicName: platform.rhsm-subscriptions.subscription-sync-task
+        - replicas: ${{KAFKA_CONTRACT_SYNC_REPLICAS}}
+          partitions: ${{KAFKA_CONTRACT_SYNC_PARTITIONS}}
+          topicName: platform.rhsm-subscriptions.contract-sync
         - replicas: ${{KAFKA_CAPACITY_RECONCILE_REPLICAS}}
           partitions: ${{KAFKA_CAPACITY_RECONCILE_PARTITIONS}}
           topicName: platform.rhsm-subscriptions.capacity-reconcile
@@ -461,6 +472,30 @@ objects:
                 cpu: ${CURL_CRON_CPU_LIMIT}
                 memory: ${CURL_CRON_MEMORY_LIMIT}
 
+        - name: contracts-sync
+          schedule: ${CONTRACTS_SYNC_SCHEDULE}
+          successfulJobsHistoryLimit: 2
+          restartPolicy: Never
+          podSpec:
+            image: ${CURL_CRON_IMAGE}:${CURL_CRON_IMAGE_TAG}
+            command:
+              - /usr/bin/bash
+              - -c
+              - >
+                /usr/bin/curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-contracts-service:8000/api/swatch-contracts/internal/rpc/contracts/sync"
+            env:
+              - name: SWATCH_SELF_PSK
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-psks
+                    key: self
+            resources:
+              requests:
+                cpu: ${CURL_CRON_CPU_REQUEST}
+                memory: ${CURL_CRON_MEMORY_REQUEST}
+              limits:
+                cpu: ${CURL_CRON_CPU_LIMIT}
+                memory: ${CURL_CRON_MEMORY_LIMIT}
 
   - apiVersion: v1
     kind: Secret

--- a/swatch-contracts/docs/adr/0004-do-not-pre-cleanup-in-sync-all-contracts.md
+++ b/swatch-contracts/docs/adr/0004-do-not-pre-cleanup-in-sync-all-contracts.md
@@ -1,4 +1,4 @@
-# ADR-001: Remove pre-cleanup from the global contract sync
+# ADR-001: Remove pre-cleanup from contracts sync all
 
 **Status:** Accepted  
 **Deciders:** @karshah @tlencion
@@ -14,16 +14,16 @@ The per-org sync endpoint (`/internal/rpc/sync/contracts/{org_id}`) accepts an o
 the upstream partner API. The intent is to let operators clean up incomplete records that
 were partially written and never fully populated.
 
-The global sync endpoint (`/internal/rpc/syncAllContracts`) was hardcoding this flag to
+The contracts sync all endpoint (`/api/swatch-contracts/internal/rpc/contracts/sync`) was hardcoding this flag to
 `true` for every org it processed.
 
 ---
 
 ## Problem
 
-Hardcoding `is_pre_cleanup=true` in the global sync creates two risks:
+Hardcoding `is_pre_cleanup=true` in contracts sync all creates two risks:
 
-1. **Unnecessary data deletion.** The global sync is a routine reconciliation job, not a
+1. **Unnecessary data deletion.** Contracts sync all is a routine reconciliation job, not a
    repair tool. Deleting records before every upsert is a side effect that is not needed
    for correct reconciliation — the upsert logic already handles existing records by
    matching on `start_date` and provider-specific IDs.
@@ -41,15 +41,15 @@ Hardcoding `is_pre_cleanup=true` in the global sync creates two risks:
 `syncAllContracts` passes `isPreCleanup=false` to the per-org sync for every org it visits.
 
 The pre-cleanup capability remains available on the per-org endpoint as an opt-in parameter
-for operators who need to repair a specific org's data. It is not applied globally.
+for operators who need to repair a specific org's data. It is not applied across all orgs.
 
 ---
 
 ## Consequences
 
-- The global sync is purely additive/updating — it never deletes before upserting.
+- Contracts sync all is purely additive/updating — it never deletes before upserting.
 - Contracts with incomplete data (null `billing_provider_id` or null `end_date`) are not
-  automatically cleaned up by the global sync; an operator must explicitly call the per-org
+  automatically cleaned up by contracts sync all; an operator must explicitly call the per-org
   endpoint with `is_pre_cleanup=true` to repair them.
-- Idempotency of the global sync is improved: running it multiple times on the same data
+- Idempotency of contracts sync all is improved: running it multiple times on the same data
   produces the same result with no risk of accidental deletion.

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
@@ -28,6 +28,8 @@ public final class Channels {
   public static final String ENABLED_ORGS = "enabled-orgs";
   public static final String SUBSCRIPTION_SYNC_TASK_TOPIC = "subscription-sync-task";
   public static final String SUBSCRIPTION_SYNC_TASK_UMB = "subscription-sync-umb";
+  public static final String CONTRACT_SYNC = "contract-sync";
+  public static final String CONTRACT_SYNC_TASK = "contract-sync-task";
   public static final String OFFERING_SYNC = "offering-sync";
   public static final String OFFERING_SYNC_TASK_TOPIC = "offering-sync-task";
   public static final String OFFERING_SYNC_TASK_SERVICE_UMB = "offering-sync-service-umb";

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSyncTask.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractSyncTask.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.model;
+
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class ContractSyncTask {
+  @NonNull private final String orgId;
+
+  @java.beans.ConstructorProperties("orgId")
+  public ContractSyncTask(String orgId) {
+    this.orgId = orgId;
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractRepository.java
@@ -48,9 +48,9 @@ public class ContractRepository implements PanacheSpecificationSupport<ContractE
     return find("uuid", uuid).firstResult();
   }
 
-  public List<String> getDistinctOrgIds() {
+  public Stream<String> getDistinctOrgIds() {
     return getEntityManager()
         .createQuery("SELECT DISTINCT c.orgId FROM ContractEntity c", String.class)
-        .getResultList();
+        .getResultStream();
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -50,6 +50,7 @@ import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.service.AccountResetService;
 import com.redhat.swatch.contract.service.CapacityReconciliationService;
 import com.redhat.swatch.contract.service.ContractService;
+import com.redhat.swatch.contract.service.ContractSyncService;
 import com.redhat.swatch.contract.service.EnabledOrgsProducer;
 import com.redhat.swatch.contract.service.OfferingProductTagLookupService;
 import com.redhat.swatch.contract.service.OfferingSyncService;
@@ -94,6 +95,7 @@ public class ContractsResource implements DefaultApi {
   private final SubscriptionSyncService subscriptionSyncService;
   private final UsageContextSubscriptionProvider usageContextSubscriptionProvider;
   private final MetricMapper metricMapper;
+  private final ContractSyncService contractSyncService;
 
   /**
    * Create contract record in database from provided contract dto payload
@@ -147,21 +149,20 @@ public class ContractsResource implements DefaultApi {
   }
 
   @Override
-  @Transactional
-  @RolesAllowed({"test", "support"})
+  @RolesAllowed({"test", "support", "service"})
   public StatusResponse syncAllContracts() throws ProcessingException {
-    log.info("Syncing All Contracts");
+    log.info("Starting contracts sync all");
 
-    var orgIds = service.getOrgIdUsedInContracts();
+    long count = contractSyncService.enqueueContractSyncForAllOrgs();
 
-    if (orgIds.isEmpty()) {
+    if (count == 0) {
+      log.info("Contracts sync all: no orgs with contracts in database");
       return new StatusResponse().status("No active contract found for the orgIds");
     }
 
-    for (String orgId : orgIds) {
-      service.syncContractsByOrgId(orgId);
-    }
-    return new StatusResponse().status("All Contract are Synced");
+    log.info("Contracts sync all: enqueued {} org(s)", count);
+    return new StatusResponse()
+        .status(String.format("Enqueued %d org(s) for contract sync", count));
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -140,11 +140,6 @@ public class ContractService {
     return response;
   }
 
-  @Transactional
-  public List<String> getOrgIdUsedInContracts() {
-    return contractRepository.getDistinctOrgIds();
-  }
-
   /**
    * Build Specifications based on provided parameters if not null and use to query the database
    * based on specifications.

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static com.redhat.swatch.contract.config.Channels.CONTRACT_SYNC;
+
+import com.redhat.swatch.contract.model.ContractSyncTask;
+import com.redhat.swatch.contract.repository.ContractRepository;
+import io.smallrye.reactive.messaging.MutinyEmitter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+/**
+ * Enqueues per-org contract sync tasks onto the Kafka topic. Analogous to {@code
+ * CaptureSnapshotsTaskManager} in swatch-tally.
+ */
+@ApplicationScoped
+@Slf4j
+public class ContractSyncService {
+
+  private final ContractRepository contractRepository;
+  private final MutinyEmitter<ContractSyncTask> contractSyncTaskEmitter;
+
+  @Inject
+  public ContractSyncService(
+      ContractRepository contractRepository,
+      @Channel(CONTRACT_SYNC) MutinyEmitter<ContractSyncTask> contractSyncTaskEmitter) {
+    this.contractRepository = contractRepository;
+    this.contractSyncTaskEmitter = contractSyncTaskEmitter;
+  }
+
+  /**
+   * Enqueues one {@link ContractSyncTask} per distinct org that has contracts in the database. The
+   * stream is consumed within the transaction so the JDBC cursor remains open for its full
+   * lifetime.
+   *
+   * @return number of orgs enqueued
+   */
+  @Transactional
+  public long enqueueContractSyncForAllOrgs() {
+    log.info("Queuing contract sync tasks for all orgs");
+    AtomicLong count = new AtomicLong(0);
+    try (Stream<String> orgIds = contractRepository.getDistinctOrgIds()) {
+      orgIds.forEach(
+          orgId -> {
+            contractSyncTaskEmitter.sendAndAwait(new ContractSyncTask(orgId));
+            count.incrementAndGet();
+          });
+    }
+    log.info("Done queuing contract sync tasks for {} org(s)", count.get());
+    return count.get();
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncTaskConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncTaskConsumer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static com.redhat.swatch.contract.config.Channels.CONTRACT_SYNC_TASK;
+
+import com.redhat.swatch.contract.model.ContractSyncTask;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.smallrye.reactive.messaging.annotations.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+@Slf4j
+public class ContractSyncTaskConsumer {
+
+  private final ContractService service;
+  private final Counter successCounter;
+  private final Counter failureCounter;
+
+  public ContractSyncTaskConsumer(ContractService service, MeterRegistry meterRegistry) {
+    this.service = service;
+    this.successCounter = meterRegistry.counter("swatch_contract_sync_task", "outcome", "success");
+    this.failureCounter = meterRegistry.counter("swatch_contract_sync_task", "outcome", "failure");
+  }
+
+  @Blocking
+  @Incoming(CONTRACT_SYNC_TASK)
+  public void consumeFromTopic(ContractSyncTask task) {
+    String orgId = task.getOrgId();
+    log.info("Contract sync triggered for orgId={}", orgId);
+    try {
+      var result = service.syncContractsByOrgId(orgId);
+      if (ContractService.FAILURE_MESSAGE.equals(result.getStatus())) {
+        failureCounter.increment();
+        log.warn("Contract sync failed for orgId={}: {}", orgId, result.getMessage());
+      } else {
+        successCounter.increment();
+        log.info("Contract sync succeeded for orgId={}", orgId);
+      }
+    } catch (Exception e) {
+      failureCounter.increment();
+      log.error("Contract sync threw exception for orgId={}", orgId, e);
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/json/ContractSyncTaskDeserializer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/json/ContractSyncTaskDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service.json;
+
+import com.redhat.swatch.contract.model.ContractSyncTask;
+import io.quarkus.kafka.client.serialization.ObjectMapperDeserializer;
+
+public class ContractSyncTaskDeserializer extends ObjectMapperDeserializer<ContractSyncTask> {
+  public ContractSyncTaskDeserializer() {
+    super(ContractSyncTask.class);
+  }
+}

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -175,6 +175,29 @@ paths:
         - support: [ ]
         - test: [ ]
       operationId: syncSubscriptionsForContractsByOrg
+  /api/swatch-contracts/internal/rpc/contracts/sync:
+    description: "Trigger a sync for all orgs that have contracts in the upstream database."
+    post:
+      summary: "Sync all contracts."
+      operationId: syncAllContracts
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              examples:
+                status response:
+                  value:
+                    status: 'Success'
+                    message: "All contracts Synced"
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - support: []
+        - test: []
+        - service: []
   /api/swatch-contracts/internal/rpc/reset/{org_id}:
     description: "Clear all contracts and subscriptions for a given org ID. "
     delete:
@@ -194,26 +217,6 @@ paths:
         - test: [ ]
         - service: [ ]
       operationId: deleteDataForOrg
-  /internal/rpc/syncAllContracts:
-    description: "Trigger a sync for all contracts"
-    post:
-      summary: "Sync all contracts."
-      operationId: syncAllContracts
-      responses:
-        '202':
-          description: "The request for syncing all contracts is successfully running."
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: "#/components/schemas/StatusResponse"
-              examples:
-                status response:
-                  value:
-                    status: 'Success'
-                    message: "All contracts Synced"
-      security:
-        - support: []
-        - test: []
   '/api/swatch-contracts/internal/rpc/partner/contracts':
     post:
       operationId: createPartnerEntitlementContract

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -318,6 +318,21 @@ mp.messaging.incoming.subscription-sync-umb.client-options-name=umb
 mp.messaging.incoming.subscription-sync-umb.enabled=${UMB_ENABLED}
 mp.messaging.incoming.subscription-sync-umb.failure-strategy=accept
 
+mp.messaging.incoming.contract-sync-task.connector=smallrye-kafka
+%test.mp.messaging.incoming.contract-sync-task.connector=smallrye-in-memory
+mp.messaging.incoming.contract-sync-task.topic=platform.rhsm-subscriptions.contract-sync
+mp.messaging.incoming.contract-sync-task.group.id=contract-worker
+mp.messaging.incoming.contract-sync-task.value.deserializer=com.redhat.swatch.contract.service.json.ContractSyncTaskDeserializer
+mp.messaging.incoming.contract-sync-task.failure-strategy=ignore
+mp.messaging.incoming.contract-sync-task.throttled.unprocessed-record-max-age.ms=360000
+mp.messaging.incoming.contract-sync-task.commit-strategy=throttled
+
+mp.messaging.outgoing.contract-sync.connector=smallrye-kafka
+%test.mp.messaging.outgoing.contract-sync.connector=smallrye-in-memory
+mp.messaging.outgoing.contract-sync.topic=platform.rhsm-subscriptions.contract-sync
+mp.messaging.outgoing.contract-sync.group.id=contract-worker
+mp.messaging.outgoing.contract-sync.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+
 mp.messaging.incoming.offering-sync-task.connector=smallrye-kafka
 %test.mp.messaging.incoming.offering-sync-task.connector=smallrye-in-memory
 mp.messaging.incoming.offering-sync-task.topic=platform.rhsm-subscriptions.offering-sync

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -25,8 +25,11 @@ import static com.redhat.swatch.contract.resource.ContractsResource.FEATURE_NOT_
 import static com.redhat.swatch.contract.security.RhIdentityUtils.CUSTOMER_IDENTITY_HEADER;
 import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.AMBIGUOUS_SUBSCRIPTIONS_COUNTER_NAME;
 import static com.redhat.swatch.contract.service.UsageContextSubscriptionProvider.MISSING_SUBSCRIPTIONS_COUNTER_NAME;
+import static com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter.SWATCH_PSK_HEADER;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -52,6 +55,7 @@ import com.redhat.swatch.contract.openapi.model.UsageType;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.service.ContractService;
+import com.redhat.swatch.contract.service.ContractSyncService;
 import com.redhat.swatch.contract.service.EnabledOrgsProducer;
 import com.redhat.swatch.contract.service.OfferingProductTagLookupService;
 import com.redhat.swatch.contract.service.OfferingSyncService;
@@ -83,7 +87,12 @@ class ContractsResourceTest {
   private static final String ORG_ID = "org123";
   private static final String ANOTHER_ORG_ID = "org456";
   private static final String ROSA = "rosa";
-  private static final String SYNC_ALL_CONTRACTS_ENDPOINT = "/internal/rpc/syncAllContracts";
+  private static final String SYNC_ALL_CONTRACTS_ENDPOINT =
+      "/api/swatch-contracts/internal/rpc/contracts/sync";
+
+  /** Must match %test.SWATCH_SELF_PSK (application.properties). */
+  private static final String PLACEHOLDER_PSK = "placeholder";
+
   private final OffsetDateTime defaultEndDate =
       OffsetDateTime.of(2022, 7, 22, 8, 0, 0, 0, ZoneOffset.UTC);
   private final OffsetDateTime defaultLookUpDate =
@@ -91,6 +100,7 @@ class ContractsResourceTest {
 
   @InjectMock ApplicationConfiguration applicationConfiguration;
   @InjectMock ContractService contractService;
+  @InjectMock ContractSyncService contractSyncService;
   @InjectMock EnabledOrgsProducer enabledOrgsProducer;
   @InjectMock OfferingSyncService offeringSyncService;
   @InjectMock OfferingProductTagLookupService offeringProductTagLookupService;
@@ -519,37 +529,68 @@ class ContractsResourceTest {
 
   @Test
   void testSyncAllContractsWhenNoActiveContracts() {
-    when(contractService.getOrgIdUsedInContracts()).thenReturn(Collections.emptyList());
+    when(contractSyncService.enqueueContractSyncForAllOrgs()).thenReturn(0L);
 
     StatusResponse response = whenSyncAllContractsRequest();
 
     assertEquals("No active contract found for the orgIds", response.getStatus());
-    verify(contractService).getOrgIdUsedInContracts();
+    verify(contractSyncService).enqueueContractSyncForAllOrgs();
     verify(contractService, times(0)).syncContractsByOrgId(any());
   }
 
   @Test
-  void testSyncAllContractsWithContractsExist() {
-    when(contractService.getOrgIdUsedInContracts()).thenReturn(List.of(ORG_ID));
+  void testSyncAllContractsEnqueuesOrgs() {
+    when(contractSyncService.enqueueContractSyncForAllOrgs()).thenReturn(1L);
 
     StatusResponse response = whenSyncAllContractsRequest();
 
-    assertEquals("All Contract are Synced", response.getStatus());
-    verify(contractService).getOrgIdUsedInContracts();
-    verify(contractService).syncContractsByOrgId(ORG_ID);
+    assertEquals("Enqueued 1 org(s) for contract sync", response.getStatus());
+    verify(contractSyncService).enqueueContractSyncForAllOrgs();
   }
 
   @Test
-  void testSyncAllContractsCallsPerOrgSync() {
-    // Global sync calls per-org sync for each org with contracts.
-    // Per ADR-0004, isPreCleanup has been removed - contracts missing from upstream
-    // are now terminated (not deleted) to preserve historical records.
-    when(contractService.getOrgIdUsedInContracts()).thenReturn(List.of(ORG_ID, ANOTHER_ORG_ID));
+  void testSyncAllContractsEnqueuesMultipleOrgs() {
+    when(contractSyncService.enqueueContractSyncForAllOrgs()).thenReturn(2L);
 
-    whenSyncAllContractsRequest();
+    StatusResponse response = whenSyncAllContractsRequest();
 
-    verify(contractService).syncContractsByOrgId(ORG_ID);
-    verify(contractService).syncContractsByOrgId(ANOTHER_ORG_ID);
+    assertEquals("Enqueued 2 org(s) for contract sync", response.getStatus());
+    verify(contractSyncService).enqueueContractSyncForAllOrgs();
+  }
+
+  /**
+   * Contracts sync all nightly CronJob uses {@link
+   * com.redhat.swatch.resteasy.client.SwatchPskHeaderFilter#SWATCH_PSK_HEADER} only. With RBAC
+   * disabled in tests, PSK principals still receive the service role via RolesAugmentor; production
+   * RBAC does not call the RBAC API for PskPrincipal.
+   */
+  @Test
+  void testSyncAllContractsWithPskHeaderOnly() {
+    when(contractSyncService.enqueueContractSyncForAllOrgs()).thenReturn(1L);
+
+    StatusResponse response =
+        given()
+            .header(SWATCH_PSK_HEADER, PLACEHOLDER_PSK)
+            .post(SYNC_ALL_CONTRACTS_ENDPOINT)
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(StatusResponse.class);
+
+    assertEquals("Enqueued 1 org(s) for contract sync", response.getStatus());
+    verify(contractSyncService).enqueueContractSyncForAllOrgs();
+  }
+
+  @Test
+  void testSyncAllContractsWithoutAuthIsRejected() {
+    given()
+        .header(SWATCH_PSK_HEADER, "invalid-psk")
+        .post(SYNC_ALL_CONTRACTS_ENDPOINT)
+        .then()
+        .statusCode(anyOf(is(HttpStatus.SC_UNAUTHORIZED), is(HttpStatus.SC_FORBIDDEN)));
+
+    verify(contractSyncService, times(0)).enqueueContractSyncForAllOrgs();
+    verify(contractService, times(0)).syncContractsByOrgId(any());
   }
 
   private StatusResponse whenSyncAllContractsRequest() {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractSyncTaskConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractSyncTaskConsumerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.contract.model.ContractSyncTask;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContractSyncTaskConsumerTest {
+
+  @Mock private ContractService contractService;
+  private MeterRegistry meterRegistry;
+  private ContractSyncTaskConsumer consumer;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    consumer = new ContractSyncTaskConsumer(contractService, meterRegistry);
+  }
+
+  @Test
+  void testConsumeCallsSyncContractsByOrgId() {
+    when(contractService.syncContractsByOrgId("org123"))
+        .thenReturn(new StatusResponse().status(ContractService.SUCCESS_MESSAGE));
+
+    consumer.consumeFromTopic(new ContractSyncTask("org123"));
+
+    verify(contractService).syncContractsByOrgId("org123");
+    assertEquals(
+        1.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "success").count());
+    assertEquals(
+        0.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "failure").count());
+  }
+
+  @Test
+  void testConsumeIncrementsFailureOnFailedStatus() {
+    when(contractService.syncContractsByOrgId("org456"))
+        .thenReturn(
+            new StatusResponse().status(ContractService.FAILURE_MESSAGE).message("upstream error"));
+
+    consumer.consumeFromTopic(new ContractSyncTask("org456"));
+
+    verify(contractService).syncContractsByOrgId("org456");
+    assertEquals(
+        0.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "success").count());
+    assertEquals(
+        1.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "failure").count());
+  }
+
+  @Test
+  void testConsumeIncrementsFailureOnException() {
+    when(contractService.syncContractsByOrgId("org789")).thenThrow(new RuntimeException("boom"));
+
+    consumer.consumeFromTopic(new ContractSyncTask("org789"));
+
+    verify(contractService).syncContractsByOrgId("org789");
+    assertEquals(
+        0.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "success").count());
+    assertEquals(
+        1.0, meterRegistry.counter("swatch_contract_sync_task", "outcome", "failure").count());
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4563

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Adds a scheduled CronJob that calls POST /api/swatch-contracts/internal/rpc/contracts/sync with the service PSK. That endpoint only enqueues work: one ContractSyncTask per distinct org that already has contracts in our DB. A Kafka consumer runs the existing per-org sync so the HTTP path stays light and consistent with other “sync all” RPCs (POST, not PUT). ClowdApp wires contracts-sync, CONTRACTS_SYNC_SCHEDULE, and topic platform.rhsm-subscriptions.contract-sync.

Contract sync Kafka topic is created here https://github.com/RedHatInsights/platform-mq/pull/513

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Run `./mvnw install -Pcomponent-tests -pl swatch-contracts/ct -am`