### PR TITLE
SWATCH-4811: Add last_modified to hosts, host_tally_buckets, instance_measurements

### DIFF
--- a/src/main/resources/liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml
+++ b/src/main/resources/liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml
@@ -23,20 +23,12 @@
   avoids a round-trip while keeping timestamp generation on the DB.
   -->
 
-  <changeSet id="202601301404-01" author="awood" dbms="postgresql">
-    <createProcedure>
-      CREATE OR REPLACE FUNCTION update_last_modified_column()
-        RETURNS TRIGGER AS
-      $$
-      BEGIN
-        NEW.last_modified = CURRENT_TIMESTAMP;
-        RETURN NEW;
-      END;
-      $$ LANGUAGE plpgsql;
-    </createProcedure>
-    <rollback>
-      DROP FUNCTION IF EXISTS update_last_modified_column();
-    </rollback>
+  <changeSet id="202601301404-01" author="awood" dbms="postgresql" runOnChange="true">
+    <sqlFile path="liquibase/procedures/update_last_modified_column.sql"
+      splitStatements="false"
+    />
+    <!-- No rollback provided as other changesets rely on this stored procedure -->
+    <rollback/>
   </changeSet>
 
   <changeSet id="202601301404-02" author="awood">
@@ -82,8 +74,8 @@
       END
     </sql>
     <rollback>
-      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_create
-      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_update
+      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_update;
     </rollback>
   </changeSet>
 
@@ -133,8 +125,8 @@
       END
     </sql>
     <rollback>
-      DROP TRIGGER IF EXISTS trg_tally_measurements_last_modified_create
-      DROP TRIGGER IF EXISTS trg_tally_measurements_last_modified_update
+      DROP TRIGGER IF EXISTS trg_tally_measurements_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_tally_measurements_last_modified_update;
     </rollback>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml
+++ b/src/main/resources/liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <!--
+  Why are we using triggers here?  Especially since Hibernate's @CurrentTimestamp(source=DB)
+  annotation offers this ability?  The catch with the annotation is it requires an extra round-trip
+  to the database to fetch the current time.  We want the last_modified column to use the
+  CURRENT_TIMESTAMP from the database since these timestamps are later referenced by jobs that
+  run in different environments (not in the JVM).  We want the DB to be the final authority on
+  what time it is.  However, high performance for these tables is critical, so we don't want any
+  additional overhead that we can avoid.  Using a trigger and
+
+  @Column(name = "last_modified", insertable = false, updatable = false)
+  @ColumnDefault("CURRENT_TIMESTAMP")
+  @Generated
+  private Instant lastModified;
+
+  will populate the entity correctly using a RETURNING clause after an UPDATE or INSERT which
+  avoids a round-trip while keeping timestamp generation on the DB.
+
+  The procedure itself is created in 202601301404-last-modified-on-snapshots-and-measurements.xml
+  and marked runOnChange="true" so that any changes to the procedure in
+  procedures/update_last_modified_column.sql will automatically be applied.
+  -->
+  <changeSet id="202604151137-01" author="awood">
+    <addColumn tableName="hosts">
+      <column name="last_modified" type="TIMESTAMP WITH TIME ZONE"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202604151137-02" author="awood">
+    <addColumn tableName="host_tally_buckets">
+      <column name="last_modified" type="TIMESTAMP WITH TIME ZONE"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202604151137-03" author="awood">
+    <!-- This column is unmapped in Hibernate since the records in instance_measurements are not
+    their own entities.  They're members of a CollectionTable.  Mapping this column would require
+    converting instance_measurements to be mapped to hosts with a @OneToMany -->
+    <addColumn tableName="instance_measurements">
+      <column name="last_modified" type="TIMESTAMP WITH TIME ZONE"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="202604151137-04" author="awood" dbms="postgresql">
+    <sql>
+      CREATE OR REPLACE TRIGGER trg_hosts_last_modified
+        BEFORE INSERT OR UPDATE
+        ON hosts
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified ON hosts;
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202604151137-05" author="awood" dbms="postgresql">
+    <sql>
+      CREATE OR REPLACE TRIGGER trg_host_tally_buckets_last_modified
+        BEFORE INSERT OR UPDATE
+        ON host_tally_buckets
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified ON host_tally_buckets;
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202604151137-06" author="awood" dbms="postgresql">
+    <sql>
+      CREATE OR REPLACE TRIGGER trg_instance_measurements_last_modified
+        BEFORE INSERT OR UPDATE
+        ON instance_measurements
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_instance_measurements_last_modified ON instance_measurements;
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202604151137-07" author="awood" dbms="hsqldb">
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_hosts_last_modified_create
+        BEFORE INSERT
+        ON hosts
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_hosts_last_modified_update
+        BEFORE UPDATE
+        ON hosts
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified_update;
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202604151137-08" author="awood" dbms="hsqldb">
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_host_tally_buckets_last_modified_create
+        BEFORE INSERT
+        ON host_tally_buckets
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_host_tally_buckets_last_modified_update
+        BEFORE UPDATE
+        ON host_tally_buckets
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified_update;
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202604151137-09" author="awood" dbms="hsqldb">
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_instance_measurements_last_modified_create
+        BEFORE INSERT
+        ON instance_measurements
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER trg_instance_measurements_last_modified_update
+        BEFORE UPDATE
+        ON instance_measurements
+        REFERENCING NEW AS newrow
+        FOR EACH ROW
+      BEGIN
+        ATOMIC
+        SET newrow.last_modified = CURRENT_TIMESTAMP;
+      END
+    </sql>
+    <rollback>
+      DROP TRIGGER IF EXISTS trg_instance_measurements_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_instance_measurements_last_modified_update;
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -206,5 +206,6 @@
     <include file="liquibase/202602091104-add-tally-index-is-primary.xml"/>
     <include file="liquibase/202602241326-add-org-prod-snap-date-idx.xml"/>
     <include file="liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml"/>
+    <include file="liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/procedures/update_last_modified_column.sql
+++ b/src/main/resources/liquibase/procedures/update_last_modified_column.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION update_last_modified_column()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.last_modified = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -40,6 +40,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,6 +52,8 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Generated;
 
 /**
  * Represents a reported Host from inventory. This entity stores normalized facts for a Host
@@ -156,6 +159,16 @@ public class Host implements Serializable {
   @MapKeyColumn(name = "service_type")
   @Column(name = "last_applied_event_record_date")
   private Map<String, OffsetDateTime> lastAppliedEventRecordDateByServiceType = new HashMap<>();
+
+  @Column(name = "last_modified", insertable = false, updatable = false)
+  @ColumnDefault("CURRENT_TIMESTAMP")
+  @Generated
+  /* A last_modified column also exists in the instance_measurements table; however, it is unmapped
+  in Hibernate since the records in instance_measurements are not their own entities.  They're
+  members of a CollectionTable.  Mapping the column there would require converting
+  hosts to be mapped to instance_measurements with a @OneToMany -->
+  */
+  private Instant lastModified = null;
 
   public Host() {}
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -32,11 +32,14 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Generated;
 
 /** Represents a bucket that this host contributes to. */
 @ToString
@@ -65,6 +68,11 @@ public class HostTallyBucket implements Serializable {
 
   // Version to enable optimistic locking
   @Version @Column private Integer version;
+
+  @Column(name = "last_modified", insertable = false, updatable = false)
+  @ColumnDefault("CURRENT_TIMESTAMP")
+  @Generated
+  private Instant lastModified = null;
 
   @SuppressWarnings("java:S107")
   public HostTallyBucket(


### PR DESCRIPTION

Jira issue: SWATCH-4811

## Description
This PR adds a `last_modified` column to the `hosts`, `host_tally_buckets`, and
`instance_measurements` tables.  It also continues with the pattern used in
#5650 where the value for `last_modified` is allocated on the database and
returned to Hibernate after an UPDATE or INSERT via a RETURNING clause.

## Testing

### Steps
1. `make swatch-tally`
1. Demonstrate that out-of-band DB inserts set the column
    ```shell
    bin/insert-mock-hosts --cores 2 --sockets 2 --org 123 --num-physical 10
    ```
1. Create some HBI hosts to tally
    ```shell
    bin/insert-mock-hosts --hbi --org 345 --product "479,204" --num-aws 1 --marketplace --cores 2 --sockets 2
    ```
1.  Opt org 345 in.
    ```shell
    http PUT :8010/api/rhsm-subscriptions/v1/opt-in \                      
    x-rh-identity:$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"345"}}}' | base64 -w 0)
    ```
1. Run a tally for org 345.
    ```shell
    http PUT ":8010/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/345" x-rh-swatch-psk:placeholder x-rh-swatch-synchronous-request:true
    ```

### Verification
1. You'll see records in the `hosts`, `host_tally_buckets`, and the `instance_measurements` tables with the `last_modified` column populated.
    ```shell
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select last_modified, org_id from hosts;'
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select last_modified from host_tally_buckets;'
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select last_modified from instance_measurements;'
    ```
