### PR TITLE
SWATCH-4751: Add additional tracing to swatch-billable-usage

### DIFF
--- a/config/otel/docker-compose.yml
+++ b/config/otel/docker-compose.yml
@@ -1,10 +1,20 @@
 ---
-version: '3.1'
 services:
   otel-collector:
-    image: otel/opentelemetry-collector:0.110.0
-    command: ["--config=/etc/otel-collector-config.yaml"]
+    image: jaegertracing/all-in-one:1.60
+    command: ["--config-file=/etc/otel-collector-config.yaml"]
     volumes:
-      - ./collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./collector-config.yaml:/etc/otel-collector-config.yaml:z
+    environment:
+      - COLLECTOR_ZIPKIN_HOST_PORT=9411
     ports:
-      - "4317:4317"   # OTLP gRPC receiver
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686" # UI
+      - "4317:4317" # OTLP gRPC receiver
+      - "4318:4318"
+      - "14250:14250"
+      - "14268:14268"
+      - "14269:14269"
+      - "9411:9411"

--- a/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallyWorkerConfiguration.java
@@ -233,8 +233,10 @@ public class TallyWorkerConfiguration {
 
   @Bean
   public KafkaTemplate<String, Event> eventKafkaTemplate(
-      ProducerFactory<String, Event> eventProducerFactory) {
-    return new KafkaTemplate<>(eventProducerFactory);
+      ProducerFactory<String, Event> eventProducerFactory, KafkaProperties kafkaProperties) {
+    KafkaTemplate<String, Event> kafkaTemplate = new KafkaTemplate<>(eventProducerFactory);
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 
   @Bean(name = "updatePrimaryTallySnapshotsTaskExecutor")
@@ -277,8 +279,12 @@ public class TallyWorkerConfiguration {
 
   @Bean
   public KafkaTemplate<String, String> eventDeadLetterKafkaTemplate(
-      ProducerFactory<String, String> eventDeadLetterProducerFactory) {
-    return new KafkaTemplate<>(eventDeadLetterProducerFactory);
+      ProducerFactory<String, String> eventDeadLetterProducerFactory,
+      KafkaProperties kafkaProperties) {
+    KafkaTemplate<String, String> kafkaTemplate =
+        new KafkaTemplate<>(eventDeadLetterProducerFactory);
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 
   @Bean
@@ -331,6 +337,9 @@ public class TallyWorkerConfiguration {
     // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
     factory.getContainerProperties().setConsumerRebalanceListener(registry);
     factory.setCommonErrorHandler(deadLetterErrorHandler);
+    factory
+        .getContainerProperties()
+        .setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
     return factory;
   }
 
@@ -376,8 +385,11 @@ public class TallyWorkerConfiguration {
   @Bean
   public KafkaTemplate<String, EnabledOrgsResponse> enabledOrgsKafkaTemplate(
       KafkaProperties kafkaProperties) {
-    return new KafkaTemplate<>(
-        new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties)));
+    KafkaTemplate<String, EnabledOrgsResponse> kafkaTemplate =
+        new KafkaTemplate<>(
+            new DefaultKafkaProducerFactory<>(getProducerProperties(kafkaProperties)));
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 
   @Bean
@@ -401,6 +413,9 @@ public class TallyWorkerConfiguration {
     }
     // hack to track the Kafka consumers, so SeekableKafkaConsumer can commit when needed
     factory.getContainerProperties().setConsumerRebalanceListener(registry);
+    factory
+        .getContainerProperties()
+        .setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
     return factory;
   }
 }

--- a/swatch-billable-usage/src/main/resources/application.properties
+++ b/swatch-billable-usage/src/main/resources/application.properties
@@ -78,6 +78,7 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=${DATABASE_USERNAME}
 quarkus.datasource.password=${DATABASE_PASSWORD}
 quarkus.datasource.jdbc.url=jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?ApplicationName=${quarkus.application.name:swatch-billable-usage}
+quarkus.datasource.jdbc.telemetry=true
 quarkus.datasource.metrics.enabled=true
 quarkus.hibernate-orm.schema-management.strategy=validate
 quarkus.hibernate-orm.log.sql=${LOGGING_SHOW_SQL_QUERIES:false}

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryServiceConfiguration.java
@@ -80,8 +80,8 @@ public class InventoryServiceConfiguration {
 
   @Bean
   public KafkaTemplate<String, CreateUpdateHostMessage> inventoryServiceKafkaProducerTemplate(
-      ProducerFactory<String, CreateUpdateHostMessage> factory) {
-    return kafkaConfigurator.taskMessageKafkaTemplate(factory);
+      ProducerFactory<String, CreateUpdateHostMessage> factory, KafkaProperties kafkaProperties) {
+    return kafkaConfigurator.taskMessageKafkaTemplate(factory, kafkaProperties);
   }
 
   @Bean

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/InventoryServiceKafkaConfigurator.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/kafka/InventoryServiceKafkaConfigurator.java
@@ -54,7 +54,9 @@ public class InventoryServiceKafkaConfigurator {
   }
 
   public KafkaTemplate<String, CreateUpdateHostMessage> taskMessageKafkaTemplate(
-      ProducerFactory<String, CreateUpdateHostMessage> factory) {
-    return new KafkaTemplate<>(factory);
+      ProducerFactory<String, CreateUpdateHostMessage> factory, KafkaProperties kafkaProperties) {
+    KafkaTemplate<String, CreateUpdateHostMessage> kafkaTemplate = new KafkaTemplate<>(factory);
+    kafkaTemplate.setObservationEnabled(kafkaProperties.getTemplate().isObservationEnabled());
+    return kafkaTemplate;
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-4751

## Description
This PR enabled JDBC tracing in swatch-billable-usage.  It also does a little
extra configuration for swatch-tally to prevent regressions in case we ever
change the tracing approach.

## Testing

### Setup
1. Start the Jaeger All-In-One compose so events can be gathered and viewed.
    ```shell
    podman compose --file config/otel/docker-compose.yml up -d
    ```

1. Open the [Jaeger UI](http://localhost:16686).

### Steps
1. Start swatch-tally with OTEL enabled.
    ```
    JAVA_TOOL_OPTIONS="-javaagent:$(git rev-parse --show-toplevel)/swatch-tally/target/javaagent/splunk-otel-javaagent.jar" \
    OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
    OTEL_SERVICE_NAME=swatch-tally \
    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
    OTEL_JAVAAGENT_ENABLED=true \
    OTEL_TRACES_EXPORTER=otlp \
    OTEL_METRICS_EXPORTER=none \
    OTEL_LOGS_EXPORTER=none \
    make swatch-tally
    ```
1. Start swatch-billable-usage with OTEL enabled
    ```
    OTEL_DISABLED=false make swatch-billable-usage
    ```
1. Run an IQE test against localhost that will use swatch-billable-usage.
    ```
    ENV_FOR_DYNACONF=local iqe tests plugin rhsm_subscriptions -k test_billing_account_id_endpoint_via_instances
    ```

### Verification
1. Check the Jaeger UI; select `swatch-billable-usage` in the service drop down.
1. Pick a trace that crosses between swatch-tally and swatch-billable usage so
   you'll get a trace that has some database activity.
1. View the DB queries

<img width="1392" height="443" alt="Selection_027" src="https://github.com/user-attachments/assets/be0be9be-3017-4a2f-b298-04e8524bf95d" />
