### PR TITLE
chore: fix s3 upload artifacts

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -914,14 +914,15 @@ spec:
               #!/bin/bash
               set -ex
 
-              # upload-to-s3.sh syncs /artifacts only; mirror the workspace there (see bonfire-tekton teardown).
-              export ARTIFACTS_DIR="$(workspaces.artifacts.path)"
+              ARTIFACTS_DIR="$(workspaces.artifacts.path)"
               mkdir -p "$ARTIFACTS_DIR"
-              if [ "$ARTIFACTS_DIR" != "/artifacts" ]; then
-                ln -sfn "$ARTIFACTS_DIR" /artifacts
-              fi
-              echo "Copying files to S3"
-              upload-to-s3.sh | tee "$(results.ARTIFACTS_URL.path)"
+              bucket="${BUCKET:-rh-artifacts-bucket}"
+              artifacts_key="${ARTIFACTS_KEY:?ARTIFACTS_KEY required}"
+              region="${AWS_DEFAULT_REGION:-us-east-1}"
+              echo "Copying files to S3 from $ARTIFACTS_DIR"
+              aws s3 cp --recursive "$ARTIFACTS_DIR" "s3://${bucket}/${artifacts_key}" --quiet
+              url="https://s3.console.aws.amazon.com/s3/buckets/${bucket}?region=${region}&prefix=${artifacts_key}/&showversions=false"
+              echo -n "$url" | tee "$(results.ARTIFACTS_URL.path)"
 
   finally:
     - name: check-test-results


### PR DESCRIPTION
## Description
The upload-artifacts-to-s3 pipeline task is failing with:
```
The user-provided path /artifacts does not exist.
```