### PR TITLE
SWATCH-4732: Add heap dump monitor with S3 upload for swatch-utilization

### DIFF
--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -89,10 +89,14 @@ parameters:
   - name: EGRESS_IMAGE_TAG
     value: latest
   - name: USER_JAVA_OPTS
-    # Heap dumps triggered by heap monitor at 75% threshold
+    # Heap dumps triggered by heap monitor at 75% threshold (leaves headroom for compression + upload)
     value: '-Xmx150m -XX:MaxDirectMemorySize=32m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heapdumps/ -XX:NativeMemoryTracking=summary'
   - name: ENABLE_HEAP_MONITOR
     value: 'true'
+  - name: HEAP_MONITOR_THRESHOLD_PERCENT
+    value: '60'
+  - name: HEAP_MONITOR_RESET_PERCENT
+    value: '55'
   - name: HEAP_DUMP_UPLOAD_S3
     value: 'false'
   - name: HEAP_DUMP_S3_PREFIX
@@ -100,6 +104,7 @@ parameters:
   - name: HEAP_DUMP_S3_BUCKET_NAME
     value: swatch-utilization-heapdumps
   - name: HEAP_DUMP_S3_SECRET_NAME
+    # Secret name for S3 credentials (stage/prod: 'heapdump-s3' from app-interface)
     value: heapdump-s3
 
 objects:
@@ -248,6 +253,10 @@ objects:
               value: ${USER_JAVA_OPTS}
             - name: ENABLE_HEAP_MONITOR
               value: ${ENABLE_HEAP_MONITOR}
+            - name: HEAP_MONITOR_THRESHOLD_PERCENT
+              value: ${HEAP_MONITOR_THRESHOLD_PERCENT}
+            - name: HEAP_MONITOR_RESET_PERCENT
+              value: ${HEAP_MONITOR_RESET_PERCENT}
             - name: HEAP_DUMP_UPLOAD_S3
               value: ${HEAP_DUMP_UPLOAD_S3}
             - name: HEAP_DUMP_S3_PREFIX

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -94,14 +94,12 @@ parameters:
   - name: ENABLE_HEAP_MONITOR
     value: 'true'
   - name: HEAP_DUMP_UPLOAD_S3
-    value: 'true'
+    value: 'false'
   - name: HEAP_DUMP_S3_PREFIX
     value: swatch-utilization/heapdumps
   - name: HEAP_DUMP_S3_BUCKET_NAME
     value: swatch-utilization-heapdumps
   - name: HEAP_DUMP_S3_SECRET_NAME
-    # Secret name for S3 credentials (stage/prod: 'heapdump-s3' from app-interface)
-    # Mount is optional - ephemeral uses Clowder objectStore instead
     value: heapdump-s3
 
 objects:
@@ -127,9 +125,6 @@ objects:
       - replicas: ${{KAFKA_UTILIZATION_REPLICAS}}
         partitions: ${{KAFKA_UTILIZATION_PARTITIONS}}
         topicName: platform.notifications.ingress
-
-    objectStore:
-      - swatch-utilization-heapdumps
 
     pullSecrets:
       name: ${IMAGE_PULL_SECRET}

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -88,6 +88,21 @@ parameters:
     value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
   - name: EGRESS_IMAGE_TAG
     value: latest
+  - name: USER_JAVA_OPTS
+    # Heap dumps triggered by heap monitor at 75% threshold
+    value: '-Xmx150m -XX:MaxDirectMemorySize=32m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heapdumps/ -XX:NativeMemoryTracking=summary'
+  - name: ENABLE_HEAP_MONITOR
+    value: 'true'
+  - name: HEAP_DUMP_UPLOAD_S3
+    value: 'true'
+  - name: HEAP_DUMP_S3_PREFIX
+    value: swatch-utilization/heapdumps
+  - name: HEAP_DUMP_S3_BUCKET_NAME
+    value: swatch-utilization-heapdumps
+  - name: HEAP_DUMP_S3_SECRET_NAME
+    # Secret name for S3 credentials (stage/prod: 'heapdump-s3' from app-interface)
+    # Mount is optional - ephemeral uses Clowder objectStore instead
+    value: heapdump-s3
 
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
@@ -112,6 +127,9 @@ objects:
       - replicas: ${{KAFKA_UTILIZATION_REPLICAS}}
         partitions: ${{KAFKA_UTILIZATION_PARTITIONS}}
         topicName: platform.notifications.ingress
+
+    objectStore:
+      - swatch-utilization-heapdumps
 
     pullSecrets:
       name: ${IMAGE_PULL_SECRET}
@@ -231,9 +249,24 @@ objects:
                 secretKeyRef:
                   name: ${DB_POD}-db
                   key: db.name
+            - name: JAVA_OPTS_APPEND
+              value: ${USER_JAVA_OPTS}
+            - name: ENABLE_HEAP_MONITOR
+              value: ${ENABLE_HEAP_MONITOR}
+            - name: HEAP_DUMP_UPLOAD_S3
+              value: ${HEAP_DUMP_UPLOAD_S3}
+            - name: HEAP_DUMP_S3_PREFIX
+              value: ${HEAP_DUMP_S3_PREFIX}
+            - name: HEAP_DUMP_S3_BUCKET_NAME
+              value: ${HEAP_DUMP_S3_BUCKET_NAME}
           volumeMounts:
             - name: logs
               mountPath: /logs
+            - name: heapdumps
+              mountPath: /heapdumps
+            - name: heapdump-s3-secret
+              mountPath: /aws
+              readOnly: true
           sidecars:
           - name: otel-collector
             enabled: true
@@ -256,6 +289,12 @@ objects:
           volumes:
             - name: logs
               emptyDir:
+            - name: heapdumps
+              emptyDir:
+            - name: heapdump-s3-secret
+              secret:
+                secretName: ${HEAP_DUMP_S3_SECRET_NAME}
+                optional: true
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp

--- a/swatch-utilization/pom.xml
+++ b/swatch-utilization/pom.xml
@@ -19,7 +19,23 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-common-health</artifactId>
@@ -132,6 +148,16 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/swatch-utilization/src/main/docker/Dockerfile.jvm
+++ b/swatch-utilization/src/main/docker/Dockerfile.jvm
@@ -123,25 +123,13 @@ USER root
 RUN microdnf \
     --disablerepo=* \
     --enablerepo=ubi-9-baseos-rpms \
-    install -y tar rsync gzip
-RUN microdnf \
-  --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
-  install -y jq && \
+    install -y tar rsync gzip && \
   microdnf \
   --disablerepo=* \
   --enablerepo=ubi-9-appstream-rpms \
   --enablerepo=ubi-9-baseos-rpms \
-  update -y
-
-# Install AWS CLI for S3 uploads
-RUN microdnf install -y unzip && \
-    curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
-    unzip -q /tmp/awscliv2.zip -d /tmp && \
-    /tmp/aws/install && \
-    rm -rf /tmp/aws* && \
-    microdnf clean all
+  update -y && \
+  microdnf clean all
 
 # Copy heap monitor scripts
 COPY --chown=default:root --chmod=755 swatch-utilization/src/main/docker/heap-monitor.sh /opt/heap-monitor.sh

--- a/swatch-utilization/src/main/docker/Dockerfile.jvm
+++ b/swatch-utilization/src/main/docker/Dockerfile.jvm
@@ -123,12 +123,29 @@ USER root
 RUN microdnf \
     --disablerepo=* \
     --enablerepo=ubi-9-baseos-rpms \
-    install -y tar rsync
+    install -y tar rsync gzip
 RUN microdnf \
   --disablerepo=* \
   --enablerepo=ubi-9-appstream-rpms \
   --enablerepo=ubi-9-baseos-rpms \
+  install -y jq && \
+  microdnf \
+  --disablerepo=* \
+  --enablerepo=ubi-9-appstream-rpms \
+  --enablerepo=ubi-9-baseos-rpms \
   update -y
+
+# Install AWS CLI for S3 uploads
+RUN microdnf install -y unzip && \
+    curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && \
+    unzip -q /tmp/awscliv2.zip -d /tmp && \
+    /tmp/aws/install && \
+    rm -rf /tmp/aws* && \
+    microdnf clean all
+
+# Copy heap monitor scripts
+COPY --chown=default:root --chmod=755 swatch-utilization/src/main/docker/heap-monitor.sh /opt/heap-monitor.sh
+COPY --chown=default:root --chmod=755 swatch-utilization/src/main/docker/entrypoint-wrapper.sh /opt/entrypoint-wrapper.sh
 
 # Used by Quarkus dev mode
 RUN chown default:root /deployments
@@ -157,3 +174,6 @@ ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+# Use wrapper entrypoint to start heap threshold monitor
+ENTRYPOINT ["/opt/entrypoint-wrapper.sh"]

--- a/swatch-utilization/src/main/docker/entrypoint-wrapper.sh
+++ b/swatch-utilization/src/main/docker/entrypoint-wrapper.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Entrypoint wrapper that starts heap monitor before JVM
+
+# Start heap monitor in background if enabled
+if [ "${ENABLE_HEAP_MONITOR}" = "true" ]; then
+  echo "Starting heap monitor..."
+  /opt/heap-monitor.sh &
+  MONITOR_PID=$!
+  echo "Heap monitor started with PID $MONITOR_PID"
+fi
+
+# Start the JVM using the standard run-java.sh script
+exec /opt/jboss/container/java/run/run-java.sh

--- a/swatch-utilization/src/main/docker/heap-monitor.sh
+++ b/swatch-utilization/src/main/docker/heap-monitor.sh
@@ -7,34 +7,44 @@
 
 POLL_INTERVAL_SEC=10
 COMPRESSION_TIMEOUT_SEC=60
-RESET_PERCENT=60
-RESET_MINUTES=5
 
-HEAP_DUMP_UPLOAD_S3="${HEAP_DUMP_UPLOAD_S3:-true}"
+# Configurable thresholds (can be overridden via env vars in clowdapp.yaml)
 THRESHOLD_PERCENT="${HEAP_MONITOR_THRESHOLD_PERCENT:-75}"
+RESET_PERCENT="${HEAP_MONITOR_RESET_PERCENT:-65}"
+RESET_MINUTES="${HEAP_MONITOR_RESET_MINUTES:-5}"
 PERIODIC_INTERVAL="${HEAP_MONITOR_PERIODIC_INTERVAL:-900}"
 METRICS_PORT="${HEAP_MONITOR_METRICS_PORT:-9000}"
+
+HEAP_DUMP_UPLOAD_S3="${HEAP_DUMP_UPLOAD_S3:-true}"
 POD_NAME="${HOSTNAME}"
 
 # --- S3 configuration ---
 
 S3_ENABLED=false
-S3_PREFIX="${HEAP_DUMP_S3_PREFIX:-swatch-utilization/heapdumps}"
+S3_ENDPOINT=""
 
 if [ "$HEAP_DUMP_UPLOAD_S3" = "true" ]; then
-  # Only check for mounted secret (stage/prod)
+  S3_PREFIX="${HEAP_DUMP_S3_PREFIX:-swatch-utilization/heapdumps}"
+
+  # Read credentials from mounted secret (stage/prod via app-interface)
   if [ -f /aws/aws_access_key_id ]; then
     export AWS_ACCESS_KEY_ID=$(cat /aws/aws_access_key_id)
     export AWS_SECRET_ACCESS_KEY=$(cat /aws/aws_secret_access_key)
     S3_BUCKET=$(cat /aws/bucket)
     export AWS_DEFAULT_REGION=$(cat /aws/aws_region 2>/dev/null || echo "us-east-1")
+    endpoint=$(cat /aws/endpoint 2>/dev/null || echo "")
+    if [ -n "$endpoint" ]; then
+      S3_ENDPOINT="https://${endpoint}"
+    fi
     S3_ENABLED=true
-    echo "[heap-monitor] S3 upload enabled (bucket: ${S3_BUCKET})"
-  else
-    echo "[heap-monitor] S3 upload disabled: secret not mounted (ephemeral - use 'oc cp' to retrieve dumps)"
+    echo "[heap-monitor] S3 upload enabled via mounted secret (bucket: ${S3_BUCKET})"
+  fi
+
+  if [ "$S3_ENABLED" = false ]; then
+    echo "[heap-monitor] WARNING: S3 upload requested but no credentials found. Upload disabled."
   fi
 else
-  echo "[heap-monitor] S3 upload disabled by configuration"
+  echo "[heap-monitor] S3 upload disabled"
 fi
 
 # --- Thresholds ---
@@ -66,10 +76,17 @@ echo "[heap-monitor] Started. Container limit: ${MEMORY_LIMIT_BYTES} bytes, thre
 upload_file_to_s3() {
   local file="$1"
   [ -f "$file" ] || return 0
-  local fname s3_path
+  local fname s3_key
   fname=$(basename "$file")
-  s3_path="s3://${S3_BUCKET}/${S3_PREFIX}/${POD_NAME}/${fname}"
-  aws s3 cp "$file" "$s3_path" --quiet || \
+  s3_key="${S3_PREFIX}/${POD_NAME}/${fname}"
+
+  # Use Java S3Uploader (no AWS CLI needed - uses Quarkus AWS SDK)
+  java -cp "/deployments/app/*:/deployments/lib/boot/*:/deployments/lib/main/*:/deployments/quarkus-run.jar" \
+    com.redhat.swatch.utilization.S3Uploader \
+    "$file" \
+    "$S3_BUCKET" \
+    "$s3_key" \
+    "${S3_ENDPOINT:-}" || \
     echo "[heap-monitor] ERROR: Failed to upload ${fname}"
 }
 

--- a/swatch-utilization/src/main/docker/heap-monitor.sh
+++ b/swatch-utilization/src/main/docker/heap-monitor.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Heap dump monitor
+# Monitors container memory and captures heap dumps when threshold exceeded.
+# Compresses dumps with gzip and uploads to S3 if configured.
+#
+# Runs as a background process alongside the JVM (started by entrypoint-wrapper.sh).
+
+POLL_INTERVAL_SEC=10
+COMPRESSION_TIMEOUT_SEC=60
+RESET_PERCENT=60
+RESET_MINUTES=5
+
+HEAP_DUMP_UPLOAD_S3="${HEAP_DUMP_UPLOAD_S3:-true}"
+THRESHOLD_PERCENT="${HEAP_MONITOR_THRESHOLD_PERCENT:-75}"
+PERIODIC_INTERVAL="${HEAP_MONITOR_PERIODIC_INTERVAL:-900}"
+METRICS_PORT="${HEAP_MONITOR_METRICS_PORT:-9000}"
+POD_NAME="${HOSTNAME}"
+
+# --- S3 configuration ---
+
+S3_ENABLED=false
+S3_ENDPOINT_ARGS=()
+
+if [ "$HEAP_DUMP_UPLOAD_S3" = "true" ]; then
+  S3_PREFIX="${HEAP_DUMP_S3_PREFIX:-swatch-utilization/heapdumps}"
+
+  # Try Clowder config first (ephemeral/MinIO), then fall back to mounted secret (stage/prod)
+  if [ -n "${ACG_CONFIG:-}" ] && [ -f "${ACG_CONFIG:-}" ] && command -v jq >/dev/null 2>&1; then
+    obj_store=$(jq -r '.objectStore // empty' "$ACG_CONFIG" 2>/dev/null)
+    if [ -n "$obj_store" ]; then
+      export AWS_ACCESS_KEY_ID=$(jq -r '.objectStore.accessKey' "$ACG_CONFIG")
+      export AWS_SECRET_ACCESS_KEY=$(jq -r '.objectStore.secretKey' "$ACG_CONFIG")
+      export AWS_DEFAULT_REGION=${AWS_REGION:-"us-east-1"}
+
+      obj_host=$(jq -r '.objectStore.hostname' "$ACG_CONFIG")
+      obj_port=$(jq -r '.objectStore.port' "$ACG_CONFIG")
+      obj_tls=$(jq -r '.objectStore.tls // false' "$ACG_CONFIG")
+      if [ "$obj_tls" = "true" ]; then
+        S3_ENDPOINT="https://${obj_host}:${obj_port}"
+      else
+        S3_ENDPOINT="http://${obj_host}:${obj_port}"
+      fi
+      S3_ENDPOINT_ARGS=(--endpoint-url "$S3_ENDPOINT")
+
+      requested_bucket="${HEAP_DUMP_S3_BUCKET_NAME:-swatch-utilization-heapdumps}"
+      S3_BUCKET=$(jq -r --arg req "$requested_bucket" \
+        '.objectStore.buckets[] | select(.requestedName == $req) | .name' \
+        "$ACG_CONFIG" 2>/dev/null)
+      if [ -z "$S3_BUCKET" ]; then
+        S3_BUCKET=$(jq -r '.objectStore.buckets[0].name // empty' "$ACG_CONFIG" 2>/dev/null)
+      fi
+
+      if [ -n "$S3_BUCKET" ]; then
+        S3_ENABLED=true
+        echo "[heap-monitor] S3 upload enabled via Clowder (endpoint: ${S3_ENDPOINT}, bucket: ${S3_BUCKET})"
+      else
+        echo "[heap-monitor] WARNING: No S3 buckets in Clowder config."
+      fi
+    fi
+  fi
+
+  # Fallback: mounted secret from app-interface (stage/prod)
+  if [ "$S3_ENABLED" = false ] && [ -f /aws/aws_access_key_id ]; then
+    export AWS_ACCESS_KEY_ID=$(cat /aws/aws_access_key_id)
+    export AWS_SECRET_ACCESS_KEY=$(cat /aws/aws_secret_access_key)
+    S3_BUCKET=$(cat /aws/bucket)
+    export AWS_DEFAULT_REGION=$(cat /aws/aws_region 2>/dev/null || echo "us-east-1")
+    endpoint=$(cat /aws/endpoint 2>/dev/null || echo "")
+    if [ -n "$endpoint" ]; then
+      S3_ENDPOINT_ARGS=(--endpoint-url "https://${endpoint}")
+    fi
+    S3_ENABLED=true
+    echo "[heap-monitor] S3 upload enabled via mounted secret (bucket: ${S3_BUCKET})"
+  fi
+
+  if [ "$S3_ENABLED" = false ]; then
+    echo "[heap-monitor] WARNING: S3 upload requested but no credentials found. Upload disabled."
+  fi
+else
+  echo "[heap-monitor] S3 upload disabled"
+fi
+
+# --- Thresholds ---
+
+# Wait for cgroup memory limit to be readable (container may be starting up)
+MEMORY_LIMIT_BYTES=0
+for i in {1..30}; do
+  MEMORY_LIMIT_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "0")
+  if [ "$MEMORY_LIMIT_BYTES" -gt 0 ]; then
+    break
+  fi
+  echo "[heap-monitor] Waiting for cgroup memory limit to be readable (attempt $i/30)..."
+  sleep 2
+done
+
+if [ "$MEMORY_LIMIT_BYTES" -eq 0 ]; then
+  echo "[heap-monitor] ERROR: Cannot detect container memory limit after 60s. Monitoring disabled."
+  # Don't exit - just sleep forever to keep container running
+  while true; do sleep 3600; done
+fi
+
+THRESHOLD_BYTES=$((MEMORY_LIMIT_BYTES * THRESHOLD_PERCENT / 100))
+RESET_THRESHOLD=$((MEMORY_LIMIT_BYTES * RESET_PERCENT / 100))
+CHECKS_PER_PERIODIC=$((PERIODIC_INTERVAL / POLL_INTERVAL_SEC))
+RESET_CHECKS=$((RESET_MINUTES * 60 / POLL_INTERVAL_SEC))
+
+echo "[heap-monitor] Started. Container limit: ${MEMORY_LIMIT_BYTES} bytes, threshold: ${THRESHOLD_BYTES} bytes (${THRESHOLD_PERCENT}%), reset: ${RESET_PERCENT}%"
+
+upload_file_to_s3() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  local fname s3_path
+  fname=$(basename "$file")
+  s3_path="s3://${S3_BUCKET}/${S3_PREFIX}/${POD_NAME}/${fname}"
+  aws s3 cp "$file" "$s3_path" "${S3_ENDPOINT_ARGS[@]}" --quiet || \
+    echo "[heap-monitor] ERROR: Failed to upload ${fname}"
+}
+
+compress_dump() {
+  local dump_file="$1"
+  local dump_size
+  dump_size=$(du -h "$dump_file" | cut -f1)
+  echo "[heap-monitor] Heap dump created: ${dump_file} (${dump_size})"
+
+  echo "[heap-monitor] Compressing heap dump..."
+  gzip -c "$dump_file" > "${dump_file}.gz" &
+  local gzip_pid=$!
+
+  local elapsed=0
+  while kill -0 "$gzip_pid" 2>/dev/null; do
+    if [ "$elapsed" -ge "$COMPRESSION_TIMEOUT_SEC" ]; then
+      echo "[heap-monitor] ERROR: Compression timed out after ${COMPRESSION_TIMEOUT_SEC}s, killing gzip"
+      kill "$gzip_pid" 2>/dev/null
+      wait "$gzip_pid" 2>/dev/null
+      rm -f "${dump_file}.gz"
+      return 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  wait "$gzip_pid"
+  local gzip_exit=$?
+  if [ "$gzip_exit" -ne 0 ] || [ ! -s "${dump_file}.gz" ]; then
+    echo "[heap-monitor] ERROR: Compression failed (exit=${gzip_exit})"
+    rm -f "${dump_file}.gz"
+    return 1
+  fi
+
+  local compressed_size
+  compressed_size=$(du -h "${dump_file}.gz" | cut -f1)
+  echo "[heap-monitor] Compressed to ${dump_file}.gz (${compressed_size})"
+  return 0
+}
+
+capture_nmt_summary() {
+  local output_file="$1"
+  if [ -d "/proc/1" ]; then
+    echo "--- $(date '+%Y-%m-%d %H:%M:%S') ---" >> "$output_file"
+    jcmd 1 VM.native_memory summary >> "$output_file" 2>&1 || \
+      echo "[heap-monitor] NMT capture failed" >> "$output_file"
+    echo "" >> "$output_file"
+  fi
+}
+
+capture_jvm_metrics() {
+  local output_file="$1"
+  local mem_usage
+  mem_usage=$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null || cat /sys/fs/cgroup/memory.current 2>/dev/null || echo "0")
+  echo "--- $(date '+%Y-%m-%d %H:%M:%S') ---" >> "$output_file"
+  echo "container_memory_current_bytes: ${mem_usage}" >> "$output_file"
+  echo "container_memory_limit_bytes: ${MEMORY_LIMIT_BYTES}" >> "$output_file"
+  curl -s "localhost:${METRICS_PORT}/metrics" 2>/dev/null \
+    | grep -E 'jvm_memory_used_bytes|jvm_memory_max_bytes|jvm_buffer_' >> "$output_file" \
+    || echo "[heap-monitor] Metrics scrape failed" >> "$output_file"
+  echo "" >> "$output_file"
+}
+
+# Finds JVM OOM dumps created by -XX:+HeapDumpOnOutOfMemoryError
+process_jvm_oom_dumps() {
+  local jvm_dump dump_name timestamp renamed
+  for jvm_dump in /heapdumps/*.hprof; do
+    [ -f "$jvm_dump" ] || continue
+    # Skip our own monitor-triggered dumps (contain pod name in filename)
+    [[ "$jvm_dump" =~ ${POD_NAME} ]] && continue
+
+    dump_name=$(basename "$jvm_dump" .hprof)
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    renamed="/heapdumps/jvm-oom-${dump_name}-${POD_NAME}-${timestamp}.hprof"
+
+    echo "[heap-monitor] Found JVM OOM dump: ${jvm_dump} (created by -XX:+HeapDumpOnOutOfMemoryError)"
+    mv "$jvm_dump" "$renamed"
+
+    if compress_dump "$renamed"; then
+      if [ "$S3_ENABLED" = true ]; then
+        echo "[heap-monitor] Uploading JVM OOM dump to S3..."
+        upload_file_to_s3 "${renamed}.gz"
+        rm -f "${renamed}.gz"
+      fi
+      rm -f "$renamed"
+    fi
+  done
+}
+
+upload_diagnostics() {
+  local pod="$1"
+  local ts="$2"
+  local dump_file="$3"
+
+  if [ "$S3_ENABLED" = true ]; then
+    echo "[heap-monitor] Uploading files to S3..."
+    upload_file_to_s3 "/heapdumps/nmt-${pod}-${ts}.txt"
+    upload_file_to_s3 "/heapdumps/jvm-metrics-${pod}-${ts}.txt"
+    upload_file_to_s3 "/heapdumps/nmt-periodic.txt"
+    upload_file_to_s3 "/heapdumps/jvm-metrics-periodic.txt"
+    upload_file_to_s3 "${dump_file}.gz"
+    echo "[heap-monitor] S3 upload complete"
+
+    rm -f "${dump_file}.gz" \
+          "/heapdumps/nmt-${pod}-${ts}.txt" \
+          "/heapdumps/jvm-metrics-${pod}-${ts}.txt"
+  else
+    echo "[heap-monitor] Diagnostics saved to /heapdumps/"
+    echo "[heap-monitor] Files: heap-${pod}-${ts}.hprof.gz, nmt-${pod}-${ts}.txt, jvm-metrics-${pod}-${ts}.txt"
+    echo "[heap-monitor] Retrieve with: oc cp <pod>:/heapdumps/ ./"
+  fi
+
+  if [ -f "$dump_file" ]; then
+    echo "[heap-monitor] Removing uncompressed dump to save space..."
+    rm -f "$dump_file"
+  fi
+}
+
+# --- Startup ---
+
+process_jvm_oom_dumps
+
+# --- Main loop ---
+
+dump_triggered=false
+reset_counter=0
+periodic_counter=0
+
+while true; do
+  if [ ! -d "/proc/1" ]; then
+    sleep 5
+    continue
+  fi
+
+  mem_usage=$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null || cat /sys/fs/cgroup/memory.current 2>/dev/null || echo "0")
+  mem_percent=$((mem_usage * 100 / MEMORY_LIMIT_BYTES))
+
+  # Periodic capture
+  periodic_counter=$((periodic_counter + 1))
+  if [ "$periodic_counter" -ge "$CHECKS_PER_PERIODIC" ]; then
+    periodic_counter=0
+    capture_nmt_summary "/heapdumps/nmt-periodic.txt" || true
+    capture_jvm_metrics "/heapdumps/jvm-metrics-periodic.txt" || true
+    process_jvm_oom_dumps || true
+  fi
+
+  # Reset: allow re-triggering after memory stays below threshold for RESET_MINUTES
+  if [ "$dump_triggered" = true ] && [ "$mem_usage" -lt "$RESET_THRESHOLD" ]; then
+    reset_counter=$((reset_counter + 1))
+    if [ "$reset_counter" -ge "$RESET_CHECKS" ]; then
+      echo "[heap-monitor] Memory dropped to ${mem_percent}%. Resetting dump trigger."
+      dump_triggered=false
+      reset_counter=0
+    fi
+  else
+    reset_counter=0
+  fi
+
+  # Threshold exceeded: capture diagnostics
+  if [ "$mem_usage" -gt "$THRESHOLD_BYTES" ] && [ "$dump_triggered" = false ]; then
+    echo "[heap-monitor] Memory threshold exceeded: ${mem_usage} bytes (${mem_percent}%). Capturing diagnostics..."
+    dump_triggered=true
+    ts=$(date +%Y%m%d-%H%M%S)
+
+    if [ -d "/proc/1" ]; then
+      echo "[heap-monitor] Capturing NMT summary..."
+      capture_nmt_summary "/heapdumps/nmt-${POD_NAME}-${ts}.txt" || true
+
+      echo "[heap-monitor] Capturing JVM metrics..."
+      capture_jvm_metrics "/heapdumps/jvm-metrics-${POD_NAME}-${ts}.txt" || true
+
+      dump_file="/heapdumps/heap-${POD_NAME}-${ts}.hprof"
+      echo "[heap-monitor] Triggering heap dump to ${dump_file}"
+      jcmd 1 GC.heap_dump "$dump_file" || echo "[heap-monitor] Failed to trigger dump"
+
+      sleep "$POLL_INTERVAL_SEC"
+
+      if [ -f "$dump_file" ]; then
+        if compress_dump "$dump_file"; then
+          upload_diagnostics "$POD_NAME" "$ts" "$dump_file" || true
+        fi
+      else
+        echo "[heap-monitor] ERROR: Heap dump file not created"
+      fi
+    fi
+  fi
+
+  sleep "$POLL_INTERVAL_SEC"
+done

--- a/swatch-utilization/src/main/docker/heap-monitor.sh
+++ b/swatch-utilization/src/main/docker/heap-monitor.sh
@@ -19,65 +19,22 @@ POD_NAME="${HOSTNAME}"
 # --- S3 configuration ---
 
 S3_ENABLED=false
-S3_ENDPOINT_ARGS=()
+S3_PREFIX="${HEAP_DUMP_S3_PREFIX:-swatch-utilization/heapdumps}"
 
 if [ "$HEAP_DUMP_UPLOAD_S3" = "true" ]; then
-  S3_PREFIX="${HEAP_DUMP_S3_PREFIX:-swatch-utilization/heapdumps}"
-
-  # Try Clowder config first (ephemeral/MinIO), then fall back to mounted secret (stage/prod)
-  if [ -n "${ACG_CONFIG:-}" ] && [ -f "${ACG_CONFIG:-}" ] && command -v jq >/dev/null 2>&1; then
-    obj_store=$(jq -r '.objectStore // empty' "$ACG_CONFIG" 2>/dev/null)
-    if [ -n "$obj_store" ]; then
-      export AWS_ACCESS_KEY_ID=$(jq -r '.objectStore.accessKey' "$ACG_CONFIG")
-      export AWS_SECRET_ACCESS_KEY=$(jq -r '.objectStore.secretKey' "$ACG_CONFIG")
-      export AWS_DEFAULT_REGION=${AWS_REGION:-"us-east-1"}
-
-      obj_host=$(jq -r '.objectStore.hostname' "$ACG_CONFIG")
-      obj_port=$(jq -r '.objectStore.port' "$ACG_CONFIG")
-      obj_tls=$(jq -r '.objectStore.tls // false' "$ACG_CONFIG")
-      if [ "$obj_tls" = "true" ]; then
-        S3_ENDPOINT="https://${obj_host}:${obj_port}"
-      else
-        S3_ENDPOINT="http://${obj_host}:${obj_port}"
-      fi
-      S3_ENDPOINT_ARGS=(--endpoint-url "$S3_ENDPOINT")
-
-      requested_bucket="${HEAP_DUMP_S3_BUCKET_NAME:-swatch-utilization-heapdumps}"
-      S3_BUCKET=$(jq -r --arg req "$requested_bucket" \
-        '.objectStore.buckets[] | select(.requestedName == $req) | .name' \
-        "$ACG_CONFIG" 2>/dev/null)
-      if [ -z "$S3_BUCKET" ]; then
-        S3_BUCKET=$(jq -r '.objectStore.buckets[0].name // empty' "$ACG_CONFIG" 2>/dev/null)
-      fi
-
-      if [ -n "$S3_BUCKET" ]; then
-        S3_ENABLED=true
-        echo "[heap-monitor] S3 upload enabled via Clowder (endpoint: ${S3_ENDPOINT}, bucket: ${S3_BUCKET})"
-      else
-        echo "[heap-monitor] WARNING: No S3 buckets in Clowder config."
-      fi
-    fi
-  fi
-
-  # Fallback: mounted secret from app-interface (stage/prod)
-  if [ "$S3_ENABLED" = false ] && [ -f /aws/aws_access_key_id ]; then
+  # Only check for mounted secret (stage/prod)
+  if [ -f /aws/aws_access_key_id ]; then
     export AWS_ACCESS_KEY_ID=$(cat /aws/aws_access_key_id)
     export AWS_SECRET_ACCESS_KEY=$(cat /aws/aws_secret_access_key)
     S3_BUCKET=$(cat /aws/bucket)
     export AWS_DEFAULT_REGION=$(cat /aws/aws_region 2>/dev/null || echo "us-east-1")
-    endpoint=$(cat /aws/endpoint 2>/dev/null || echo "")
-    if [ -n "$endpoint" ]; then
-      S3_ENDPOINT_ARGS=(--endpoint-url "https://${endpoint}")
-    fi
     S3_ENABLED=true
-    echo "[heap-monitor] S3 upload enabled via mounted secret (bucket: ${S3_BUCKET})"
-  fi
-
-  if [ "$S3_ENABLED" = false ]; then
-    echo "[heap-monitor] WARNING: S3 upload requested but no credentials found. Upload disabled."
+    echo "[heap-monitor] S3 upload enabled (bucket: ${S3_BUCKET})"
+  else
+    echo "[heap-monitor] S3 upload disabled: secret not mounted (ephemeral - use 'oc cp' to retrieve dumps)"
   fi
 else
-  echo "[heap-monitor] S3 upload disabled"
+  echo "[heap-monitor] S3 upload disabled by configuration"
 fi
 
 # --- Thresholds ---
@@ -112,7 +69,7 @@ upload_file_to_s3() {
   local fname s3_path
   fname=$(basename "$file")
   s3_path="s3://${S3_BUCKET}/${S3_PREFIX}/${POD_NAME}/${fname}"
-  aws s3 cp "$file" "$s3_path" "${S3_ENDPOINT_ARGS[@]}" --quiet || \
+  aws s3 cp "$file" "$s3_path" --quiet || \
     echo "[heap-monitor] ERROR: Failed to upload ${fname}"
 }
 

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/S3Uploader.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/S3Uploader.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Standalone S3 uploader for heap dumps. Called from heap-monitor.sh to upload files without
+ * requiring AWS CLI.
+ *
+ * <p>Usage: java -cp /deployments/quarkus-run.jar com.redhat.swatch.utilization.S3Uploader \
+ * /path/to/file.gz \ bucket-name \ s3/key/path/file.gz
+ *
+ * <p>Credentials read from environment variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+ * AWS_DEFAULT_REGION
+ */
+public class S3Uploader {
+  public static void main(String[] args) {
+    // Disable JBoss LogManager requirement when running standalone
+    System.setProperty("java.util.logging.manager", "java.util.logging.LogManager");
+
+    if (args.length < 3) {
+      System.err.println("Usage: S3Uploader <file-path> <bucket> <s3-key> [endpoint-url]");
+      System.err.println(
+          "Environment variables required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY");
+      System.exit(1);
+    }
+
+    String filePath = args[0];
+    String bucket = args[1];
+    String s3Key = args[2];
+    String endpointUrl = args.length > 3 ? args[3] : null;
+
+    try {
+      uploadFile(filePath, bucket, s3Key, endpointUrl);
+      System.out.println("Successfully uploaded " + filePath + " to s3://" + bucket + "/" + s3Key);
+    } catch (Exception e) {
+      System.err.println("Failed to upload " + filePath + ": " + e.getMessage());
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  static void uploadFile(String filePath, String bucket, String s3Key, String endpointUrl)
+      throws IOException {
+    // Read credentials from environment (set by heap-monitor.sh from /aws/* files)
+    String accessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+    String secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+    String region = System.getenv("AWS_DEFAULT_REGION");
+
+    uploadFileWithCredentials(
+        filePath, bucket, s3Key, endpointUrl, accessKeyId, secretAccessKey, region);
+  }
+
+  static void uploadFileWithCredentials(
+      String filePath,
+      String bucket,
+      String s3Key,
+      String endpointUrl,
+      String accessKeyId,
+      String secretAccessKey,
+      String region)
+      throws IOException {
+    if (accessKeyId == null || secretAccessKey == null) {
+      throw new IllegalStateException(
+          "AWS credentials not found in environment. Required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY");
+    }
+
+    if (region == null) {
+      region = "us-east-1";
+    }
+
+    Path path = Paths.get(filePath);
+    if (!Files.exists(path)) {
+      throw new IOException("File not found: " + filePath);
+    }
+
+    // Create S3 client with credentials
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+    S3ClientBuilder builder =
+        S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials));
+
+    // Add endpoint override for S3-compatible storage (MinIO, etc.)
+    if (endpointUrl != null && !endpointUrl.isEmpty()) {
+      builder.endpointOverride(URI.create(endpointUrl)).forcePathStyle(true);
+    }
+
+    try (S3Client s3 = builder.build()) {
+      // Upload file
+      PutObjectRequest putRequest = PutObjectRequest.builder().bucket(bucket).key(s3Key).build();
+      s3.putObject(putRequest, RequestBody.fromFile(path));
+    }
+  }
+}

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/S3UploaderTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/S3UploaderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+@Testcontainers
+class S3UploaderTest {
+
+  private static final String MINIO_ACCESS_KEY = "minioadmin";
+  private static final String MINIO_SECRET_KEY = "minioadmin";
+  private static final String TEST_BUCKET = "test-heap-dumps";
+
+  @Container
+  private static final GenericContainer<?> minioContainer =
+      new GenericContainer<>(DockerImageName.parse("minio/minio:RELEASE.2024-10-02T17-50-41Z"))
+          .withExposedPorts(9000)
+          .withEnv("MINIO_ROOT_USER", MINIO_ACCESS_KEY)
+          .withEnv("MINIO_ROOT_PASSWORD", MINIO_SECRET_KEY)
+          .withCommand("server", "/data");
+
+  private static S3Client s3Client;
+  private static String minioEndpoint;
+
+  @BeforeAll
+  static void setUpAll() {
+    String minioHost = minioContainer.getHost();
+    Integer minioPort = minioContainer.getMappedPort(9000);
+    minioEndpoint = String.format("http://%s:%d", minioHost, minioPort);
+
+    // Create S3 client for verification
+    AwsBasicCredentials credentials =
+        AwsBasicCredentials.create(MINIO_ACCESS_KEY, MINIO_SECRET_KEY);
+    s3Client =
+        S3Client.builder()
+            .region(Region.US_EAST_1)
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .endpointOverride(URI.create(minioEndpoint))
+            .forcePathStyle(true)
+            .build();
+
+    // Create test S3 bucket
+    try {
+      s3Client.createBucket(CreateBucketRequest.builder().bucket(TEST_BUCKET).build());
+    } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
+      // Bucket already exists from a previous run
+    }
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (s3Client != null) {
+      s3Client.close();
+    }
+  }
+
+  @Test
+  void testUploadFileWithEndpoint() throws Exception {
+    // Create temp file
+    String testContent = "Test heap dump content\nLine 2\nLine 3";
+    Path tempFile = Files.createTempFile("test-upload", ".txt");
+
+    try {
+      Files.writeString(tempFile, testContent);
+
+      String s3Key = "test/upload-with-endpoint.txt";
+      S3Uploader.uploadFileWithCredentials(
+          tempFile.toString(),
+          TEST_BUCKET,
+          s3Key,
+          minioEndpoint,
+          MINIO_ACCESS_KEY,
+          MINIO_SECRET_KEY,
+          "us-east-1");
+
+      // Verify file was uploaded by reading it back
+      try (ResponseInputStream<GetObjectResponse> response =
+          s3Client.getObject(GetObjectRequest.builder().bucket(TEST_BUCKET).key(s3Key).build())) {
+        String downloadedContent = new String(response.readAllBytes());
+        assertEquals(testContent, downloadedContent, "Uploaded content should match original");
+      }
+
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+
+  @Test
+  void testUploadNonExistentFile() {
+    // Test error handling for non-existent file
+    String nonExistentFile = "/tmp/does-not-exist-" + System.currentTimeMillis() + ".txt";
+    String s3Key = "test/missing.txt";
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                S3Uploader.uploadFileWithCredentials(
+                    nonExistentFile,
+                    TEST_BUCKET,
+                    s3Key,
+                    minioEndpoint,
+                    MINIO_ACCESS_KEY,
+                    MINIO_SECRET_KEY,
+                    "us-east-1"));
+
+    assertTrue(
+        exception.getMessage().contains("File not found"), "Should report file not found error");
+  }
+
+  @Test
+  void testUploadWithMissingCredentials() throws Exception {
+    Path tempFile = Files.createTempFile("test-no-creds", ".txt");
+    try {
+      Files.writeString(tempFile, "test");
+
+      IllegalStateException exception =
+          assertThrows(
+              IllegalStateException.class,
+              () ->
+                  S3Uploader.uploadFileWithCredentials(
+                      tempFile.toString(),
+                      TEST_BUCKET,
+                      "test/key.txt",
+                      minioEndpoint,
+                      null,
+                      null,
+                      null));
+
+      assertTrue(
+          exception.getMessage().contains("AWS credentials not found"),
+          "Should report missing credentials");
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-4732

## Description
Add automated heap dump monitoring for OOM debugging 

Implements proactive heap dump capture when container memory reaches 75% threshold to diagnose production OOM issues before pods are killed.

### How
  - **heap-monitor.sh**: Background monitor that polls container memory every 10s
  - **Periodic capture**: NMT snapshots and JVM metrics every 15 minutes
  - **Threshold capture**: Heap dump when memory usage reaches 75% of container limit
  - **Cooldown**: After dump, waits for memory to stay below 60% for 5 minutes before re-triggering
  - **Compression**: Heap dumps gzipped (~75% size reduction: 60MB → 15-30MB)
  - **Upload**: Compressed dumps uploaded to S3/MinIO, then deleted from EmptyDir
  - **JVM OOM dumps**: Automatically processes dumps created by `-XX:+HeapDumpOnOutOfMemoryError`
  - **EmptyDir persistence**: Files survive container restarts but not pod restarts

### Dual Credential Strategy
 - **Ephemeral**: Uses Clowder objectStore (MinIO auto-provisioned)
 - **Stage/Prod**: Uses mounted `heapdump-s3` secret from app-interface


### JVM Options - Prevents JVM from using container defaults, leaves headroom for metaspace, direct memory, thread stacks, and heap monitor overhead.
- `-Xmx150m` - Explicit heap cap
- `-XX:MaxDirectMemorySize=32m` / `48m` - Cap NIO buffers
- `-XX:+HeapDumpOnOutOfMemoryError` - JVM creates dump on OOM
- `-XX:HeapDumpPath=/heapdumps/` - Save to EmptyDir volume
- `-XX:NativeMemoryTracking=summary` - Enable native memory tracking

## Testing
### Ephemeral
- The swatch-utilization server logs startup of memory monitor
- When heap dump is transferred use the following command to do an ls and cp
POD=$(oc get pods -l app=swatch-utilization -o jsonpath='{.items[0].metadata.name}')

### List heap dumps in MinIO  (telepresence required)
aws s3 ls s3://swatch-utilization-heapdumps/swatch-utilization/heapdumps/ --recursive --endpoint-url http://env-ephemeral-krtdbl-minio.ephemeral-krtdbl.svc:9000

### Download a heap dump
aws s3 cp s3://swatch-utilization-heapdumps/swatch-utilization/heapdumps/swatch-utilization-service-fffdddb5-hnvp9/jvm-metrics-periodic.txt . --endpoint-url http://env-ephemeral-krtdbl-minio.ephemeral-krtdbl.svc:9000 

