### PR TITLE
SWATCH-4732: Update memory requirements to obtain valid memory dumps in swatch-utilization

### DIFF
--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -12,9 +12,9 @@ parameters:
   - name: IMAGE_PULL_SECRET
     value: quay-cloudservices-pull
   - name: MEMORY_REQUEST
-    value: 512Mi
+    value: 640Mi
   - name: MEMORY_LIMIT
-    value: 512Mi
+    value: 768Mi
   - name: CPU_REQUEST
     value: 200m
   - name: CPU_LIMIT
@@ -89,14 +89,13 @@ parameters:
   - name: EGRESS_IMAGE_TAG
     value: latest
   - name: USER_JAVA_OPTS
-    # Heap dumps triggered by heap monitor at 75% threshold (leaves headroom for compression + upload)
-    value: '-Xmx150m -XX:MaxDirectMemorySize=32m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heapdumps/ -XX:NativeMemoryTracking=summary'
+    value: '-Xmx384m -XX:MaxDirectMemorySize=64m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/heapdumps/ -XX:NativeMemoryTracking=detail'
   - name: ENABLE_HEAP_MONITOR
     value: 'true'
   - name: HEAP_MONITOR_THRESHOLD_PERCENT
-    value: '60'
+    value: '88'
   - name: HEAP_MONITOR_RESET_PERCENT
-    value: '55'
+    value: '82'
   - name: HEAP_DUMP_UPLOAD_S3
     value: 'false'
   - name: HEAP_DUMP_S3_PREFIX

--- a/swatch-utilization/src/main/docker/heap-monitor.sh
+++ b/swatch-utilization/src/main/docker/heap-monitor.sh
@@ -75,10 +75,19 @@ echo "[heap-monitor] Started. Container limit: ${MEMORY_LIMIT_BYTES} bytes, thre
 
 upload_file_to_s3() {
   local file="$1"
+  local datetime_folder="${2:-}"
   [ -f "$file" ] || return 0
   local fname s3_key
   fname=$(basename "$file")
-  s3_key="${S3_PREFIX}/${POD_NAME}/${fname}"
+  if [ -z "$datetime_folder" ]; then
+    if [[ "$fname" =~ ([0-9]{8}-[0-9]{6})\.(txt|hprof\.gz|hprof)$ ]]; then
+      datetime_folder="${BASH_REMATCH[1]}"
+    else
+      datetime_folder=$(date +%Y%m%d-%H%M%S)
+    fi
+  fi
+  s3_key="${S3_PREFIX}/${datetime_folder}/${fname}"
+  echo "[heap-monitor] S3 object key: ${s3_key}"
 
   # Use Java S3Uploader (no AWS CLI needed - uses Quarkus AWS SDK)
   java -cp "/deployments/app/*:/deployments/lib/boot/*:/deployments/lib/main/*:/deployments/quarkus-run.jar" \
@@ -168,7 +177,7 @@ process_jvm_oom_dumps() {
     if compress_dump "$renamed"; then
       if [ "$S3_ENABLED" = true ]; then
         echo "[heap-monitor] Uploading JVM OOM dump to S3..."
-        upload_file_to_s3 "${renamed}.gz"
+        upload_file_to_s3 "${renamed}.gz" "$timestamp"
         rm -f "${renamed}.gz"
       fi
       rm -f "$renamed"
@@ -183,11 +192,11 @@ upload_diagnostics() {
 
   if [ "$S3_ENABLED" = true ]; then
     echo "[heap-monitor] Uploading files to S3..."
-    upload_file_to_s3 "/heapdumps/nmt-${pod}-${ts}.txt"
-    upload_file_to_s3 "/heapdumps/jvm-metrics-${pod}-${ts}.txt"
-    upload_file_to_s3 "/heapdumps/nmt-periodic.txt"
-    upload_file_to_s3 "/heapdumps/jvm-metrics-periodic.txt"
-    upload_file_to_s3 "${dump_file}.gz"
+    upload_file_to_s3 "/heapdumps/nmt-${pod}-${ts}.txt" "$ts"
+    upload_file_to_s3 "/heapdumps/jvm-metrics-${pod}-${ts}.txt" "$ts"
+    upload_file_to_s3 "/heapdumps/nmt-periodic.txt" "$ts"
+    upload_file_to_s3 "/heapdumps/jvm-metrics-periodic.txt" "$ts"
+    upload_file_to_s3 "${dump_file}.gz" "$ts"
     echo "[heap-monitor] S3 upload complete"
 
     rm -f "${dump_file}.gz" \

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/S3Uploader.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/S3Uploader.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * requiring AWS CLI.
  *
  * <p>Usage: java -cp /deployments/quarkus-run.jar com.redhat.swatch.utilization.S3Uploader \
- * /path/to/file.gz \ bucket-name \ s3/key/path/file.gz
+ * /path/to/file.gz \ bucket-name \ prefix/YYYYMMDD-HHMMSS/basename (basename may include hostname)
  *
  * <p>Credentials read from environment variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
  * AWS_DEFAULT_REGION


### PR DESCRIPTION
Jira issue: SWATCH-4732

## Description
Regarding the recent .hprof files, the uncompressed size is 80 MB. This is still significantly smaller than the container’s overall memory usage, indicating that the heap dump is being triggered at a time when the Java heap is not under stress.

As a result, the current snapshots are unrepresentative of the memory pressure causing the container issues. Furthermore, since a standard heap dump only records objects on the Java heap, it cannot capture growth in native memory, direct buffers, or other off-heap allocations that contribute to the cgroup limits.

To improve our diagnostics, I recommend updating the configuration from NativeMemoryTracking=summary to NativeMemoryTracking=detail. This will allow us to use jcmd to obtain a granular breakdown of memory allocation. With detailed tracking, we can correlate container memory usage with specific categories such as metaspace or individual malloc sites that are not visible in the .hprof file.

Additionally, I've updated the script to write the hprof in a folder date-time based, so it's easier to see what is the latest hprof file. 