### PR TITLE
SWATCH-4948: Propagate product service failures when offering sync API

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -920,6 +920,14 @@ This section verifies the automatic contract termination behavior when contracts
   - Product tag returned matches expected value for unlimited offering.
   - Offering synchronization completes without errors.
 
+**offering-sync-TC005: Upstream product service unavailable during offering sync**
+- **Description:** Verify that when the upstream product API returns HTTP 503 for the product tree, `syncOffering` returns the same HTTP status (503), not HTTP 404.
+- **Setup:** Stub the product tree endpoint (WireMock) to return 503 for the test SKU.
+- **Action:** Call internal sync offering for that SKU.
+- **Verification:** Response status matches upstream (503).
+- **Expected Result:**
+  - Callers can distinguish upstream unavailability from “offering not found”; status code reflects the product API response.
+
 ## Product Tag Management
 
 **offering-tags-TC001: Retrieve product tags for synchronized offering**

--- a/swatch-contracts/ct/java/api/ProductApiStubs.java
+++ b/swatch-contracts/ct/java/api/ProductApiStubs.java
@@ -23,6 +23,7 @@ package api;
 import domain.Offering;
 import java.util.ArrayList;
 import java.util.Map;
+import org.apache.http.HttpStatus;
 
 /** Facade for stubbing Product API (Offering) endpoints. */
 public class ProductApiStubs {
@@ -126,27 +127,47 @@ public class ProductApiStubs {
 
     var responseBody = Map.of("products", java.util.List.of(product));
 
+    registerProductTreeStub(
+        offering.getSku(),
+        9,
+        Map.of(
+            "status",
+            HttpStatus.SC_OK,
+            "headers",
+            Map.of("Content-Type", "application/json"),
+            "jsonBody",
+            responseBody));
+  }
+
+  public void stubUpstreamProductTreeReturnsServiceUnavailable(String sku) {
+    registerProductTreeStub(
+        sku,
+        1,
+        Map.of(
+            "status",
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            "headers",
+            Map.of("Content-Type", "text/plain"),
+            "body",
+            "Service Unavailable"));
+  }
+
+  private static String productTreeUrlPattern(String sku) {
+    return String.format("/mock/product/products/%s/tree.*", sku);
+  }
+
+  private void registerProductTreeStub(String sku, int priority, Map<String, Object> response) {
     wiremockService
         .given()
         .contentType("application/json")
         .body(
             Map.of(
                 "request",
-                Map.of(
-                    "method",
-                    "GET",
-                    "urlPathPattern",
-                    String.format("/mock/product/products/%s/tree.*", offering.getSku())),
+                Map.of("method", "GET", "urlPathPattern", productTreeUrlPattern(sku)),
                 "response",
-                Map.of(
-                    "status",
-                    200,
-                    "headers",
-                    Map.of("Content-Type", "application/json"),
-                    "jsonBody",
-                    responseBody),
+                response,
                 "priority",
-                9,
+                priority,
                 "metadata",
                 wiremockService.getMetadataTags()))
         .when()

--- a/swatch-contracts/ct/java/tests/OfferingSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/OfferingSyncComponentTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -146,6 +147,23 @@ public class OfferingSyncComponentTest extends BaseContractComponentTest {
         productTags,
         "RHEL for x86",
         "Product tag should match expected value for unlimited RHEL offering");
+  }
+
+  @TestPlanName("offering-sync-TC005")
+  @Test
+  void shouldPropagate503WhenUpstreamProductTreeReturns503() {
+    // Given: Upstream product API returns 503 for the product tree request
+    String sku = "SKU_503_" + RandomUtils.generateRandom();
+    wiremock.forProductAPI().stubUpstreamProductTreeReturnsServiceUnavailable(sku);
+
+    // When: syncOffering is invoked
+    Response syncResponse = whenOfferingIsSynced(sku);
+
+    // Then: Same HTTP status as upstream (not 404 / not a generic 500)
+    assertEquals(
+        HttpStatus.SC_SERVICE_UNAVAILABLE,
+        syncResponse.statusCode(),
+        "syncOffering should return 503 when upstream product service returns 503");
   }
 
   /**

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -128,13 +128,17 @@ public class UpstreamProductData {
           .map(mid -> mid.fetchAndAddEngProdsIfExist(productDataSource))
           .map(UpstreamProductData::toOffering);
     } catch (ApiException e) {
+      int apiExceptionStatus = e.getResponse().getStatus();
+      Response.Status mappedStatus =
+          Optional.ofNullable(Response.Status.fromStatusCode(apiExceptionStatus))
+              .orElse(Response.Status.INTERNAL_SERVER_ERROR);
       throw new ServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR,
-          Response.Status.INTERNAL_SERVER_ERROR,
+          mappedStatus,
           "Unable to retrieve upstream offeringSku=" + sku,
           String.format(
               "Unable to retrieve upstream offeringSku=\"%s\". API returned status: %s, message: %s, and responseBody: %s",
-              sku, e.getResponse().getStatus(), e.getMessage(), e.getResponse().getEntity()),
+              sku, apiExceptionStatus, e.getMessage(), e.getResponse().getEntity()),
           e);
     }
   }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -67,6 +67,8 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -384,7 +386,11 @@ public class ContractsResource implements DefaultApi {
       response.detail(String.format("%s for offeringSku=\"%s\".", result, sku));
     } catch (RuntimeException e) {
       if (e.getCause() instanceof ApiException apiException) {
-        switch (apiException.getResponse().getStatus()) {
+        int apiExceptionStatus = apiException.getResponse().getStatus();
+        if (apiExceptionStatus < 100 || apiExceptionStatus > 599) {
+          throw new InternalServerErrorException(apiException.getMessage());
+        }
+        switch (apiExceptionStatus) {
           case 400:
             throw new BadRequestException(apiException.getMessage());
           case 403:
@@ -392,7 +398,8 @@ public class ContractsResource implements DefaultApi {
           case 404:
             throw new NotFoundException(apiException.getMessage());
           default:
-            throw new InternalServerErrorException(apiException.getMessage());
+            throw new WebApplicationException(
+                Response.status(apiExceptionStatus).entity(apiException.getMessage()).build());
         }
       }
       throw new InternalServerErrorException(e.getMessage());

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.openapi.model.Error;
 import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -46,6 +47,11 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
       return Response.status(e.getStatus()).entity(e.error()).build();
     } else if (exception instanceof ClientErrorException clientErrorException) {
       return Response.status(clientErrorException.getResponse().getStatus()).build();
+    } else if (exception instanceof WebApplicationException webApplicationException) {
+      Response webResponse = webApplicationException.getResponse();
+      if (webResponse != null) {
+        return webResponse;
+      }
     }
 
     var status = Status.INTERNAL_SERVER_ERROR;

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
@@ -133,14 +133,9 @@ public class OfferingSyncService {
    */
   private Optional<OfferingEntity> getUpstreamOffering(String sku) {
     log.debug("Retrieving product tree for offeringSku=\"{}\"", sku);
-    try {
-      var offering = UpstreamProductData.offeringFromUpstream(sku, productService);
-      discoverProductTagsBySku(offering);
-      return offering;
-    } catch (ServiceException e) {
-      log.error("Unable to retrieve offering from upstream ", e);
-      return Optional.empty();
-    }
+    var offering = UpstreamProductData.offeringFromUpstream(sku, productService);
+    discoverProductTagsBySku(offering);
+    return offering;
   }
 
   /**

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -85,7 +85,6 @@ class ContractsResourceTest {
 
   private static final String SKU = "mw123";
   private static final String ORG_ID = "org123";
-  private static final String ANOTHER_ORG_ID = "org456";
   private static final String ROSA = "rosa";
   private static final String SYNC_ALL_CONTRACTS_ENDPOINT =
       "/api/swatch-contracts/internal/rpc/contracts/sync";
@@ -270,6 +269,14 @@ class ContractsResourceTest {
         .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(400);
+
+    when(r.getStatus()).thenReturn(503);
+    doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
+    given()
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .then()
+        .statusCode(503);
 
     when(r.getStatus()).thenReturn(0);
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));


### PR DESCRIPTION
Jira issue: SWATCH-4948

## Description
This change updates how PUT /api/swatch-contracts/internal/rpc/offerings/sync/{sku} handles failures from the product service. The API now keeps the same HTTP status as the upstream call when it is not a “not found” case (e.g. 503 stays 503 instead of being turned into 404 or a generic 500), and DefaultExceptionMapper is fixed so WebApplicationException responses are not always mapped to 500.

Scope is limited to the internal offering sync API and its error handling. The UMB offering consumer and related messaging paths are unchanged—UpstreamProductData.offeringUpstream and the UMB flow still catch upstream errors and avoid breaking the AMQP consumer, as before. Component and unit tests were updated accordingly.

## Testing
Added new component test with the scenario. 