### PR TITLE
SWATCH-4898 Tag notification counters and add Grafana rate panel

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -6724,6 +6724,112 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
+              "description": "Rate of notification events emitted by swatch-utilization (each increment corresponds to a notifications ingress payload for that event type).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 74
+              },
+              "id": 137,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(rate(swatch_utilization_over_usage_total{service=\"swatch-utilization-service\"}[5m]))",
+                  "legendFormat": "exceeded-utilization-threshold",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(rate(swatch_utilization_custom_threshold_total{service=\"swatch-utilization-service\"}[5m]))",
+                  "legendFormat": "exceeded-custom-utilization-threshold",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Utilization notification events (rate)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -6976,7 +7082,7 @@ data:
       "timezone": "utc",
       "title": "Subscription Watch",
       "uid": "lkPhH-1Zk",
-      "version": 10
+      "version": 11
     }
 kind: ConfigMap
 metadata:

--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -145,6 +145,9 @@ The service exposes several metrics for monitoring and alerting:
 - `billing`: Billing provider (if present)
 - `sla`: Service level when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
 - `usage`: Usage type when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
+- `event_type`: Notifications ingress event type (for example `exceeded-utilization-threshold`)
+
+**swatch_utilization_custom_threshold**: Counter for custom org-threshold notifications, with the same dimensional tags as over-usage, including `event_type` (for example `exceeded-custom-utilization-threshold`).
 
 **swatch_utilization_customer_threshold_percent**: Distribution summary of observed utilization threshold percentages, tagged by `source`:
 - `api_get` / `api_put`: values returned or saved via the org preferences API

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
@@ -212,7 +212,9 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
             "sla",
             metricSlaLabelValue(payload.getSla()),
             "usage",
-            metricUsageLabelValue(payload.getUsage()))
+            metricUsageLabelValue(payload.getUsage()),
+            "event_type",
+            eventType())
         .increment();
   }
 

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
@@ -478,6 +478,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
             .tag("metric_id", metricId)
             .tag("sla", BaseThresholdUtilizationHandlerService.metricSlaLabelValue(sla))
             .tag("usage", BaseThresholdUtilizationHandlerService.metricUsageLabelValue(usage))
+            .tag("event_type", CustomThresholdUtilizationHandlerService.EVENT_TYPE)
             .counter();
     return counter != null ? counter.count() : 0.0;
   }

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerServiceTest.java
@@ -580,6 +580,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             .tag("metric_id", metricId)
             .tag("sla", BaseThresholdUtilizationHandlerService.metricSlaLabelValue(sla))
             .tag("usage", BaseThresholdUtilizationHandlerService.metricUsageLabelValue(usage))
+            .tag("event_type", OverThresholdUtilizationHandlerService.EVENT_TYPE)
             .counter();
     return counter != null ? counter.count() : 0.0;
   }


### PR DESCRIPTION
## Summary
- Add `event_type` tag to utilization notification counters; update unit tests and README.
- Add Subscription Watch Grafana timeseries **Utilization notification events (rate)**.

**Merge after** SWATCH-4897 / #6133.

Closes SWATCH-4898.
Part of SWATCH-4800.