### PR TITLE
(HOTFIX) SWATCH-4964: Update Maven settings to Google Mirror, optimize Dockerfiles and Konflux pipelines

### DIFF
--- a/.mvn/maven-settings.xml
+++ b/.mvn/maven-settings.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- Force Maven central id to resolve via Google mirror. -->
+  <mirrors>
+    <mirror>
+      <id>google-central-mirror</id>
+      <name>Google Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  <proxies />
+
+  <profiles>
+    <profile>
+      <id>direct-repositories</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>Maven Central</name>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>central-direct</id>
+          <name>Maven Central direct fallback</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>splunk-artifactory</id>
+          <name>Splunk Releases</name>
+          <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>confluent</id>
+          <name>Confluent</name>
+          <url>https://packages.confluent.io/maven/</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <name>Maven Central</name>
+          <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>central-direct</id>
+          <name>Maven Central direct fallback</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>splunk-artifactory</id>
+          <name>Splunk Releases</name>
+          <url>https://splunk.jfrog.io/splunk/ext-releases-local</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>confluent</id>
+          <name>Confluent</name>
+          <url>https://packages.confluent.io/maven/</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>direct-repositories</activeProfile>
+  </activeProfiles>
+</settings>

--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -538,7 +538,7 @@ spec:
                 value: "$(params.SERVICE)"
             script: |
               #!/bin/bash
-              ./mvnw clean install --no-transfer-progress -Pcomponent-tests -am -pl ${SERVICE}/ct -Dswatch.component-tests.global.target=openshift -Dlog.disable-color=true -Dlog.level=FINE -Dlog.print-errors-to-std-err=true -Dswatch.component-tests.services.all.log.enabled=true
+              mvn -s .mvn/maven-settings.xml clean install --no-transfer-progress -Pcomponent-tests -am -pl ${SERVICE}/ct -Dswatch.component-tests.global.target=openshift -Dlog.disable-color=true -Dlog.level=FINE -Dlog.print-errors-to-std-err=true -Dswatch.component-tests.services.all.log.enabled=true
     - name: send-results-task
       onError: continue
       params:

--- a/.tekton/swatch-api-pull-request.yaml
+++ b/.tekton/swatch-api-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy

--- a/.tekton/swatch-api-push.yaml
+++ b/.tekton/swatch-api-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-billable-usage-pull-request.yaml
+++ b/.tekton/swatch-billable-usage-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-billable-usage-push.yaml
+++ b/.tekton/swatch-billable-usage-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-contracts-pull-request.yaml
+++ b/.tekton/swatch-contracts-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-contracts-push.yaml
+++ b/.tekton/swatch-contracts-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-metrics-hbi-pull-request.yaml
+++ b/.tekton/swatch-metrics-hbi-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-metrics-hbi-push.yaml
+++ b/.tekton/swatch-metrics-hbi-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-metrics-pull-request.yaml
+++ b/.tekton/swatch-metrics-pull-request.yaml
@@ -110,7 +110,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -225,6 +225,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-metrics-push.yaml
+++ b/.tekton/swatch-metrics-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-producer-aws-pull-request.yaml
+++ b/.tekton/swatch-producer-aws-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-producer-aws-push.yaml
+++ b/.tekton/swatch-producer-aws-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-producer-azure-pull-request.yaml
+++ b/.tekton/swatch-producer-azure-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-producer-azure-push.yaml
+++ b/.tekton/swatch-producer-azure-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-system-conduit-pull-request.yaml
+++ b/.tekton/swatch-system-conduit-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-system-conduit-push.yaml
+++ b/.tekton/swatch-system-conduit-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-tally-pull-request.yaml
+++ b/.tekton/swatch-tally-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-tally-push.yaml
+++ b/.tekton/swatch-tally-push.yaml
@@ -108,7 +108,7 @@ spec:
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
     - name: enable-cache-proxy
-      default: 'false'
+      default: 'true'
       description: Enable cache proxy configuration
       type: string
     - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/swatch-utilization-pull-request.yaml
+++ b/.tekton/swatch-utilization-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
       - name: enable-cache-proxy
-        default: 'false'
+        default: 'true'
         description: Enable cache proxy configuration
         type: string
       - name: enable-package-registry-proxy
@@ -226,6 +226,10 @@ spec:
             value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
           - name: BUILDAH_FORMAT
             value: $(params.buildah-format)
+          - name: HTTP_PROXY
+            value: $(tasks.init.results.http-proxy)
+          - name: NO_PROXY
+            value: $(tasks.init.results.no-proxy)
         runAfter:
           - prefetch-dependencies
         taskRef:

--- a/.tekton/swatch-utilization-push.yaml
+++ b/.tekton/swatch-utilization-push.yaml
@@ -108,7 +108,7 @@ spec:
         type: string
         description: The format for the resulting image's mediaType. Valid values are oci or docker.
       - name: enable-cache-proxy
-        default: 'false'
+        default: 'true'
         description: Enable cache proxy configuration
         type: string
       - name: enable-package-registry-proxy
@@ -223,6 +223,10 @@ spec:
             value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
           - name: BUILDAH_FORMAT
             value: $(params.buildah-format)
+          - name: HTTP_PROXY
+            value: $(tasks.init.results.http-proxy)
+          - name: NO_PROXY
+            value: $(tasks.init.results.no-proxy)
         runAfter:
           - prefetch-dependencies
         taskRef:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,21 +12,14 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl swatch-tally -am -DskipTests ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl swatch-tally -am -DskipTests ${MAVEN_BUILD_ARGS}
 
 RUN (cd /stage/swatch-tally && exec jar -xf ./target/*.jar)
 RUN ls -al /stage/swatch-tally

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -88,22 +88,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-billable-usage'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -87,22 +87,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-contracts'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -87,22 +87,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-metrics-hbi'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package
+# mvn package
 #
 # Then, build the image with:
 #
@@ -89,22 +89,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-metrics'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package
+# mvn package
 #
 # Then, build the image with:
 #
@@ -89,22 +89,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-producer-aws'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package
+# mvn package
 #
 # Then, build the image with:
 #
@@ -89,22 +89,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-producer-azure'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -12,21 +12,14 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG MAVEN_BUILD_ARGS=''
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl swatch-system-conduit -am -DskipTests ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl swatch-system-conduit -am -DskipTests ${MAVEN_BUILD_ARGS}
 
 # See https://stackoverflow.com/a/786515
 RUN (cd /stage/swatch-system-conduit && exec jar -xf ./target/*.jar)

--- a/swatch-utilization/src/main/docker/Dockerfile.jvm
+++ b/swatch-utilization/src/main/docker/Dockerfile.jvm
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package
+# mvn package
 #
 # Then, build the image with:
 #
@@ -89,22 +89,15 @@ RUN microdnf \
   git
 WORKDIR /stage
 
-COPY mvnw .
-COPY .mvn .mvn
 COPY pom.xml ./
+COPY .mvn/maven-settings.xml /tmp/maven-settings.xml
 
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-# See: https://issues.redhat.com/browse/APPSRE-13062
-# This makes builds slower but allows them to work with runc until infra configures crun
-# TODO: Re-enable cache mounts once infra switches to crun
-RUN ./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never
 COPY . .
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-utilization'
 ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
-# TEMPORARY WORKAROUND: Removed --mount=type=cache due to runc incompatibility
-RUN ./mvnw ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
+RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1773186561
 


### PR DESCRIPTION
Cherry-pick from https://github.com/RedHatInsights/rhsm-subscriptions/pull/6087

JIRA Ticket:
[SWATCH-4964](https://redhat.atlassian.net/browse/SWATCH-4964)

## Description
Changes:
- Added maven-settings.xml to list the repositories we use to download dependencies.
- Since maven central randomly returns 429 errors, we will now use the Google Maven Central mirror
- Using the Maven Wrapper + Download the Maven Distro also failed, so we will now use directly the `mvn` distro that is included in the openjdk images.
- Remove `./mvnw -P download dependency:resolve-plugins dependency:resolve --fail-never` from all our dockerfile since this caused to download ALL the dependencies, but only the required ones by a single project.

Other related changes after the conversation with the Konflux team:
- Enabling cache proxy as it's the recomended configuration by Konflux
- Normalize the swatch-api pipelines configuration to the rest: include the HTTP_PROXY and NO_PROXY from the init task.

[SWATCH-4964]: https://redhat.atlassian.net/browse/SWATCH-4964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ