### PR TITLE
swatch-contracts: disable health check for IT Partner Gateway Kafka consumer

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -274,6 +274,7 @@ mp.messaging.incoming.contracts-from-gateway.topic=${IT_PARTNER_KAFKA_TOPIC}
 mp.messaging.incoming.contracts-from-gateway.group.id=it-partner-kafka-worker
 mp.messaging.incoming.contracts-from-gateway.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.contracts-from-gateway.failure-strategy=ignore
+mp.messaging.incoming.contracts-from-gateway.health-enabled=false
 
 mp.messaging.incoming.subscription-sync-task.connector=smallrye-kafka
 %test.mp.messaging.incoming.subscription-sync-task.connector=smallrye-in-memory


### PR DESCRIPTION
## Description
To prevent service restarts in case the IT Partner Gateway Kafka consumer starts working. 

## Testing
Regression testing only.