### PR TITLE
SWATCH-4897 Add customer threshold distribution and Grafana panel

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -6628,6 +6628,102 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
+              "description": "Rolling average of observed org utilization threshold (percent), by how it was recorded: API GET/PUT vs Kafka pipeline reads.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "max": 100,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 74
+              },
+              "id": 136,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(rate(swatch_utilization_customer_threshold_percent_sum{service=\"swatch-utilization-service\"}[5m])) by (source) / sum(rate(swatch_utilization_customer_threshold_percent_count{service=\"swatch-utilization-service\"}[5m])) by (source)",
+                  "legendFormat": "{{ source }}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Customer utilization threshold (avg %)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -6738,7 +6834,7 @@ data:
                 "h": 8,
                 "w": 21,
                 "x": 0,
-                "y": 74
+                "y": 82
               },
               "id": 131,
               "options": {
@@ -6880,7 +6976,7 @@ data:
       "timezone": "utc",
       "title": "Subscription Watch",
       "uid": "lkPhH-1Zk",
-      "version": 9
+      "version": 10
     }
 kind: ConfigMap
 metadata:

--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -146,6 +146,10 @@ The service exposes several metrics for monitoring and alerting:
 - `sla`: Service level when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
 - `usage`: Usage type when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
 
+**swatch_utilization_customer_threshold_percent**: Distribution summary of observed utilization threshold percentages, tagged by `source`:
+- `api_get` / `api_put`: values returned or saved via the org preferences API
+- `pipeline`: values read while evaluating custom thresholds from Kafka summaries
+
 These metrics enable:
 - Dashboards showing utilization monitoring coverage
 - Alerts when over-usage is detected frequently

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -56,6 +56,8 @@ public class CustomThresholdUtilizationHandlerService
 
     var preference = preferenceOpt.get();
     int threshold = preference.getCustomThreshold();
+    CustomerThresholdPercentMetric.record(
+        meterRegistry, CustomerThresholdPercentMetric.SOURCE_PIPELINE, threshold);
 
     if (utilizationPercent >= threshold) {
       log.info(

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomerThresholdPercentMetric.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomerThresholdPercentMetric.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.service;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Micrometer wiring for the {@code swatch_utilization_customer_threshold_percent} distribution
+ * summary (not a CDI bean; callers inject {@link MeterRegistry} like other services).
+ */
+final class CustomerThresholdPercentMetric {
+
+  static final String METRIC = "swatch_utilization_customer_threshold_percent";
+  static final String TAG_SOURCE = "source";
+  static final String SOURCE_API_GET = "api_get";
+  static final String SOURCE_API_PUT = "api_put";
+  static final String SOURCE_PIPELINE = "pipeline";
+
+  private CustomerThresholdPercentMetric() {}
+
+  static void record(MeterRegistry meterRegistry, String source, int thresholdPercent) {
+    DistributionSummary.builder(METRIC)
+        .description("Observed customer utilization threshold (whole percent)")
+        .tag(TAG_SOURCE, source)
+        .register(meterRegistry)
+        .record(thresholdPercent);
+  }
+}

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceEntity;
 import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceRepository;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
@@ -34,12 +35,15 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 public class OrgPreferencesService {
 
   private final OrgUtilizationPreferenceRepository repository;
+  private final MeterRegistry meterRegistry;
 
   @ConfigProperty(name = "ORG_PREFERENCE_DEFAULT_THRESHOLD")
   Integer defaultThreshold;
 
-  public OrgPreferencesService(OrgUtilizationPreferenceRepository repository) {
+  public OrgPreferencesService(
+      OrgUtilizationPreferenceRepository repository, MeterRegistry meterRegistry) {
     this.repository = repository;
+    this.meterRegistry = meterRegistry;
   }
 
   /**
@@ -56,6 +60,10 @@ public class OrgPreferencesService {
     } else {
       response.setCustomThreshold(entityOpt.get().getCustomThreshold());
     }
+    CustomerThresholdPercentMetric.record(
+        meterRegistry,
+        CustomerThresholdPercentMetric.SOURCE_API_GET,
+        response.getCustomThreshold());
     return response;
   }
 
@@ -71,6 +79,8 @@ public class OrgPreferencesService {
     repository.persist(entity);
     var response = new OrgPreferencesResponse();
     response.setCustomThreshold(request.getCustomThreshold());
+    CustomerThresholdPercentMetric.record(
+        meterRegistry, CustomerThresholdPercentMetric.SOURCE_API_PUT, request.getCustomThreshold());
     log.debug("Updated utilization preference '{}' to orgId={}", request, orgId);
     return response;
   }


### PR DESCRIPTION
## Summary
- Add `swatch_utilization_customer_threshold_percent` (API GET/PUT + pipeline) via `CustomerThresholdPercentMetric` and `MeterRegistry` on org preferences / custom threshold handler.
- Add Subscription Watch Grafana timeseries **Customer utilization threshold (avg %)** and move the over-usages table down.

Closes SWATCH-4897.
Part of SWATCH-4800.