### PR TITLE
add response status in the debug log statement for clients

### DIFF
--- a/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/DebugClientLogger.java
+++ b/swatch-common-resteasy-client/src/main/java/com/redhat/swatch/resteasy/client/DebugClientLogger.java
@@ -87,9 +87,10 @@ public class DebugClientLogger implements ClientRequestFilter, ClientResponseFil
       }
 
       log.debug(
-          "Response method={} URI={} headers={}: \n{}",
+          "Response method={} URI={} status={} headers={}: \n{}",
           requestContext.getMethod(),
           requestContext.getUri().toString(),
+          responseContext.getStatus(),
           mapToString(responseContext.getHeaders()),
           bodyToString(responseBody));
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/DebugClientLoggerTest.java
@@ -55,7 +55,12 @@ import org.junit.jupiter.api.Test;
 @TestProfile(DebugClientLoggerTest.LogAll.class)
 @QuarkusTestResource(value = WireMockResource.class, restrictToAnnotatedClass = true)
 public class DebugClientLoggerTest {
+  private static final String URI_FORMAT =
+      "https://localhost:%s"
+          + "/mock/subscription/search/criteria;"
+          + "subscription_number=any/options;products=ALL;showExternalReferences=true/";
   private static final LoggerCaptor LOGGER_CAPTOR = new LoggerCaptor();
+
   @RestClient SearchApi searchApi;
   @RestClient PartnerApi partnerApi;
   @InjectWireMock WireMockServer wireMockServer;
@@ -87,8 +92,10 @@ public class DebugClientLoggerTest {
     assertEquals(1, response.size());
     assertEquals(123456, response.get(0).getId());
     thenLogWithMessage(
-        "Response method=GET URI=https://localhost:%s/mock/subscription/search/criteria;subscription_number=any"
-            .formatted(wireMockServer.httpsPort()));
+        "Response method=GET"
+            + " URI="
+            + URI_FORMAT.formatted(wireMockServer.httpsPort())
+            + " status=200");
   }
 
   @Test


### PR DESCRIPTION
## Description
These changes will help to identify what response status returned the API we use in our Quarkus services like swatch-contracts.

From:

```
2026-05-07 12:31:05,776 DEBUG [com.red.swa.res.cli.DebugClientLogger] (executor-thread-11) Response method=GET URI=https://product.stage.api.redhat.com/svcrest/product/v3/products/MCT4701/tree?attributes=true headers=(omit): 
(omit)
```

To:

```
2026-05-07 12:31:05,776 DEBUG [com.red.swa.res.cli.DebugClientLogger] (executor-thread-11) Response method=GET URI=https://product.stage.api.redhat.com/svcrest/product/v3/products/MCT4701/tree?attributes=true status=503 headers=(omit): 
(omit)
```
