### PR TITLE
Unleash environment variable matches those in other projects

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,5 +6,5 @@ ENABLE_SYNCHRONOUS_OPERATIONS: true
 DEV_MODE: true
 RHSM_CONTRACTS_URL: http://localhost:8011
 UNLEASH_ENVIRONMENT: development
-UNLEASH_API_URL: http://localhost:4242/api
+UNLEASH_URL: http://localhost:4242/api
 UNLEASH_API_TOKEN: default:development.unleash-insecure-api-token

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ io:
     app-name: ${UNLEASH_APP_NAME:swatch-tally}
     instance-id: ${UNLEASH_INSTANCE_ID:swatch-tally}
     environment: ${UNLEASH_ENVIRONMENT:production}
-    api-url: ${UNLEASH_API_URL:http://localhost:4242/api}
+    api-url: ${UNLEASH_URL:http://localhost:4242/api}
     api-token: ${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
 management:
   health:


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The environment variable already in use is UNLEASH_URL. The initial variable name in swatch-tally was UNLEASH-API-URL. This corrects that discrepancy.

### Verification
<!-- Enter the steps needed to verify the test passed -->

The swatch-tally pod will not throw ```Could not fetch toggles
io.getunleash.UnleashException: Could not fetch toggles``` exceptions.
