### PR TITLE
chore: fix s3 upload artifacts

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -914,7 +914,12 @@ spec:
               #!/bin/bash
               set -ex
 
+              # upload-to-s3.sh syncs /artifacts only; mirror the workspace there (see bonfire-tekton teardown).
               export ARTIFACTS_DIR="$(workspaces.artifacts.path)"
+              mkdir -p "$ARTIFACTS_DIR"
+              if [ "$ARTIFACTS_DIR" != "/artifacts" ]; then
+                ln -sfn "$ARTIFACTS_DIR" /artifacts
+              fi
               echo "Copying files to S3"
               upload-to-s3.sh | tee "$(results.ARTIFACTS_URL.path)"
 


### PR DESCRIPTION
## Description
The upload-artifacts-to-s3 pipeline task is failing with:
```
The user-provided path /artifacts does not exist.
```