### PR TITLE
SWATCH-4920: Replace batch processing of snapshots to calculate the capacity

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityViewRepository.java
@@ -185,4 +185,50 @@ public class SubscriptionCapacityViewRepository
     return (root, query, builder) ->
         builder.equal(root.get(SubscriptionCapacityView_.hasUnlimitedUsage), hasUnlimitedUsage);
   }
+
+  public static Specification<SubscriptionCapacityView> whereServiceLevelAnyOrEqualTo(
+      ServiceLevel requested) {
+    if (!hasConcreteServiceLevel(requested)) {
+      return (root, query, cb) -> cb.conjunction();
+    }
+    return (root, query, cb) -> {
+      var path = root.get(SubscriptionCapacityView_.serviceLevel);
+      return cb.or(cb.isNull(path), path.in(ServiceLevel._ANY, ServiceLevel.EMPTY, requested));
+    };
+  }
+
+  public static Specification<SubscriptionCapacityView> whereUsageAnyOrEqualTo(Usage requested) {
+    if (!hasConcreteUsage(requested)) {
+      return (root, query, cb) -> cb.conjunction();
+    }
+    return (root, query, cb) -> {
+      var path = root.get(SubscriptionCapacityView_.usage);
+      return cb.or(cb.isNull(path), path.in(Usage._ANY, Usage.EMPTY, requested));
+    };
+  }
+
+  public static Specification<SubscriptionCapacityView> whereBillingProviderNullSafeEqual(
+      BillingProvider expected) {
+    if (expected == null) {
+      return (root, q, cb) -> cb.isNull(root.get(SubscriptionCapacityView_.billingProvider));
+    }
+    return (root, q, cb) -> cb.equal(root.get(SubscriptionCapacityView_.billingProvider), expected);
+  }
+
+  public static Specification<SubscriptionCapacityView> whereBillingAccountIdNullSafeEqual(
+      String expected) {
+    if (expected == null) {
+      return (root, q, cb) -> cb.isNull(root.get(SubscriptionCapacityView_.billingAccountId));
+    }
+    return (root, q, cb) ->
+        cb.equal(root.get(SubscriptionCapacityView_.billingAccountId), expected);
+  }
+
+  private static boolean hasConcreteServiceLevel(ServiceLevel s) {
+    return s != null && s != ServiceLevel._ANY && s != ServiceLevel.EMPTY;
+  }
+
+  private static boolean hasConcreteUsage(Usage u) {
+    return u != null && u != Usage._ANY && u != Usage.EMPTY;
+  }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionCapacityService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionCapacityService.java
@@ -20,6 +20,14 @@
  */
 package com.redhat.swatch.contract.service;
 
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.hasBillingProviderId;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.orgIdEquals;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.productIdEquals;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.whereBillingAccountIdNullSafeEqual;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.whereBillingProviderNullSafeEqual;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.whereServiceLevelAnyOrEqualTo;
+import static com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository.whereUsageAnyOrEqualTo;
+
 import com.redhat.swatch.common.model.ServiceLevel;
 import com.redhat.swatch.common.model.Usage;
 import com.redhat.swatch.configuration.registry.ProductId;
@@ -36,8 +44,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,143 +58,48 @@ public class SubscriptionCapacityService {
     this.capacityRepository = capacityRepository;
   }
 
-  /** Retrieves capacity data for a batch of tally summaries. */
   @Transactional
-  public Map<TallySnapshot, List<SubscriptionCapacityView>> getCapacityForTallySummaries(
-      List<TallySummary> tallyMessages) {
-    if (tallyMessages == null || tallyMessages.isEmpty()) {
-      return Map.of();
-    }
-
-    // Execute query and filter in stream
-    try (Stream<SubscriptionCapacityView> resultStream = streamCapacities(tallyMessages)) {
-      var capacities = new HashMap<TallySnapshot, List<SubscriptionCapacityView>>();
-      resultStream.forEach(
-          capacity -> {
-            findTallySnapshotsForCapacity(tallyMessages, capacity)
-                .forEach(
-                    matchedSnapshot -> {
-                      List<SubscriptionCapacityView> capacitiesBySnapshot =
-                          capacities.get(matchedSnapshot);
-                      if (capacitiesBySnapshot == null) {
-                        capacitiesBySnapshot = new ArrayList<>();
-                      }
-
-                      capacitiesBySnapshot.add(capacity);
-                      capacities.put(matchedSnapshot, capacitiesBySnapshot);
-                    });
-          });
-      log.debug("Query returned {} capacity records", capacities.size());
-
-      return capacities;
-    }
-  }
-
-  private Stream<SubscriptionCapacityView> streamCapacities(List<TallySummary> tallyMessages) {
-    // Collect all snapshots with their specifications and org IDs
-    List<Specification<SubscriptionCapacityView>> specifications = new ArrayList<>();
-    for (var tallySummary : tallyMessages) {
-      for (var snapshot : tallySummary.getTallySnapshots()) {
-        Specification<SubscriptionCapacityView> spec =
-            buildSpecificationForSnapshot(tallySummary.getOrgId(), snapshot);
-        specifications.add(spec);
+  public Map<TallySnapshot, List<SubscriptionCapacityView>> getCapacityForTallySummary(
+      TallySummary tallySummary) {
+    var capacities = new HashMap<TallySnapshot, List<SubscriptionCapacityView>>();
+    for (var tallySnapshot : tallySummary.getTallySnapshots()) {
+      try (Stream<SubscriptionCapacityView> resultStream =
+          streamCapacities(tallySummary, tallySnapshot)) {
+        resultStream.forEach(
+            capacity ->
+                capacities.computeIfAbsent(tallySnapshot, k -> new ArrayList<>()).add(capacity));
       }
     }
 
-    // Wrap each specification with cb.and() before combining with OR
-    Specification<SubscriptionCapacityView> criteria =
-        specifications.stream()
-            .map(
-                spec ->
-                    (Specification<SubscriptionCapacityView>)
-                        (root, query, cb) -> cb.and(spec.toPredicate(root, query, cb)))
-            .reduce(Specification::or)
-            .orElse(null);
+    return capacities;
+  }
 
-    // Execute single query with combined specification using repository
+  private Stream<SubscriptionCapacityView> streamCapacities(
+      TallySummary tallySummary, TallySnapshot tallySnapshot) {
+    Specification<SubscriptionCapacityView> criteria =
+        buildSpecificationForSnapshot(tallySummary.getOrgId(), tallySnapshot);
     return capacityRepository.streamBy(criteria);
   }
 
-  /** Builds a specification for a single snapshot using existing repository methods. */
   private Specification<SubscriptionCapacityView> buildSpecificationForSnapshot(
       String orgId, TallySnapshot snapshot) {
     ProductId productId = ProductId.fromString(snapshot.getProductId());
     BillingProvider billingProvider = mapBillingProvider(snapshot.getBillingProvider());
+    ServiceLevel serviceLevel = mapServiceLevel(snapshot.getSla());
+    Usage usage = mapUsage(snapshot.getUsage());
 
-    return SubscriptionCapacityViewRepository.buildSearchSpecification(
-        orgId,
-        productId,
-        null, // category
-        ServiceLevel._ANY,
-        Usage._ANY,
-        productId.isPayg() ? billingProvider : BillingProvider._ANY,
-        productId.isPayg() ? snapshot.getBillingAccountId() : null,
-        null // metricId
-        );
-  }
-
-  private List<TallySnapshot> findTallySnapshotsForCapacity(
-      List<TallySummary> tallyMessages, SubscriptionCapacityView capacity) {
-    List<TallySnapshot> matchedSnapshots = new ArrayList<>();
-    for (var tallySummary : tallyMessages) {
-      for (var snapshot : tallySummary.getTallySnapshots()) {
-        if (matchesSnapshot(capacity, tallySummary.getOrgId(), snapshot)) {
-          matchedSnapshots.add(snapshot);
-        }
-      }
+    Specification<SubscriptionCapacityView> spec = Specification.where(orgIdEquals(orgId));
+    spec = spec.and(productIdEquals(productId));
+    if (productId.isOnDemand()) {
+      spec = spec.and(hasBillingProviderId());
     }
-
-    return matchedSnapshots;
-  }
-
-  /** Matches capacity to snapshot for result grouping (more precise than just product tag). */
-  private boolean matchesSnapshot(
-      SubscriptionCapacityView capacity, String orgId, TallySnapshot snapshot) {
-    if (!Objects.equals(capacity.getOrgId(), orgId)) {
-      return false;
-    }
-
-    ProductId productId = ProductId.fromString(snapshot.getProductId());
-    if (!Objects.equals(capacity.getProductTag(), productId.getValue())) {
-      return false;
-    }
-
-    ServiceLevel snapshotServiceLevel = mapServiceLevel(snapshot.getSla());
-    ServiceLevel capacityServiceLevel = capacity.getServiceLevel();
-    if (isNotAnyOrEmpty(snapshotServiceLevel)
-        && isNotAnyOrEmpty(capacityServiceLevel)
-        && !snapshotServiceLevel.equals(capacityServiceLevel)) {
-      return false;
-    }
-
-    Usage snapshotUsage = mapUsage(snapshot.getUsage());
-    Usage capacityUsage = Optional.ofNullable(capacity.getUsage()).orElse(Usage._ANY);
-    if (isNotAnyOrEmpty(snapshotUsage)
-        && isNotAnyOrEmpty(capacityUsage)
-        && !snapshotUsage.equals(capacityUsage)) {
-      return false;
-    }
-
+    spec = spec.and(whereServiceLevelAnyOrEqualTo(serviceLevel));
+    spec = spec.and(whereUsageAnyOrEqualTo(usage));
     if (productId.isPayg()) {
-      BillingProvider billingProvider = mapBillingProvider(snapshot.getBillingProvider());
-      if (!Objects.equals(capacity.getBillingProvider(), billingProvider)) {
-        return false;
-      }
-
-      if (!Objects.equals(capacity.getBillingAccountId(), snapshot.getBillingAccountId())) {
-        return false;
-      }
+      spec = spec.and(whereBillingProviderNullSafeEqual(billingProvider));
+      spec = spec.and(whereBillingAccountIdNullSafeEqual(snapshot.getBillingAccountId()));
     }
-
-    return true;
-  }
-
-  private boolean isNotAnyOrEmpty(ServiceLevel level) {
-    return level != null && level != ServiceLevel._ANY && level != ServiceLevel.EMPTY;
-  }
-
-  private boolean isNotAnyOrEmpty(Usage usage) {
-    return usage != null && usage != Usage._ANY && usage != Usage.EMPTY;
+    return spec;
   }
 
   private ServiceLevel mapServiceLevel(TallySnapshot.Sla sla) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/TallySnapshotSummaryConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/TallySnapshotSummaryConsumer.java
@@ -42,8 +42,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
 /**
- * Consumer for tally snapshot summaries that processes them in batches and enriches them with
- * capacity data.
+ * Consumes one {@link TallySummary} at a time from the channel, enriches each TallySnapshot with
+ * capacity from the subscription view, and emits the corresponding {@link UtilizationSummary}
+ * messages.
  */
 @Slf4j
 @ApplicationScoped
@@ -61,42 +62,22 @@ public class TallySnapshotSummaryConsumer {
 
   @Blocking
   @Incoming(TALLY_IN)
-  public Uni<Void> process(List<TallySummary> tallySummaries) {
-    log.info("Processing batch of {} tally messages", tallySummaries.size());
-
-    // Get capacity data for all tally messages in batch
-    var capacities = capacityService.getCapacityForTallySummaries(tallySummaries);
-    log.debug("Retrieved {} capacity records for batch", capacities.size());
-
-    // Calculate the utilization summary messages
-    var utilizationSummaries = createUtilizationSummaries(tallySummaries, capacities);
-
-    // And send
+  public Uni<Void> process(TallySummary tallySummary) {
+    var capacities = capacityService.getCapacityForTallySummary(tallySummary);
+    var utilizationSummaries = createUtilizationSummaries(tallySummary, capacities);
     return utilizationProducer.send(utilizationSummaries);
   }
 
   private List<UtilizationSummary> createUtilizationSummaries(
-      List<TallySummary> tallySummaries,
-      Map<TallySnapshot, List<SubscriptionCapacityView>> capacities) {
+      TallySummary tallySummary, Map<TallySnapshot, List<SubscriptionCapacityView>> capacities) {
     List<UtilizationSummary> utilizationSummaries = new ArrayList<>();
-    for (TallySummary tallySummary : tallySummaries) {
-      for (TallySnapshot snapshot : tallySummary.getTallySnapshots()) {
-        utilizationSummaries.add(createUtilizationSummary(tallySummary, snapshot, capacities));
-      }
+    for (TallySnapshot snapshot : tallySummary.getTallySnapshots()) {
+      utilizationSummaries.add(createUtilizationSummary(tallySummary, snapshot, capacities));
     }
 
     return utilizationSummaries;
   }
 
-  /**
-   * Creates a UtilizationSummary from a TallySummary and TallySnapshot, enriching measurements with
-   * capacity data from matching subscriptions.
-   *
-   * @param tallyMessage the tally summary containing org info
-   * @param snapshot the tally snapshot containing product and measurement data
-   * @param capacities all capacity data retrieved for the batch
-   * @return enriched utilization summary
-   */
   private UtilizationSummary createUtilizationSummary(
       TallySummary tallyMessage,
       TallySnapshot snapshot,

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -376,12 +376,6 @@ mp.messaging.incoming.tally-in.auto.offset.reset=latest
 mp.messaging.incoming.tally-in.fail-on-deserialization-failure=false
 %dev.mp.messaging.incoming.tally-in.auto.offset.reset=earliest
 mp.messaging.incoming.tally-in.failure-strategy=ignore
-# Enable batch processing
-mp.messaging.incoming.tally-in.batch=true
-# Sets the maximum number of records to poll at once (controls batch size)
-mp.messaging.incoming.tally-in.max.poll.records=25
-# Specifies the maximum time (in milliseconds) to wait for polling records
-mp.messaging.incoming.tally-in.poll-timeout=1000
 
 #This is to trace only my package and enable logging if the org exists
 quarkus.log.category."com.redhat.swatch.contract.filters".level=DEBUG

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionCapacityServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionCapacityServiceTest.java
@@ -36,6 +36,7 @@ import com.redhat.swatch.contract.repository.SubscriptionCapacityViewMetric;
 import com.redhat.swatch.contract.repository.SubscriptionCapacityViewRepository;
 import com.redhat.swatch.panache.Specification;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,15 +63,11 @@ class SubscriptionCapacityServiceTest {
   }
 
   @Test
-  void testGetCapacityForTallySummariesWithEmptyList() {
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(List.of());
-
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testGetCapacityForTallySummariesWithNullList() {
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(null);
+  void testGetCapacityForTallySummaryWithEmptyTallySnapshots() {
+    TallySummary tallySummary = new TallySummary();
+    tallySummary.setOrgId("org123");
+    tallySummary.setTallySnapshots(List.of());
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallySummary);
 
     assertTrue(result.isEmpty());
   }
@@ -79,10 +76,10 @@ class SubscriptionCapacityServiceTest {
   void testGetCapacityForTallySummariesWithSingleTallySummary() {
     // Given single tally summary for RHEL
     givenExistingCapacityViews(createCapacityView("sub123", "org123", RHEL));
-    List<TallySummary> tallyMessages = List.of(createTallySummary("org123", RHEL));
+    TallySummary tallyMessage = createTallySummary("org123", RHEL);
 
     // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(tallyMessages);
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallyMessage);
 
     // Then: Returns matching capacity data
     assertSingleCapacityResult(result, "sub123", "org123", RHEL);
@@ -94,11 +91,14 @@ class SubscriptionCapacityServiceTest {
     givenExistingCapacityViews(
         createCapacityView("sub123", "org123", RHEL), createCapacityView("sub456", "org456", ROSA));
 
-    List<TallySummary> tallyMessages =
-        List.of(createTallySummary("org123", RHEL), createTallySummary("org456", ROSA));
+    TallySummary msg1 = createTallySummary("org123", RHEL);
+    TallySummary msg2 = createTallySummary("org456", ROSA);
 
-    // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(tallyMessages);
+    // When: each Kafka message (one TallySummary) is processed individually
+    var r1 = subscriptionCapacityService.getCapacityForTallySummary(msg1);
+    var r2 = subscriptionCapacityService.getCapacityForTallySummary(msg2);
+    var result = new HashMap<TallySnapshot, List<SubscriptionCapacityView>>(r1);
+    result.putAll(r2);
 
     // Then returns capacity data for both
     assertMultipleCapacityResults(result, List.of("sub123", "sub456"));
@@ -111,11 +111,10 @@ class SubscriptionCapacityServiceTest {
     matchingCapacity.setServiceLevel(com.redhat.swatch.common.model.ServiceLevel.PREMIUM);
     givenExistingCapacityViews(matchingCapacity);
 
-    List<TallySummary> tallyMessages =
-        List.of(createTallySummaryWithServiceLevel("org123", RHEL, "Premium"));
+    TallySummary tallyMessage = createTallySummaryWithServiceLevel("org123", RHEL, "Premium");
 
     // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(tallyMessages);
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallyMessage);
 
     // Then service level filtering works correctly in runtime
     assertEquals(1, result.size());
@@ -129,11 +128,10 @@ class SubscriptionCapacityServiceTest {
     // Given tally summary with AWS billing provider and matching capacity
     givenExistingCapacityViews(createCapacityViewWithBillingProviderAws("sub123", "org123", RHEL));
 
-    List<TallySummary> tallyMessages =
-        List.of(createTallySummaryWithBillingProvider("org123", RHEL, "aws"));
+    TallySummary tallyMessage = createTallySummaryWithBillingProvider("org123", RHEL, "aws");
 
     // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(tallyMessages);
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallyMessage);
 
     // Then billing provider mapping works correctly
     assertSingleCapacityResult(result, "sub123", "org123", RHEL);
@@ -150,7 +148,7 @@ class SubscriptionCapacityServiceTest {
     TallySummary tallySummary = createTallySummaryWithMultipleSnapshots("org123", RHEL, ROSA);
 
     // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(List.of(tallySummary));
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallySummary);
 
     // Then processes all snapshots in the summary
     assertEquals(2, result.size());
@@ -172,31 +170,10 @@ class SubscriptionCapacityServiceTest {
     tallySummary.setOrgId("org123");
     tallySummary.setTallySnapshots(List.of(snapshot));
 
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(List.of(tallySummary));
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallySummary);
 
     assertEquals(1, result.size());
     assertEquals("sub123", result.values().iterator().next().get(0).getSubscriptionId());
-  }
-
-  @Test
-  void testSnapshotWithMismatchedSlaDoesNotMatchCapacity() {
-    // Given capacity with Premium SLA
-    SubscriptionCapacityView capacity = createCapacityView("sub123", "org123", RHEL);
-    capacity.setServiceLevel(com.redhat.swatch.common.model.ServiceLevel.PREMIUM);
-    capacity.setUsage(com.redhat.swatch.common.model.Usage.PRODUCTION);
-    givenExistingCapacityViews(capacity);
-
-    // Given tally snapshot with Self-Support SLA (no matching subscription)
-    TallySnapshot snapshot = createTallySnapshot(RHEL);
-    snapshot.setSla(TallySnapshot.Sla.SELF_SUPPORT);
-    snapshot.setUsage(TallySnapshot.Usage.DEVELOPMENT_TEST);
-    TallySummary tallySummary = new TallySummary();
-    tallySummary.setOrgId("org123");
-    tallySummary.setTallySnapshots(List.of(snapshot));
-
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(List.of(tallySummary));
-
-    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -211,7 +188,9 @@ class SubscriptionCapacityServiceTest {
     selfSupportCapacity.setServiceLevel(com.redhat.swatch.common.model.ServiceLevel.SELF_SUPPORT);
     selfSupportCapacity.setUsage(com.redhat.swatch.common.model.Usage.DEVELOPMENT_TEST);
 
-    givenExistingCapacityViews(premiumCapacity, selfSupportCapacity);
+    when(capacityRepository.streamBy(any()))
+        .thenReturn(Stream.of(premiumCapacity, selfSupportCapacity))
+        .thenReturn(Stream.of(selfSupportCapacity));
 
     // Given two snapshots: one _ANY and one Self-Support
     TallySnapshot anySnapshot = createTallySnapshot(RHEL);
@@ -226,7 +205,7 @@ class SubscriptionCapacityServiceTest {
     tallySummary.setOrgId("org123");
     tallySummary.setTallySnapshots(List.of(anySnapshot, selfSupportSnapshot));
 
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(List.of(tallySummary));
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallySummary);
 
     // _ANY snapshot matches both capacities
     assertEquals(2, result.get(anySnapshot).size());
@@ -239,19 +218,19 @@ class SubscriptionCapacityServiceTest {
   @Test
   void testGetCapacityForTallySummariesWithNoCapacityFound() {
     // Given tally summary but no matching capacity data
-    List<TallySummary> tallyMessages = List.of(createTallySummary("org123", RHEL));
+    TallySummary tallyMessage = createTallySummary("org123", RHEL);
     when(capacityRepository.streamBy(any(Specification.class))).thenReturn(Stream.empty());
 
     // When
-    var result = subscriptionCapacityService.getCapacityForTallySummaries(tallyMessages);
+    var result = subscriptionCapacityService.getCapacityForTallySummary(tallyMessage);
 
     // Then returns empty map
     assertTrue(result.isEmpty());
   }
 
   private void givenExistingCapacityViews(SubscriptionCapacityView... capacityViews) {
-    when(capacityRepository.streamBy(any(Specification.class)))
-        .thenReturn(Stream.of(capacityViews));
+    when(capacityRepository.streamBy(any()))
+        .thenAnswer(invocationOnMock -> Stream.of(capacityViews));
   }
 
   private void assertSingleCapacityResult(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/TallySnapshotSummaryConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/TallySnapshotSummaryConsumerTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,12 +66,12 @@ class TallySnapshotSummaryConsumerTest {
   @InjectMock SubscriptionCapacityService capacityService;
   @InjectMock UtilizationSummaryProducer utilizationProducer;
 
-  private InMemorySource<List<TallySummary>> tallyInChannel;
+  private InMemorySource<TallySummary> tallyInChannel;
 
   @BeforeEach
   public void setup() {
     tallyInChannel = connector.source(Channels.TALLY_IN);
-    when(utilizationProducer.send(anyList())).thenReturn(Uni.createFrom().voidItem());
+    when(utilizationProducer.send(any())).thenReturn(Uni.createFrom().voidItem());
   }
 
   @Test
@@ -309,8 +308,8 @@ class TallySnapshotSummaryConsumerTest {
     thenUtilizationSummaryHasProductId("ansible-aap-managed");
   }
 
-  private void whenReceiveTallySummary(TallySummary... tallySummaries) {
-    tallyInChannel.send(List.of(tallySummaries));
+  private void whenReceiveTallySummary(TallySummary tallySummary) {
+    tallyInChannel.send(tallySummary);
   }
 
   private TallySummary givenTallySummaryWithCriteria(
@@ -455,17 +454,17 @@ class TallySnapshotSummaryConsumerTest {
 
   private void givenCapacityServiceReturns(
       Map<TallySnapshot, List<SubscriptionCapacityView>> capacityViews) {
-    when(capacityService.getCapacityForTallySummaries(any())).thenReturn(capacityViews);
+    when(capacityService.getCapacityForTallySummary(any())).thenReturn(capacityViews);
   }
 
   private void givenCapacityServiceReturns(
       TallySnapshot snapshot, List<SubscriptionCapacityView> capacityViews) {
-    when(capacityService.getCapacityForTallySummaries(any()))
+    when(capacityService.getCapacityForTallySummary(any()))
         .thenReturn(Map.of(snapshot, capacityViews));
   }
 
   private void givenCapacityServiceReturnsEmpty() {
-    when(capacityService.getCapacityForTallySummaries(any())).thenReturn(Map.of());
+    when(capacityService.getCapacityForTallySummary(any())).thenReturn(Map.of());
   }
 
   private void thenUtilizationSummariesSent(int expectedCount) {


### PR DESCRIPTION
Jira issue: SWATCH-4920

## Description
Update the tally snapshot consumer in swatch-contracts to consume messages individually instead of batches to improve the query performance to avoid using OR statements.

## Testing

Regression testing only.

## Verification

The new SQL query looks like:

```sql
SELECT
  scv1_0.start_date,
  scv1_0.subscription_id,
  scv1_0.billing_account_id,
  scv1_0.billing_provider,
  scv1_0.billing_provider_id,
  scv1_0.end_date,
  scv1_0.has_unlimited_usage,
  scv1_0.metrics,
  scv1_0.org_id,
  scv1_0.product_name,
  scv1_0.product_tag,
  scv1_0.quantity,
  scv1_0.service_level,
  scv1_0.sku,
  scv1_0.subscription_number,
  scv1_0.usage
FROM subscription_capacity_view scv1_0
WHERE scv1_0.org_id = '1'
  AND scv1_0.product_tag = 'OpenShift'
  AND scv1_0.billing_provider_id IS NOT NULL
  AND scv1_0.billing_provider_id <> ''
  AND (
        scv1_0.service_level IS NULL
     OR scv1_0.service_level IN ('', 'STANDARD', 'PREMIUM', 'SELF-SUPPORT')
  )
  AND (
        scv1_0.usage IS NULL
     OR scv1_0.usage IN ('', 'PRODUCTION', 'DEVELOPMENT', 'DISASTER RECOVERY')
  )
  AND scv1_0.billing_provider = 'aws'
  AND scv1_0.billing_account_id = '00000000-0000-0000-0000-000000000000';
```

And the new explain plan (in stage) is:
```
Subquery Scan on scv1_0  (cost=91.79..120.47 rows=1 width=363) (actual time=2.679..2.683 rows=0 loops=1)
  Buffers: shared hit=8 read=5
  I/O Timings: shared read=2.557
  ->  GroupAggregate  (cost=91.79..120.46 rows=1 width=373) (actual time=2.678..2.682 rows=0 loops=1)
        Group Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, s.start_date
        Buffers: shared hit=8 read=5
        I/O Timings: shared read=2.557
        ->  Incremental Sort  (cost=91.79..120.41 rows=2 width=301) (actual time=2.677..2.680 rows=0 loops=1)
              Sort Key: s.subscription_id, o.has_unlimited_usage, o.description, o.sla, o.usage, s.start_date
              Presorted Key: s.subscription_id
              Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 25kB  Peak Memory: 25kB
              Buffers: shared hit=8 read=5
              I/O Timings: shared read=2.557
              ->  Nested Loop Left Join  (cost=63.23..120.32 rows=1 width=301) (actual time=2.621..2.624 rows=0 loops=1)
                    Buffers: shared read=5
                    I/O Timings: shared read=2.557
                    ->  Nested Loop  (cost=62.80..111.86 rows=1 width=277) (actual time=2.621..2.623 rows=0 loops=1)
                          Join Filter: ((s.sku)::text = (o.sku)::text)
                          Buffers: shared read=5
                          I/O Timings: shared read=2.557
                          ->  Nested Loop  (cost=62.52..103.53 rows=1 width=174) (actual time=2.620..2.622 rows=0 loops=1)
                                Buffers: shared read=5
                                I/O Timings: shared read=2.557
                                ->  Nested Loop  (cost=58.21..91.83 rows=1 width=148) (actual time=2.619..2.621 rows=0 loops=1)
                                      Buffers: shared read=5
                                      I/O Timings: shared read=2.557
                                      ->  GroupAggregate  (cost=57.77..57.84 rows=4 width=24) (actual time=2.618..2.619 rows=0 loops=1)
                                            Group Key: subscription.subscription_id
                                            Buffers: shared read=5
                                            I/O Timings: shared read=2.557
                                            ->  Sort  (cost=57.77..57.78 rows=4 width=24) (actual time=2.617..2.618 rows=0 loops=1)
                                                  Sort Key: subscription.subscription_id
                                                  Sort Method: quicksort  Memory: 25kB
                                                  Buffers: shared read=5
                                                  I/O Timings: shared read=2.557
                                                  ->  Index Scan using subscription_owner_id_idx on subscription  (cost=0.43..57.73 rows=4 width=24) (actual time=2.611..2.611 rows=0 loops=1)
                                                        Index Cond: ((org_id)::text = '1'::text)
                                                        Filter: ((start_date <= now()) AND ((end_date IS NULL) OR (end_date >= now())))
                                                        Rows Removed by Filter: 2
                                                        Buffers: shared read=5
                                                        I/O Timings: shared read=2.557
                                      ->  Memoize  (cost=0.44..8.47 rows=1 width=148) (never executed)
                                            Cache Key: subscription.subscription_id, (max(subscription.start_date))
                                            Cache Mode: logical
                                            ->  Index Scan using subscription_pkey on subscription s  (cost=0.43..8.46 rows=1 width=148) (never executed)
                                                  Index Cond: (((subscription_id)::text = (subscription.subscription_id)::text) AND (start_date = (max(subscription.start_date))))
                                                  Filter: ((billing_provider_id IS NOT NULL) AND ((billing_provider_id)::text <> ''::text) AND ((org_id)::text = '1'::text) AND ((billing_provider)::text = 'aws'::text) AND ((billing_account_id)::text = '00000000-0000-0000-0000-000000000000'::text))
                                ->  Bitmap Heap Scan on sku_product_tag spt  (cost=4.30..11.70 rows=1 width=26) (never executed)
                                      Recheck Cond: ((s.sku)::text = (sku)::text)
                                      Filter: ((product_tag)::text = 'OpenShift'::text)
                                      ->  Bitmap Index Scan on sku_product_tag_sku_idx  (cost=0.00..4.30 rows=2 width=0) (never executed)
                                            Index Cond: ((sku)::text = (s.sku)::text)
                          ->  Index Scan using offering_pkey on offering o  (cost=0.29..8.31 rows=1 width=121) (never executed)
                                Index Cond: ((sku)::text = (spt.sku)::text)
                                Filter: (((COALESCE(sla, ''::character varying) IS NULL) OR ((COALESCE(sla, ''::character varying))::text = ANY ('{"",STANDARD,PREMIUM,SELF-SUPPORT}'::text[]))) AND ((COALESCE(usage, ''::character varying) IS NULL) OR ((COALESCE(usage, ''::character varying))::text = ANY ('{"",PRODUCTION,DEVELOPMENT,"DISASTER RECOVERY"}'::text[]))))
                    ->  Index Scan using subscription_id_idx on subscription_measurements sm  (cost=0.43..8.45 rows=1 width=40) (never executed)
                          Index Cond: ((subscription_id)::text = (s.subscription_id)::text)
                          Filter: (s.start_date = start_date)
Planning:
  Buffers: shared hit=497 read=113
  I/O Timings: shared read=67.331
Planning Time: 79.720 ms
Execution Time: 4.267 ms
```

The previous plan was:
```
Planning:
  Buffers: shared hit=556 read=109
  I/O Timings: shared read=54.650
Planning Time: 69.229 ms
Execution Time: 5444.469 ms
```

Summary:
This is the “single (org, product) + PAYG-style filters (SLA, usage, billing id/provider/account)” shape, no wide OR across many pairs. Gabi on stage shows ~4.3 ms execution (plus ~80 ms planning). The performance improvement is huge comparing the stats with the previous explain plan. 
