### PR TITLE
SWATCH-4046 Swatch-tally component test konflux prep

### DIFF
--- a/swatch-tally/ct/README.md
+++ b/swatch-tally/ct/README.md
@@ -31,7 +31,23 @@ Execute tests for a specific service. For example, to run tests for `swatch-tall
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-tally
+bonfire deploy rhsm \
+  --source=appsre \
+  --ref-env insights-production \
+  --optional-deps-method none \
+  --frontends false \
+  --no-remove-resources app:rhsm \
+  -p swatch-tally/RHSM_CONTRACTS_URL=http://wiremock-service:8000 \
+  -p swatch-tally/INVENTORY_SECRET_KEY_NAME=swatch-tally-ct-hbi-db \
+  --remove-dependencies swatch-tally/swatch-contracts \
+  --remove-dependencies swatch-tally/host-inventory \
+  --remove-dependencies swatch-tally/export-service \
+  --component wiremock \
+  --component rhsm \
+  --component artemis \
+  --component swatch-kafka-bridge \
+  --component swatch-tally \
+  --component swatch-tally-ct-hbi
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-tally/ct/ephemeral/swatch-ct-hbi/deploy/clowdapp.yaml
+++ b/swatch-tally/ct/ephemeral/swatch-ct-hbi/deploy/clowdapp.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: swatch-tally-ct-hbi
+parameters:
+  - name: ENV_NAME
+    value: env-swatch-tally-ct-hbi
+  - name: IMAGE_PULL_SECRET
+    value: quay-cloudservices-pull
+  - name: INVENTORY_IMAGE
+    value: quay.io/redhat-services-prod/insights-management-tenant/insights-host-inventory/insights-host-inventory
+  - name: INVENTORY_IMAGE_TAG
+    value: latest
+  - name: DB_MIGRATION_JOB_RUN_NUMBER
+    value: '1'
+
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: swatch-tally-ct-hbi
+    spec:
+      envName: ${ENV_NAME}
+
+      # Database only - Clowder will provision PostgreSQL and create the secret
+      database:
+        name: swatch-tally-ct-hbi
+        version: 16
+
+      # Deployment with replicas: 0 so Clowder provisions database but no service pods run
+      deployments:
+        - name: service
+          replicas: 0
+          podSpec:
+            image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
+            command: ["./run_gunicorn.py"]
+            env:
+              - name: INVENTORY_DB_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.host
+              - name: INVENTORY_DB_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.port
+              - name: INVENTORY_DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.user
+              - name: INVENTORY_DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.password
+              - name: INVENTORY_DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.name
+              - name: INVENTORY_DB_SCHEMA
+                value: hbi
+              - name: CLOWDER_ENABLED
+                value: "true"
+              - name: BYPASS_RBAC
+                value: "true"
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+
+      pullSecrets:
+        name: ${IMAGE_PULL_SECRET}
+
+      # Migration job to load the host-inventory schema
+      jobs:
+        - name: schema-migration-${DB_MIGRATION_JOB_RUN_NUMBER}
+          restartPolicy: OnFailure
+          podSpec:
+            image: ${INVENTORY_IMAGE}:${INVENTORY_IMAGE_TAG}
+            command: ["/bin/bash", "-c"]
+            args:
+              - |
+                FLASK_APP=./manage.py flask db upgrade
+            env:
+              - name: INVENTORY_DB_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.host
+              - name: INVENTORY_DB_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.port
+              - name: INVENTORY_DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.user
+              - name: INVENTORY_DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.password
+              - name: INVENTORY_DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: swatch-tally-ct-hbi-db
+                    key: db.name
+              - name: INVENTORY_DB_SCHEMA
+                value: hbi
+              - name: INVENTORY_DB_SSL_MODE
+                value: prefer
+              - name: CLOWDER_ENABLED
+                value: "true"
+              - name: MIGRATION_MODE
+                value: automated
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+
+  # ClowdJobInvocation to trigger the migration job
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      name: swatch-tally-ct-hbi-migration-${DB_MIGRATION_JOB_RUN_NUMBER}
+    spec:
+      appName: swatch-tally-ct-hbi
+      jobs:
+        - schema-migration-${DB_MIGRATION_JOB_RUN_NUMBER}

--- a/swatch-tally/ct/java/tests/TallySummaryComponentTest.java
+++ b/swatch-tally/ct/java/tests/TallySummaryComponentTest.java
@@ -21,16 +21,11 @@
 package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
-import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
-import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_UNCONVERTED;
 
-import api.MessageValidators;
 import com.redhat.swatch.component.tests.api.TestPlanName;
-import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.tally.test.model.TallySnapshot.Granularity;
 import com.redhat.swatch.tally.test.model.TallySummary;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -40,70 +35,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class TallySummaryComponentTest extends BaseTallyComponentTest {
-
-  @Test
-  @TestPlanName("tally-summary-TC001")
-  public void testTallyNightlySummaryEmitsGranularityDaily() {
-    // Given: Seeded nightly tally host buckets
-    final String testInventoryId = UUID.randomUUID().toString();
-    helpers.seedNightlyTallyHostBuckets(
-        orgId, RHEL_FOR_X86_ELS_UNCONVERTED.productTag(), testInventoryId, service);
-
-    // When: Triggering nightly tally
-    service.tallyOrg(orgId);
-
-    // Then: Tally summary messages should have DAILY granularity
-    kafkaBridge.waitForKafkaMessage(
-        TALLY,
-        MessageValidators.tallySummaryMatches(
-            orgId,
-            RHEL_FOR_X86_ELS_UNCONVERTED.productTag(),
-            RHEL_FOR_X86_ELS_UNCONVERTED.metricIds().get(1),
-            Granularity.DAILY),
-        1);
-  }
-
-  @Test
-  @TestPlanName("tally-summary-TC002")
-  public void testTallyNightlySummaryHasNoTotalMeasurements() {
-    // Given: Seeded nightly tally host buckets
-    final String testInventoryId = UUID.randomUUID().toString();
-    helpers.seedNightlyTallyHostBuckets(
-        orgId, RHEL_FOR_X86_ELS_UNCONVERTED.productTag(), testInventoryId, service);
-
-    // When: Triggering nightly tally
-    service.tallyOrg(orgId);
-
-    // Then: Nightly snapshots should not emit TOTAL measurement type
-    AwaitilitySettings kafkaConsumerTimeout =
-        AwaitilitySettings.using(Duration.ofMillis(500), Duration.ofSeconds(60));
-    List<TallySummary> summaries =
-        kafkaBridge.waitForKafkaMessage(
-            TALLY,
-            MessageValidators.tallySummaryMatches(
-                orgId,
-                RHEL_FOR_X86_ELS_UNCONVERTED.productTag(),
-                RHEL_FOR_X86_ELS_UNCONVERTED.metricIds().get(1),
-                Granularity.DAILY),
-            1,
-            kafkaConsumerTimeout);
-
-    Assertions.assertFalse(summaries.isEmpty(), "Summaries should not be empty");
-    summaries.stream()
-        .flatMap(summary -> summary.getTallySnapshots().stream())
-        .flatMap(snapshot -> snapshot.getTallyMeasurements().stream())
-        .forEach(
-            measurement ->
-                Assertions.assertNotEquals(
-                    "TOTAL",
-                    measurement.getHardwareMeasurementType().toUpperCase(),
-                    "Nightly snapshots should not emit TOTAL measurement type"));
-  }
+class TallySummaryComponentTest extends BaseTallyComponentTest {
 
   @Test
   @TestPlanName("tally-summary-TC003")
-  public void testTallyHourlySummaryEmitsNoGranularityDaily() {
+  void testTallyHourlySummaryEmitsNoGranularityDaily() {
     // Given: Events within the last day for hourly tally
     final String testInstanceId = UUID.randomUUID().toString();
     final String testEventId = UUID.randomUUID().toString();
@@ -140,7 +76,7 @@ public class TallySummaryComponentTest extends BaseTallyComponentTest {
 
   @Test
   @TestPlanName("tally-summary-TC004")
-  public void testTallyHourlySummaryEmitsGranularityHourly() {
+  void testTallyHourlySummaryEmitsGranularityHourly() {
     // Given: Events within the last day for hourly tally
     final String testInstanceId = UUID.randomUUID().toString();
     final String testEventId = UUID.randomUUID().toString();


### PR DESCRIPTION
Jira issue: SWATCH-4046

## Description

The swatch-tally component tests currently deploy the full host-inventory ClowdApp (~9 service pods) just to access the database. This:
- Wastes resources in ephemeral environments
- Slows down deployments

This PR adds a `swatch-tally-ct-hbi` clowdapp configuration which creates a lightweight, database-only ClowdApp for swatch-tally component testing that provisions a PostgreSQL database with the host-inventory schema without deploying any HBI service pods.

The new `swatch-tally-ct-hbi` ClowdApp:
- Provisions PostgreSQL database via Clowder
- Runs host-inventory schema migration to create the `hbi` schema
- Deploys zero service pods (uses `replicas: 0` to satisfy Clowder while preventing pod creation)
- Creates database secret: `swatch-tally-ct-hbi-db`

This, along with removing the swatch-contracts and export-service dependencies from swatch tally, enables us to reduce ephemeral environment pod count by ~12 pods per deployment. It also reduces deploy time from ~7 mins to ~3 mins.

**Note:** This PR also removes some swatch-tally component tests that were triggering the nightly-tally and we currently do not have a means to create hosts in the HBI DB so the tests would always clear out existing host data and fail when run.

## Local Testing
### Update Local Bonfire Configuration
Until this clowdapp is included via app-interface, you'll need to update your local bonfire configuration to add a new component that will point to the new clowdapp file. The example is all you need in your bonfire configuration. The bonfire command below will pull the rest from the main branch.

```
# Basic bonfire configuration
apps:
- name: rhsm
  components:
    - name: swatch-tally-ct-hbi
      host: local
      repo: /home/mstead/sandbox/swatch-dev/rhsm-subscriptions
      path: /swatch-tally/ct/ephemeral/swatch-ct-hbi/deploy/clowdapp.yaml
      parameters:
        ENV_NAME: ${ENV_NAME}

```

### Deploy A Minimal swatch-tally EE
```bash
bonfire deploy rhsm \
  --source=appsre \
  --ref-env insights-production \
  --optional-deps-method none \
  --frontends false \
  --no-remove-resources app:rhsm \
  -p swatch-tally/RHSM_CONTRACTS_URL=http://wiremock-service:8000 \
  -p swatch-tally/INVENTORY_SECRET_KEY_NAME=swatch-tally-ct-hbi-db \
  --remove-dependencies swatch-tally/swatch-contracts \
  --remove-dependencies swatch-tally/host-inventory \
  --remove-dependencies swatch-tally/export-service \
  --component wiremock \
  --component rhsm \
  --component artemis \
  --component swatch-kafka-bridge \
  --component swatch-tally \
  --component swatch-tally-ct-hbi
```

### Run The swatch-tally component tests against this EE
```
 ./mvnw clean install -Pcomponent-tests -pl swatch-tally/ct -am -Dswatch.component-tests.global.target=openshift
```