### PR TITLE
SWATCH-4962 Fix tally API returns has_data=true with value=0 for category-filtered reports

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
@@ -384,7 +384,9 @@ public class TallyResource implements TallyApi {
   private UnroundedTallyReportDataPoint unroundedDataPointFromMeasurement(
       MetricId metricId, ReportCategory category, TallyMeasurement measurement) {
     return new UnroundedTallyReportDataPoint(
-        measurement.getSnapshotDate(), measurement.extractRawValue(metricId, category), true);
+        measurement.getSnapshotDate(),
+        measurement.extractRawValue(metricId, category),
+        measurement.hasMeasurementForCategory(metricId, category));
   }
 
   private List<UnroundedTallyReportDataPoint> transformToRunningTotalFormat(

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
@@ -221,6 +221,72 @@ class TallyResourceTest {
       assertEquals(22, response.getMeta().getTotalMonthly().getValue());
     }
 
+    /*
+     * Behavior:
+     * - If snapshot and measurements exist (value 0 or non-zero) -> has_data=true with value
+     * - If snapshot and measurements do not exist for that time -> has_data=false with value 0
+     * - If snapshot exists and measurements do not exist for that time -> has_data=false with value 0
+     */
+    @Test
+    void testHasDataFalseWhenCategoryHasNoMeasurementRows() {
+      var day1 = OffsetDateTime.parse("2025-10-01T00:00:00Z");
+      var day2 = OffsetDateTime.parse("2025-10-02T00:00:00Z");
+      var day3 = OffsetDateTime.parse("2025-10-03T00:00:00Z");
+      var day4 = OffsetDateTime.parse("2025-10-04T00:00:00Z");
+
+      // Snapshot and measurements exist with value 10 for day 1
+      var agg = new TallyMeasurementAggregate();
+      agg.setSnapshotDate(day1);
+      agg.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+      agg.setMetricId(MetricIdUtils.getSockets().toString());
+      agg.setValue(10.0);
+
+      // Snapshot and measurements exist with value 0 that's a valid case
+      var agg2 = new TallyMeasurementAggregate();
+      agg2.setSnapshotDate(day2);
+      agg2.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+      agg2.setMetricId(MetricIdUtils.getSockets().toString());
+      agg2.setValue(0.0);
+
+      // Snapshot exists and measurements do not exist for day 3
+      var agg3 = new TallyMeasurementAggregate();
+      agg3.setSnapshotDate(day3);
+
+      // Neither snapshot nor measurement are present for day 4
+
+      when(repository.findAggregatedMeasurements(
+              any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+              any()))
+          .thenReturn(new PageImpl<>(List.of(agg, agg2)));
+
+      TallyReportData response =
+          resource.getTallyReportData(
+              RHEL_FOR_X86,
+              MetricIdUtils.getSockets(),
+              GranularityType.DAILY,
+              day1,
+              day4,
+              ReportCategory.PHYSICAL,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              false,
+              null);
+
+      assertEquals(4, response.getData().size());
+      assertEquals(10, response.getData().get(0).getValue());
+      assertTrue(response.getData().get(0).getHasData());
+      assertEquals(0, response.getData().get(1).getValue());
+      assertTrue(response.getData().get(1).getHasData());
+      assertEquals(0, response.getData().get(2).getValue());
+      assertFalse(response.getData().get(2).getHasData());
+      assertEquals(0, response.getData().get(3).getValue());
+      assertFalse(response.getData().get(3).getHasData());
+    }
+
     @Test
     void testTallyReportDataTotalUsingHardwareMeasurements() {
       TallyMeasurementAggregate aggregate = new TallyMeasurementAggregate();
@@ -283,6 +349,75 @@ class TallyResourceTest {
               null);
       assertEquals(
           4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+    }
+
+    /*
+     * Behavior:
+     * - If snapshot and measurements exist (value 0 or non-zero) -> has_data=true with value
+     * - If snapshot and measurements do not exist for that time -> has_data=false with value 0
+     * - If snapshot exists and measurements do not exist for that time -> has_data=false with value 0
+     */
+    @Test
+    void testHasDataForCloudCategoryWithMultipleProviders() {
+      var day1 = OffsetDateTime.parse("2025-10-01T00:00:00Z");
+      var day2 = OffsetDateTime.parse("2025-10-02T00:00:00Z");
+      var day3 = OffsetDateTime.parse("2025-10-03T00:00:00Z");
+      var day4 = OffsetDateTime.parse("2025-10-04T00:00:00Z");
+
+      // Snapshot and measurements exists for different cloud with value 5 and 3 for day 1
+      var awsDay1 = new TallyMeasurementAggregate();
+      awsDay1.setSnapshotDate(day1);
+      awsDay1.setMeasurementType(HardwareMeasurementType.AWS);
+      awsDay1.setMetricId(MetricIdUtils.getSockets().toString());
+      awsDay1.setValue(5.0);
+
+      var azureDay1 = new TallyMeasurementAggregate();
+      azureDay1.setSnapshotDate(day1);
+      azureDay1.setMeasurementType(HardwareMeasurementType.AZURE);
+      azureDay1.setMetricId(MetricIdUtils.getSockets().toString());
+      azureDay1.setValue(3.0);
+
+      // Snapshot and measurements exist with value 7 for day 2
+      var awsDay2 = new TallyMeasurementAggregate();
+      awsDay2.setSnapshotDate(day2);
+      awsDay2.setMeasurementType(HardwareMeasurementType.AWS);
+      awsDay2.setMetricId(MetricIdUtils.getSockets().toString());
+      awsDay2.setValue(7.0);
+
+      // Snapshot exists and measurements do not exist for day 3
+      var awsDay3 = new TallyMeasurementAggregate();
+      awsDay3.setSnapshotDate(day3);
+      // Neither snapshot nor measurement are present for day 4
+
+      when(repository.findAggregatedMeasurements(
+              any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+              any()))
+          .thenReturn(new PageImpl<>(List.of(awsDay1, azureDay1, awsDay2)));
+
+      TallyReportData response =
+          resource.getTallyReportData(
+              RHEL_FOR_X86,
+              MetricIdUtils.getSockets(),
+              GranularityType.DAILY,
+              day1,
+              day4,
+              ReportCategory.CLOUD,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              false,
+              null);
+
+      assertEquals(4, response.getData().size());
+      assertTrue(response.getData().get(0).getHasData());
+      assertTrue(response.getData().get(1).getHasData());
+      assertFalse(response.getData().get(2).getHasData());
+      assertEquals(0, response.getData().get(2).getValue());
+      assertFalse(response.getData().get(3).getHasData());
+      assertEquals(0, response.getData().get(3).getValue());
     }
 
     @EnumSource(names = "CLOUD", mode = EnumSource.Mode.EXCLUDE)

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurement.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurement.java
@@ -50,4 +50,9 @@ public interface TallyMeasurement {
     }
     return contributingTypes;
   }
+
+  default boolean hasMeasurementForCategory(MetricId metricId, ReportCategory category) {
+    Set<HardwareMeasurementType> types = getContributingTypes(category);
+    return types.stream().anyMatch(type -> getMeasurement(type, metricId) != null);
+  }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementAggregate.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyMeasurementAggregate.java
@@ -102,4 +102,9 @@ public class TallyMeasurementAggregate implements Serializable, TallyMeasurement
     }
     return 0.0;
   }
+
+  @Override
+  public boolean hasMeasurementForCategory(MetricId metricId, ReportCategory category) {
+    return getContributingTypes(category).contains(getMeasurementType());
+  }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4962

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

Bug reproduced summary:

  category=cloud :

  Date 5,8,9 shows has_data true but value 0

### Setup
<!-- Add any steps required to set up the test case -->
```
 INSERT INTO tally_snapshots (id, org_id, product_id, granularity, snapshot_date, sla, usage, billing_provider, billing_account_id, is_primary)
  VALUES
    (gen_random_uuid(), '20012856', 'rhel-for-x86-ha', 'DAILY', '2026-04-05T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '20012856', 'rhel-for-x86-ha', 'DAILY', '2026-04-08T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '20012856', 'rhel-for-x86-ha', 'DAILY', '2026-04-09T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true);

  -- Insert tally_measurements: only VIRTUAL SOCKETS + TOTAL rows
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 1.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-05T00:00:00Z';

  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 1.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-08T00:00:00Z';

  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 2.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-09T00:00:00Z';

  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 1.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-05T00:00:00Z';

  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 1.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-08T00:00:00Z';

  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 2.0 FROM tally_snapshots WHERE org_id='20012856' AND snapshot_date='2026-04-09T00:00:00Z';

```

### Steps
<!-- Enter each step of the test below -->
1.  `SPRING_JPA_SHOW_SQL=true SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL=true make swatch-tally`

Unleash flag: `http://localhost:4242/projects/default/features/swatch.swatch-tally.enable-primary-row-searches`

### Verification on main
<!-- Enter the steps needed to verify the test passed -->
```
curl -s -X GET     -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0="     "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=cloud"
```

Response:
```
{"data":[{"date":"2026-04-05T00:00:00Z","value":0,"has_data":true},{"date":"2026-04-06T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-07T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-08T00:00:00Z","value":0,"has_data":true}
```

  # category=cloud (shows the bug: value=0, has_data=true on Apr 5, 8, 9)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=cloud"
```

  # category=virtual (correct: value=1,1,2 with has_data=true on Apr 5, 8, 9)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=virtual"
```

  # category=physical (correct: all has_data=false)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=physical"
```

  # category=hypervisor (correct: all has_data=false)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=hypervisor"
```

### Verification on this branch
<!-- Enter the steps needed to verify the test passed -->
```
curl -s -X GET     -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0="     "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/rhel-for-x86-ha/Sockets?granularity=Daily&beginning=2026-04-05T00:00:00Z&ending=2026-04-09T23:59:59.999Z&category=cloud"
```

Response:
```
{"data":[{"date":"2026-04-05T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-06T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-07T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-08T00:00:00Z","value":0,"has_data":false},{"date":"2026-04-09T00:00:00Z","value":0,"has_data":false}],"meta":{"count":5,"product":"rhel-for-x86-ha","metric_id":"Sockets","granularity":"Daily"}}
```


## Scenario 2
Mentioned in the Jira card
```
org_id=11789772

product_id=RHEL for x86

metric_id=SOCKETS

granularity=Daily

beginning=2026-04-17T00:00:00Z

ending=2026-04-23T23:59:59.999Z

categories affected: physical, hypervisor

DB evidence (raw measurements):
For 2026-04-19, 2026-04-20, 2026-04-21, there are no PHYSICAL/HYPERVISOR SOCKETS measurement rows, but snapshots exist for the product/day (other categories present).

2026-04-17: PHYSICAL=86, HYPERVISOR=86

2026-04-18: PHYSICAL=36, HYPERVISOR=36

2026-04-19: no PHYSICAL/HYPERVISOR SOCKETS rows

2026-04-20: no PHYSICAL/HYPERVISOR SOCKETS rows

2026-04-21: no PHYSICAL/HYPERVISOR SOCKETS rows

2026-04-22: PHYSICAL=60, HYPERVISOR=46

2026-04-23: PHYSICAL=124, HYPERVISOR=96
```

### Setup
```
-- Insert tally_snapshots for all 7 days (Apr 17-23)
  INSERT INTO tally_snapshots (id, org_id, product_id, granularity, snapshot_date, sla, usage, billing_provider, billing_account_id, is_primary)
  VALUES
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-17T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-18T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-19T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-20T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-21T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-22T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    (gen_random_uuid(), '11789772', 'RHEL for x86', 'DAILY', '2026-04-23T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true);

  -- PHYSICAL SOCKETS (Apr 17,18,22,23 only — NOT 19,20,21)
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'PHYSICAL', 'SOCKETS', 86.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-17T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'PHYSICAL', 'SOCKETS', 36.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-18T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'PHYSICAL', 'SOCKETS', 60.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-22T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'PHYSICAL', 'SOCKETS', 124.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-23T00:00:00Z';

  -- HYPERVISOR SOCKETS (Apr 17,18,22,23 only — NOT 19,20,21)
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'HYPERVISOR', 'SOCKETS', 86.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-17T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'HYPERVISOR', 'SOCKETS', 36.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-18T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'HYPERVISOR', 'SOCKETS', 46.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-22T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'HYPERVISOR', 'SOCKETS', 96.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-23T00:00:00Z';

  -- VIRTUAL SOCKETS on all 7 days (so snapshots exist for Apr 19-21)
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-17T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-18T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-19T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-20T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-21T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-22T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'VIRTUAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-23T00:00:00Z';

  -- TOTAL rows
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 182.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-17T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 82.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-18T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-19T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-20T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 10.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-21T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 116.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-22T00:00:00Z';
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  SELECT id, 'TOTAL', 'SOCKETS', 230.0 FROM tally_snapshots WHERE org_id='11789772' AND snapshot_date='2026-04-23T00:00:00Z';

```


### Steps and Verification
Opt-in
```
 curl -s -X PUT \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMTc4OTc3MiJ9fX0=" \
    -H "Content-Type: application/json" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/opt-in"
```
API calls

  # category=physical (bug: Apr 19-21 should be has_data=false)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMTc4OTc3MiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Sockets?granularity=Daily&beginning=2026-04-17T00:00:00Z&ending=2026-04-23T23:59:59.999Z&category=physical"
  ```

  # category=hypervisor (bug: Apr 19-21 should be has_data=false)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMTc4OTc3MiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Sockets?granularity=Daily&beginning=2026-04-17T00:00:00Z&ending=2026-04-23T23:59:59.999Z&category=hypervisor"
```

  # category=virtual (correct: all 7 days has_data=true, value=10)
```
  curl -s -X GET \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IiIsInR5cGUiOiJVc2VyIiwidXNlciI6eyJpc19vcmdfYWRtaW4iOnRydWV9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMTc4OTc3MiJ9fX0=" \
    "http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Sockets?granularity=Daily&beginning=2026-04-17T00:00:00Z&ending=2026-04-23T23:59:59.999Z&category=virtual"
```


## For Cloud category

### Behavior is still same

### Steps
```
 Step 1: Insert test data
INSERT INTO tally_snapshots (id, org_id, product_id, granularity, snapshot_date, sla, usage, billing_provider, billing_account_id, is_primary)
  VALUES
    ('c0000001-0000-0000-0000-000000000001', '20012856', 'RHEL for x86', 'DAILY', '2025-12-01T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true),
    ('c0000002-0000-0000-0000-000000000002', '20012856', 'RHEL for x86', 'DAILY', '2025-12-02T00:00:00Z', '_ANY', '_ANY', '_ANY', '_ANY', true)
  ON CONFLICT DO NOTHING;
  
  INSERT INTO tally_measurements (snapshot_id, measurement_type, metric_id, value)
  VALUES 
    ('c0000001-0000-0000-0000-000000000001', 'AWS', 'SOCKETS', 5.0),
    ('c0000001-0000-0000-0000-000000000001', 'AZURE', 'SOCKETS', 3.0),
    ('c0000002-0000-0000-0000-000000000002', 'AWS', 'SOCKETS', 7.0)
  ON CONFLICT DO NOTHING;

```

Call the API with category=cloud

```
curl -s 'http://localhost:8010/api/rhsm-subscriptions/v1/tally/products/RHEL%20for%20x86/Sockets?granularity=daily&beginning=2025-12-01T00:00:00Z&ending=2025-12-04T00:00:00Z&category=cloud' \
    -H 'x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwib3JnX2lkIjoiMjAwMTI4NTYiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIyMDAxMjg1NiJ9fX0K' | jq '.data[] | {date, value, 
  has_data}'
```

### Verification
```
{
  "date": "2025-12-01T00:00:00Z",
  "value": 5,
  "has_data": true
}
{
  "date": "2025-12-02T00:00:00Z",
  "value": 7,
  "has_data": true
}
{
  "date": "2025-12-03T00:00:00Z",
  "value": 0,
  "has_data": false
}
{
  "date": "2025-12-04T00:00:00Z",
  "value": 0,
  "has_data": false
}

```


### Extra Notes for future refrence:
- Old query with unleash flag on turning is_primary feature off: 
2026-05-13 17:41:30,910 [thread=http-nio-8010-exec-7] [WARN ] [org.candlepin.subscriptions.resource.api.v1.TallyResource] 20012856- Tally API called for a range more or less than a full month. Not populating totalMonthly
Hibernate: 
``` 
   select
        oc1_0.org_id 
    from
        org_config oc1_0 
    where
        oc1_0.org_id=? 
    fetch
        first ? rows only
Hibernate: 
    select
        oc1_0.org_id 
    from
        org_config oc1_0 
    where
        oc1_0.org_id=? 
    fetch
        first ? rows only
Hibernate: 
    select
        distinct ts1_0.id,
        ts1_0.billing_account_id,
        ts1_0.billing_provider,
        ts1_0.granularity,
        ts1_0.is_primary,
        ts1_0.last_modified,
        ts1_0.org_id,
        ts1_0.product_id,
        ts1_0.sla,
        ts1_0.snapshot_date,
        tm1_0.snapshot_id,
        tm1_0.measurement_type,
        tm1_0.metric_id,
        tm1_0.value,
        ts1_0.usage 
    from
        tally_snapshots ts1_0 
    left join
        tally_measurements tm1_0 
            on ts1_0.id=tm1_0.snapshot_id 
    where
        ts1_0.org_id=? 
        and ts1_0.product_id=? 
        and ts1_0.granularity=? 
        and ts1_0.sla=? 
        and ts1_0.usage=? 
        and ts1_0.billing_provider=? 
        and ts1_0.billing_account_id=? 
        and ts1_0.snapshot_date between ? and ? 
    order by
        ts1_0.snapshot_date
```

- NEW Query
2026-05-13 18:04:11,082 [thread=http-nio-8010-exec-9] [WARN ] [org.candlepin.subscriptions.resource.api.v1.TallyResource] 20012856- Tally API called for a range more or less than a full month. Not populating totalMonthly
Hibernate: 
```
    select
        oc1_0.org_id 
    from
        org_config oc1_0 
    where
        oc1_0.org_id=? 
    fetch
        first ? rows only
Hibernate: 
    select
        oc1_0.org_id 
    from
        org_config oc1_0 
    where
        oc1_0.org_id=? 
    fetch
        first ? rows only
Hibernate: 
    select
        distinct ts1_0.snapshot_date,
        tm1_0.measurement_type,
        tm1_0.metric_id,
        sum(tm1_0.value) 
    from
        tally_snapshots ts1_0 
    left join
        tally_measurements tm1_0 
            on ts1_0.id=tm1_0.snapshot_id 
    where
        ts1_0.is_primary=? 
        and ts1_0.org_id=? 
        and ts1_0.product_id=? 
        and ts1_0.granularity=? 
        and ts1_0.snapshot_date between ? and ? 
        and tm1_0.metric_id=? 
        and tm1_0.measurement_type=? 
    group by
        1,
        2,
        3
```


- There are two query paths depending on the isPrimaryRowSearchesEnabled() feature flag:

  Path 1: findSnapshot (feature flag OFF — legacy path)

  JPQL (TallySnapshotRepository.java:69-80):
```
  SELECT DISTINCT t FROM TallySnapshot t
    LEFT JOIN FETCH t.tallyMeasurements
  WHERE t.orgId = :orgId
    AND t.productId = :productId
    AND t.granularity = :granularity
    AND t.serviceLevel = :serviceLevel
    AND t.usage = :usage 
    AND t.billingProvider = :billingProvider
    AND t.billingAccountId = :billingAcctId
    AND t.snapshotDate BETWEEN :beginning AND :ending
  ORDER BY t.snapshotDate
```
  
  This fetches entire snapshots with ALL their measurements (all categories). The category filtering happens in Java via extractRawValue(metricId, category) which sums only the matching HardwareMeasurementTypes.
   This is where the bug lives — a snapshot row is returned (because other categories have data), has_data is hardcoded to true at line 387, but extractRawValue returns 0 for the requested category.

  Path 2: findAggregatedMeasurements (feature flag ON — new path)

  Criteria API query (TallySnapshotRepository.java:361-460), equivalent SQL:
```
  SELECT DISTINCT s.snapshot_date, m.measurement_type, m.metric_id, SUM(m.value)
  FROM tally_snapshots s
    LEFT JOIN tally_measurements m ON m.snapshot_id = s.id
  WHERE s.is_primary = true
    AND s.org_id = :orgId
    AND s.product_id = :productId
    AND s.granularity = :granularity
    AND s.sla = :serviceLevel
    AND s.usage = :usage
    AND s.billing_provider = :billingProvider
    AND s.billing_account_id = :billingAcctId
    AND s.snapshot_date BETWEEN :beginning AND :ending
    AND UPPER(m.metric_id) = UPPER(:metricId)
    AND m.measurement_type = :hardwareMeasurementType
  GROUP BY s.snapshot_date, m.measurement_type, m.metric_id
 ```

