### PR TITLE
SWATCH-4800: Add Grafana panel for custom threshold notification event sent by swatch-utilization

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -6835,6 +6835,208 @@ data:
                 "x": 0,
                 "y": 82
               },
+              "id": 137,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true
+              },
+              "pluginVersion": "11.6.3",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "disableTextWrap": false,
+                  "editorMode": "code",
+                  "expr": "sum(increase(swatch_utilization_custom_threshold_total{service=\"swatch-utilization-service\"}[$__range])) by (product, metric_id, sla, usage)",
+                  "format": "table",
+                  "fullMetaSearch": false,
+                  "includeNullMetadata": true,
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true,
+                  "refId": "A",
+                  "useBackend": false
+                }
+              ],
+              "title": "Subscriptions custom threshold",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "includeByName": {},
+                    "indexByName": {
+                      "Value (max)": 4,
+                      "metric_id": 1,
+                      "product": 0,
+                      "sla": 2,
+                      "usage": 3
+                    },
+                    "renameByName": {
+                      "Value": "",
+                      "metric_id": ""
+                    }
+                  }
+                },
+                {
+                  "id": "groupBy",
+                  "options": {
+                    "fields": {
+                      "Value": {
+                        "aggregations": [
+                          "max"
+                        ],
+                        "operation": "aggregate"
+                      },
+                      "metric_id": {
+                        "aggregations": [],
+                        "operation": "groupby"
+                      },
+                      "product": {
+                        "aggregations": [],
+                        "operation": "groupby"
+                      },
+                      "sla": {
+                        "aggregations": [],
+                        "operation": "groupby"
+                      },
+                      "usage": {
+                        "aggregations": [],
+                        "operation": "groupby"
+                      }
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value (max)"
+                    },
+                    "properties": [
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Total Notifications Sent"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "metric_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Metric Id"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "product"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "sla"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "SLA"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Usage"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value (max)"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Count"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 21,
+                "x": 0,
+                "y": 90
+              },
               "id": 131,
               "options": {
                 "cellHeight": "sm",
@@ -6975,7 +7177,7 @@ data:
       "timezone": "utc",
       "title": "Subscription Watch",
       "uid": "lkPhH-1Zk",
-      "version": 10
+      "version": 11
     }
 kind: ConfigMap
 metadata:

--- a/swatch-utilization/README.md
+++ b/swatch-utilization/README.md
@@ -86,8 +86,8 @@ PostgreSQL database (via Clowder) with table `org_utilization_preference`. Each 
 stores optional per-organization settings: `org_id` (primary key), `custom_threshold` (integer
 percentage points, e.g. 5 for 5%), and `last_updated`. Schema is owned by Liquibase;
 the `OrgUtilizationPreferenceRepository` exposes persistence through Hibernate Panache.
-Application code can later read this table to override product defaults per org without
-redeploying configuration.
+`CustomThresholdUtilizationHandlerService` reads org preferences to evaluate the custom
+threshold path.
 
 ### Granularity Filtering
 The service processes utilization summaries regardless of their granularity (HOURLY, DAILY, MONTHLY).
@@ -137,14 +137,30 @@ The service performs comprehensive validation on incoming utilization summaries:
 Invalid summaries or measurements are logged and skipped without processing.
 
 ### Monitoring and Metrics
-The service exposes several metrics for monitoring and alerting:
 
-**swatch_utilization_over_usage**: Counter tracking detected over-usage events, tagged by:
-- `product`: Product ID
-- `metric_id`: Metric ID
-- `billing`: Billing provider (if present)
-- `sla`: Service level when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
-- `usage`: Usage type when set on the utilization summary; otherwise `_ANY` (missing, empty, or `ANY` on the payload)
+**Threshold handler counters** increment in `sendNotification` when a measurement crosses the
+rule (once per crossing). They do not track Kafka ingress or email delivery; feature flags may
+block `platform.notifications.ingress` after the counter increments.
+
+| Prometheus name | When | Notification event type |
+|-----------------|------|-------------------------|
+| `swatch_utilization_over_usage` | Over product/default over-usage threshold | `exceeded-utilization-threshold` |
+| `swatch_utilization_custom_threshold` | Over org `custom_threshold` (preference required) | `exceeded-custom-utilization-threshold` |
+
+**Micrometer tags (both):** `product`, `metric_id`, `billing`, `sla`, `usage` (`_ANY` when unset).
+
+**Subscription Watch** (swatch-utilization row) tables use range totals grouped by
+`product`, `metric_id`, `sla`, and `usage` (not `billing`):
+
+| Panel | Metric |
+|-------|--------|
+| Subscriptions over-usages | `swatch_utilization_over_usage_total` |
+| Subscriptions custom threshold | `swatch_utilization_custom_threshold_total` |
+
+```promql
+sum(increase(swatch_utilization_over_usage_total{service="swatch-utilization-service"}[$__range])) by (product, metric_id, sla, usage)
+sum(increase(swatch_utilization_custom_threshold_total{service="swatch-utilization-service"}[$__range])) by (product, metric_id, sla, usage)
+```
 
 Org preference **POST** volume is available from Quarkus HTTP metrics (no custom counter), for example:
 


### PR DESCRIPTION
## Summary

Add Grafana panel for custom threshold notification event sent by swatch-utilization, same as the one already in place for default threshold events.

## Merge order

**Merge after #6144**.

1. #6144 — `SWATCH-4800-grafana-customer-threshold`
2. **This PR** — `SWATCH-4800-grafana-notification-event-rate`

Expect a ConfigMap merge conflict if #6144 is not merged first; resolve by keeping both panels.