### PR TITLE
swatch-4955: Fix capacity unavailable at contract start boundary

### DIFF
--- a/swatch-contracts/ct/java/tests/CapacityReportTemporalBoundariesComponentTest.java
+++ b/swatch-contracts/ct/java/tests/CapacityReportTemporalBoundariesComponentTest.java
@@ -38,35 +38,44 @@ import org.junit.jupiter.api.Test;
 public class CapacityReportTemporalBoundariesComponentTest extends BaseContractComponentTest {
 
   private static final double RHEL_SOCKETS_CAPACITY = 1.0;
+  private static final int REPORT_PERIOD_DAYS = 10;
   private static final OffsetDateTime REPORT_BEGINNING = clock.startOfToday().minusDays(9);
   private static final OffsetDateTime REPORT_ENDING = clock.endOfToday();
 
   @TestPlanName("capacity-report-temporal-boundaries-TC001")
   @Test
   void shouldIncludeCapacityWhenSubscriptionStartsDuringReportPeriod() {
-    // Given: A subscription starting on day 5 of the 10-day report period
-    givenSubscriptionActiveBetween(
-        clock.startOfToday().minusDays(5), clock.endOfToday().plusDays(1));
+    // Given: A 10-day report period from (today-9) to today
+    // And: A subscription starting on snapshot 4 (today-5) and ending after report period
+    final int SUBSCRIPTION_START_DAY = 5; // Days before today
+    final OffsetDateTime subscriptionStart = clock.startOfToday().minusDays(SUBSCRIPTION_START_DAY);
+    final OffsetDateTime subscriptionEnd = clock.endOfToday().plusDays(1);
+
+    givenSubscriptionActiveBetween(subscriptionStart, subscriptionEnd);
 
     // When: Get daily capacity report for the 10-day period
     var snapshots = whenGetDailyReportSnapshots();
 
     // Then: Verify capacity report structure
-    assertEquals(10, snapshots.size());
+    assertEquals(REPORT_PERIOD_DAYS, snapshots.size());
 
-    // Then: Days 1-4 should have no data or zero capacity (before subscription starts)
-    thenSnapshotsBeforeSubscriptionHaveNoData(snapshots, 0, 4);
+    // Then: Snapshots 0-3 (days before subscription starts) should have no data
+    // Snapshot 0 = today-9, Snapshot 1 = today-8, Snapshot 2 = today-7, Snapshot 3 = today-6
+    thenSnapshotsBeforeSubscriptionHaveNoData(snapshots, 0, 3);
 
-    // Then: Days 5-10 should have subscription capacity and hasData=true
-    thenSnapshotsWithinSubscriptionPeriodHaveData(snapshots, 5, 9);
+    // Then: Snapshots 4-9 (subscription active period) should have capacity data
+    // Snapshot 4 = today-5 (subscription START - inclusive), ..., Snapshot 9 = today
+    thenSnapshotsWithinSubscriptionPeriodHaveData(snapshots, 4, 9);
   }
 
   @TestPlanName("capacity-report-temporal-boundaries-TC002")
   @Test
   void shouldExcludeCapacityWhenSubscriptionEndsDuringReportPeriod() {
-    // Given: A subscription ending on day 5 of 10 days
+    // Given: A 10-day report period from (today-9) to today
+    // And: A subscription starting before report period and ending at end of snapshot 3 (today-6)
+    final int LAST_ACTIVE_DAY = 6; // Last day subscription is active (days before today)
     final OffsetDateTime subscriptionStart = clock.startOfToday().minusDays(15);
-    final OffsetDateTime subscriptionEnd = clock.startOfToday().minusDays(5);
+    final OffsetDateTime subscriptionEnd = clock.endOfToday().minusDays(LAST_ACTIVE_DAY);
 
     givenSubscriptionActiveBetween(subscriptionStart, subscriptionEnd);
 
@@ -74,19 +83,22 @@ public class CapacityReportTemporalBoundariesComponentTest extends BaseContractC
     var snapshots = whenGetDailyReportSnapshots();
 
     // Then: Verify capacity report structure
-    assertEquals(10, snapshots.size());
+    assertEquals(REPORT_PERIOD_DAYS, snapshots.size());
 
-    // Then: Days 1-4 should have capacity included
+    // Then: Snapshots 0-3 (subscription still active) should have capacity data
+    // Snapshot 0 = today-9, Snapshot 3 = today-6 (last active day, ends at 23:59:59.999)
     thenSnapshotsWithinSubscriptionPeriodHaveData(snapshots, 0, 3);
 
-    // Then: Days 5-10 should have capacity excluded (after subscription ends)
+    // Then: Snapshots 4-9 (after subscription ends) should have no data
+    // Snapshot 4 = today-5 (after subscription end - subscription inactive), Snapshot 9 = today
     thenSnapshotsAfterSubscriptionHaveNoData(snapshots, 4, 9);
   }
 
   @TestPlanName("capacity-report-temporal-boundaries-TC003")
   @Test
   void shouldExcludeSubscriptionCompletelyOutsideRange() {
-    // Given: A subscription with dates completely outside the report range
+    // Given: A 10-day report period from (today-9) to today
+    // And: A subscription completely outside the report period (ended 15 days ago)
     final OffsetDateTime subscriptionStart = clock.startOfToday().minusDays(30);
     final OffsetDateTime subscriptionEnd = clock.startOfToday().minusDays(15);
     givenSubscriptionActiveBetween(subscriptionStart, subscriptionEnd);
@@ -96,6 +108,7 @@ public class CapacityReportTemporalBoundariesComponentTest extends BaseContractC
 
     // Then: Subscription not included in any snapshots
     assertFalse(snapshots.isEmpty());
+    assertEquals(REPORT_PERIOD_DAYS, snapshots.size());
 
     // Then: All snapshots should have value=0 or hasData=false
     thenAllSnapshotsHaveNoData(snapshots);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1.java
@@ -266,7 +266,7 @@ public class CapacityResourceV1 implements CapacityApi {
     for (SubscriptionEntity subscription : subscriptions) {
       var begin = subscription.getStartDate();
       var end = subscription.getEndDate();
-      if (begin.isBefore(date) && (Objects.isNull(end) || end.isAfter(date))) {
+      if (!begin.isAfter(date) && (Objects.isNull(end) || !date.isAfter(end))) {
         hasData = true;
         for (var entry : subscription.getSubscriptionMeasurements().entrySet()) {
           var measurementKey = entry.getKey();

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1Test.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v1/CapacityResourceV1Test.java
@@ -26,6 +26,7 @@ import static io.restassured.RestAssured.given;
 import static java.util.Objects.isNull;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
@@ -759,5 +760,72 @@ class CapacityResourceV1Test {
         Arguments.of(RHEL_FOR_ARM, GranularityType.YEARLY),
         Arguments.of(BASILISK, GranularityType.YEARLY),
         Arguments.of(RHEL_FOR_ARM, GranularityType.DAILY));
+  }
+
+  @Test
+  void testReportByMetricIdShouldIncludeCapacityWhenSubscriptionStartsOnReportDay() {
+    // Given: A subscription starting exactly at the query date
+    OffsetDateTime queryDate = min.truncatedTo(ChronoUnit.DAYS);
+    var subscription = datedSubscription(queryDate, max);
+    subscription.setSubscriptionMeasurements(basicMeasurement());
+
+    when(subscriptionRepository.findByCriteria(
+            argThat(argument -> argument.getOrgId().equals("org123")), any(Sort.class)))
+        .thenReturn(List.of(subscription));
+
+    // When: Querying capacity at exactly the subscription start time
+    CapacityReportByMetricId report =
+        given()
+            .queryParams(
+                "granularity", GranularityType.DAILY.toString(),
+                "beginning", queryDate.toString(),
+                "ending", queryDate.toString())
+            .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+            .get(
+                String.format(
+                    "/api/rhsm-subscriptions/v1/capacity/products/%s/%s",
+                    RHEL_FOR_ARM.getValue(), METRIC_ID_CORES.getValue()))
+            .then()
+            .statusCode(200)
+            .extract()
+            .as(CapacityReportByMetricId.class);
+
+    // Then: Subscription should be included (start boundary is inclusive)
+    CapacitySnapshotByMetricId snapshot = report.getData().get(0);
+    assertEquals(42, snapshot.getValue());
+  }
+
+  @Test
+  void testReportByMetricIdShouldIncludeCapacityWhenSubscriptionEndsOnReportDay() {
+    // Given: A subscription ending exactly at the query date
+    OffsetDateTime queryDate = max.truncatedTo(ChronoUnit.DAYS);
+    var subscription = datedSubscription(min, queryDate);
+    subscription.setSubscriptionMeasurements(basicMeasurement());
+
+    when(subscriptionRepository.findByCriteria(
+            argThat(argument -> argument.getOrgId().equals("org123")), any(Sort.class)))
+        .thenReturn(List.of(subscription));
+
+    // When: Querying capacity at exactly the subscription end time
+    CapacityReportByMetricId report =
+        given()
+            .queryParams(
+                "granularity", GranularityType.DAILY.toString(),
+                "beginning", queryDate.toString(),
+                "ending", queryDate.toString())
+            .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+            .get(
+                String.format(
+                    "/api/rhsm-subscriptions/v1/capacity/products/%s/%s",
+                    RHEL_FOR_ARM.getValue(), METRIC_ID_CORES.getValue()))
+            .then()
+            .statusCode(200)
+            .extract()
+            .as(CapacityReportByMetricId.class);
+
+    // Then: Subscription should be included (end boundary is inclusive)
+    CapacitySnapshotByMetricId snapshot = report.getData().get(0);
+    assertTrue(snapshot.getHasData());
+    assertEquals(42, snapshot.getValue());
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-4955

## Description
Fix the capacity queries at the exact contract start or end timestamp, which were incorrectly excluded contracts due to strict `isBefore()` and `isAfter()` boundary checks in `CapacityResourceV1.java`.

This was demonstrated by IQE test `test_verify_contract_capacity` was failing on the first day of each month (May 1st UTC = April 30 8pm EDT to May 1st 8pm EDT).

**Fix:** Changed boundary checks to be inclusive:
- `begin.isBefore(date)`  -> `!begin.isAfter(date)`
- `end.isAfter(date)` -> `!date.isAfter(end)` 

## Testing
iqe tests plugin rhsm_subscriptions -k test_verify_contract_capacity

### Verification
The test_contract_capacity#test_verify_contract_capacity should now pass every day of the month, including May 1st UTC.  


##Unimplemented Alternative Solution - Test Modification
- Modify the test to query at `May 1, 00:01` instead of `May 1, 00:00`
- [swatch_contracts/test_contracts_capacity.py#L64](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/blob/master/iqe_rhsm_subscriptions/tests/component/swatch_contracts/test_contracts_capacity.py#L64)
- Did continue with that because it eaves a window where production queries at exact boundaries return incorrect results.
