### PR TITLE
SWATCH-4732: switch the monitoring to use the detailed native memory …

### DIFF
--- a/swatch-utilization/src/main/docker/heap-monitor.sh
+++ b/swatch-utilization/src/main/docker/heap-monitor.sh
@@ -140,7 +140,7 @@ capture_nmt_summary() {
   local output_file="$1"
   if [ -d "/proc/1" ]; then
     echo "--- $(date '+%Y-%m-%d %H:%M:%S') ---" >> "$output_file"
-    jcmd 1 VM.native_memory summary >> "$output_file" 2>&1 || \
+    jcmd 1 VM.native_memory detail >> "$output_file" 2>&1 || \
       echo "[heap-monitor] NMT capture failed" >> "$output_file"
     echo "" >> "$output_file"
   fi


### PR DESCRIPTION
Jira issue: SWATCH-4732

Have the OOM monitoring capture the detailed native memory instead of summary on stage.

This will be reverted shortly.