### PR TITLE
SWATCH-4509: Set IMPORTANT severity for over usage notifications

### DIFF
--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -50,6 +50,7 @@ Kafka messages can be injected for event-driven testing.
     - Verify notification payload
 - **Expected Result**:
     - Notification event contains correct information (org_id, product_id, metric_id and utilization_percentage)
+    - Notification action `severity` is `IMPORTANT`
     - Record timestamp reflects current calculation time
 
 **utilization-overusage-TC002 - No overusage when usage is below capacity**
@@ -155,6 +156,21 @@ Kafka messages can be injected for event-driven testing.
     - Notification event created (usage now exceeds reduced capacity + threshold)
     - Notification event contains correct information (org_id, product_id, metric_id and utilization_percentage)
     - Record timestamp reflects current calculation time
+
+**utilization-overusage-TC009 - Overusage notification severity**
+
+- **Description**: Verify that overusage notifications declare severity `IMPORTANT`.
+- **Setup**:
+    - An organization has capacity for the metric A of the product B
+    - Conditions allow sending notifications (global flag or org allowlist as applicable)
+- **Action**:
+    - Generate enough usage to exceed the threshold for the metric A of the product B
+    - Trigger utilization calculation process
+- **Verification**:
+    - Wait for notification message on notifications topic
+    - Verify `severity` on the notification action
+- **Expected Result**:
+    - Notification action `severity` is `IMPORTANT` (string name of the utilization severity enum)
 
 ## Multi-Resource Processing
 

--- a/swatch-utilization/ct/java/domain/Severity.java
+++ b/swatch-utilization/ct/java/domain/Severity.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package domain;
+
+public enum Severity {
+  IMPORTANT
+}

--- a/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
+++ b/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import api.UtilizationUnleashService;
 import com.redhat.cloud.notifications.ingress.Action;
@@ -40,6 +41,7 @@ import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.utilization.test.model.Measurement;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
 import domain.Product;
+import domain.Severity;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -159,7 +161,7 @@ public class BaseUtilizationComponentTest {
   /** Verifies notification is sent with correct product, metric, and utilization percentage. */
   protected void thenNotificationShouldBeSent(
       String productId, MetricId metricId, double usageValue, double capacity) {
-    thenNotificationShouldBeSent(productId, metricId, usageValue, capacity, null, null);
+    thenNotificationShouldBeSent(productId, metricId, usageValue, capacity, null, null, null);
   }
 
   /**
@@ -172,7 +174,8 @@ public class BaseUtilizationComponentTest {
       double usageValue,
       double capacity,
       String expectedServiceLevel,
-      String expectedUsage) {
+      String expectedUsage,
+      Severity expectedSeverity) {
     Action notification =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS, matchesOverageNotification(orgId, productId, metricId.getValue()));
@@ -192,6 +195,12 @@ public class BaseUtilizationComponentTest {
     if (expectedUsage != null) {
       assertThat(
           "Context should contain expected usage", props.get("usage"), equalTo(expectedUsage));
+    }
+    if (expectedSeverity != null) {
+      assertEquals(
+          expectedSeverity.name(),
+          notification.getSeverity(),
+          "Over-usage notification should declare severity " + expectedSeverity);
     }
 
     var events = notification.getEvents();

--- a/swatch-utilization/ct/java/tests/CustomerOverUsageComponentTest.java
+++ b/swatch-utilization/ct/java/tests/CustomerOverUsageComponentTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
@@ -38,6 +39,7 @@ import com.redhat.swatch.utilization.test.model.Measurement;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary.Granularity;
 import domain.Product;
+import domain.Severity;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -132,7 +134,8 @@ public class CustomerOverUsageComponentTest extends BaseUtilizationComponentTest
         USAGE_EXCEEDING_THRESHOLD,
         BASELINE_CAPACITY,
         "Premium",
-        "Production");
+        "Production",
+        Severity.IMPORTANT);
   }
 
   /** Verify over-usage counter is not incremented when usage is below threshold. */
@@ -288,6 +291,10 @@ public class CustomerOverUsageComponentTest extends BaseUtilizationComponentTest
   void thenNotificationShouldBeSent() {
     Action notification = kafkaBridge.waitForKafkaMessage(NOTIFICATIONS, matchesOrgId(orgId));
     assertThat("Notification should be sent", notification, notNullValue());
+    assertEquals(
+        "IMPORTANT",
+        notification.getSeverity(),
+        "Over-usage notification should declare IMPORTANT severity");
 
     // Verify context contains expected product_id and metric_id
     var context = notification.getContext();

--- a/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
@@ -21,16 +21,19 @@
 package tests;
 
 import static api.MessageValidators.matchesOrgId;
+import static api.MessageValidators.matchesOverageNotification;
 import static com.redhat.swatch.component.tests.utils.Topics.NOTIFICATIONS;
 import static com.redhat.swatch.component.tests.utils.Topics.UTILIZATION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
+import domain.Severity;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -192,6 +195,29 @@ public class UtilizationOverUsageComponentTest extends BaseUtilizationComponentT
     // Then: Notification event created (usage now exceeds reduced capacity + threshold)
     thenNotificationShouldBeSent(
         utilizationSummary.getProductId(), metricId, USAGE_SIGNIFICANTLY_ABOVE_THRESHOLD, 100.0);
+  }
+
+  @TestPlanName("utilization-overusage-TC009")
+  @Test
+  void shouldEmitImportantSeverity_onOverusageNotification() {
+    // Given: Usage exceeds threshold for metric A of product B
+    MetricId metricId = MetricIdUtils.getCores();
+    givenMeasurement(
+        utilizationSummary, metricId, 110.0, STANDARD_CAPACITY, false); // 10% over capacity
+
+    // When: Trigger utilization calculation process
+    kafkaBridge.produceKafkaMessage(UTILIZATION, utilizationSummary);
+
+    // Then: Notification declares IMPORTANT severity
+    var notification =
+        kafkaBridge.waitForKafkaMessage(
+            NOTIFICATIONS,
+            matchesOverageNotification(
+                orgId, utilizationSummary.getProductId(), metricId.getValue()));
+    assertEquals(
+        Severity.IMPORTANT.name(),
+        notification.getSeverity(),
+        "Over-usage notification should declare IMPORTANT severity");
   }
 
   // Helper methods - Then

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/model/Severity.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/model/Severity.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.model;
+
+public enum Severity {
+  CRITICAL,
+  IMPORTANT,
+  MODERATE,
+  LOW,
+  NONE
+}

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomerOverUsageService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomerOverUsageService.java
@@ -34,6 +34,7 @@ import com.redhat.swatch.configuration.registry.MetricType;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.utilization.configuration.FeatureFlags;
 import com.redhat.swatch.utilization.model.Measurement;
+import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
 import com.redhat.swatch.utilization.model.UtilizationSummary.BillingProvider;
 import io.micrometer.core.instrument.Counter;
@@ -312,6 +313,7 @@ public class CustomerOverUsageService {
     action.setEvents(List.of(buildEvent(utilizationPercent)));
     action.setContext(buildContext(payload, metricId));
     action.setRecipients(List.of(buildRecipient()));
+    action.setSeverity(Severity.IMPORTANT.name());
 
     return action;
   }

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomerOverUsageServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomerOverUsageServiceTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.utilization.service;
 
 import static com.redhat.swatch.utilization.service.CustomerOverUsageService.OVER_USAGE_METRIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -33,6 +34,7 @@ import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.utilization.configuration.FeatureFlags;
 import com.redhat.swatch.utilization.model.Measurement;
+import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.Search;
@@ -234,6 +236,27 @@ class CustomerOverUsageServiceTest {
 
     // Then
     verify(notificationsProducer, times(1)).produce(any(Action.class));
+  }
+
+  @Test
+  void shouldSendOverusageNotification_withImportantSeverity() {
+    // Given
+    when(featureFlags.sendNotifications()).thenReturn(true);
+    UtilizationSummary summary =
+        givenUtilizationSummary(PRODUCT_ID, METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
+
+    // When
+    whenCheckSummary(summary);
+
+    // Then
+    var captor = ArgumentCaptor.forClass(Action.class);
+    verify(notificationsProducer, times(1)).produce(captor.capture());
+    Action action = captor.getValue();
+    assertNotNull(action.getSeverity(), "Notification action should define severity");
+    assertEquals(
+        Severity.IMPORTANT.name(),
+        action.getSeverity(),
+        "Over-usage notifications should use IMPORTANT severity");
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-4509

## Description
Updated existing logic for over usage notifications to set the IMPORTANT severity.

## Testing
Added unit tests and new component test to cover the change.