### PR TITLE
SWATCH-4784: Add feature flag to the IT Partner Gateway Kafka/UMB consumers

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -50,6 +50,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify that an AWS PAYG contract can be successfully created with valid partner entitlement data, metrics, and subscription ID.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic `contracts` is available  
   - Prepare a valid AWS partner entitlement message  
 - **Action:**  
@@ -70,6 +71,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description:** Verify that a contract can be successfully created with valid partner entitlement data, metrics, and subscription ID.  
 - **Setup:**   
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic `contracts` is available  
   - Prepare a valid AWS partner entitlement message  
 - **Action:**     
@@ -86,6 +88,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify that a contract can be successfully created with valid partner entitlement data, metrics, and subscription ID.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic available  
   - Prepare a valid Azure partner entitlement message  
 - **Action**:  
@@ -106,6 +109,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify that a contract can be successfully created with valid partner entitlement data, metrics, and subscription ID.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic available  
   - Prepare a valid Azure partner entitlement message  
 - **Action**:  
@@ -126,6 +130,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify contracts can store multiple metrics from partner entitlement dimensions.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic available  
   - Prepare a valid partner entitlement message with multiple metrics/dimensions  
 - **Action**:  
@@ -143,6 +148,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**:  Verify contracts with multiple metrics/dimensions where one of those metrics is an invalid metric, and generate a valid contract with the valid metric.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic available  
   - Prepare a valid partner entitlement message with multiple metrics/dimensions where one of those metrics is invalid.  
 - **Action**:  
@@ -160,6 +166,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify validation errors are handled gracefully.  
 - **Setup**:   
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Kafka topic available  
   - Prepare an invalid partner entitlement message with missing required fields.  
 - **Action**:  
@@ -176,6 +183,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Description**: Verify that an AWS PAYG contract can be successfully created when receiving the message as an object instead of text.
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-partner-gateway-contracts` is enabled (UMB contract consumer from IT Partner Gateway)
   - Prepare a valid AWS partner entitlement message
 - **Action:**
   - Publish message to UMB channel as an object instead of text

--- a/swatch-contracts/ct/README.md
+++ b/swatch-contracts/ct/README.md
@@ -7,7 +7,7 @@
 Start the required local services using Docker Compose:
 
 ```bash
-podman compose up -d kafka kafka-bridge kafka-setup amqp wiremock db
+podman compose up -d kafka kafka-bridge kafka-setup unleash amqp wiremock db
 ```
 
 This will start all necessary dependencies (databases, Kafka, etc.) required for the component tests.

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import com.redhat.swatch.component.tests.api.UnleashService;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+
+public class ContractsUnleashService extends UnleashService {
+
+  public static final String PARTNER_GATEWAY_CONTRACTS =
+      "swatch.swatch-contracts.enable-partner-gateway-contracts";
+
+  public void enablePartnerGatewayContracts() {
+    enableFlag(PARTNER_GATEWAY_CONTRACTS);
+    AwaitilityUtils.until(
+        () -> isFlagEnabled(PARTNER_GATEWAY_CONTRACTS),
+        enabled -> enabled,
+        AwaitilitySettings.defaults()
+            .timeoutMessage(
+                "Unleash toggle '%s' should be enabled".formatted(PARTNER_GATEWAY_CONTRACTS)));
+  }
+
+  public void disablePartnerGatewayContracts() {
+    disableFlag(PARTNER_GATEWAY_CONTRACTS);
+  }
+}

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -26,11 +26,13 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import api.ContractsSwatchService;
+import api.ContractsUnleashService;
 import api.ContractsWiremockService;
 import com.redhat.swatch.component.tests.api.ComponentTest;
 import com.redhat.swatch.component.tests.api.KafkaBridge;
 import com.redhat.swatch.component.tests.api.KafkaBridgeService;
 import com.redhat.swatch.component.tests.api.Quarkus;
+import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.api.Wiremock;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
@@ -70,6 +72,8 @@ public class BaseContractComponentTest {
 
   @Quarkus(service = "swatch-contracts")
   static ContractsSwatchService service = new ContractsSwatchService();
+
+  @Unleash static ContractsUnleashService unleash = new ContractsUnleashService();
 
   protected static final ApplicationClock clock = new ApplicationClock();
 

--- a/swatch-contracts/ct/java/tests/ContractCreationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractCreationComponentTest.java
@@ -42,6 +42,8 @@ import io.restassured.response.Response;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ContractCreationComponentTest extends BaseContractComponentTest {
@@ -50,6 +52,16 @@ public class ContractCreationComponentTest extends BaseContractComponentTest {
   private static final double INSTANCE_HOURS_CAPACITY = 18.0;
 
   @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
+
+  @BeforeAll
+  static void enablePartnerGatewayContractsFeatureFlag() {
+    unleash.enablePartnerGatewayContracts();
+  }
+
+  @AfterAll
+  static void disablePartnerGatewayContractsFeatureFlag() {
+    unleash.disablePartnerGatewayContracts();
+  }
 
   @Test
   void shouldCreatePrepaidRosaContract_whenAllDataIsValid() {

--- a/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
@@ -52,7 +52,9 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ContractsTerminationComponentTest extends BaseContractComponentTest {
@@ -62,6 +64,16 @@ public class ContractsTerminationComponentTest extends BaseContractComponentTest
   private static final double RHEL_SOCKETS_CAPACITY = 1.0;
 
   @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
+
+  @BeforeAll
+  static void enablePartnerGatewayContractsFeatureFlag() {
+    unleash.enablePartnerGatewayContracts();
+  }
+
+  @AfterAll
+  static void disablePartnerGatewayContractsFeatureFlag() {
+    unleash.disablePartnerGatewayContracts();
+  }
 
   @TestPlanName("contracts-termination-TC001")
   @Test

--- a/swatch-contracts/ct/java/tests/ContractsUpdateComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsUpdateComponentTest.java
@@ -50,6 +50,8 @@ public class ContractsUpdateComponentTest extends BaseContractComponentTest {
   @TestPlanName("contracts-update-TC001")
   @Test
   void shouldUpdateExistingContractWhenReceivingAnUpdateEvent() {
+    unleash.enablePartnerGatewayContracts();
+
     // given: An initial contract is created via UMB message
     Contract initialContract = givenContractCreatedViaMessageBroker();
 
@@ -70,6 +72,8 @@ public class ContractsUpdateComponentTest extends BaseContractComponentTest {
   @TestPlanName("contracts-update-TC002")
   @Test
   void shouldProcessRedundantContractMessage() {
+    unleash.enablePartnerGatewayContracts();
+
     // given: An initial contract is created via UMB message
     Contract contract = givenContractCreatedViaMessageBroker();
 

--- a/swatch-contracts/ct/pom.xml
+++ b/swatch-contracts/ct/pom.xml
@@ -94,6 +94,18 @@
               </sourcePaths>
             </configuration>
           </execution>
+          <execution>
+            <id>from-swatch-contracts</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${maven.multiModuleProjectDirectory}/swatch-contracts/schemas</sourceDirectory>
+              <sourcePaths>
+                <sourcePath>enable_partner_gateway_contracts_variant_payload.yaml</sourcePath>
+              </sourcePaths>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/swatch-contracts/ct/resources/test.properties
+++ b/swatch-contracts/ct/resources/test.properties
@@ -1,2 +1,3 @@
 swatch.component-tests.services.kafkaBridge.log.enabled=false
 swatch.component-tests.services.wiremock.log.enabled=false
+swatch.component-tests.services.unleash.log.enabled=false

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -167,6 +167,8 @@ objects:
         - rbac
         - export-service
 
+      featureFlags: true
+
       kafkaTopics:
         - replicas: ${{KAFKA_ENABLED_ORGS_REPLICAS}}
           partitions: ${{KAFKA_ENABLED_ORGS_PARTITIONS}}

--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -137,6 +137,10 @@
       <artifactId>swatch-common-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkiverse.unleash</groupId>
+      <artifactId>quarkus-unleash</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.redhat.cloud.common</groupId>
       <artifactId>clowder-quarkus-config-source</artifactId>
     </dependency>
@@ -343,6 +347,7 @@
                 <sourcePath>subscriptions_export_json.yaml</sourcePath>
                 <sourcePath>subscriptions_export_json_item.yaml</sourcePath>
                 <sourcePath>subscriptions_export_json_measurement.yaml</sourcePath>
+                <sourcePath>enable_partner_gateway_contracts_variant_payload.yaml</sourcePath>
               </sourcePaths>
             </configuration>
           </execution>

--- a/swatch-contracts/schemas/partner_gateway_contracts_feature_flag_variant_payload.yaml
+++ b/swatch-contracts/schemas/partner_gateway_contracts_feature_flag_variant_payload.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: PartnerGatewayContractsFeatureFlagVariantPayload
+description: JSON payload for the enable-partner-gateway-contracts feature toggle variant.
+type: object
+properties:
+  kafka_consumer_enabled:
+    description: If the kafka consumer is enabled.
+    type: boolean
+    default: true
+  umb_consumer_enabled:
+    description: If the UMB consumer is enabled.
+    type: boolean
+    default: true

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.model.PartnerGatewayContractsFeatureFlagVariantPayload;
+import io.getunleash.Unleash;
+import io.getunleash.variant.Variant;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+@AllArgsConstructor
+public class FeatureFlags {
+  public static final String PARTNER_GATEWAY_CONTRACTS =
+      "swatch.swatch-contracts.enable-partner-gateway-contracts";
+  public static final String CONFIG_VARIANT = "config";
+
+  protected static final boolean DEFAULT_IS_ENABLED = true;
+
+  private final Unleash unleash;
+  private final ObjectMapper mapper;
+
+  /** Whether the Kafka consumer for partner-gateway contracts is allowed. */
+  public boolean isPartnerGatewayContractsKafkaConsumerEnabled() {
+    return isPartnerGatewayContractsEnabled(
+        PartnerGatewayContractsFeatureFlagVariantPayload::getKafkaConsumerEnabled);
+  }
+
+  /** Whether the UMB consumer for partner-gateway contracts is allowed. */
+  public boolean isPartnerGatewayContractsUmbConsumerEnabled() {
+    return isPartnerGatewayContractsEnabled(
+        PartnerGatewayContractsFeatureFlagVariantPayload::getUmbConsumerEnabled);
+  }
+
+  /**
+   * If {@value #PARTNER_GATEWAY_CONTRACTS} is disabled, returns {@code false}.
+   *
+   * <p>If the toggle is enabled and Unleash returns a variant whose name is not {@value
+   * #CONFIG_VARIANT}, returns {@code true} (no structured payload to interpret).
+   *
+   * <p>If the variant is named {@value #CONFIG_VARIANT} but {@link Variant#isEnabled()} is {@code
+   * false}, returns {@code true}.
+   *
+   * <p>If the variant is {@value #CONFIG_VARIANT} and enabled, the variant payload is parsed as
+   * JSON; this method returns the consumer_enabled flag from that object. Missing payload, invalid
+   * JSON, or a null/false flag yields {@code true}.
+   */
+  private boolean isPartnerGatewayContractsEnabled(
+      Function<PartnerGatewayContractsFeatureFlagVariantPayload, Boolean> condition) {
+    if (!unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)) {
+      return false;
+    }
+
+    Variant variant = unleash.getVariant(PARTNER_GATEWAY_CONTRACTS);
+    if (!CONFIG_VARIANT.equals(variant.getName())) {
+      log.debug("Feature flag '{}' with no valid variant '{}'", PARTNER_GATEWAY_CONTRACTS, variant);
+      return true;
+    }
+
+    if (!variant.isEnabled()) {
+      return true;
+    }
+
+    return mapToPartnerGatewayContractsPayload(variant).map(condition).orElse(true);
+  }
+
+  private Optional<PartnerGatewayContractsFeatureFlagVariantPayload>
+      mapToPartnerGatewayContractsPayload(Variant variant) {
+    var payload = variant.getPayload();
+    if (payload.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String payloadValue = payload.get().getValue();
+    try {
+      return Optional.ofNullable(
+          mapper.readValue(payloadValue, PartnerGatewayContractsFeatureFlagVariantPayload.class));
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "Failed to parse the payload '{}' for feature flag '{}'",
+          payloadValue,
+          PARTNER_GATEWAY_CONTRACTS,
+          e);
+      return Optional.empty();
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractUMBMessageConsumer.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.resource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.exception.CreateContractException;
 import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
@@ -41,6 +42,7 @@ public class ContractUMBMessageConsumer {
 
   @Inject ObjectMapper mapper;
   @Inject ContractService service;
+  @Inject FeatureFlags featureFlags;
 
   @ConfigProperty(name = "UMB_ENABLED")
   boolean umbEnabled;
@@ -49,6 +51,11 @@ public class ContractUMBMessageConsumer {
   @Incoming("contracts")
   public void consumeMessage(Object dtoContract) {
     log.info("Consumer was called");
+    if (!featureFlags.isPartnerGatewayContractsUmbConsumerEnabled()) {
+      log.debug("IT Partner UMB consumer for contracts is disabled by feature flag.");
+      return;
+    }
+
     if (umbEnabled && dtoContract != null) {
       try {
         String dtoContractString = MessageUtils.toString(dtoContract);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.contract.resource;
 import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -34,11 +35,17 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 @Slf4j
 public class ContractsPartnerEntitlementMessageConsumer {
 
+  @Inject FeatureFlags featureFlags;
   @Inject ObjectMapper mapper;
 
   @Blocking
   @Incoming(CONTRACTS_FROM_GATEWAY)
   public void consumeMessage(String dtoContract) {
+    if (!featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()) {
+      log.debug("IT Partner Kafka consumer for contracts is disabled by feature flag.");
+      return;
+    }
+
     log.debug("IT Partner Kafka consumer was called");
     if (dtoContract == null) {
       return;

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -395,6 +395,18 @@ quarkus.smallrye-openapi.management.enabled=false
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/api/${quarkus.application.name}/internal/swagger-ui
 
+# Unleash configuration
+quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
+quarkus.unleash.url=${UNLEASH_URL:http://localhost:4242/api}
+quarkus.unleash.token=${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
+quarkus.unleash.name-prefix=swatch
+## Disable the service in the test environment so that we can mock the service.
+%test.quarkus.unleash.active=false
+## Dev configuration
+%dev.quarkus.unleash.fetch-toggles-interval=1
+## Ephemeral configuration
+%ephemeral.quarkus.unleash.fetch-toggles-interval=1
+
 rhsm-subscriptions.subscription-sync-enabled=${SUBSCRIPTION_SYNC_ENABLED:true}
 
 # Disable Micrometer JVM-Metrics for tests.

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.config;
+
+import static com.redhat.swatch.contract.config.FeatureFlags.CONFIG_VARIANT;
+import static com.redhat.swatch.contract.config.FeatureFlags.DEFAULT_IS_ENABLED;
+import static com.redhat.swatch.contract.config.FeatureFlags.PARTNER_GATEWAY_CONTRACTS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.getunleash.Unleash;
+import io.getunleash.variant.Payload;
+import io.getunleash.variant.Variant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagsTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Mock Unleash unleash;
+  FeatureFlags featureFlags;
+
+  @BeforeEach
+  void setUp() {
+    featureFlags = new FeatureFlags(unleash, OBJECT_MAPPER);
+  }
+
+  @Test
+  void shouldReturnFalse_whenPartnerGatewayContractsDisabled_forKafka() {
+    when(unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)).thenReturn(false);
+
+    assertFalse(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnFalse_whenPartnerGatewayContractsDisabled_forUmb() {
+    when(unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)).thenReturn(false);
+
+    assertFalse(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenToggleEnabledAndVariantIsNotConfig_forKafka() {
+    givenPartnerGatewayContractsEnabledWithVariant(
+        new Variant("disabled", new Payload("json", "{}"), true, "any", true));
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenToggleEnabledAndVariantIsNotConfig_forUmb() {
+    givenPartnerGatewayContractsEnabledWithVariant(
+        new Variant("disabled", new Payload("json", "{}"), true, "any", true));
+
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantNotEnabled_forKafka() {
+    givenPartnerGatewayContractsEnabledWithVariant(
+        new Variant(
+            CONFIG_VARIANT,
+            new Payload("json", "{\"kafka_consumer_enabled\":false}"),
+            false,
+            "any",
+            true));
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantNotEnabled_forUmb() {
+    givenPartnerGatewayContractsEnabledWithVariant(
+        new Variant(
+            CONFIG_VARIANT,
+            new Payload("json", "{\"umb_consumer_enabled\":false}"),
+            false,
+            "any",
+            true));
+
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withKafkaTrueInPayload() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{\"kafka_consumer_enabled\":true}");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnFalse_whenConfigVariantEnabled_withKafkaFalseInPayload() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{\"kafka_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withUmbTrueInPayload() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{\"umb_consumer_enabled\":true}");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnFalse_whenConfigVariantEnabled_withUmbFalseInPayload() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{\"umb_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withEmptyJsonObject_forKafka() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{}");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withEmptyJsonObject_forUmb() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{}");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldDecoupleKafkaAndUmb_whenConfigVariantEnabled_withBothFlagsInPayload() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload(
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
+
+    assertFalse(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withEmptyPayloadValue_forKafka() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withInvalidJsonPayload_forKafka() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{invalid");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldReturnTrue_whenConfigVariantEnabled_withInvalidJsonPayload_forUmb() {
+    givenPartnerGatewayContractsEnabledWithConfigPayload("{invalid");
+
+    assertTrue(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled());
+  }
+
+  private void givenPartnerGatewayContractsEnabledWithConfigPayload(String json) {
+    givenPartnerGatewayContractsEnabledWithVariant(
+        new Variant(CONFIG_VARIANT, new Payload("json", json), true, "any", true));
+  }
+
+  private void givenPartnerGatewayContractsEnabledWithVariant(Variant variant) {
+    when(unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)).thenReturn(true);
+    when(unleash.getVariant(PARTNER_GATEWAY_CONTRACTS)).thenReturn(variant);
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractUMBMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractUMBMessageConsumerTest.java
@@ -22,8 +22,11 @@ package com.redhat.swatch.contract.resource;
 
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.service.ContractService;
@@ -65,6 +68,7 @@ class ContractUMBMessageConsumerTest {
 
   @InjectMock ContractService contractService;
 
+  @InjectMock FeatureFlags featureFlags;
   @Inject @Any InMemoryConnector connector;
 
   private InMemorySource<Object> contractsChannel;
@@ -72,7 +76,9 @@ class ContractUMBMessageConsumerTest {
   @BeforeEach
   void setUp() {
     contractsChannel = connector.source(CONTRACTS_CHANNEL);
-    Mockito.reset(contractService);
+    Mockito.reset(contractService, featureFlags);
+
+    when(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled()).thenReturn(true);
 
     // Configure mock to return a success response
     StatusResponse mockResponse = new StatusResponse();
@@ -105,6 +111,13 @@ class ContractUMBMessageConsumerTest {
     assertMessageIsProcessed();
   }
 
+  @Test
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
+    when(featureFlags.isPartnerGatewayContractsUmbConsumerEnabled()).thenReturn(false);
+    whenSendMessage(VALID_JSON_MESSAGE);
+    assertMessageIsNotProcessed();
+  }
+
   private void whenSendMessage(Object message) {
     contractsChannel.send(message);
   }
@@ -115,6 +128,15 @@ class ContractUMBMessageConsumerTest {
         .untilAsserted(
             () ->
                 verify(contractService)
+                    .createPartnerContract(any(PartnerEntitlementsRequest.class)));
+  }
+
+  private void assertMessageIsNotProcessed() {
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                verify(contractService, never())
                     .createPartnerContract(any(PartnerEntitlementsRequest.class)));
   }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
@@ -23,8 +23,12 @@ package com.redhat.swatch.contract.resource;
 import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.contract.config.FeatureFlags;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
@@ -57,6 +61,7 @@ class ContractsPartnerEntitlementMessageConsumerTest {
 
   @Inject @Any InMemoryConnector connector;
 
+  @InjectMock FeatureFlags featureFlags;
   @InjectSpy ContractsPartnerEntitlementMessageConsumer consumer;
 
   private InMemorySource<Object> contractsKafkaChannel;
@@ -64,12 +69,20 @@ class ContractsPartnerEntitlementMessageConsumerTest {
   @BeforeEach
   void setUp() {
     contractsKafkaChannel = connector.source(CONTRACTS_FROM_GATEWAY);
+    when(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()).thenReturn(true);
   }
 
   @Test
   void shouldProcessStringMessage() {
     whenSendMessage(VALID_JSON_MESSAGE);
     assertMessageIsProcessed();
+  }
+
+  @Test
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
+    when(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()).thenReturn(false);
+    whenSendMessage(VALID_JSON_MESSAGE);
+    assertMessageIsNotProcessed();
   }
 
   private void whenSendMessage(String message) {
@@ -80,5 +93,11 @@ class ContractsPartnerEntitlementMessageConsumerTest {
     await()
         .atMost(Duration.ofMillis(500))
         .untilAsserted(() -> verify(consumer).consumeContract(anyString()));
+  }
+
+  private void assertMessageIsNotProcessed() {
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(() -> verify(consumer, never()).consumeContract(anyString()));
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-4784

## Description
Update the IT Partner Gateway Kafka and UMB contract consumers behind Unleash (feature flags), with optional structured config variant payload to turn each consumer on or off independently.

Changes:
- FeatureFlags: New helper that reads `swatch.swatch-contracts.enable-partner-gateway-contracts` and, when the variant is config with JSON payload, applies kafka_consumer_enabled / umb_consumer_enabled.
- Consumers: ContractsPartnerEntitlementMessageConsumer and ContractUMBMessageConsumer return early when the corresponding flag path is disabled (with debug logging).
- Schema / build: partner_gateway_contracts_feature_flag_variant_payload.yaml plus pom.xml updates so the payload model is generated for FeatureFlags.
- Runtime: application.properties — Quarkus Unleash client settings (URL, token, name-prefix, profiles for test/dev/ephemeral). deploy/clowdapp.yaml — featureFlags: true on the deployment so Unleash is available in managed environments.

### Follow-up (separate MR in app-interface)

After this PR is approved, a separate MR in app-interface will add the swatch.swatch-contracts.enable-partner-gateway-contracts feature flag (and environment rollout as appropriate), including a config variant whose string payload is JSON, for example:

```json
{"kafka_consumer_enabled": true, "umb_consumer_enabled": true}
```

## Testing
- Unit tests: FeatureFlagsTest and updates to both consumer tests for enabled/disabled behaviour.
- Component tests / plan: ContractsUnleashService + @Unleash / @BeforeEach in ContractCreationComponentTest to enable the toggle before UMB-driven contract creation tests; TEST_PLAN.md setup updated; ct/README.md, ct/pom.xml, and ct/resources/test.properties adjusted as needed.