### PR TITLE
SWATCH-4899 Add handler timer and Grafana duration panel

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -6830,6 +6830,101 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
+              "description": "Mean wall time spent evaluating each utilization measurement in a threshold handler (Kafka pipeline).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 74
+              },
+              "id": 138,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(rate(swatch_utilization_handler_seconds_sum{service=\"swatch-utilization-service\"}[5m])) by (handler_kind) / sum(rate(swatch_utilization_handler_seconds_count{service=\"swatch-utilization-service\"}[5m])) by (handler_kind)",
+                  "legendFormat": "{{ handler_kind }}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Threshold handler duration (avg)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -7082,7 +7177,7 @@ data:
       "timezone": "utc",
       "title": "Subscription Watch",
       "uid": "lkPhH-1Zk",
-      "version": 11
+      "version": 12
     }
 kind: ConfigMap
 metadata:

--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -153,6 +153,8 @@ The service exposes several metrics for monitoring and alerting:
 - `api_get` / `api_put`: values returned or saved via the org preferences API
 - `pipeline`: values read while evaluating custom thresholds from Kafka summaries
 
+**swatch_utilization_handler**: Timer for wall time spent in each threshold handler implementation, tagged by `handler_kind` (`over_usage`, `custom_threshold`).
+
 These metrics enable:
 - Dashboards showing utilization monitoring coverage
 - Alerts when over-usage is detected frequently

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
@@ -38,6 +38,7 @@ import com.redhat.swatch.utilization.model.UtilizationSummary;
 import com.redhat.swatch.utilization.model.UtilizationSummary.BillingProvider;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import jakarta.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,6 +50,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Slf4j
 public abstract class BaseThresholdUtilizationHandlerService implements UtilizationHandlerService {
+
+  public static final String HANDLER_TIMER_METRIC = "swatch_utilization_handler";
 
   public static final String DIMENSION_ANY = "_ANY";
 
@@ -67,19 +70,31 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
   Double defaultOverUsageThresholdPercent;
 
   public boolean handle(UtilizationSummary payload, Measurement measurement) {
-    var utilizationOpt = computeUtilizationPercent(payload, measurement);
-    if (utilizationOpt.isEmpty()) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    try {
+      var utilizationOpt = computeUtilizationPercent(payload, measurement);
+      if (utilizationOpt.isEmpty()) {
+        return false;
+      }
+      double utilizationPercent = utilizationOpt.getAsDouble();
+      var eventOpt = evaluateThreshold(utilizationPercent, payload, measurement);
+      if (eventOpt.isPresent()) {
+        MetricId metricId = MetricId.fromString(measurement.getMetricId());
+        sendNotification(payload, metricId, eventType(), severity(), eventOpt.get(), metricName());
+        return true;
+      }
       return false;
+    } finally {
+      sample.stop(
+          Timer.builder(HANDLER_TIMER_METRIC)
+              .description("Time spent evaluating a utilization measurement in a threshold handler")
+              .tag("handler_kind", handlerKind())
+              .register(meterRegistry));
     }
-    double utilizationPercent = utilizationOpt.getAsDouble();
-    var eventOpt = evaluateThreshold(utilizationPercent, payload, measurement);
-    if (eventOpt.isPresent()) {
-      MetricId metricId = MetricId.fromString(measurement.getMetricId());
-      sendNotification(payload, metricId, eventType(), severity(), eventOpt.get(), metricName());
-      return true;
-    }
-    return false;
   }
+
+  /** Short stable label for {@link #HANDLER_TIMER_METRIC} (e.g. {@code over_usage}). */
+  protected abstract String handlerKind();
 
   protected abstract Optional<Event> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement);

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -93,6 +93,11 @@ public class CustomThresholdUtilizationHandlerService
     return CUSTOM_THRESHOLD_METRIC;
   }
 
+  @Override
+  protected String handlerKind() {
+    return "custom_threshold";
+  }
+
   static String hashLastUpdated(OffsetDateTime lastUpdated) {
     return DigestUtils.sha256Hex(lastUpdated.toString());
   }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
@@ -92,4 +92,9 @@ public class OverThresholdUtilizationHandlerService extends BaseThresholdUtiliza
   protected String metricName() {
     return OVER_USAGE_METRIC;
   }
+
+  @Override
+  protected String handlerKind() {
+    return "over_usage";
+  }
 }


### PR DESCRIPTION
## Summary
- Add `swatch_utilization_handler` Micrometer timer (`handler_kind`) around threshold handler evaluation.
- Add Subscription Watch Grafana timeseries **Threshold handler duration (avg)**.

**Merge after** SWATCH-4898 (stacked on SWATCH-4897).

Closes SWATCH-4899.
Part of SWATCH-4800.