### PR TITLE
SWATCH-4904: Implementation of utilization component tests GET/POST API 

### DIFF
--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -391,3 +391,90 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Allowlisted org: notification event with correct (org_id, product_id, metric_id, utilization_percentage)
     - Non-allowlisted org: no notification event
 
+## Organization Preferences API
+
+**org-preferences-TC001 - Retrieve default threshold for organization without custom preferences**
+
+- **Description**: Verify that GET request returns system default threshold when org has not configured custom preferences.
+- **Setup**:
+    - An organization has not configured any custom preferences
+- **Action**:
+    - Call GET /api/rhsm-subscriptions/v1/utilization/org-preferences with valid x-rh-identity header
+- **Verification**:
+    - Verify response status code is 200
+    - Verify response contains custom_threshold field
+- **Expected Result**:
+    - HTTP 200 response
+    - Response contains custom_threshold matching system default (ORG_PREFERENCE_DEFAULT_THRESHOLD config property)
+
+**org-preferences-TC002 - Update organization threshold preferences**
+
+- **Description**: Verify that POST request successfully persists custom threshold for organization.
+- **Setup**:
+    - An organization has not configured any custom preferences
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with valid request body containing custom_threshold value
+- **Verification**:
+    - Verify response status code is 200
+    - Verify response contains the persisted custom_threshold value
+- **Expected Result**:
+    - HTTP 200 response
+    - Response custom_threshold matches the value from request body
+
+**org-preferences-TC003 - Retrieve custom threshold after update**
+
+- **Description**: Verify that GET request returns custom threshold after organization has configured preferences.
+- **Setup**:
+    - An organization has configured custom threshold via POST request
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences to set custom threshold
+    - Call GET /api/rhsm-subscriptions/v1/utilization/org-preferences to retrieve preferences
+- **Verification**:
+    - Verify GET response status code is 200
+    - Verify GET response contains the previously configured custom_threshold
+- **Expected Result**:
+    - HTTP 200 response
+    - Response custom_threshold matches the value set in previous POST request (not the system default)
+
+**org-preferences-TC004 - Update existing custom threshold**
+
+- **Description**: Verify that POST request can update previously configured threshold.
+- **Setup**:
+    - An organization has already configured custom threshold
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with initial custom_threshold value
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences again with different custom_threshold value
+    - Call GET /api/rhsm-subscriptions/v1/utilization/org-preferences to verify
+- **Verification**:
+    - Verify final GET response returns the updated threshold value
+- **Expected Result**:
+    - HTTP 200 response
+    - Response custom_threshold matches the second POST request value (not the first)
+
+**org-preferences-TC005 - Reject invalid threshold values**
+
+- **Description**: Verify that POST request rejects threshold values outside valid range (0-100).
+- **Setup**:
+    - An organization attempts to configure invalid threshold
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with custom_threshold value outside 0-100 range (e.g., -5 or 150)
+- **Verification**:
+    - Verify response status code is 400 Bad Request
+- **Expected Result**:
+    - HTTP 400 Bad Request response for threshold values < 0 or > 100
+
+**org-preferences-TC006 - Threshold value boundary validation**
+
+- **Description**: Verify that POST request accepts threshold values at boundaries (0 and 100).
+- **Setup**:
+    - An organization configures threshold at boundary values
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with custom_threshold = 0
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with custom_threshold = 100
+- **Verification**:
+    - Verify both requests return 200
+    - Verify responses contain the boundary values
+- **Expected Result**:
+    - HTTP 200 response for both 0 and 100 threshold values
+    - Response custom_threshold matches request value
+

--- a/swatch-utilization/ct/java/api/UtilizationSwatchService.java
+++ b/swatch-utilization/ct/java/api/UtilizationSwatchService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.securityHeadersWithServiceRole;
+import static org.apache.http.HttpStatus.SC_OK;
+
+import com.redhat.swatch.component.tests.api.SwatchService;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.util.Objects;
+
+public class UtilizationSwatchService extends SwatchService {
+
+  private static final String ORG_PREFERENCES_ENDPOINT =
+      "/api/rhsm-subscriptions/v1/utilization/org-preferences";
+
+  public Response getOrgPreferences(String orgId) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+
+    return given()
+        .headers(securityHeadersWithServiceRole(orgId))
+        .when()
+        .get(ORG_PREFERENCES_ENDPOINT);
+  }
+
+  public OrgPreferencesResponse getOrgPreferencesExpectSuccess(String orgId) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+
+    return getOrgPreferences(orgId)
+        .then()
+        .statusCode(SC_OK)
+        .extract()
+        .as(OrgPreferencesResponse.class);
+  }
+
+  public Response updateOrgPreferences(String orgId, OrgPreferencesRequest request) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(request, "request must not be null");
+
+    return given()
+        .headers(securityHeadersWithServiceRole(orgId))
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when()
+        .post(ORG_PREFERENCES_ENDPOINT);
+  }
+
+  public OrgPreferencesResponse updateOrgPreferencesExpectSuccess(
+      String orgId, OrgPreferencesRequest request) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(request, "request must not be null");
+
+    return updateOrgPreferences(orgId, request)
+        .then()
+        .statusCode(SC_OK)
+        .extract()
+        .as(OrgPreferencesResponse.class);
+  }
+}

--- a/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
+++ b/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
@@ -28,13 +28,13 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import api.UtilizationSwatchService;
 import api.UtilizationUnleashService;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.swatch.component.tests.api.ComponentTest;
 import com.redhat.swatch.component.tests.api.KafkaBridge;
 import com.redhat.swatch.component.tests.api.KafkaBridgeService;
 import com.redhat.swatch.component.tests.api.Quarkus;
-import com.redhat.swatch.component.tests.api.SwatchService;
 import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.configuration.registry.MetricId;
@@ -61,7 +61,7 @@ public class BaseUtilizationComponentTest {
   @Unleash static UtilizationUnleashService unleash = new UtilizationUnleashService();
 
   @Quarkus(service = "swatch-utilization")
-  static SwatchService service = new SwatchService();
+  static UtilizationSwatchService service = new UtilizationSwatchService();
 
   protected String orgId;
 

--- a/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
+
+  /** Matches ORG_PREFERENCE_DEFAULT_THRESHOLD in swatch-utilization application.properties */
+  private static final Integer DEFAULT_THRESHOLD = 80;
+
+  @TestPlanName("org-preferences-TC001")
+  @Test
+  void shouldRetrieveDefaultThresholdForOrganizationWithoutCustomPreferences() {
+    // Given: Organization has not configured any custom preferences
+
+    // When: Retrieving org preferences
+    OrgPreferencesResponse response = whenGetOrgPreferences();
+
+    // Then: Response contains system default threshold
+    assertNotNull(response, "Response should not be null");
+    assertNotNull(response.getCustomThreshold(), "Custom threshold should not be null");
+    assertEquals(
+        DEFAULT_THRESHOLD,
+        response.getCustomThreshold(),
+        "Should return system default threshold when org has no custom preferences");
+  }
+
+  @TestPlanName("org-preferences-TC002")
+  @Test
+  void shouldUpdateOrganizationThresholdPreferences() {
+    // Given: Organization has not configured any custom preferences
+    Integer customThreshold = 15;
+
+    // When: Updating org preferences with custom threshold
+    OrgPreferencesResponse postResponse = whenUpdateOrgPreferences(customThreshold);
+
+    // Then: Response contains the persisted custom threshold value
+    assertNotNull(postResponse, "POST response should not be null");
+    assertEquals(
+        customThreshold,
+        postResponse.getCustomThreshold(),
+        "POST response should contain custom threshold");
+
+    // Verify persistence by retrieving
+    OrgPreferencesResponse getResponse = whenGetOrgPreferences();
+    assertEquals(
+        customThreshold, getResponse.getCustomThreshold(), "GET should return persisted value");
+  }
+
+  @TestPlanName("org-preferences-TC003")
+  @Test
+  void shouldRetrieveCustomThresholdAfterUpdate() {
+    // Given: Organization has configured custom threshold
+    Integer customThreshold = 20;
+    whenUpdateOrgPreferences(customThreshold);
+
+    // When: Retrieving org preferences
+    OrgPreferencesResponse response = whenGetOrgPreferences();
+
+    // Then: Response contains the previously configured custom threshold (not system default)
+    assertNotNull(response, "Response should not be null");
+    assertEquals(
+        customThreshold,
+        response.getCustomThreshold(),
+        "Should return custom threshold, not system default");
+  }
+
+  @TestPlanName("org-preferences-TC004")
+  @Test
+  void shouldUpdateExistingCustomThreshold() {
+    // Given: Organization has already configured custom threshold
+    Integer initialThreshold = 10;
+    Integer updatedThreshold = 25;
+    whenUpdateOrgPreferences(initialThreshold);
+
+    // When: Updating threshold with different value
+    whenUpdateOrgPreferences(updatedThreshold);
+
+    // Then: Response contains updated threshold (not initial value)
+    OrgPreferencesResponse response = whenGetOrgPreferences();
+    assertEquals(
+        updatedThreshold,
+        response.getCustomThreshold(),
+        "Should return updated threshold, not initial threshold");
+  }
+
+  @TestPlanName("org-preferences-TC005")
+  @Test
+  void shouldRejectNegativeThresholdValues() {
+    // Given: Organization attempts to configure negative threshold
+
+    // When: Attempting to set threshold below minimum (< 0)
+    Response response = attemptUpdateOrgPreferences(-5);
+
+    // Then: Request is rejected with 400 Bad Request
+    assertEquals(
+        HttpStatus.SC_BAD_REQUEST,
+        response.statusCode(),
+        "Should reject negative threshold values with 400");
+  }
+
+  @TestPlanName("org-preferences-TC005")
+  @Test
+  void shouldRejectThresholdValuesAboveMaximum() {
+    // Given: Organization attempts to configure threshold above maximum
+
+    // When: Attempting to set threshold above 100
+    Response response = attemptUpdateOrgPreferences(150);
+
+    // Then: Request is rejected with 400 Bad Request
+    assertEquals(
+        HttpStatus.SC_BAD_REQUEST,
+        response.statusCode(),
+        "Should reject threshold values > 100 with 400");
+  }
+
+  @TestPlanName("org-preferences-TC006")
+  @Test
+  void shouldAcceptMinimumBoundaryValue() {
+    // Given: Organization configures threshold at minimum boundary
+
+    // When: Setting threshold to minimum boundary (0)
+    OrgPreferencesResponse response = whenUpdateOrgPreferences(0);
+
+    // Then: Request is accepted and returns boundary value
+    assertEquals(0, response.getCustomThreshold(), "Should accept threshold value 0");
+  }
+
+  @TestPlanName("org-preferences-TC006")
+  @Test
+  void shouldAcceptMaximumBoundaryValue() {
+    // Given: Organization configures threshold at maximum boundary
+
+    // When: Setting threshold to maximum boundary (100)
+    OrgPreferencesResponse response = whenUpdateOrgPreferences(100);
+
+    // Then: Request is accepted and returns boundary value
+    assertEquals(100, response.getCustomThreshold(), "Should accept threshold value 100");
+  }
+
+  private OrgPreferencesResponse whenGetOrgPreferences() {
+    return service.getOrgPreferencesExpectSuccess(orgId);
+  }
+
+  private OrgPreferencesResponse whenUpdateOrgPreferences(Integer customThreshold) {
+    OrgPreferencesRequest request = new OrgPreferencesRequest();
+    request.setCustomThreshold(customThreshold);
+    return service.updateOrgPreferencesExpectSuccess(orgId, request);
+  }
+
+  private Response attemptUpdateOrgPreferences(Integer customThreshold) {
+    OrgPreferencesRequest request = new OrgPreferencesRequest();
+    request.setCustomThreshold(customThreshold);
+    return service.updateOrgPreferences(orgId, request);
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4904

## Description
This PR adds component tests and updates the swatch-utilization test plan as part of [SWATCH-4789](https://redhat.atlassian.net/browse/SWATCH-4789) after the creation of the POST and GET endpoints for custom threshold in utilization service.

## Testing
1. podman compose up -d
1. make build component-test swatch-utilization


[SWATCH-4789]: https://redhat.atlassian.net/browse/SWATCH-4789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ