### PR TITLE
SWATCH-4637: Invalid openshift_cluster_id

### DIFF
--- a/swatch-system-conduit/ct/java/api/RhsmApiStubs.java
+++ b/swatch-system-conduit/ct/java/api/RhsmApiStubs.java
@@ -124,9 +124,6 @@ public class RhsmApiStubs {
   /**
    * Build a full consumer map with all fields needed to validate the resulting HbiHost message. Use
    * fixed UUIDs/values when you need to assert exact match in the test.
-   *
-   * <p>TODO SWATCH-4637: openshift_cluster_id was backed out (legacy values failed HBI validation)
-   * and will be re-added as part of SWATCH-4637. Param retained for stub compatibility until then.
    */
   public static Map<String, Object> buildFullConsumer(
       String orgId,
@@ -162,8 +159,6 @@ public class RhsmApiStubs {
     Map<String, String> facts = new HashMap<>();
     facts.put("network.fqdn", fqdn);
     facts.put("dmi.system.uuid", biosUuid);
-    // TODO SWATCH-4637: openshift_cluster_id was backed out (legacy values failed HBI validation),
-    // will be re-added in SWATCH-4637
     if (openshiftClusterId != null) {
       facts.put("openshift.cluster_id", openshiftClusterId);
     }

--- a/swatch-system-conduit/ct/java/tests/PublicCloudConduitComponentTest.java
+++ b/swatch-system-conduit/ct/java/tests/PublicCloudConduitComponentTest.java
@@ -46,6 +46,9 @@ public class PublicCloudConduitComponentTest extends BaseConduitComponentTest {
   private static final String EXPECTED_UUID = "550e8400-e29b-41d4-a716-446655440000";
   private static final String EXPECTED_FQDN = "host1.openshift.test.com";
   private static final String EXPECTED_BIOS_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+  private static final String EXPECTED_OPENSHIFT_CLUSTER_ID = "test-cluster-1";
+  private static final String EXPECTED_OPENSHIFT_CLUSTER_UUID =
+      "5dd23807-2bf1-4670-9d6a-42364dc4fddb";
   private static final String EXPECTED_INSIGHTS_ID = "e7f8c9d0-1a2b-3c4d-5e6f-7890abcdef12";
   private static final List<String> EXPECTED_IP_ADDRESSES = List.of("192.168.1.10", "10.0.0.5");
   private static final List<String> EXPECTED_MAC_ADDRESSES = List.of("00:11:22:33:44:55");
@@ -110,8 +113,8 @@ public class PublicCloudConduitComponentTest extends BaseConduitComponentTest {
         EXPECTED_UUID,
         EXPECTED_FQDN,
         EXPECTED_BIOS_UUID,
-        null,
-        null,
+        EXPECTED_OPENSHIFT_CLUSTER_ID,
+        EXPECTED_OPENSHIFT_CLUSTER_UUID,
         EXPECTED_INSIGHTS_ID,
         EXPECTED_IP_ADDRESSES,
         EXPECTED_MAC_ADDRESSES,
@@ -158,7 +161,9 @@ public class PublicCloudConduitComponentTest extends BaseConduitComponentTest {
   private void verifyHbiHostIdentityFields(HbiHost data) {
     assertEquals(orgId, data.getOrgId(), "HbiHost orgId should match stubbed consumer");
     assertEquals(
-        EXPECTED_DISPLAY_NAME, data.getDisplayName(), "Display name should match consumer name");
+        EXPECTED_OPENSHIFT_CLUSTER_UUID,
+        data.getDisplayName(),
+        "Display name should match openshift.cluster_uuid fact");
     assertEquals(EXPECTED_FQDN, data.getFqdn(), "FQDN should match network.fqdn fact");
     assertEquals(
         EXPECTED_UUID,
@@ -167,6 +172,10 @@ public class PublicCloudConduitComponentTest extends BaseConduitComponentTest {
     assertEquals(EXPECTED_BIOS_UUID, data.getBiosUuid(), "BIOS UUID should match dmi.system.uuid");
     assertEquals(
         EXPECTED_INSIGHTS_ID, data.getInsightsId(), "Insights ID should match insights_id fact");
+    assertEquals(
+        EXPECTED_OPENSHIFT_CLUSTER_UUID,
+        data.getOpenshiftClusterId(),
+        "OpenShift cluster ID should match openshift.cluster_uuid fact");
   }
 
   private void verifyHbiHostReporterAndTimestamps(HbiHost data) {

--- a/swatch-system-conduit/schemas/inventory/hbi-host.yaml
+++ b/swatch-system-conduit/schemas/inventory/hbi-host.yaml
@@ -44,3 +44,5 @@ properties:
   provider_type:
     type: string
     existingJavaType: org.candlepin.subscriptions.utilization.api.model.ConsumerInventory.ProviderTypeEnum
+  openshift_cluster_id:
+    type: string

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/InventoryController.java
@@ -199,6 +199,10 @@ public class InventoryController {
     facts.setSysPurposeAddons(consumer.getSysPurposeAddons());
     facts.setSysPurposeUnits(rhsmFacts.get(OCM_UNITS));
     facts.setBillingModel(rhsmFacts.get(OCM_BILLING_MODEL));
+    // The JSON we get from the consumer contains both openshift.cluster_id and
+    // openshift.cluster_uuid. We use the cluster_uuid because the downstream
+    // API expects a valid UUID
+    facts.setOpenshiftClusterId(rhsmFacts.get(OPENSHIFT_CLUSTER_UUID));
     extractConversionsActivity(rhsmFacts, facts);
 
     extractNetworkFacts(consumer, rhsmFacts, facts);

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/inventory/InventoryService.java
@@ -126,6 +126,7 @@ public abstract class InventoryService {
     host.setInsightsId(facts.getInsightsId());
     host.setProviderId(facts.getProviderId());
     host.setProviderType(facts.getProviderType());
+    host.setOpenshiftClusterId(facts.getOpenshiftClusterId());
     host.setSystemProfile(createSystemProfile(facts));
 
     return host;

--- a/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
+++ b/swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml
@@ -302,6 +302,8 @@ components:
           enum: [ aws, azure, gcp ]
         conversions_activity:
           type: boolean
+        openshift_cluster_id:
+          type: string
     DefaultResponse:
       properties:
         status:

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/InventoryControllerTest.java
@@ -607,6 +607,27 @@ class InventoryControllerTest {
   }
 
   @Test
+  void testOpenshiftClusterIdCollected() {
+    String uuid = UUID.randomUUID().toString();
+    String openshiftClusterId = UUID.randomUUID().toString();
+    Consumer consumer = new Consumer();
+    consumer.setUuid(uuid);
+    consumer.getFacts().put(InventoryController.OPENSHIFT_CLUSTER_UUID, openshiftClusterId);
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertEquals(openshiftClusterId, conduitFacts.getOpenshiftClusterId());
+  }
+
+  @Test
+  void testOpenshiftClusterIdNullWhenFactAbsent() {
+    Consumer consumer = new Consumer();
+    consumer.setUuid(UUID.randomUUID().toString());
+
+    ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+    assertNull(conduitFacts.getOpenshiftClusterId());
+  }
+
+  @Test
   void testCanonicalFactsUuidIsNormalizedWithHyphens() {
     String insightsId = "40819041673b443b98765b0a1c2cc1b1\n";
     String uuid = "ca85ccb82d384317a5d14dc05a6ea1e9";
@@ -892,6 +913,7 @@ class InventoryControllerTest {
     expected.setSubscriptionManagerId(uuid.toString());
     expected.setRhProd(new ArrayList<>());
     expected.setSysPurposeAddons(new ArrayList<>());
+    expected.setOpenshiftClusterId("JustAnotherCluster");
 
     when(rhsmService.getPageOfConsumers(eq("123"), nullable(String.class), anyString()))
         .thenReturn(pageOf(consumer));

--- a/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/swatch-system-conduit/src/test/java/org/candlepin/subscriptions/conduit/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -113,6 +113,7 @@ class KafkaEnabledInventoryServiceTest {
     expectedFacts.setThreadsPerCore(THREADS_PER_CORE);
     expectedFacts.setProviderType(ConsumerInventory.ProviderTypeEnum.AZURE);
     expectedFacts.setProviderId(UUID.randomUUID().toString());
+    expectedFacts.setOpenshiftClusterId(UUID.randomUUID().toString());
 
     InventoryServiceProperties props = new InventoryServiceProperties();
     props.setKafkaHostIngressTopic("placeholder");
@@ -149,6 +150,7 @@ class KafkaEnabledInventoryServiceTest {
     assertEquals(THREADS_PER_CORE, message.getData().getSystemProfile().getThreadsPerCore());
     assertEquals(expectedFacts.getProviderId(), message.getData().getProviderId());
     assertEquals(expectedFacts.getProviderType(), message.getData().getProviderType());
+    assertEquals(expectedFacts.getOpenshiftClusterId(), message.getData().getOpenshiftClusterId());
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4637

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

openshift.cluster_uuid should be passed as the cluster id from swatch-system-conduit to HBI. 

## Testing

Component testing:

`podman compose up -d kafka kafka-bridge kafka-setup amqp wiremock db`

`./mvnw clean install -Pcomponent-tests -pl swatch-system-conduit/ct`

This test validates that when the conduit syncs for an org, it fetches consumers from the RHSM API (stubbed by WireMock), then emits an `add_host` message to the inventory host ingress topic with all `HbiHost` fields populated from the consumer.

---

## Section 1: Initial Environment Setup

1. **Start Pods**
   ```bash
   podman-compose up -d
   ```

2. **Start Service**
   ```bash
   make swatch-system-conduit
   ```

---

## Section 2: SQL Data Setup

This test does **not** use any database setup. 
---

## Section 3: WireMock Mappings

The test stubs the RHSM API via `wiremock.forRhsmApi().stubConsumersForOrg(orgId, List.of(consumer))`, where `consumer` is built with `RhsmApiStubs.buildFullConsumer(...)` using the constants in the test class.

### 1. Mapping file for `config/wiremock/mappings/`

Use a **fixed org ID** when replaying manually so the same value can be used in both the WireMock stub and the sync curl. The repo already has a mapping that uses `test-org-add-host-all-fields`; the mapping below uses the same so you can reuse it.

**File:** `config/wiremock/mappings/rhsm-consumers-feeds-add-host-all-fields.json`

```json
{
  "priority": 9,
  "request": {
    "method": "GET",
    "urlPathPattern": "/candlepin/consumers/feeds.*",
    "headers": {
      "X-RhsmApi-AccountID": {
        "equalTo": "test-org-add-host-all-fields"
      }
    }
  },
  "response": {
    "status": 200,
    "headers": {
      "Content-Type": "application/json"
    },
    "body": "{\"body\":[{\"type\":\"system\",\"id\":\"test-consumer-1\",\"uuid\":\"550e8400-e29b-41d4-a716-446655440000\",\"name\":\"test-display-name\",\"orgId\":\"test-org-add-host-all-fields\",\"lastCheckin\":\"2024-01-01T12:00:00Z\",\"sysPurposeRole\":\"\",\"sysPurposeUsage\":\"\",\"sysPurposeAddons\":[],\"installedProducts\":[{\"productId\":\"72\",\"productName\":\"RHEL\",\"productVersion\":\"8\"}],\"facts\":{\"network.fqdn\":\"host1.openshift.test.com\",\"dmi.system.uuid\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\",\"openshift.cluster_uuid\":\"5dd23807-2bf1-4670-9d6a-42364dc4fddb\",\"openshift.cluster_id\":\"common_name\",\"insights_id\":\"e7f8c9d0-1a2b-3c4d-5e6f-7890abcdef12\",\"uname.machine\":\"x86_64\",\"cpu.cpu_socket(s)\":\"2\",\"cpu.core(s)_per_socket\":\"4\",\"memory.memtotal\":\"16000000\",\"net.interface.eth0.ipv4_address_list\":\"192.168.1.10, 10.0.0.5\",\"net.interface.eth0.mac_address\":\"00:11:22:33:44:55\"}}],\"pagination\":{\"offset\":\"\",\"limit\":1000,\"count\":1}}"
  },
  "metadata": {
    "component-test-generated": "true"
  }
}
```


If WireMock is already running (e.g. on port 8006 per `application-dev.yaml`), you can register the mapping with:

```bash
curl -X POST 'http://localhost:8006/__admin/mappings' \
  -H 'Content-Type: application/json' \
  -d @config/wiremock/mappings/rhsm-consumers-feeds-add-host-all-fields.json
```

Ensure the conduit is configured to use this WireMock base URL (e.g. `RHSM_URL=http://localhost:8006`).

---

## Section 4: API Command Execution

The test triggers the flow by calling the **internal RPC** sync endpoint. That endpoint uses **PSK headers** only (no `x-rh-identity`). Use the **same org ID** as in the WireMock mapping so the conduit’s RHSM client sends `X-RhsmApi-AccountID: test-org-add-host-all-fields` and gets the stubbed response.

**Sync conduit for org (triggers fetch from RHSM stub and emit to Kafka):**

```bash
curl -X POST 'http://localhost:8017/api/rhsm-subscriptions/v1/internal/rpc/syncOrg' \
  -H 'Content-Type: application/json' \
  -H 'Origin: console.redhat.com' \
  -H 'x-rh-swatch-psk: placeholder' \
  -d '{"org_id": "test-org-add-host-all-fields"}'
```

Expected: HTTP 200. The service will call WireMock’s `/candlepin/consumers/feeds...` with `X-RhsmApi-AccountID: test-org-add-host-all-fields`, receive the stubbed consumer list, then produce an `add_host` message to the inventory host ingress topic. 

## Section 5: Kafka Verification

Verify the openshift_cluster_id is populated on the kafka response:

```
podman exec swatch-kafka /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic platform.inventory.host-ingress --from-beginning 
```