### PR TITLE
Use CurrentTimestamp annotation where possible in swatch-tally

### DIFF
--- a/src/main/resources/liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml
+++ b/src/main/resources/liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml
@@ -22,6 +22,7 @@
   will populate the entity correctly using a RETURNING clause after an UPDATE or INSERT which
   avoids a round-trip while keeping timestamp generation on the DB.
   -->
+  <!-- See liquibase/202605111456-remove-last-modified-triggers.xml for important revisions -->
 
   <changeSet id="202601301404-01" author="awood" dbms="postgresql" runOnChange="true">
     <sqlFile path="liquibase/procedures/update_last_modified_column.sql"

--- a/src/main/resources/liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml
+++ b/src/main/resources/liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml
@@ -26,6 +26,7 @@
   and marked runOnChange="true" so that any changes to the procedure in
   procedures/update_last_modified_column.sql will automatically be applied.
   -->
+  <!-- See liquibase/202605111456-remove-last-modified-triggers.xml for important revisions -->
   <changeSet id="202604151137-01" author="awood">
     <addColumn tableName="hosts">
       <column name="last_modified" type="TIMESTAMP WITH TIME ZONE"/>

--- a/src/main/resources/liquibase/202605111456-remove-last-modified-triggers.xml
+++ b/src/main/resources/liquibase/202605111456-remove-last-modified-triggers.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <!--
+  As of Hibernate 6.5, https://in.relation.to/2024/04/19/generated-values/, the
+  @CurrentTimestamp(source = DB) annotation is capable of storing a result given by a SQL
+  RETURNING clause.  This means that we can avoid the round-trip problem that initially informed
+  the decision to go with trigger to write the last_modified column.  We will still need those
+  triggers for tables that are not directly mapped (e.g. ElementCollection properties).  But using
+  triggers only where absolutely necessary will make schema management much easier.
+  -->
+  <changeSet id="202605111456-01" author="awood" dbms="postgresql">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified ON hosts;
+    </sql>
+    <rollback>
+      CREATE OR REPLACE TRIGGER trg_hosts_last_modified
+        BEFORE INSERT OR UPDATE
+        ON hosts
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202605111456-02" author="awood" dbms="hsqldb">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_hosts_last_modified_update;
+    </sql>
+  </changeSet>
+
+  <changeSet id="202605111456-03" author="awood" dbms="postgresql">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified ON host_tally_buckets;
+    </sql>
+    <rollback>
+      CREATE OR REPLACE TRIGGER trg_host_tally_buckets_last_modified
+        BEFORE INSERT OR UPDATE
+        ON host_tally_buckets
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202605111456-04" author="awood" dbms="hsqldb">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_host_tally_buckets_last_modified_update;
+    </sql>
+  </changeSet>
+
+  <changeSet id="202605111456-05" author="awood" dbms="postgresql">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified ON tally_snapshots;
+    </sql>
+    <rollback>
+      CREATE OR REPLACE TRIGGER trg_tally_snapshots_last_modified
+        BEFORE INSERT OR UPDATE
+        ON tally_snapshots
+        FOR EACH ROW
+      EXECUTE FUNCTION update_last_modified_column();
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202605111456-06" author="awood" dbms="hsqldb">
+    <sql>
+      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_create;
+      DROP TRIGGER IF EXISTS trg_tally_snapshots_last_modified_update;
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -208,5 +208,6 @@
     <include file="liquibase/202601301404-last-modified-on-snapshots-and-measurements.xml"/>
     <include file="liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml"/>
     <include file="liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml"/>
+    <include file="liquibase/202605111456-remove-last-modified-triggers.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -40,7 +40,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,8 +51,6 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Generated;
 
 /**
  * Represents a reported Host from inventory. This entity stores normalized facts for a Host
@@ -64,7 +61,7 @@ import org.hibernate.annotations.Generated;
 @Entity
 @ToString
 @Table(name = "hosts")
-public class Host implements Serializable {
+public class Host extends ModificationTrackedEntity implements Serializable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
@@ -159,16 +156,6 @@ public class Host implements Serializable {
   @MapKeyColumn(name = "service_type")
   @Column(name = "last_applied_event_record_date")
   private Map<String, OffsetDateTime> lastAppliedEventRecordDateByServiceType = new HashMap<>();
-
-  @Column(name = "last_modified", insertable = false, updatable = false)
-  @ColumnDefault("CURRENT_TIMESTAMP")
-  @Generated
-  /* A last_modified column also exists in the instance_measurements table; however, it is unmapped
-  in Hibernate since the records in instance_measurements are not their own entities.  They're
-  members of a CollectionTable.  Mapping the column there would require converting
-  hosts to be mapped to instance_measurements with a @OneToMany -->
-  */
-  private Instant lastModified = null;
 
   public Host() {}
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -32,14 +32,11 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Generated;
 
 /** Represents a bucket that this host contributes to. */
 @ToString
@@ -48,7 +45,7 @@ import org.hibernate.annotations.Generated;
 @NoArgsConstructor
 @Entity
 @Table(name = "host_tally_buckets")
-public class HostTallyBucket implements Serializable {
+public class HostTallyBucket extends ModificationTrackedEntity implements Serializable {
 
   @EmbeddedId private HostBucketKey key;
 
@@ -71,11 +68,6 @@ public class HostTallyBucket implements Serializable {
 
   // Version to enable optimistic locking
   @Version @Column private Integer version;
-
-  @Column(name = "last_modified", insertable = false, updatable = false)
-  @ColumnDefault("CURRENT_TIMESTAMP")
-  @Generated
-  private Instant lastModified = null;
 
   @SuppressWarnings("java:S107")
   public HostTallyBucket(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/ModificationTrackedEntity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/ModificationTrackedEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.db.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.hibernate.annotations.SourceType;
+
+/**
+ * A MappedSuperclass to hold the information for a last_modified column. This column is used to
+ * limit the number of rows fetched when we do data exports to the data warehouse.
+ *
+ * <p>Hibernate will populate the value for this column using a RETURNING clause which eliminates an
+ * extra round trip to the database. See <a
+ * href="https://in.relation.to/2024/04/19/generated-values/">here</a>
+ */
+@MappedSuperclass
+public abstract class ModificationTrackedEntity {
+
+  // Do not include in equals() as this doesn't affect logical equality
+  @Column(name = "last_modified")
+  @CurrentTimestamp(source = SourceType.DB)
+  private Instant lastModified = null;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallySnapshot.java
@@ -35,7 +35,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyClass;
 import jakarta.persistence.Table;
 import java.io.Serializable;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,8 +49,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.candlepin.subscriptions.utilization.api.v1.model.ReportCategory;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Generated;
 
 /** Model object to represent pieces of tally data. */
 @ToString
@@ -62,7 +59,8 @@ import org.hibernate.annotations.Generated;
 @Builder
 @Entity
 @Table(name = "tally_snapshots")
-public class TallySnapshot implements Serializable, TallyMeasurement {
+public class TallySnapshot extends ModificationTrackedEntity
+    implements Serializable, TallyMeasurement {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
@@ -99,16 +97,6 @@ public class TallySnapshot implements Serializable, TallyMeasurement {
   @Enumerated(EnumType.STRING)
   @Column(name = "granularity")
   private Granularity granularity;
-
-  @Column(name = "last_modified", insertable = false, updatable = false)
-  @ColumnDefault("CURRENT_TIMESTAMP")
-  @Generated
-  /* A last_modified column also exists in the tally_measurements table; however, it is unmapped
-  in Hibernate since the records in tally_measurements are not their own entities.  They're members
-  of a CollectionTable.  Mapping the column there would require converting tally_snapshots to be
-  mapped to tally_measurements with a @OneToMany -->
-  */
-  private Instant lastModified = null;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "tally_measurements", joinColumns = @JoinColumn(name = "snapshot_id"))


### PR DESCRIPTION
Jira issue: None (this is a follow-up to something I discovered in SWATCH-4812)

## Description
Initially, we used triggers to set the last_modified date on
swatch-tally tables.  In conjunction with this, we set up the Hibernate
annotations to populate the last_modified date during a CREATE or UPDATE
via the RETURNING clause based on what the trigger inserted.

As of Hibernate 6.5
(https://in.relation.to/2024/04/19/generated-values/), the
CurrentTimestamp annotation will take care of populating the
last_modified column without necessitating a trigger.  We still need
triggers for tables that aren't fully mapped (e.g. tally_measurements
which is mapped as an ElementCollection), but I prefer to keep trigger
use at a minimum as it makes schema management easier.

## Testing

### Setup
1. `SPRING_JPA_SHOW_SQL=true SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL=true make swatch-tally`

### Steps
1. Create some mock hosts
    ```
    bin/insert-mock-hosts --cores 2 --sockets 2 --org 123 --num-physical 10 --hbi
    ```
1. Run a tally
    ```
    http PUT ":8010/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/123" x-rh-swatch-psk:placeholder x-rh-swatch-synchronous-request:true
    ```

### Verification
1. Scroll up quite a bit.  When you get to where the inserts are happening to
   `host_tally_buckets` you'll see
    ```sql
    insert                                                                                                                                                                                          
    into                                                                                                                                                                                            
        host_tally_buckets                                                                                                                                                                          
        (cores, is_primary, last_modified, measurement_type, sockets, version, as_hypervisor, billing_account_id, billing_provider, host_id, product_id, sla, usage)                                
    values                                                                                                                                                                                          
        (?, ?, localtimestamp, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)                                                                                                                                        
    returning last_modified 
    ```
1.  Even further up, for `hosts`:
    ```sql
    insert 
    into
        hosts
        (billing_account_id, billing_provider, cloud_provider, display_name, is_guest, hardware_type, hypervisor_uuid, insights_id, instance_id, instance_type, inventory_id, is_hypervisor, is_unmapped_guest, last_modified, last_seen, num_of_guests, org_id, subscription_manager_id, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, localtimestamp, ?, ?, ?, ?, ?) 
    ```
    `last_modified` is being generated on the database side via [function call](https://docs.hibernate.org/stable/orm/javadocs/org/hibernate/annotations/CurrentTimestamp.html) and those `returning` clauses mean that the `last_modified` date is will be populated into the entity without the requirement of an additional round-trip to select the entity after creation.
1. Verify the `last_modified` columns are populated in `hosts` and
   `host_tally_buckets`:
   ```
   psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select id, last_modified from hosts;'
   psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c 'select host_id, last_modified from host_tally_buckets;'
   ```
