### PR TITLE
SWATCH-4791: GET API for notifications UI to get the user's preferences.

### DIFF
--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -71,6 +71,8 @@ parameters:
     value: token
   - name: CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT
     value: '5.0'
+  - name: ORG_PREFERENCE_DEFAULT_THRESHOLD
+    value: '80'
   - name: LOGGING_SHOW_SQL_QUERIES
     value: 'false'
   # allow overriding to support independent deploy with bonfire
@@ -200,6 +202,8 @@ objects:
               value: ${OTEL_DISABLED}
             - name: CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT
               value: ${CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT}
+            - name: ORG_PREFERENCE_DEFAULT_THRESHOLD
+              value: ${ORG_PREFERENCE_DEFAULT_THRESHOLD}
             - name: LOGGING_SHOW_SQL_QUERIES
               value: ${LOGGING_SHOW_SQL_QUERIES}
             - name: DATABASE_HOST

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
@@ -42,6 +42,13 @@ public class OrgPreferencesResource implements OrgPreferencesApi {
 
   @Override
   @RolesAllowed({"customer", "service"})
+  public OrgPreferencesResponse getOrgPreferences(String xRhIdentity) {
+    String orgId = orgIdResolver.getOrgId(securityContext, httpHeaders);
+    return orgPreferencesService.getOrgPreferences(orgId);
+  }
+
+  @Override
+  @RolesAllowed({"customer", "service"})
   public OrgPreferencesResponse updateOrgPreferences(
       String xRhIdentity, OrgPreferencesRequest orgPreferencesRequest) {
     String orgId = orgIdResolver.getOrgId(securityContext, httpHeaders);

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
@@ -26,15 +26,38 @@ import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Slf4j
 @ApplicationScoped
-@AllArgsConstructor
 public class OrgPreferencesService {
 
   private final OrgUtilizationPreferenceRepository repository;
+
+  @ConfigProperty(name = "ORG_PREFERENCE_DEFAULT_THRESHOLD")
+  Integer defaultThreshold;
+
+  public OrgPreferencesService(OrgUtilizationPreferenceRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Retrieves preferences for the given organization. Returns default threshold from
+   * ORG_PREFERENCE_DEFAULT_THRESHOLD property if not configured.
+   */
+  @Transactional
+  public OrgPreferencesResponse getOrgPreferences(String orgId) {
+    log.info("Retrieving utilization preference for orgId={}", orgId);
+    var entityOpt = repository.findByIdOptional(orgId);
+    var response = new OrgPreferencesResponse();
+    if (entityOpt.isEmpty()) {
+      response.setCustomThreshold(defaultThreshold);
+    } else {
+      response.setCustomThreshold(entityOpt.get().getCustomThreshold());
+    }
+    return response;
+  }
 
   /**
    * Persists {@link OrgPreferencesRequest#getCustomThreshold()} for the organization and returns

--- a/swatch-utilization/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-utilization/src/main/resources/META-INF/openapi.yaml
@@ -12,6 +12,34 @@ tags:
     description: Organization-level utilization preferences
 paths:
   /api/rhsm-subscriptions/v1/utilization/org-preferences:
+    get:
+      tags:
+        - OrgPreferences
+      operationId: getOrgPreferences
+      summary: Get organization utilization preferences
+      description: >-
+        Retrieves the organization utilization preferences for the organization resolved
+        from the authenticated x-rh-identity header.
+      parameters:
+        - name: x-rh-identity
+          in: header
+          required: true
+          schema:
+            type: string
+          description: >-
+            Base64-encoded JSON identity document for x-rh-identity (must include org_id for User
+            and ServiceAccount identities, per the authenticated principal).
+      responses:
+        "200":
+          description: Preferences retrieved successfully. Returns system default threshold if not configured.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrgPreferencesResponse"
+        "403":
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/Forbidden"
+        "500":
+          $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
     post:
       tags:
         - OrgPreferences

--- a/swatch-utilization/src/main/resources/application.properties
+++ b/swatch-utilization/src/main/resources/application.properties
@@ -22,6 +22,9 @@ DATABASE_PASSWORD=${clowder.database.password:rhsm-subscriptions}
 # Customer over-usage detection threshold (percentage)
 CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT=5.0
 
+# Organization preference default threshold (percentage, 0-100)
+ORG_PREFERENCE_DEFAULT_THRESHOLD=80
+
 # Public HTTP APIs use x-rh-identity; JAX-RS resources must opt in with roles.
 quarkus.security.deny-unannotated-members=true
 # Disable role checking in dev mode. Use QUARKUS_SECURITY_AUTH_ENABLED_IN_DEV_MODE=true to override.

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
@@ -55,6 +55,38 @@ class OrgPreferencesResourceTest {
   @InjectMock OrgPreferencesService orgPreferencesService;
 
   @Test
+  void getOrgPreferences_whenPreferencesExist_returnsPreferences() {
+    var expected = new OrgPreferencesResponse();
+    expected.setCustomThreshold(10);
+    when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
+
+    var actual =
+        whenGetOrgPreferences()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(OrgPreferencesResponse.class);
+
+    assertNotNull(actual);
+    assertEquals(expected.getCustomThreshold(), actual.getCustomThreshold());
+  }
+
+  @Test
+  void getOrgPreferences_whenPreferencesDoNotExist_returnsDefaultThreshold() {
+    var expected = new OrgPreferencesResponse();
+    expected.setCustomThreshold(80);
+    when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
+
+    var actual =
+        whenGetOrgPreferences()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(OrgPreferencesResponse.class);
+
+    assertNotNull(actual);
+    assertEquals(80, actual.getCustomThreshold());
+  }
+
+  @Test
   void updateOrgPreferences_whenPayloadValid_invokesServiceWithResolvedOrgId() {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(4);
@@ -87,6 +119,14 @@ class OrgPreferencesResourceTest {
 
     verify(orgPreferencesService, never())
         .updateOrgPreferences(anyString(), any(OrgPreferencesRequest.class));
+  }
+
+  private static ValidatableResponse whenGetOrgPreferences() {
+    return given()
+        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID))
+        .when()
+        .get(ORG_PREFERENCES_PATH)
+        .then();
   }
 
   private static ValidatableResponse whenUpdateOrgPreferencesTo(Integer customThreshold) {

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
@@ -27,22 +27,42 @@ import static org.mockito.Mockito.when;
 import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceEntity;
 import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceRepository;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@QuarkusTest
 class OrgPreferencesServiceTest {
 
   private static final String ORG_ID = "org-456";
 
-  @Mock OrgUtilizationPreferenceRepository repository;
+  @InjectMock OrgUtilizationPreferenceRepository repository;
 
-  @InjectMocks OrgPreferencesService service;
+  @Inject OrgPreferencesService service;
+
+  @Test
+  void getOrgPreferences_whenPreferenceExists_returnsPreference() {
+    var entity = new OrgUtilizationPreferenceEntity();
+    entity.setOrgId(ORG_ID);
+    entity.setCustomThreshold(7);
+    when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.of(entity));
+
+    var response = service.getOrgPreferences(ORG_ID);
+
+    assertEquals(7, response.getCustomThreshold());
+  }
+
+  @Test
+  void getOrgPreferences_whenPreferenceDoesNotExist_returnsDefaultThreshold() {
+    when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.empty());
+
+    var response = service.getOrgPreferences(ORG_ID);
+
+    assertEquals(80, response.getCustomThreshold());
+  }
 
   @Test
   void whenNoExistingPreference_persistsNewEntity() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4791

## Description
This PR adds a GET endpoint to retrieve per-organization over-usage threshold preferences that notification UI will use to get custom threshold preferences.

Since the UI does not handle 404, we are going to set a default threshold of 80 and always return 200, this has been discussed with product before implementing.

## Testing
IQE tests and component tests are part of the parent task [SWATCH-4789](https://redhat.atlassian.net/browse/SWATCH-4789) and will be implemented later.


[SWATCH-4789]: https://redhat.atlassian.net/browse/SWATCH-4789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ