### PR TITLE
SWATCH-4547 Avoid preprod job in stage and avoid dev job for floorist in prod

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -250,6 +250,14 @@ parameters:
     description: Disable Floorist cronjob execution
     required: true
     value: 'false'
+  - name: FLOORIST_SUSPEND_DEV
+    description: Disable Floorist dev cronjob execution
+    required: true
+    value: 'false'
+  - name: FLOORIST_SUSPEND_PREPROD
+    description: Disable Floorist preprod cronjob execution
+    required: true
+    value: 'false'
   - name: FLOORIST_S3_SNOWPIPE_PATH
     description: Path for dataproduct in snowpipe s3 bucket
     value: 'swatch'
@@ -841,6 +849,7 @@ objects:
     name: swatch-tally-dev
   spec:
     <<: *floorplan_spec_base
+    suspend: ${{FLOORIST_SUSPEND_DEV}}
     objectStore:
       secretName: ${FLOORIST_BUCKET_SECRET_NAME_DEV}
 - apiVersion: metrics.console.redhat.com/v1alpha1
@@ -849,6 +858,7 @@ objects:
     name: swatch-tally-preprod
   spec:
     <<: *floorplan_spec_base
+    suspend: ${{FLOORIST_SUSPEND_PREPROD}}
     objectStore:
       secretName: ${FLOORIST_BUCKET_SECRET_NAME_PREPROD}
 - apiVersion: cloud.redhat.com/v1alpha1

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -231,16 +231,14 @@ parameters:
   - description: database secret name
     name: FLOORIST_DB_SECRET_NAME
     value: swatch-db-ro
+  # FloorPlan swatch-tally: Stage=dev, Prod=prod
   - description: bucket secret name
     name: FLOORIST_BUCKET_SECRET_NAME
     required: true
     value: egress-s3
-  - description: bucket secret name for dev
-    name: FLOORIST_BUCKET_SECRET_NAME_DEV
-    required: true
-    value: egress-s3
-  - description: bucket secret name for preprod
-    name: FLOORIST_BUCKET_SECRET_NAME_PREPROD
+  # FloorPlan swatch-tally-test: Stage=sandbox, Prod=preprod
+  - description: bucket secret name for test environment
+    name: FLOORIST_BUCKET_SECRET_NAME_TEST
     required: true
     value: egress-s3
   - name: FLOORIST_LOGLEVEL
@@ -248,14 +246,6 @@ parameters:
     value: 'DEBUG'
   - name: FLOORIST_SUSPEND
     description: Disable Floorist cronjob execution
-    required: true
-    value: 'false'
-  - name: FLOORIST_SUSPEND_DEV
-    description: Disable Floorist dev cronjob execution
-    required: true
-    value: 'false'
-  - name: FLOORIST_SUSPEND_PREPROD
-    description: Disable Floorist preprod cronjob execution
     required: true
     value: 'false'
   - name: FLOORIST_S3_SNOWPIPE_PATH
@@ -846,21 +836,11 @@ objects:
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
   metadata:
-    name: swatch-tally-dev
+    name: swatch-tally-test
   spec:
     <<: *floorplan_spec_base
-    suspend: ${{FLOORIST_SUSPEND_DEV}}
     objectStore:
-      secretName: ${FLOORIST_BUCKET_SECRET_NAME_DEV}
-- apiVersion: metrics.console.redhat.com/v1alpha1
-  kind: FloorPlan
-  metadata:
-    name: swatch-tally-preprod
-  spec:
-    <<: *floorplan_spec_base
-    suspend: ${{FLOORIST_SUSPEND_PREPROD}}
-    objectStore:
-      secretName: ${FLOORIST_BUCKET_SECRET_NAME_PREPROD}
+      secretName: ${FLOORIST_BUCKET_SECRET_NAME_TEST}
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4547

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

As part of previous changes for [SWATCH-4547](https://redhat.atlassian.net/browse/SWATCH-4547?atlOrigin=eyJpIjoiYjM0MTA4MzUyYTYxNDVkY2IwMzVjOGQ3ZWQ3NzMwM2QiLCJwIjoianN3LWdpdGxhYlNNLWludCJ9) we introduced a bug where we created snowflake job for preprod in stage. We don't want to happen same for dev job in prod. This happened because clowdapp has definitions for all env. The changes are to avoid multiple jobs and use same bucket names for each env.




[SWATCH-4547]: https://redhat.atlassian.net/browse/SWATCH-4547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ