### PR TITLE
SWATCH-4792: Add primary key to swatch-utilization Liquibase changeset log table

### DIFF
--- a/swatch-utilization/src/main/resources/db/202604200730-add-primary-key-to-changelog-table.xml
+++ b/swatch-utilization/src/main/resources/db/202604200730-add-primary-key-to-changelog-table.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <!--
+  These changeSets are only for PostgreSQL because the primary keys we're adding are just to satisfy
+  PostgreSQL's requirements for logical replication.  See
+    https://www.postgresql.org/docs/12/logical-replication-publication.html
+
+  Consequently, these keys aren't mapped in JPA so we don't need to worry about them during
+  in-memory DB tests.
+  -->
+  <changeSet id="202604200730-01" author="jcarvaja" dbms="postgresql">
+    <!--
+    Creating an extension requires superuser permissions.  But in some environments, we don't
+    have those permissions.  We have to create the extension in an out-of-band migration.
+
+    The creation command checks permissions before it checks the extensions existence, so even an
+    invocation that would have no effect will cause the changeset to fail.  Accordingly, we have to
+    have a pre-condition to check if we should even attempt to create the extension.  That way we
+    can use the same changeset everywhere.
+    -->
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT count(1) FROM pg_extension WHERE extname = 'uuid-ossp';
+      </sqlCheck>
+    </preConditions>
+    <sql>
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    </sql>
+    <!--
+    I am intentionally not providing a rollback because we have multiple change logs: this one and
+    ones for swatch-contracts and swatch-tally.  Rolling back the extension in one changelog could
+    adversely affect the operations of the other changelog.
+    -->
+  </changeSet>
+
+  <changeSet id="202604200730-02" author="jcarvaja" dbms="postgresql">
+    <addColumn tableName="databasechangelog_swatch_utilization">
+      <column name="uuid" type="uuid" defaultValueComputed="uuid_generate_v4()">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-utilization/src/main/resources/db/changelog.xml
+++ b/swatch-utilization/src/main/resources/db/changelog.xml
@@ -7,5 +7,6 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
 
   <include file="/db/202604161200-create-organization-utilization-preference-table.xml"/>
+  <include file="/db/202604200730-add-primary-key-to-changelog-table.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Jira issue: SWATCH-4792

## Description
In order to do a blue-green update, all tables must be eligible for
logical replication. For a table to be eligible, it must have a primary key.
When we created the Liquibase context for swatch-utilization, no primary key
was added to the databasechangelog table it would be using. This PR corrects
that.

## Testing

### Setup
1. `make swatch-utilization`

### Steps
1. `psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c '\d
   databasechangelog_swatch_utilization'`

### Verification
1. The table will have a primary key on the `uuid` column.
