### PR TITLE
Fix swatch-tally component tests when run in EE

### DIFF
--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -29,10 +29,13 @@ import com.redhat.swatch.component.tests.api.ComponentTest;
 import com.redhat.swatch.component.tests.api.KafkaBridge;
 import com.redhat.swatch.component.tests.api.KafkaBridgeService;
 import com.redhat.swatch.component.tests.api.SpringBoot;
+import com.redhat.swatch.component.tests.api.SwatchDatabase;
 import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.api.Wiremock;
+import com.redhat.swatch.component.tests.api.db.DatabaseService;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
+import utils.TallyDbHostSeeder;
 import utils.TallyTestHelpers;
 
 /**
@@ -67,11 +70,12 @@ public class BaseTallyComponentTest {
 
   @Unleash static TallyUnleashService unleash = new TallyUnleashService();
 
+  @SwatchDatabase static DatabaseService swatchDatabase = new DatabaseService();
+
   // --- Instance fields ---
 
+  protected final TallyDbHostSeeder seeder = new TallyDbHostSeeder(swatchDatabase);
   protected String orgId;
-
-  // --- Lifecycle methods ---
 
   @BeforeEach
   void setUp() {

--- a/swatch-tally/ct/java/tests/TallyHypervisorTest.java
+++ b/swatch-tally/ct/java/tests/TallyHypervisorTest.java
@@ -38,22 +38,22 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import utils.TallyDbHostSeeder;
 
-public class TallyHypervisorTests extends BaseTallyComponentTest {
+public class TallyHypervisorTest extends BaseTallyComponentTest {
 
   @Test
   @TestPlanName("tally-hypervisor-TC003")
   public void testHypervisorWithNoGuestsDoesNotShowInInstancesReport() {
     // Given: Baseline tally data and a hypervisor host with no guests
     helpers.seedNightlyTallyHostBuckets(
-        orgId, RHEL_FOR_X86.productTag(), UUID.randomUUID().toString(), service);
+        seeder, orgId, RHEL_FOR_X86.productTag(), UUID.randomUUID().toString(), service);
     service.tallyOrg(orgId);
 
     OffsetDateTime startOfToday = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.DAYS);
     OffsetDateTime endOfToday = startOfToday.plusDays(1).minusNanos(1);
 
     TallyDbHostSeeder.SeededHost hypervisorHost =
-        TallyDbHostSeeder.insertHost(
-            orgId, UUID.randomUUID().toString(), "VIRTUAL", false, false, true, 0, null);
+        seeder.insertHost(
+            orgId, UUID.randomUUID().toString(), "VIRTUALIZED", false, false, true, 0, null);
 
     // When: Running tally for the org
     service.tallyOrg(orgId);
@@ -72,7 +72,7 @@ public class TallyHypervisorTests extends BaseTallyComponentTest {
   public void testHypervisorWithNoGuestsDoesNotChangeDailyTotal() {
     // Given: Baseline usage and a hypervisor host with no guests
     helpers.seedNightlyTallyHostBuckets(
-        orgId, RHEL_FOR_X86.productTag(), UUID.randomUUID().toString(), service);
+        seeder, orgId, RHEL_FOR_X86.productTag(), UUID.randomUUID().toString(), service);
     service.tallyOrg(orgId);
 
     OffsetDateTime startOfToday = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.DAYS);
@@ -80,8 +80,8 @@ public class TallyHypervisorTests extends BaseTallyComponentTest {
 
     long initialSockets = getDailySocketsTotal(startOfToday, endOfToday);
 
-    TallyDbHostSeeder.insertHost(
-        orgId, UUID.randomUUID().toString(), "VIRTUAL", false, false, true, 0, null);
+    seeder.insertHost(
+        orgId, UUID.randomUUID().toString(), "VIRTUALIZED", false, false, true, 0, null);
 
     // When: Running tally for the org
     service.tallyOrg(orgId);

--- a/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
@@ -36,13 +36,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import utils.TallyDbHostSeeder;
 
-public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
+class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
 
   /** Two distinct rows after tally (distinguish-by-billing). */
   private record DistinctBillings(String first, String second) {}
@@ -228,7 +226,7 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
   @Test
   @TestPlanName("tally-instances-billing-account-TC001")
-  public void shouldExcludeBillingAccountsWithLastSeenBeforeCurrentMonth() {
+  void shouldExcludeBillingAccountsWithLastSeenBeforeCurrentMonth() {
     final String isolatedOrg = RandomUtils.generateRandom();
     final String testInventoryId = UUID.randomUUID().toString();
     final String billingAccountId = UUID.randomUUID().toString();
@@ -236,7 +234,7 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
     service.createOptInConfig(isolatedOrg);
 
-    TallyDbHostSeeder.insertHostWithBillingAccountAndDate(
+    seeder.insertHostWithBillingAccountAndDate(
         isolatedOrg,
         testInventoryId,
         RHEL_FOR_X86_ELS_PAYG.productTag(),
@@ -266,7 +264,7 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
   @Test
   @TestPlanName("tally-instances-billing-account-TC002")
-  public void shouldReturnDistinctBillingAccountIdsAfterHourlyTally() {
+  void shouldReturnDistinctBillingAccountIdsAfterHourlyTally() {
     Map<String, Object> queryParams = new HashMap<>();
     Response response = service.getBillingAccountIds(testOrgId, queryParams);
     List<Map<String, String>> ids = response.jsonPath().getList("ids");
@@ -274,7 +272,7 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
         ids, "Response ids should not be null. Response body: " + response.getBody().asString());
 
     List<String> billingAccountIds =
-        ids.stream().map(item -> item.get("billing_account_id")).collect(Collectors.toList());
+        ids.stream().map(item -> item.get("billing_account_id")).toList();
     assertTrue(
         billingAccountIds.contains(distinct.first()),
         "Response should contain billing account ID: " + distinct.first());
@@ -294,12 +292,11 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
   @Test
   @TestPlanName("tally-instances-billing-account-TC003")
-  public void shouldReturnInstancesWithThreeDistinctBillingAccountIds() {
+  void shouldReturnInstancesWithThreeDistinctBillingAccountIds() {
     Response response = service.getBillingAccountIds(testOrgId, new HashMap<>());
     List<Map<String, String>> ids = response.jsonPath().getList("ids");
     assertNotNull(ids);
-    List<String> accounts =
-        ids.stream().map(m -> m.get("billing_account_id")).collect(Collectors.toList());
+    List<String> accounts = ids.stream().map(m -> m.get("billing_account_id")).toList();
     assertTrue(accounts.contains(three.a()));
     assertTrue(accounts.contains(three.b()));
     assertTrue(accounts.contains(three.c()));
@@ -307,7 +304,7 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
   @Test
   @TestPlanName("tally-instances-billing-account-TC004")
-  public void shouldReturnInstancesWithTwoInstancesSharingSameBillingAccountId() {
+  void shouldReturnInstancesWithTwoInstancesSharingSameBillingAccountId() {
     Response response = service.getBillingAccountIds(testOrgId, new HashMap<>());
     List<Map<String, String>> ids = response.jsonPath().getList("ids");
     assertNotNull(ids);
@@ -321,12 +318,11 @@ public class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest 
 
   @Test
   @TestPlanName("tally-instances-billing-account-TC005")
-  public void shouldReturnInstancesWithMixedBillingProviders() {
+  void shouldReturnInstancesWithMixedBillingProviders() {
     Response response = service.getBillingAccountIds(testOrgId, new HashMap<>());
     List<Map<String, String>> ids = response.jsonPath().getList("ids");
     assertNotNull(ids);
-    List<String> prov =
-        ids.stream().map(m -> m.get("billing_provider")).sorted().collect(Collectors.toList());
+    List<String> prov = ids.stream().map(m -> m.get("billing_provider")).sorted().toList();
     assertTrue(prov.contains("aws"));
     assertTrue(prov.contains("azure"));
   }

--- a/swatch-tally/ct/java/utils/TallyDbHostSeeder.java
+++ b/swatch-tally/ct/java/utils/TallyDbHostSeeder.java
@@ -20,9 +20,8 @@
  */
 package utils;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
+import com.redhat.swatch.component.tests.api.db.DatabaseService;
+import com.redhat.swatch.component.tests.api.db.TransactionContext;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.OffsetDateTime;
@@ -35,33 +34,22 @@ import java.util.UUID;
  *
  * <p>This is intentionally isolated in CT utils so it can be removed later.
  *
- * <p>Connection is configured via env vars (with local docker-compose defaults):
- *
- * <ul>
- *   <li>SWATCH_CT_DB_HOST (default: localhost)
- *   <li>SWATCH_CT_DB_PORT (default: 5432)
- *   <li>SWATCH_CT_DB_NAME (default: rhsm-subscriptions)
- *   <li>SWATCH_CT_DB_USER (default: rhsm-subscriptions)
- *   <li>SWATCH_CT_DB_PASSWORD (default: rhsm-subscriptions)
- *   <li>SWATCH_CT_DB_SSLMODE (optional, e.g. disable/require)
- * </ul>
+ * <p>Database connection is provided by {@link DatabaseService} which is injected via constructor.
  */
 public final class TallyDbHostSeeder {
 
-  private static final String DEFAULT_DB_HOST = "localhost";
-  private static final String DEFAULT_DB_PORT = "5432";
-  private static final String DEFAULT_DB_NAME = "rhsm-subscriptions";
-  private static final String DEFAULT_DB_USER = "rhsm-subscriptions";
-  private static final String DEFAULT_DB_PASSWORD = "rhsm-subscriptions";
-
   private static final String HBI_INSTANCE_TYPE = "HBI_HOST";
 
-  private TallyDbHostSeeder() {}
+  private final DatabaseService database;
+
+  public TallyDbHostSeeder(DatabaseService database) {
+    this.database = database;
+  }
 
   public record SeededHost(UUID hostId, String inventoryId, String subscriptionManagerId) {}
 
   /** Insert a single HBI_HOST in the swatch DB and return its UUID. */
-  public static UUID insertHbiHost(String orgId, String inventoryId) {
+  public UUID insertHbiHost(String orgId, String inventoryId) {
     return insertHost(orgId, inventoryId, "PHYSICAL", false, false, false, null, null).hostId();
   }
 
@@ -75,7 +63,7 @@ public final class TallyDbHostSeeder {
    * @param billingAccountId the billing account ID
    * @return the host UUID
    */
-  public static UUID insertHostWithBillingAccount(
+  public UUID insertHostWithBillingAccount(
       String orgId,
       String inventoryId,
       String productTag,
@@ -102,7 +90,7 @@ public final class TallyDbHostSeeder {
    * @param lastSeen the last_seen date for the host
    * @return the host UUID
    */
-  public static UUID insertHostWithBillingAccountAndDate(
+  public UUID insertHostWithBillingAccountAndDate(
       String orgId,
       String inventoryId,
       String productTag,
@@ -119,68 +107,42 @@ public final class TallyDbHostSeeder {
     UUID hostId = UUID.randomUUID();
     String subManId = UUID.randomUUID().toString();
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(), dbUser(), dbPassword())) {
-      conn.setAutoCommit(false);
+    database.executeInTransaction(
+        ctx -> {
+          ensureAccountServiceRow(ctx, orgId);
+          insertHostRow(
+              ctx,
+              hostId,
+              inventoryId,
+              subManId,
+              orgId,
+              false,
+              false,
+              false,
+              "CLOUD",
+              null,
+              lastSeen,
+              billingProvider,
+              billingAccountId,
+              null);
+          insertBucket(
+              ctx,
+              hostId,
+              productTag,
+              "Premium",
+              "Production",
+              4,
+              2,
+              "CLOUD",
+              billingProvider,
+              billingAccountId);
+        });
 
-      ensureAccountServiceRow(conn, orgId);
-
-      try (PreparedStatement ps =
-          conn.prepareStatement(
-              """
-              INSERT INTO hosts
-                (id, instance_id, inventory_id, insights_id, display_name, org_id,
-                 subscription_manager_id, is_guest, is_unmapped_guest, is_hypervisor,
-                 hardware_type, num_of_guests, last_seen, instance_type, billing_provider,
-                 billing_account_id, hypervisor_uuid)
-              VALUES
-                (?, ?, ?, ?, ?, ?,
-                 ?, ?, ?, ?,
-                 ?, ?, ?, ?, ?,
-                 ?, ?)
-              """)) {
-        ps.setObject(1, hostId);
-        ps.setString(2, inventoryId);
-        ps.setString(3, inventoryId);
-        ps.setString(4, inventoryId);
-        ps.setString(5, inventoryId);
-        ps.setString(6, orgId);
-        ps.setString(7, subManId);
-        ps.setBoolean(8, false); // is_guest
-        ps.setBoolean(9, false); // is_unmapped_guest
-        ps.setBoolean(10, false); // is_hypervisor
-        ps.setString(11, "CLOUD"); // hardware_type
-        ps.setNull(12, Types.INTEGER); // num_of_guests
-        ps.setObject(13, lastSeen);
-        ps.setString(14, HBI_INSTANCE_TYPE);
-        ps.setString(15, billingProvider);
-        ps.setString(16, billingAccountId);
-        ps.setNull(17, Types.VARCHAR); // hypervisor_uuid
-        ps.executeUpdate();
-      }
-
-      // Insert buckets for the product tag with billing provider and billing account ID
-      insertBucket(
-          conn,
-          hostId,
-          productTag,
-          "Premium",
-          "Production",
-          4,
-          2,
-          "CLOUD",
-          billingProvider,
-          billingAccountId);
-
-      conn.commit();
-      return hostId;
-    } catch (SQLException e) {
-      throw new RuntimeException(
-          "Failed to seed host with billing account in DB: " + e.getMessage(), e);
-    }
+    return hostId;
   }
 
   /** Insert a host row only (no buckets) and return identifying fields for assertions. */
-  public static SeededHost insertHost(
+  public SeededHost insertHost(
       String orgId,
       String inventoryId,
       String hardwareType,
@@ -196,54 +158,27 @@ public final class TallyDbHostSeeder {
     String subManId = UUID.randomUUID().toString();
     OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(), dbUser(), dbPassword())) {
-      conn.setAutoCommit(false);
+    database.executeInTransaction(
+        ctx -> {
+          ensureAccountServiceRow(ctx, orgId);
+          insertHostRow(
+              ctx,
+              hostId,
+              inventoryId,
+              subManId,
+              orgId,
+              isGuest,
+              isUnmappedGuest,
+              isHypervisor,
+              hardwareType,
+              numOfGuests,
+              now,
+              null,
+              null,
+              hypervisorUuid);
+        });
 
-      ensureAccountServiceRow(conn, orgId);
-
-      try (PreparedStatement ps =
-          conn.prepareStatement(
-              """
-              INSERT INTO hosts
-                (id, instance_id, inventory_id, insights_id, display_name, org_id,
-                 subscription_manager_id, is_guest, is_unmapped_guest, is_hypervisor,
-                 hardware_type, num_of_guests, last_seen, instance_type, billing_provider,
-                 billing_account_id, hypervisor_uuid)
-              VALUES
-                (?, ?, ?, ?, ?, ?,
-                 ?, ?, ?, ?,
-                 ?, ?, ?, ?, ?,
-                 ?, ?)
-              """)) {
-        ps.setObject(1, hostId);
-        ps.setString(2, inventoryId);
-        ps.setString(3, inventoryId);
-        ps.setString(4, inventoryId);
-        ps.setString(5, inventoryId);
-        ps.setString(6, orgId);
-        ps.setString(7, subManId);
-        ps.setBoolean(8, isGuest);
-        ps.setBoolean(9, isUnmappedGuest);
-        ps.setBoolean(10, isHypervisor);
-        ps.setString(11, hardwareType);
-        if (numOfGuests == null) {
-          ps.setNull(12, Types.INTEGER);
-        } else {
-          ps.setInt(12, numOfGuests);
-        }
-        ps.setObject(13, now);
-        ps.setString(14, HBI_INSTANCE_TYPE);
-        ps.setNull(15, Types.VARCHAR);
-        ps.setNull(16, Types.VARCHAR);
-        ps.setString(17, hypervisorUuid);
-        ps.executeUpdate();
-      }
-
-      conn.commit();
-      return new SeededHost(hostId, inventoryId, subManId);
-    } catch (SQLException e) {
-      throw new RuntimeException("Failed to seed host in DB: " + e.getMessage(), e);
-    }
+    return new SeededHost(hostId, inventoryId, subManId);
   }
 
   /**
@@ -252,7 +187,7 @@ public final class TallyDbHostSeeder {
    * <p>Inserts the 4 combinations of (sla=_ANY|sla) x (usage=_ANY|usage) to match existing local
    * seeding behavior.
    */
-  public static void insertBuckets(
+  public void insertBuckets(
       UUID hostId,
       String productId,
       String sla,
@@ -266,17 +201,12 @@ public final class TallyDbHostSeeder {
     Objects.requireNonNull(usage, "usage is required");
     Objects.requireNonNull(measurementType, "measurementType is required");
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(), dbUser(), dbPassword())) {
-      conn.setAutoCommit(false);
-      insertBucket(conn, hostId, productId, sla, usage, cores, sockets, measurementType);
-      conn.commit();
-    } catch (SQLException e) {
-      throw new RuntimeException("Failed to seed host buckets in DB: " + e.getMessage(), e);
-    }
+    database.executeInTransaction(
+        ctx -> insertBucket(ctx, hostId, productId, sla, usage, cores, sockets, measurementType));
   }
 
-  private static void insertBucket(
-      Connection conn,
+  private void insertBucket(
+      TransactionContext ctx,
       UUID hostId,
       String productId,
       String sla,
@@ -285,11 +215,11 @@ public final class TallyDbHostSeeder {
       int sockets,
       String measurementType)
       throws SQLException {
-    insertBucket(conn, hostId, productId, sla, usage, cores, sockets, measurementType, "");
+    insertBucket(ctx, hostId, productId, sla, usage, cores, sockets, measurementType, "");
   }
 
-  private static void insertBucket(
-      Connection conn,
+  private void insertBucket(
+      TransactionContext ctx,
       UUID hostId,
       String productId,
       String sla,
@@ -300,11 +230,11 @@ public final class TallyDbHostSeeder {
       String billingAccountId)
       throws SQLException {
     insertBucket(
-        conn, hostId, productId, sla, usage, cores, sockets, measurementType, "", billingAccountId);
+        ctx, hostId, productId, sla, usage, cores, sockets, measurementType, "", billingAccountId);
   }
 
-  private static void insertBucket(
-      Connection conn,
+  private void insertBucket(
+      TransactionContext ctx,
       UUID hostId,
       String productId,
       String sla,
@@ -315,72 +245,106 @@ public final class TallyDbHostSeeder {
       String billingProvider,
       String billingAccountId)
       throws SQLException {
-    try (PreparedStatement ps =
-        conn.prepareStatement(
-            """
-            INSERT INTO host_tally_buckets
-              (host_id, product_id, usage, sla, as_hypervisor,
-               cores, sockets, measurement_type, billing_provider, billing_account_id, version)
-            VALUES
-              (?, ?, ?, ?, ?,
-               ?, ?, ?, ?, ?, 0)
-            """)) {
-      ps.setObject(1, hostId);
-      ps.setString(2, productId);
-      ps.setString(3, usage);
-      ps.setString(4, sla);
-      ps.setBoolean(5, false);
-      ps.setInt(6, cores);
-      ps.setInt(7, sockets);
-      ps.setString(8, measurementType);
-      if (billingProvider == null || billingProvider.isEmpty()) {
-        ps.setString(9, "");
-      } else {
-        ps.setString(9, billingProvider);
-      }
-      if (billingAccountId == null) {
-        ps.setNull(10, Types.VARCHAR);
-      } else {
-        ps.setString(10, billingAccountId);
-      }
-      ps.executeUpdate();
-    }
+    ctx.executeUpdate(
+        """
+        INSERT INTO host_tally_buckets
+          (host_id, product_id, usage, sla, as_hypervisor,
+           cores, sockets, measurement_type, billing_provider, billing_account_id, version)
+        VALUES
+          (?, ?, ?, ?, ?,
+           ?, ?, ?, ?, ?, 0)
+        """,
+        ps -> {
+          ps.setObject(1, hostId);
+          ps.setString(2, productId);
+          ps.setString(3, usage);
+          ps.setString(4, sla);
+          ps.setBoolean(5, false);
+          ps.setInt(6, cores);
+          ps.setInt(7, sockets);
+          ps.setString(8, measurementType);
+          if (billingProvider == null || billingProvider.isEmpty()) {
+            ps.setString(9, "");
+          } else {
+            ps.setString(9, billingProvider);
+          }
+          if (billingAccountId == null) {
+            ps.setNull(10, Types.VARCHAR);
+          } else {
+            ps.setString(10, billingAccountId);
+          }
+        });
   }
 
-  private static void ensureAccountServiceRow(Connection conn, String orgId) throws SQLException {
-    try (PreparedStatement ps =
-        conn.prepareStatement(
-            "INSERT INTO account_services (org_id, service_type) VALUES (?, ?) ON CONFLICT DO NOTHING")) {
-      ps.setString(1, orgId);
-      ps.setString(2, HBI_INSTANCE_TYPE);
-      ps.executeUpdate();
-    }
+  private void insertHostRow(
+      TransactionContext ctx,
+      UUID hostId,
+      String inventoryId,
+      String subManId,
+      String orgId,
+      boolean isGuest,
+      boolean isUnmappedGuest,
+      boolean isHypervisor,
+      String hardwareType,
+      Integer numOfGuests,
+      OffsetDateTime lastSeen,
+      String billingProvider,
+      String billingAccountId,
+      String hypervisorUuid)
+      throws SQLException {
+    ctx.executeUpdate(
+        """
+        INSERT INTO hosts
+          (id, instance_id, inventory_id, insights_id, display_name, org_id,
+           subscription_manager_id, is_guest, is_unmapped_guest, is_hypervisor,
+           hardware_type, num_of_guests, last_seen, instance_type, billing_provider,
+           billing_account_id, hypervisor_uuid)
+        VALUES
+          (?, ?, ?, ?, ?, ?,
+           ?, ?, ?, ?,
+           ?, ?, ?, ?, ?,
+           ?, ?)
+        """,
+        ps -> {
+          ps.setObject(1, hostId);
+          ps.setString(2, inventoryId);
+          ps.setString(3, inventoryId);
+          ps.setString(4, inventoryId);
+          ps.setString(5, inventoryId);
+          ps.setString(6, orgId);
+          ps.setString(7, subManId);
+          ps.setBoolean(8, isGuest);
+          ps.setBoolean(9, isUnmappedGuest);
+          ps.setBoolean(10, isHypervisor);
+          ps.setString(11, hardwareType);
+          if (numOfGuests == null) {
+            ps.setNull(12, Types.INTEGER);
+          } else {
+            ps.setInt(12, numOfGuests);
+          }
+          ps.setObject(13, lastSeen);
+          ps.setString(14, HBI_INSTANCE_TYPE);
+          if (billingProvider == null) {
+            ps.setNull(15, Types.VARCHAR);
+          } else {
+            ps.setString(15, billingProvider);
+          }
+          if (billingAccountId == null) {
+            ps.setNull(16, Types.VARCHAR);
+          } else {
+            ps.setString(16, billingAccountId);
+          }
+          ps.setString(17, hypervisorUuid);
+        });
   }
 
-  private static String jdbcUrl() {
-    String host = env("SWATCH_CT_DB_HOST", DEFAULT_DB_HOST);
-    String port = env("SWATCH_CT_DB_PORT", DEFAULT_DB_PORT);
-    String db = env("SWATCH_CT_DB_NAME", DEFAULT_DB_NAME);
-    String sslmode = System.getenv("SWATCH_CT_DB_SSLMODE");
-
-    String base = String.format("jdbc:postgresql://%s:%s/%s", host, port, db);
-    if (sslmode == null || sslmode.isBlank()) {
-      return base;
-    }
-    return base + "?sslmode=" + sslmode;
-  }
-
-  private static String dbUser() {
-    return env("SWATCH_CT_DB_USER", DEFAULT_DB_USER);
-  }
-
-  private static String dbPassword() {
-    return env("SWATCH_CT_DB_PASSWORD", DEFAULT_DB_PASSWORD);
-  }
-
-  private static String env(String name, String defaultValue) {
-    String v = System.getenv(name);
-    return v == null || v.isBlank() ? defaultValue : v;
+  private void ensureAccountServiceRow(TransactionContext ctx, String orgId) throws SQLException {
+    ctx.executeUpdate(
+        "INSERT INTO account_services (org_id, service_type) VALUES (?, ?) ON CONFLICT DO NOTHING",
+        ps -> {
+          ps.setString(1, orgId);
+          ps.setString(2, HBI_INSTANCE_TYPE);
+        });
   }
 
   // Intentionally no application logic here; this helper is temporary and removable.

--- a/swatch-tally/ct/java/utils/TallyTestHelpers.java
+++ b/swatch-tally/ct/java/utils/TallyTestHelpers.java
@@ -268,18 +268,23 @@ public class TallyTestHelpers {
    * is considered "metered" (currently mapped to PAYG eligibility), so we seed one PAYG bucket to
    * keep the host and one non-PAYG bucket that we assert on.
    *
+   * @param seeder the database seeder instance
    * @param orgId the organization ID
    * @param productId the product ID
    * @param inventoryId the inventory ID
    * @param service the tally service
    */
   public void seedNightlyTallyHostBuckets(
-      String orgId, String productId, String inventoryId, TallySwatchService service) {
+      TallyDbHostSeeder seeder,
+      String orgId,
+      String productId,
+      String inventoryId,
+      TallySwatchService service) {
     service.createOptInConfig(orgId);
 
-    var hostId = TallyDbHostSeeder.insertHbiHost(orgId, inventoryId);
+    var hostId = seeder.insertHbiHost(orgId, inventoryId);
     // Keep the host from being deleted (PAYG-eligible tag)
-    TallyDbHostSeeder.insertBuckets(
+    seeder.insertBuckets(
         hostId,
         TallyTestProducts.RHEL_FOR_X86_ELS_PAYG.productTag(),
         "Premium",
@@ -288,7 +293,7 @@ public class TallyTestHelpers {
         2,
         "AWS");
     // Produce DAILY summary messages (non-PAYG tag)
-    TallyDbHostSeeder.insertBuckets(hostId, productId, "Premium", "Production", 4, 2, "PHYSICAL");
+    seeder.insertBuckets(hostId, productId, "Premium", "Production", 4, 2, "PHYSICAL");
   }
 
   // --- When/Then helper methods: Perform actions and wait for results ---

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchDatabase.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchDatabase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwatchDatabase {}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/DatabaseService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/DatabaseService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.api.db;
+
+import com.redhat.swatch.component.tests.core.BaseService;
+import com.redhat.swatch.component.tests.exceptions.ServiceException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * PostgreSQL database service providing connection management, transaction, and query execution
+ * logic.
+ *
+ * <p>Properties (host, port, database, username, password, sslmode) are set by the managed resource
+ * before the service starts.
+ */
+public class DatabaseService extends BaseService<DatabaseService> {
+
+  public DatabaseService() {}
+
+  /**
+   * Get a JDBC connection to the database.
+   *
+   * @return a new database connection
+   * @throws SQLException if connection fails
+   */
+  public Connection getConnection() throws SQLException {
+    String username = getRequiredProperty("username");
+    String password = getRequiredProperty("password");
+    return DriverManager.getConnection(getJdbcUrl(), username, password);
+  }
+
+  /**
+   * Execute multiple SQL statements in a single transaction.
+   *
+   * @param operation the transaction operation
+   */
+  public void executeInTransaction(TransactionOperation operation) {
+    try (Connection conn = getConnection()) {
+      conn.setAutoCommit(false);
+      try {
+        operation.execute(new TransactionContext(conn));
+        conn.commit();
+      } catch (Exception e) {
+        conn.rollback();
+        throw new ServiceException("Transaction failed: " + e.getMessage(), e);
+      }
+    } catch (SQLException e) {
+      throw new ServiceException("Failed to execute transaction: " + e.getMessage(), e);
+    }
+  }
+
+  /** Build the JDBC URL for this PostgreSQL database. */
+  private String getJdbcUrl() {
+    String host = getRequiredProperty("host");
+    int port = Integer.parseInt(getRequiredProperty("port"));
+    String database = getRequiredProperty("database");
+
+    String baseUrl = String.format("jdbc:postgresql://%s:%s/%s", host, port, database);
+
+    // Add SSL mode if configured
+    String sslMode = getProperty("sslmode", null);
+    if (sslMode != null && !sslMode.isBlank()) {
+      baseUrl += "?sslmode=" + sslMode;
+    }
+
+    return baseUrl;
+  }
+
+  private String getRequiredProperty(String key) {
+    String value = getProperty(key, null);
+    if (value == null) {
+      throw new ServiceException(
+          String.format(
+              "Required property '%s' not set. Ensure the database managed resource has started.",
+              key));
+    }
+    return value;
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/ParameterBinder.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/ParameterBinder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.api.db;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** Functional interface for binding parameters to a PreparedStatement. */
+@FunctionalInterface
+public interface ParameterBinder {
+  void bind(PreparedStatement ps) throws SQLException;
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/TransactionContext.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/TransactionContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.api.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** Context for executing statements within a transaction. */
+public class TransactionContext {
+  private final Connection connection;
+
+  public TransactionContext(Connection connection) {
+    this.connection = connection;
+  }
+
+  /**
+   * Execute a SQL update statement with parameters.
+   *
+   * @param sql the SQL statement
+   * @param params parameters to bind
+   * @return number of rows affected
+   */
+  public int executeUpdate(String sql, Object... params) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      this.bindParameters(ps, params);
+      return ps.executeUpdate();
+    }
+  }
+
+  /**
+   * Execute a SQL update statement with a custom parameter binder.
+   *
+   * @param sql the SQL statement
+   * @param binder function to bind parameters to the prepared statement
+   * @return number of rows affected
+   */
+  public int executeUpdate(String sql, ParameterBinder binder) throws SQLException {
+    try (PreparedStatement ps = connection.prepareStatement(sql)) {
+      binder.bind(ps);
+      return ps.executeUpdate();
+    }
+  }
+
+  /**
+   * Get the underlying connection for custom operations.
+   *
+   * @return the connection
+   */
+  public Connection getConnection() {
+    return connection;
+  }
+
+  private void bindParameters(PreparedStatement ps, Object... params) throws SQLException {
+    for (int i = 0; i < params.length; i++) {
+      ps.setObject(i + 1, params[i]);
+    }
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/TransactionOperation.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/db/TransactionOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.api.db;
+
+import java.sql.SQLException;
+
+/** Functional interface for transaction operations. */
+@FunctionalInterface
+public interface TransactionOperation {
+  void execute(TransactionContext context) throws SQLException;
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/exceptions/ServiceException.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/exceptions/ServiceException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.exceptions;
+
+/** Exception thrown when service operations fail. */
+public class ServiceException extends RuntimeException {
+
+  public ServiceException(String message) {
+    super(message);
+  }
+
+  public ServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/LocalDatabaseManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/LocalDatabaseManagedResource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.resources.db;
+
+import com.redhat.swatch.component.tests.resources.containers.LocalContainerManagedResource;
+
+/**
+ * Generic local database managed resource that works for any database service.
+ *
+ * <p>Uses configuration-driven approach to eliminate per-database boilerplate.
+ */
+public class LocalDatabaseManagedResource extends LocalContainerManagedResource {
+
+  private static final int POSTGRESQL_PORT = 5432;
+
+  private final LocalDatabaseResourceConfig localConfig;
+
+  public LocalDatabaseManagedResource(LocalDatabaseResourceConfig localConfig) {
+    super(localConfig.getContainerNameRegex());
+    this.localConfig = localConfig;
+  }
+
+  @Override
+  public void start() {
+    String host;
+    String port;
+
+    String envHostKey = localConfig.getEnvVarPrefix() + "_DB_HOST";
+    if (System.getenv(envHostKey) != null) {
+      host = env(envHostKey, localConfig.getDefaultHost());
+      port = env(localConfig.getEnvVarPrefix() + "_DB_PORT", localConfig.getDefaultPort());
+    } else {
+      super.start();
+      host = getHost();
+      port = String.valueOf(getMappedPort(POSTGRESQL_PORT));
+    }
+
+    setProperty("host", host);
+    setProperty("port", port);
+    setProperty(
+        "database",
+        env(localConfig.getEnvVarPrefix() + "_DB_NAME", localConfig.getDefaultDatabaseName()));
+    setProperty(
+        "username",
+        env(localConfig.getEnvVarPrefix() + "_DB_USER", localConfig.getDefaultUsername()));
+    setProperty(
+        "password",
+        env(localConfig.getEnvVarPrefix() + "_DB_PASSWORD", localConfig.getDefaultPassword()));
+    setProperty(
+        "sslmode",
+        env(localConfig.getEnvVarPrefix() + "_DB_SSLMODE", localConfig.getDefaultSslMode()));
+  }
+
+  private void setProperty(String name, String value) {
+    context.getOwner().withProperty(name, value);
+  }
+
+  private String env(String name, String defaultValue) {
+    String v = System.getenv(name);
+    return v == null || v.isBlank() ? defaultValue : v;
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/LocalDatabaseResourceConfig.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/LocalDatabaseResourceConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.resources.db;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Configuration for local database managed resources.
+ *
+ * <p>Captures configuration for local database resources:
+ *
+ * <ul>
+ *   <li>Container name pattern for container discovery
+ *   <li>Environment variable prefix for overrides
+ *   <li>Default connection values used when env vars aren't set
+ * </ul>
+ */
+@Builder
+@Getter
+public class LocalDatabaseResourceConfig {
+  @NonNull private final String containerNameRegex;
+  @NonNull private final String envVarPrefix;
+
+  @Builder.Default private final String defaultHost = "localhost";
+  @Builder.Default private final String defaultPort = "5432";
+  @Builder.Default private final String defaultDatabaseName = "postgres";
+  @Builder.Default private final String defaultUsername = "postgres";
+  @Builder.Default private final String defaultPassword = "postgres";
+  private final String defaultSslMode;
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/OpenShiftDatabaseManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/OpenShiftDatabaseManagedResource.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.resources.db;
+
+import com.redhat.swatch.component.tests.api.clients.OpenshiftClient;
+import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBootstrap;
+import com.redhat.swatch.component.tests.resources.containers.OpenShiftContainerManagedResource;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Generic OpenShift database managed resource that works for any database service.
+ *
+ * <p>Uses configuration-driven approach to eliminate per-database boilerplate.
+ */
+public class OpenShiftDatabaseManagedResource extends OpenShiftContainerManagedResource {
+
+  private final OpenShiftDatabaseResourceConfig osConfig;
+
+  public OpenShiftDatabaseManagedResource(OpenShiftDatabaseResourceConfig osConfig) {
+    super(osConfig.getServiceName(), Map.of());
+    this.osConfig = osConfig;
+  }
+
+  @Override
+  public void start() {
+    if (isRunning()) {
+      return;
+    }
+
+    super.start();
+
+    OpenshiftClient client = context.get(OpenShiftExtensionBootstrap.CLIENT);
+    String dbPort = getSecretValue(client, osConfig.getPortSecretKey());
+    int actualPort = Integer.parseInt(dbPort);
+
+    setProperty("host", getHost());
+    setProperty("port", String.valueOf(getMappedPort(actualPort)));
+    setProperty("database", getSecretValue(client, osConfig.getDatabaseSecretKey()));
+    setProperty("username", getSecretValue(client, osConfig.getUsernameSecretKey()));
+    setProperty("password", getSecretValue(client, osConfig.getPasswordSecretKey()));
+
+    if (osConfig.getSslModeSecretKey() != null) {
+      getOptionalSecretValue(client, osConfig.getSslModeSecretKey())
+          .ifPresent(sslMode -> setProperty("sslmode", sslMode));
+    }
+  }
+
+  @Override
+  protected Map<String, String> podLabels() {
+    return Map.of("app", osConfig.getPodLabel());
+  }
+
+  private String getSecretValue(OpenshiftClient client, String key) {
+    return client.getSecretValue(osConfig.getSecretName(), key);
+  }
+
+  private Optional<String> getOptionalSecretValue(OpenshiftClient client, String key) {
+    try {
+      return Optional.ofNullable(getSecretValue(client, key));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private void setProperty(String name, String value) {
+    context.getOwner().withProperty(name, value);
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/OpenShiftDatabaseResourceConfig.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/OpenShiftDatabaseResourceConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.resources.db;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Configuration for OpenShift database managed resources.
+ *
+ * <p>Captures OpenShift-specific naming:
+ *
+ * <ul>
+ *   <li>Kubernetes secret name
+ *   <li>Service name for networking
+ *   <li>Pod label for discovery
+ *   <li>Secret key names (different secrets may use different key structures)
+ * </ul>
+ */
+@Builder
+@Getter
+public class OpenShiftDatabaseResourceConfig {
+  @NonNull private final String secretName;
+  @NonNull private final String serviceName;
+  @NonNull private final String podLabel;
+
+  @NonNull private final String portSecretKey;
+  @NonNull private final String databaseSecretKey;
+  @NonNull private final String usernameSecretKey;
+  @NonNull private final String passwordSecretKey;
+  private final String sslModeSecretKey;
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/SwatchDatabaseAnnotationBinding.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/db/SwatchDatabaseAnnotationBinding.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.resources.db;
+
+import com.redhat.swatch.component.tests.api.Service;
+import com.redhat.swatch.component.tests.api.SwatchDatabase;
+import com.redhat.swatch.component.tests.api.extensions.AnnotationBinding;
+import com.redhat.swatch.component.tests.core.ComponentTestContext;
+import com.redhat.swatch.component.tests.core.ManagedResource;
+import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBootstrap;
+import java.lang.annotation.Annotation;
+
+public class SwatchDatabaseAnnotationBinding implements AnnotationBinding {
+
+  private static final String DEFAULT_DB_HOST = "localhost";
+  private static final String DEFAULT_DB_PORT = "5432";
+  private static final String DEFAULT_DB_DATABASE = "rhsm-subscriptions";
+  private static final String DEFAULT_DB_USERNAME = "rhsm-subscriptions";
+  private static final String DEFAULT_DB_PASSWORD = "rhsm-subscriptions";
+
+  @Override
+  public boolean isFor(Annotation... annotations) {
+    return findAnnotation(annotations, SwatchDatabase.class).isPresent();
+  }
+
+  @Override
+  public ManagedResource getManagedResource(
+      ComponentTestContext context, Service service, Annotation... annotations) {
+    if (OpenShiftExtensionBootstrap.isEnabled(context)) {
+      return createOpenShiftResource();
+    }
+
+    return createLocalResource();
+  }
+
+  private LocalDatabaseManagedResource createLocalResource() {
+    var localConfig =
+        LocalDatabaseResourceConfig.builder()
+            .containerNameRegex("rhsm-subscriptions_db")
+            .envVarPrefix("SWATCH_DB")
+            .defaultHost(DEFAULT_DB_HOST)
+            .defaultPort(DEFAULT_DB_PORT)
+            .defaultDatabaseName(DEFAULT_DB_DATABASE)
+            .defaultUsername(DEFAULT_DB_USERNAME)
+            .defaultPassword(DEFAULT_DB_PASSWORD)
+            .build();
+
+    return new LocalDatabaseManagedResource(localConfig);
+  }
+
+  private OpenShiftDatabaseManagedResource createOpenShiftResource() {
+    var osConfig =
+        OpenShiftDatabaseResourceConfig.builder()
+            .secretName("swatch-database-db")
+            .serviceName("swatch-database-db")
+            .podLabel("swatch-database")
+            .portSecretKey("db.port")
+            .databaseSecretKey("db.name")
+            .usernameSecretKey("db.user")
+            .passwordSecretKey("db.password")
+            .sslModeSecretKey("db.sslmode")
+            .build();
+
+    return new OpenShiftDatabaseManagedResource(osConfig);
+  }
+}

--- a/swatch-test-framework/src/main/resources/META-INF/services/com.redhat.swatch.component.tests.api.extensions.AnnotationBinding
+++ b/swatch-test-framework/src/main/resources/META-INF/services/com.redhat.swatch.component.tests.api.extensions.AnnotationBinding
@@ -4,3 +4,4 @@ com.redhat.swatch.component.tests.resources.wiremock.WiremockAnnotationBinding
 com.redhat.swatch.component.tests.resources.springboot.SpringBootAnnotationBinding
 com.redhat.swatch.component.tests.resources.unleash.UnleashAnnotationBinding
 com.redhat.swatch.component.tests.resources.artemis.ArtemisAnnotationBinding
+com.redhat.swatch.component.tests.resources.db.SwatchDatabaseAnnotationBinding


### PR DESCRIPTION
Jira issue: SWATCH-4046

## Description
Some swatch-tally component tests were failing when run against an ephemeral environment because they were not able to discover the database in that environment (hard-coded credentials). A test run against an EE locally would appear to pass IF you had previously brought up pods locally since it could connect to the local DB pod.

This PR implements the infrastructure to support database-dependent component tests in both local and ephemeral environments.

### New components
- DatabaseService: Generic PostgreSQL connection and transaction management using property-based configuration
- LocalDatabaseResourceConfig/LocalDatabaseManagedResource: Configure and manage local database containers with environment overrides
- OpenShiftDatabaseResourceConfig/OpenShiftDatabaseManagedResource: Configure and manage OpenShift databases with configurable secret keys
- SwatchDatabaseAnnotationBinding: @SwatchDatabase annotation support with environment-specific resource creation

### Highlights
  - Properties scoped per service instance (no prefixes needed)
  - Configurable secret key names for OpenShift (db.user, db.password, etc.)
  - Optional SSL mode support
  - Transaction-based query execution
  - Automatic environment detection and resource selection

## Testing
Testing should be done against local and EE environments.

### Local Environment
```
# Start up dependent services
podman-compose up -d
```
```
# Ensure everything is built/refreshed
./mvnw clean install -DskipTests
```

```
# Run the swatch-tally component tests against local env
./mvnw clean install test -Pcomponent-tests -pl swatch-tally/ct -am
```


### Ephemeral Environment
The easiest way to get an EE up and running is to rename your current bonfire configuration so that it has no overrides (no config file) before running the command below. When the following bonfire command is run it will use the latest images.
```
# Bring up a minimal EE for the swatch-tally component tests
bonfire deploy rhsm   --source=appsre   --ref-env insights-production   --optional-deps-method none   --frontends false   --no-remove-resources app:rhsm   -p swatch-tally/RHSM_CONTRACTS_URL=http://wiremock-service:8000   -p swatch-tally/INVENTORY_SECRET_KEY_NAME=swatch-tally-ct-hbi-db   --remove-dependencies swatch-tally/swatch-contracts   --remove-dependencies swatch-tally/host-inventory   --remove-dependencies swatch-tally/export-service   --component wiremock   --component rhsm   --component artemis   --component swatch-kafka-bridge   --component swatch-tally   --component swatch-tally-ct-hbi
```

```
# Make sure you stop all local service pods
podman-compose down
```

```
# Run the tests against the ephemeral environment
./mvnw clean install test -Pcomponent-tests -pl swatch-tally/ct -am -Dswatch.component-tests.global.target=openshift
```