### PR TITLE
Configure swatch-contracts to use the product dev api instead of stage.

### DIFF
--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -174,7 +174,7 @@ quarkus.rest-client."com.redhat.swatch.clients.subscription.api.resources.Search
 
 # configuration properties for product client
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
-quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".uri=${PRODUCT_URL:https://product.stage.api.redhat.com/svcrest/product/v3}
+quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".uri=${PRODUCT_URL:https://product.dev.api.redhat.com/svcrest/product/v3}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store=${PRODUCT_KEYSTORE_RESOURCE:}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".key-store-password=${PRODUCT_KEYSTORE_PASSWORD:redhat}
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".trust-store=${TRUSTSTORE_RESOURCE:}


### PR DESCRIPTION
## Description
Change the product stage api to the product dev api because product stage api is not accessible from outside the vpn. 