### PR TITLE
SWATCH-4855 Add is_primary column to host_tally_buckets

### DIFF
--- a/src/main/resources/liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml
+++ b/src/main/resources/liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+    <changeSet id="202604301200-01" author="mstead">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="host_tally_buckets" columnName="is_primary"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="host_tally_buckets">
+            <column name="is_primary" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="host_tally_buckets" columnName="is_primary"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -207,5 +207,6 @@
     <include file="liquibase/202602241326-add-org-prod-snap-date-idx.xml"/>
     <include file="liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml"/>
     <include file="liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml"/>
+    <include file="liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/HostTallyBucketRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/HostTallyBucketRepositoryTest.java
@@ -21,6 +21,8 @@
 package org.candlepin.subscriptions.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
@@ -153,6 +155,78 @@ class HostTallyBucketRepositoryTest {
 
     AccountBucketTally abt = tallies.get(0);
     assertBucketTally(abt, null, null, 1.0);
+  }
+
+  @Transactional
+  @Test
+  void testIsPrimaryCanBeSetOnInsert() {
+    AccountServiceInventory account = new AccountServiceInventory("org123", "HBI_HOST");
+
+    Host h1 = createHost("inv1", "org123");
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(
+        new HostBucketKey(
+            h1, "P1", ServiceLevel._ANY, Usage._ANY, BillingProvider.RED_HAT, "redhat1", false));
+    bucket.setHost(h1);
+    bucket.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+    bucket.setPrimary(true);
+    h1.addBucket(bucket);
+    account.getServiceInstances().put(h1.getInstanceId(), h1);
+
+    accountRepo.save(account);
+    accountRepo.flush();
+
+    var accountId = account.getId();
+    String instanceId = h1.getInstanceId();
+    bucketRepo.getEntityManager().clear();
+
+    // Re-fetch from DB through account → host → bucket
+    AccountServiceInventory refetchedAccount = accountRepo.findById(accountId).orElseThrow();
+    Host refetchedHost = refetchedAccount.getServiceInstances().get(instanceId);
+    HostTallyBucket refetchedBucket = refetchedHost.getBuckets().iterator().next();
+
+    assertTrue(refetchedBucket.isPrimary());
+  }
+
+  @Transactional
+  @Test
+  void testIsPrimaryCanBeUpdated() {
+    AccountServiceInventory account = new AccountServiceInventory("org123", "HBI_HOST");
+
+    Host h1 = createHost("inv1", "org123");
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(
+        new HostBucketKey(
+            h1, "P1", ServiceLevel._ANY, Usage._ANY, BillingProvider.RED_HAT, "redhat1", false));
+    bucket.setHost(h1);
+    bucket.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+    h1.addBucket(bucket);
+    account.getServiceInstances().put(h1.getInstanceId(), h1);
+
+    accountRepo.save(account);
+    accountRepo.flush();
+
+    var accountId = account.getId();
+    String instanceId = h1.getInstanceId();
+    bucketRepo.getEntityManager().clear();
+
+    // Re-fetch from DB to verify default value
+    AccountServiceInventory refetchedAccount = accountRepo.findById(accountId).orElseThrow();
+    Host refetchedHost = refetchedAccount.getServiceInstances().get(instanceId);
+    HostTallyBucket refetchedBucket = refetchedHost.getBuckets().iterator().next();
+    assertFalse(refetchedBucket.isPrimary());
+
+    // Update isPrimary to true
+    refetchedBucket.setPrimary(true);
+    accountRepo.save(refetchedAccount);
+    accountRepo.flush();
+    bucketRepo.getEntityManager().clear();
+
+    // Re-fetch again to verify update was persisted
+    AccountServiceInventory refetchedAccount2 = accountRepo.findById(accountId).orElseThrow();
+    Host refetchedHost2 = refetchedAccount2.getServiceInstances().get(instanceId);
+    HostTallyBucket updatedBucket = refetchedHost2.getBuckets().iterator().next();
+    assertTrue(updatedBucket.isPrimary());
   }
 
   private void assertBucketTally(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -52,6 +52,9 @@ public class HostTallyBucket implements Serializable {
 
   @EmbeddedId private HostBucketKey key;
 
+  @Column(name = "is_primary")
+  private boolean isPrimary = false;
+
   private Integer cores;
   private Integer sockets;
 


### PR DESCRIPTION
Jira issue: SWATCH-4855

## Description
Adds is_primary column (boolean, NOT NULL, default false) to host_tally_buckets table and updates the JPA entity to include an isPrimary field with a supporting getter/setter.

## Testing
1. Deploy swatch-tally from **main** -- verify the column does not exist.
2. Deploy from this PRs branch -- verify the column was added and the correct constraints are set on the column (NOT NULL, default false)

