### PR TITLE
Liquibase utility updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ SHELL=/bin/bash
 	install \
 	test \
 	clean \
-	rollback \
 	status
 
 # Add a profile(s) to use like so:
@@ -126,19 +125,6 @@ swatch-utilization:
 swatch-api:
 	$(eval override PROFILES+=api)
 	$(call SPRING_PROXY,swatch-tally,8019)
-
-rollback:
-	@echo "Select database context:"
-	@echo "1. Core context"
-	@echo "2. Contracts context"
-	@read -p "Enter context choice (1-2): " context; \
-	case $$context in \
-		1) CONTEXT="core" ;; \
-		2) CONTEXT="contracts" ;; \
-		*) echo "Invalid context choice"; exit 1 ;; \
-	esac; \
-	read -p "Enter number of changesets: " count; \
-	./mvnw -f swatch-database/pom.xml exec:java -Dexec.args="$$CONTEXT rollbackCountSql --count=$$count"
 
 # $1 = service name, $2 = port
 define CHECK_SERVICE_STATUS

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,12 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-maven-plugin</artifactId>
+          <version>${liquibase.version}</version>
+        </plugin>
+
         <!-- Required to start spring services in dev mode from the Maven command -->
         <plugin>
           <groupId>org.springframework.boot</groupId>

--- a/swatch-tally/pom.xml
+++ b/swatch-tally/pom.xml
@@ -296,6 +296,17 @@
 
     <plugins>
       <plugin>
+        <groupId>org.liquibase</groupId>
+        <artifactId>liquibase-maven-plugin</artifactId>
+        <configuration>
+          <changeLogFile>liquibase/changelog.xml</changeLogFile>
+          <url>jdbc:postgresql://localhost:5432/rhsm-subscriptions</url>
+          <username>rhsm-subscriptions</username>
+          <emptyPassword/>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Jira issue: None

## Description
The application portion of the `swatch-database` module has been removed.  That code allowed us to easily execute Liquibase tasks during development.  To replace the now missing functionality, I've added in the Liquibase Maven plugin and removed an entry in the Makefile that is obsolete.

Being able to run Liquibase rollbacks, diffs, and the like is very helpful.  Especially since just running the Liquibase CLI is not easy.  On my machine, to use the CLI, I had to checkout Liquibase, run a maven install, unpack the distribution zip, add 2 missing JARs to the classpath, and set the search path correctly. 

## Testing

### Steps
1. `./mvwn -pl swatch-tally liquibase:status`
1. `./mvnw -pl swatch-billable-usage liquibase:status`
1. `./mvnw -pl swatch-contracts liquibase:status`
