### PR TITLE
SWATCH-4800: Org preference POST and Grafana panel

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -6628,6 +6628,101 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
+              "description": "POST /api/rhsm-subscriptions/v1/utilization/org-preferences request volume by HTTP status (Quarkus http_server_requests_seconds_count).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "bars",
+                    "fillOpacity": 100,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 74
+              },
+              "id": 136,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (status) (increase(http_server_requests_seconds_count{service=\"swatch-utilization-service\",method=\"POST\",uri=\"/api/rhsm-subscriptions/v1/utilization/org-preferences\"}[$__interval]))",
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Org preference POST requests by status",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -6738,7 +6833,7 @@ data:
                 "h": 8,
                 "w": 21,
                 "x": 0,
-                "y": 74
+                "y": 82
               },
               "id": 131,
               "options": {
@@ -6880,7 +6975,7 @@ data:
       "timezone": "utc",
       "title": "Subscription Watch",
       "uid": "lkPhH-1Zk",
-      "version": 9
+      "version": 10
     }
 kind: ConfigMap
 metadata:

--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -146,6 +146,16 @@ The service exposes several metrics for monitoring and alerting:
 - `sla`: Service level when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
 - `usage`: Usage type when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
 
+Org preference **POST** volume is available from Quarkus HTTP metrics (no custom counter), for example:
+
+```promql
+sum by (status) (increase(http_server_requests_seconds_count{
+  service="swatch-utilization-service",
+  method="POST",
+  uri="/api/rhsm-subscriptions/v1/utilization/org-preferences"
+}[5m]))
+```
+
 These metrics enable:
 - Dashboards showing utilization monitoring coverage
 - Alerts when over-usage is detected frequently


### PR DESCRIPTION
## Summary

Adds a Subscription Watch stat panel for how often and the status of customers POST org utilization preferences (custom threshold saves).

## Merge order

**Merge this PR first** (1 of 2). The notification-rate and handler-duration PRs touch the same dashboard ConfigMap; merging in this order avoids unnecessary conflicts.

1. **This PR** — `SWATCH-4800-grafana-customer-threshold`
2. `SWATCH-4800-grafana-notification-event-rate`
