### PR TITLE
SWATCH-4860: Set is_primary flag for primary buckets during tally processing

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/MetricUsageCollector.java
@@ -59,6 +59,7 @@ import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.tally.UsageCalculation.Key;
+import org.candlepin.subscriptions.util.PrimaryRecordUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -360,6 +361,7 @@ public class MetricUsageCollector {
           activeHostBucketKeys.add(key);
           bucket.setCores(cores);
           bucket.setSockets(sockets);
+          bucket.setPrimary(PrimaryRecordUtils.isPrimaryRecord(bucket));
           host.addBucket(bucket);
         });
     // mark as deleted the buckets that are not active

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollector.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.util.PrimaryRecordUtils;
 
 /** The default product usage collection rules. */
 public class DefaultProductUsageCollector implements ProductUsageCollector {
@@ -63,7 +64,7 @@ public class DefaultProductUsageCollector implements ProductUsageCollector {
             appliedCores,
             appliedSockets,
             appliedType);
-
+    appliedBucket.setPrimary(PrimaryRecordUtils.isPrimaryRecord(appliedBucket));
     return Optional.of(appliedBucket);
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollector.java
@@ -25,6 +25,7 @@ import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.tally.UsageCalculation;
 import org.candlepin.subscriptions.tally.facts.NormalizedFacts;
+import org.candlepin.subscriptions.util.PrimaryRecordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,16 +102,19 @@ public class RHELProductUsageCollector implements ProductUsageCollector {
       Integer appliedCores,
       Integer appliedSockets,
       HardwareMeasurementType appliedType) {
-    return new HostTallyBucket(
-        null,
-        key.getProductId(),
-        key.getSla(),
-        key.getUsage(),
-        key.getBillingProvider(),
-        key.getBillingAccountId(),
-        asHypervisor,
-        appliedCores,
-        appliedSockets,
-        appliedType);
+    HostTallyBucket bucket =
+        new HostTallyBucket(
+            null,
+            key.getProductId(),
+            key.getSla(),
+            key.getUsage(),
+            key.getBillingProvider(),
+            key.getBillingAccountId(),
+            asHypervisor,
+            appliedCores,
+            appliedSockets,
+            appliedType);
+    bucket.setPrimary(PrimaryRecordUtils.isPrimaryRecord(bucket));
+    return bucket;
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/util/PrimaryRecordUtils.java
+++ b/src/main/java/org/candlepin/subscriptions/util/PrimaryRecordUtils.java
@@ -24,6 +24,7 @@ import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -72,41 +73,84 @@ public class PrimaryRecordUtils {
     if (snapshot.getProductId() == null) {
       throw new IllegalArgumentException("TallySnapshot productId cannot be null");
     }
+    return isPrimary(
+        snapshot.getProductId(),
+        snapshot.getServiceLevel(),
+        snapshot.getUsage(),
+        snapshot.getBillingProvider(),
+        snapshot.getBillingAccountId());
+  }
 
-    boolean slaIsNotAny = snapshot.getServiceLevel() != ServiceLevel._ANY;
-    boolean usageIsNotAny = snapshot.getUsage() != Usage._ANY;
+  /**
+   * Determines if a HostTallyBucket record is a primary record based on its product type and
+   * attributes.
+   *
+   * <p>For PAYG products, a bucket is primary if:
+   *
+   * <ul>
+   *   <li>SLA is not _ANY
+   *   <li>Usage is not _ANY
+   *   <li>Billing provider is not _ANY
+   *   <li>Billing account ID is not null and not _ANY
+   * </ul>
+   *
+   * <p>For traditional (non-PAYG) products, a bucket is primary if:
+   *
+   * <ul>
+   *   <li>SLA is not _ANY
+   *   <li>Usage is not _ANY
+   *   <li>Billing provider is _ANY
+   *   <li>Billing account ID is _ANY
+   * </ul>
+   *
+   * @param bucket the HostTallyBucket to evaluate
+   * @return true if the bucket is a primary record, false otherwise
+   * @throws IllegalArgumentException if bucket is null, has a null key, or has a null product ID
+   * @throws IllegalStateException if the product ID is not found in the subscription configuration
+   */
+  public static boolean isPrimaryRecord(HostTallyBucket bucket) {
+    if (bucket == null) {
+      throw new IllegalArgumentException("HostTallyBucket cannot be null");
+    }
+    if (bucket.getKey() == null) {
+      throw new IllegalArgumentException("HostTallyBucket key cannot be null");
+    }
+    if (bucket.getKey().getProductId() == null) {
+      throw new IllegalArgumentException("HostTallyBucket productId cannot be null");
+    }
+    return isPrimary(
+        bucket.getKey().getProductId(),
+        bucket.getKey().getSla(),
+        bucket.getKey().getUsage(),
+        bucket.getKey().getBillingProvider(),
+        bucket.getKey().getBillingAccountId());
+  }
 
-    // Look up the subscription definition to determine if it's PAYG eligible
+  private static boolean isPrimary(
+      String productId,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId) {
+
+    boolean slaIsNotAny = sla != ServiceLevel._ANY;
+    boolean usageIsNotAny = usage != Usage._ANY;
+
     SubscriptionDefinition subscriptionDefinition =
-        SubscriptionDefinition.lookupSubscriptionByTag(snapshot.getProductId())
+        SubscriptionDefinition.lookupSubscriptionByTag(productId)
             .orElseThrow(
                 () ->
                     new IllegalStateException(
-                        snapshot.getProductId() + " missing in subscription configuration"));
+                        productId + " missing in subscription configuration"));
 
     if (subscriptionDefinition.isPaygEligible()) {
-      // For PAYG products, all four fields must be non-_ANY
-      boolean billingProviderIsNotAny = snapshot.getBillingProvider() != BillingProvider._ANY;
+      boolean billingProviderIsNotAny = billingProvider != BillingProvider._ANY;
       boolean billingAccountIdIsNotAny =
-          !Objects.isNull(snapshot.getBillingAccountId())
-              && !ANY.equals(snapshot.getBillingAccountId());
+          !Objects.isNull(billingAccountId) && !ANY.equals(billingAccountId);
       return slaIsNotAny && usageIsNotAny && billingProviderIsNotAny && billingAccountIdIsNotAny;
     } else {
-      // For traditional products, SLA and usage must be non-_ANY, and billing fields must be _ANY
-      boolean billingProviderIsAny = snapshot.getBillingProvider() == BillingProvider._ANY;
-      boolean billingAccountIdIsAny = ANY.equals(snapshot.getBillingAccountId());
-
-      // Log warning if billing fields are not _ANY for traditional products
-      if (!billingProviderIsAny || !billingAccountIdIsAny) {
-        log.warn(
-            "Traditional product snapshot has unexpected billing field values. "
-                + "productId={}, billingProvider={}, billingAccountId={}. "
-                + "Expected both to be _ANY.",
-            snapshot.getProductId(),
-            snapshot.getBillingProvider(),
-            snapshot.getBillingAccountId());
-      }
-
+      boolean billingProviderIsAny = billingProvider == BillingProvider._ANY;
+      boolean billingAccountIdIsAny = ANY.equals(billingAccountId);
       return slaIsNotAny && usageIsNotAny && billingProviderIsAny && billingAccountIdIsAny;
     }
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/MetricUsageCollectorTest.java
@@ -435,6 +435,117 @@ class MetricUsageCollectorTest {
   }
 
   @Test
+  void testUpdateHostsSetsIsPrimaryOnPaygProductBuckets() {
+    Measurement measurement =
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
+    Event event =
+        createEvent()
+            .withEventId(UUID.randomUUID())
+            .withProductIds(List.of(RHEL_ELS_PAYG_ENG_ID))
+            .withProductTag(Set.of(RHEL_FOR_X86_ELS_PAYG))
+            .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
+            .withServiceType("RHEL System")
+            .withHardwareType(HardwareType.VIRTUAL)
+            .withMeasurements(Collections.singletonList(measurement))
+            .withSla(Event.Sla.PREMIUM)
+            .withBillingProvider(Event.BillingProvider.AWS)
+            .withBillingAccountId(Optional.of("123456"));
+
+    metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event));
+
+    ArgumentCaptor<Host> saveHostCaptor = ArgumentCaptor.forClass(Host.class);
+    verify(hostRepository).save(saveHostCaptor.capture());
+
+    Host instance = saveHostCaptor.getValue();
+
+    // Find the primary bucket (non-_ANY SLA, Usage, BillingProvider, and BillingAccountId)
+    Optional<HostTallyBucket> primaryBucket =
+        instance.getBuckets().stream()
+            .filter(
+                b ->
+                    b.getKey().getSla() == ServiceLevel.PREMIUM
+                        && b.getKey().getUsage() == Usage.PRODUCTION
+                        && b.getKey().getBillingProvider() == BillingProvider.AWS
+                        && "123456".equals(b.getKey().getBillingAccountId()))
+            .findFirst();
+
+    assertTrue(primaryBucket.isPresent(), "Primary bucket should exist");
+    assertTrue(
+        primaryBucket.get().isPrimary(),
+        "PAYG product with all non-_ANY fields should have isPrimary=true");
+
+    // Verify non-primary buckets (those with _ANY values)
+    boolean allAnyBucketsAreNonPrimary =
+        instance.getBuckets().stream()
+            .filter(
+                b ->
+                    b.getKey().getSla() == ServiceLevel._ANY
+                        || b.getKey().getUsage() == Usage._ANY
+                        || b.getKey().getBillingProvider() == BillingProvider._ANY
+                        || "_ANY".equals(b.getKey().getBillingAccountId()))
+            .allMatch(b -> !b.isPrimary());
+
+    assertTrue(
+        allAnyBucketsAreNonPrimary,
+        "All buckets with _ANY values should have isPrimary=false for PAYG products");
+  }
+
+  @Test
+  void testUpdateHostsSetsIsPrimaryOnTraditionalProductBuckets() {
+    Measurement measurement =
+        new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);
+    Event event =
+        createEvent()
+            .withEventId(UUID.randomUUID())
+            .withProductTag(Set.of("rhel-for-x86-els-unconverted"))
+            .withTimestamp(OffsetDateTime.parse("2021-02-26T00:00:00Z"))
+            .withServiceType("RHEL System")
+            .withHardwareType(HardwareType.VIRTUAL)
+            .withMeasurements(Collections.singletonList(measurement))
+            .withSla(Event.Sla.PREMIUM)
+            .withBillingProvider(Event.BillingProvider.RED_HAT)
+            .withBillingAccountId(Optional.of("redhat1"));
+
+    metricUsageCollector.updateHosts(ORG_ID, SERVICE_TYPE, List.of(event));
+
+    ArgumentCaptor<Host> saveHostCaptor = ArgumentCaptor.forClass(Host.class);
+    verify(hostRepository).save(saveHostCaptor.capture());
+
+    Host instance = saveHostCaptor.getValue();
+
+    // Find the primary bucket (non-_ANY SLA/Usage, _ANY billing fields)
+    Optional<HostTallyBucket> primaryBucket =
+        instance.getBuckets().stream()
+            .filter(
+                b ->
+                    b.getKey().getSla() == ServiceLevel.PREMIUM
+                        && b.getKey().getUsage() == Usage.PRODUCTION
+                        && b.getKey().getBillingProvider() == BillingProvider._ANY
+                        && "_ANY".equals(b.getKey().getBillingAccountId()))
+            .findFirst();
+
+    assertTrue(primaryBucket.isPresent(), "Primary bucket should exist");
+    assertTrue(
+        primaryBucket.get().isPrimary(),
+        "Traditional product with non-_ANY SLA/Usage and _ANY billing fields should have isPrimary=true");
+
+    // Verify non-primary buckets (those with _ANY SLA or Usage, or non-_ANY billing fields)
+    boolean allNonPrimaryBucketsCorrect =
+        instance.getBuckets().stream()
+            .filter(
+                b ->
+                    b.getKey().getSla() == ServiceLevel._ANY
+                        || b.getKey().getUsage() == Usage._ANY
+                        || b.getKey().getBillingProvider() != BillingProvider._ANY
+                        || !"_ANY".equals(b.getKey().getBillingAccountId()))
+            .allMatch(b -> !b.isPrimary());
+
+    assertTrue(
+        allNonPrimaryBucketsCorrect,
+        "All buckets with _ANY SLA/Usage or non-_ANY billing fields should have isPrimary=false for traditional products");
+  }
+
+  @Test
   void testCalculateUsageAddsAnySlaToBuckets() {
     Measurement measurement =
         new Measurement().withMetricId(MetricIdUtils.getCores().toString()).withValue(42.0);

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/DefaultProductUsageCollectorTest.java
@@ -71,8 +71,73 @@ class DefaultProductUsageCollectorTest {
     assertEquals(0, bucket.get().getSockets());
   }
 
+  @Test
+  void testTraditionalProductBucketIsPrimaryWhenBillingFieldsAreAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-unconverted",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertTrue(
+        bucket.get().isPrimary(),
+        "Traditional product with non-_ANY SLA/Usage and _ANY billing fields should be primary");
+  }
+
+  @Test
+  void testTraditionalProductBucketIsNotPrimaryWhenUsageIsAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-unconverted",
+            ServiceLevel.PREMIUM,
+            Usage._ANY,
+            BillingProvider._ANY,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertFalse(
+        bucket.get().isPrimary(), "Traditional product with _ANY Usage should not be primary");
+  }
+
+  @Test
+  void testPaygProductBucketIsPrimaryWhenAllFieldsAreNotAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-payg",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "123456");
+    var facts = new NormalizedFacts();
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertTrue(bucket.get().isPrimary(), "PAYG product with all non-_ANY fields should be primary");
+  }
+
+  @Test
+  void testPaygProductBucketIsNotPrimaryWhenBillingAccountIdIsAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-payg",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertFalse(
+        bucket.get().isPrimary(),
+        "PAYG product with _ANY billing account ID should not be primary");
+  }
+
   private UsageCalculation.Key createUsageKey() {
     return new UsageCalculation.Key(
-        "NON_RHEL", ServiceLevel.EMPTY, Usage.EMPTY, BillingProvider.EMPTY, "_ANY");
+        "rosa", ServiceLevel.EMPTY, Usage.EMPTY, BillingProvider.EMPTY, "_ANY");
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/collector/RHELProductUsageCollectorTest.java
@@ -69,8 +69,93 @@ class RHELProductUsageCollectorTest {
     assertTrue(bucket.get().getKey().getAsHypervisor());
   }
 
+  @Test
+  void testTraditionalProductBucketIsPrimaryWhenBillingFieldsAreAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-unconverted",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    facts.setHardwareType(HostHardwareType.PHYSICAL);
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertTrue(
+        bucket.get().isPrimary(),
+        "Traditional product with non-_ANY SLA/Usage and _ANY billing fields should be primary");
+  }
+
+  @Test
+  void testTraditionalProductBucketIsNotPrimaryWhenSlaIsAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-unconverted",
+            ServiceLevel._ANY,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    facts.setHardwareType(HostHardwareType.PHYSICAL);
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertFalse(
+        bucket.get().isPrimary(), "Traditional product with _ANY SLA should not be primary");
+  }
+
+  @Test
+  void testPaygProductBucketIsPrimaryWhenAllFieldsAreNotAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-payg",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "123456");
+    var facts = new NormalizedFacts();
+    facts.setHardwareType(HostHardwareType.PHYSICAL);
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertTrue(bucket.get().isPrimary(), "PAYG product with all non-_ANY fields should be primary");
+  }
+
+  @Test
+  void testPaygProductBucketIsNotPrimaryWhenBillingProviderIsAny() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-payg",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "123456");
+    var facts = new NormalizedFacts();
+    facts.setHardwareType(HostHardwareType.PHYSICAL);
+    var bucket = collector.buildBucket(key, facts);
+    assertTrue(bucket.isPresent());
+    assertFalse(
+        bucket.get().isPrimary(), "PAYG product with _ANY billing provider should not be primary");
+  }
+
+  @Test
+  void testHypervisorBucketIsPrimaryBasedOnProductAndAttributes() {
+    var key =
+        new UsageCalculation.Key(
+            "rhel-for-x86-els-unconverted",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+    var facts = new NormalizedFacts();
+    var bucket = collector.buildBucketForHypervisor(key, facts);
+    assertTrue(bucket.isPresent());
+    assertTrue(
+        bucket.get().isPrimary(),
+        "Hypervisor bucket should have isPrimary set based on product rules");
+  }
+
   private UsageCalculation.Key createUsageKey() {
     return new UsageCalculation.Key(
-        "RHEL", ServiceLevel.EMPTY, Usage.EMPTY, BillingProvider.EMPTY, "_ANY");
+        "RHEL for x86", ServiceLevel.EMPTY, Usage.EMPTY, BillingProvider.EMPTY, "_ANY");
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/util/PrimaryRecordUtilsTest.java
+++ b/src/test/java/org/candlepin/subscriptions/util/PrimaryRecordUtilsTest.java
@@ -25,6 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallySnapshot;
 import org.candlepin.subscriptions.db.model.Usage;
@@ -40,7 +44,8 @@ class PrimaryRecordUtilsTest {
   void testNullSnapshotThrowsException() {
     IllegalArgumentException exception =
         assertThrows(
-            IllegalArgumentException.class, () -> PrimaryRecordUtils.isPrimaryRecord(null));
+            IllegalArgumentException.class,
+            () -> PrimaryRecordUtils.isPrimaryRecord((TallySnapshot) null));
     assertTrue(exception.getMessage().contains("TallySnapshot cannot be null"));
   }
 
@@ -260,5 +265,227 @@ class PrimaryRecordUtilsTest {
             .build();
 
     assertFalse(PrimaryRecordUtils.isPrimaryRecord(snapshot));
+  }
+
+  // Helper method to create a HostTallyBucket for testing
+  private HostTallyBucket createHostTallyBucket(
+      String productId,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId) {
+    Host host = new Host();
+    HostBucketKey key =
+        new HostBucketKey(host, productId, sla, usage, billingProvider, billingAccountId, false);
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(key);
+    bucket.setHost(host);
+    bucket.setCores(4);
+    bucket.setSockets(2);
+    bucket.setMeasurementType(HardwareMeasurementType.PHYSICAL);
+    return bucket;
+  }
+
+  // HostTallyBucket Tests
+
+  @Test
+  void testNullBucketThrowsException() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PrimaryRecordUtils.isPrimaryRecord((HostTallyBucket) null));
+    assertTrue(exception.getMessage().contains("HostTallyBucket cannot be null"));
+  }
+
+  @Test
+  void testBucketWithNullKeyThrowsException() {
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(null);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> PrimaryRecordUtils.isPrimaryRecord(bucket));
+    assertTrue(exception.getMessage().contains("key cannot be null"));
+  }
+
+  @Test
+  void testBucketWithNullProductIdThrowsException() {
+    Host host = new Host();
+    HostBucketKey key =
+        new HostBucketKey(
+            host,
+            null,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "123456",
+            false);
+    HostTallyBucket bucket = new HostTallyBucket();
+    bucket.setKey(key);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> PrimaryRecordUtils.isPrimaryRecord(bucket));
+    assertTrue(exception.getMessage().contains("productId cannot be null"));
+  }
+
+  @Test
+  void testBucketProductNotFoundThrowsException() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            "unknown-product",
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "123456");
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> PrimaryRecordUtils.isPrimaryRecord(bucket));
+    assertTrue(exception.getMessage().contains("unknown-product"));
+    assertTrue(exception.getMessage().contains("missing in subscription configuration"));
+  }
+
+  @Test
+  void testPaygBucketWithAllFieldsNotAnyReturnsTrue() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage.PRODUCTION, BillingProvider.AWS, "123456");
+
+    assertTrue(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithSlaAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel._ANY, Usage.PRODUCTION, BillingProvider.AWS, "123456");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithUsageAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage._ANY, BillingProvider.AWS, "123456");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithBillingProviderAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage.PRODUCTION, BillingProvider._ANY, "123456");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithNullBillingAccountIdReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage.PRODUCTION, BillingProvider.AWS, null);
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithBillingAccountIdAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage.PRODUCTION, BillingProvider.AWS, "_ANY");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testPaygBucketWithEmptyStringBillingAccountIdReturnsTrue() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            PAYG_PRODUCT, ServiceLevel.PREMIUM, Usage.PRODUCTION, BillingProvider.AWS, "");
+
+    assertTrue(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithSlaAndUsageNotAnyReturnsTrue() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+
+    assertTrue(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithSlaAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT, ServiceLevel._ANY, Usage.PRODUCTION, BillingProvider._ANY, "_ANY");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithUsageAnyReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT, ServiceLevel.PREMIUM, Usage._ANY, BillingProvider._ANY, "_ANY");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketRequiresBillingFieldsToBeAny() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "_ANY");
+
+    assertTrue(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithNonAnyBillingProviderReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider.AWS,
+            "_ANY");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithNonAnyBillingAccountIdReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            "123456");
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
+  }
+
+  @Test
+  void testTraditionalBucketWithNullBillingAccountIdReturnsFalse() {
+    HostTallyBucket bucket =
+        createHostTallyBucket(
+            TRADITIONAL_PRODUCT,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            null);
+
+    assertFalse(PrimaryRecordUtils.isPrimaryRecord(bucket));
   }
 }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/Host.java
@@ -237,8 +237,11 @@ public class Host extends ModificationTrackedEntity implements Serializable {
       b.setCores(bucket.getCores());
       b.setMeasurementType(bucket.getMeasurementType());
       b.setStale(false);
+      // isPrimary is set by the caller before adding the bucket
+      b.setPrimary(bucket.isPrimary());
     } else {
       bucket.setHost(this);
+      // isPrimary is set by the caller before adding the bucket
       getBuckets().add(bucket);
     }
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/HostTallyBucket.java
@@ -96,6 +96,14 @@ public class HostTallyBucket extends ModificationTrackedEntity implements Serial
     this.key.setHostId(host == null ? null : host.getId());
   }
 
+  public boolean isPrimary() {
+    return isPrimary;
+  }
+
+  public void setPrimary(boolean primary) {
+    this.isPrimary = primary;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4860

## Description
Identify primary bucket records on create/update and properly set isPrimary flag on records.

Created PrimaryRecordUtils to identify primary (non-aggregated) bucket records based on
product type and field values. Primary records have all required attributes fully specified
(no _ANY wildcard values).

**Primary Record Rules:**
  - PAYG products: SLA, Usage, BillingProvider, and BillingAccountId must all be non-_ANY
  - Traditional products: SLA and Usage must be non-_ANY; BillingProvider and BillingAccountId
    must be _ANY

**NOTE** This change **DOES NOT** update the isPrimary flag on ALL existing buckets during a tally, but **DOES** update any bucket that changes via measurement update. The new API (implemented outside of this PR) will handle updating the other records.


## Testing

### Setup
1. Check out the PRs changes into a new branch.

2. Create hosts in HBI DB:
```
./bin/insert-mock-hosts --hbi --num-physical 2 --org 11223344 --account a1234
```

3. **CHECK OUT THE MAIN BRANCH** and run the swatch-tally service so that we can create tally buckets that have **is_primary** defaulted to false.


4. Insert swatch events via Kafka.
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "11223344",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2026-01-04T08:00:00Z",
              "expiration": "2026-01-04T09:00:00Z",
              "display_name": "aws.host.1.test",
              "measurements": [
                {
                  "value": 1,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204",
                "69"
              ],
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "aws11223344",
              "product_tag": [
                "rhel-for-x86-els-payg"
              ],
              "conversion": true,
              "event_source": "rhelemeter",
              "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
              "org_id": "11223344",
              "instance_id": "4cfd68a6-a0b7-4590-b9c0-068a5936765b"
            }
          }
        ]
      }
	  '
```

5. Run both tally processes.

**Nightly**
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/11223344" x-rh-swatch-psk:placeholder
```

**Hourly**:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=11223344" x-rh-swatch-psk:placeholder
```

6. Verify the bucket data was initialized correctly:
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "SELECT host_id, product_id, a.is_primary, COUNT(*)
  FROM host_tally_buckets a join hosts b on a.host_id = b.id
  WHERE org_id = '11223344'
  GROUP BY host_id, product_id, is_primary
  ORDER BY host_id, product_id, is_primary;"
```

```
               host_id                |          product_id          | is_primary |  count 
--------------------------------------+------------------------------+------------+----------
 37261fc4-2a93-4442-a758-362e4762a101 | rhel-for-x86-els-unconverted | f          |     4
 6e950e22-3b0e-4212-8ad4-a0fda8813df1 | rhel-for-x86-els-unconverted | f          |     4
 79a8ccc5-3f3a-4441-b2f8-d42e23b99552 | rhel-for-x86-els-payg        | f          |    16
(3 rows)

```

- Note that there are 16 total permutations for paygo buckets.
- Note that there are 4 total permutations for traditional buckets (nightly from HBI data). 


### Steps To Verify
#### Basic Tally (New Set Of Snapshots)
1. Deploy swatch-tally from the PRs branch using ```make build swatch-tally``` [this will pick up a core change]

2. Insert a new HBI host data so that nightly tally sees a change in usage for the org and actually makes changes to the buckets.
```
./bin/insert-mock-hosts --hbi --num-physical 2 --org 11223344 --account a1234
```

3. Insert a couple new events (in the past and current hour)
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress Content-Type:application/vnd.kafka.json.v2+json Accept:application/vnd.kafka.v2+json --raw '{
        "records": [
          {
            "key": "11223344",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2026-01-04T07:00:00Z",
              "expiration": "2026-01-04T08:00:00Z",
              "display_name": "aws.host.1.test",
              "measurements": [
                {
                  "value": 1,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204",
                "69"
              ],
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "aws11223344",
              "product_tag": [
                "rhel-for-x86-els-payg"
              ],
              "conversion": true,
              "event_source": "rhelemeter",
              "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
              "org_id": "11223344",
              "instance_id": "4cfd68a6-a0b7-4590-b9c0-068a5936765b"
            }
          },
          {
            "key": "11223344",
            "value": {
              "service_type": "RHEL System",
              "timestamp": "2026-01-04T09:00:00Z",
              "expiration": "2026-01-04T10:00:00Z",
              "display_name": "aws.host.1.test",
              "measurements": [
                {
                  "value": 12,
                  "uom": "vCPUs",
                  "metric_id": "vCPUs"
                }
              ],
              "product_ids": [
                "204",
                "69"
              ],
              "sla": "Premium",
              "usage": "Production",
              "billing_provider": "aws",
              "billing_account_id": "aws11223344",
              "product_tag": [
                "rhel-for-x86-els-payg"
              ],
              "conversion": true,
              "event_source": "rhelemeter",
              "event_type": "snapshot_rhel-for-x86-els-payg_vcpus",
              "org_id": "11223344",
              "instance_id": "4cfd68a6-a0b7-4590-b9c0-068a5936765b"
            }
          }
        ]
      }
	  '
```

4. Run both tally processes.

**Nightly**
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/11223344" x-rh-swatch-psk:placeholder
```

**Hourly**:
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=11223344" x-rh-swatch-psk:placeholder
```

5. Verify the state of the buckets
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "SELECT host_id, product_id, a.is_primary, COUNT(*)
  FROM host_tally_buckets a join hosts b on a.host_id = b.id
  WHERE org_id = '11223344'
  GROUP BY host_id, product_id, is_primary
  ORDER BY host_id, product_id, is_primary;"
```

```
               host_id                |          product_id          | is_primary |  count 
--------------------------------------+------------------------------+------------+----------
 37261fc4-2a93-4442-a758-362e4762a101 | rhel-for-x86-els-unconverted | f          |     4
 6139e3ad-69bb-42f5-b1bb-050f5b58b904 | rhel-for-x86-els-unconverted | f          |     3
 6139e3ad-69bb-42f5-b1bb-050f5b58b904 | rhel-for-x86-els-unconverted | t          |     1
 6e950e22-3b0e-4212-8ad4-a0fda8813df1 | rhel-for-x86-els-unconverted | f          |     4
 743da132-5030-48b2-b464-0a140c27c05c | rhel-for-x86-els-unconverted | f          |     3
 743da132-5030-48b2-b464-0a140c27c05c | rhel-for-x86-els-unconverted | t          |     1
 79a8ccc5-3f3a-4441-b2f8-d42e23b99552 | rhel-for-x86-els-payg        | f          |    15
 79a8ccc5-3f3a-4441-b2f8-d42e23b99552 | rhel-for-x86-els-payg        | t          |     1
(8 rows)

```

- Note the buckets for **79a8ccc5-3f3a-4441-b2f8-d42e23b99552** and that 1 of them is marked primary.
- Note that there are still 4 total permutations for traditional buckets (nightly from HBI data), and the new hosts each have a single bucket marked as primary. The old hosts will need to wait for a new day to get the primary updated.