### PR TITLE
SWATCH-4954: fix NPE in contract sync and clear orphaned subscription

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -747,6 +747,53 @@ This section verifies the automatic contract termination behavior when contracts
   - Contract `end_date` is unchanged (still in the future, not terminated)
   - Contract count remains 1
 
+**contracts-sync-TC016 - Sync does not crash when upstream returns entitlement with null purchase**
+- **Description**: Verify that when upstream returns a mix of valid entitlements and entitlements with null `purchase` field, the sync skips the ones with null purchase and processes the valid contracts. Reproduces SWATCH-4954 NPE.
+- **Setup**:
+  - Stub upstream Partner API to return one valid AWS contract and one entitlement with `purchase: null`
+  - Stub offering and search API for the valid contract
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{orgId}`
+- **Verification**:
+  - Sync returns HTTP 200 with status "SUCCESS"
+  - Only the valid contract is persisted
+- **Expected Result**:
+  - HTTP 200 with StatusResponse
+  - StatusResponse status: "SUCCESS"
+  - Exactly 1 contract persisted (the valid one)
+  - The entitlement with null purchase is skipped without crashing the sync
+
+**contracts-sync-TC017 - Orphaned contract termination clears subscription's contract-provided state**
+- **Description**: Reproduces SWATCH-4954 subscription blocking. When a contract is orphaned (not found in upstream), the termination should clear the subscription's billing provider and measurements so subscription sync can update it.
+- **Setup**:
+  - Create a contract-enabled subscription for the org (AWS ROSA contract)
+  - Verify the subscription has billing provider and measurements set
+  - Re-stub upstream Partner API to return no valid contracts for the org
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{orgId}`
+- **Verification**:
+  - Contract is terminated (end_date set)
+  - Subscription's billing provider is cleared
+  - Subscription's measurements are cleared
+- **Expected Result**:
+  - HTTP 200 with StatusResponse
+  - Contract still exists but is terminated
+  - Subscription billing provider cleared and measurements cleared — subscription sync will no longer skip it
+
+**contracts-sync-TC018 - Legitimate contract termination preserves subscription's contract-provided state**
+- **Description**: When a contract is legitimately terminated (still present in upstream but with end_date in the past), the subscription should retain its billing provider, billing_account_id, and measurements — unlike orphaned contracts (TC017) which clear them.
+- **Setup**:
+  - Create a contract-enabled subscription (AWS ROSA contract with future end_date)
+  - Verify the subscription has billing provider and measurements set
+  - Re-stub upstream Partner API to return the same contract but with end_date in the past
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{orgId}`
+- **Verification**:
+  - Contract's end_date is updated to the past date from upstream
+  - Subscription billing provider is preserved (NOT cleared)
+  - Subscription measurements are preserved (NOT cleared)
+- **Expected Result**:
+  - HTTP 200 with StatusResponse status: "SUCCESS"
+  - Contract synced with upstream end_date
+  - Subscription retains all contract-provided state
+
 ## Subscription Management via UMB
 
 **subscriptions-creation-TC001 - Process a valid UMB subscription XML message from UMB**  

--- a/swatch-contracts/ct/java/api/PartnerApiStubs.java
+++ b/swatch-contracts/ct/java/api/PartnerApiStubs.java
@@ -25,6 +25,8 @@ import domain.BillingProvider;
 import domain.Contract;
 import io.restassured.http.ContentType;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -161,6 +163,44 @@ public class PartnerApiStubs {
         "azureResourceId", contract.getResourceId(), "page", Map.of("size", 20, "number", 0));
   }
 
+  /** Stub partner entitlements response mixing valid contracts with raw entitlement maps. */
+  public void stubPartnerSubscriptionsWithRawEntitlements(
+      String orgId, List<Contract> contracts, List<Map<String, Object>> rawEntitlements) {
+    var allEntitlements = new ArrayList<Map<String, Object>>();
+    allEntitlements.addAll(contracts.stream().map(this::buildPartnerEntitlementBody).toList());
+    allEntitlements.addAll(rawEntitlements);
+
+    var expectedQuery =
+        Map.of("rhAccountId", orgId, "page", Map.of("size", PAGE_SIZE, "number", 0));
+    var responseBody =
+        Map.of(
+            "content",
+            allEntitlements,
+            "page",
+            Map.of(
+                "size",
+                PAGE_SIZE,
+                "totalElements",
+                allEntitlements.size(),
+                "totalPages",
+                1,
+                "number",
+                0));
+    registerPartnerSubscriptionsMapping(expectedQuery, responseBody);
+  }
+
+  /** Build a raw entitlement body with null purchase for testing malformed data. */
+  public static Map<String, Object> buildEntitlementWithNullPurchase(
+      String orgId, String sourcePartner) {
+    var body = new HashMap<String, Object>();
+    body.put("rhAccountId", orgId);
+    body.put("sourcePartner", sourcePartner);
+    body.put("purchase", null);
+    body.put("partnerIdentities", Map.of());
+    body.put("rhEntitlements", List.of());
+    return body;
+  }
+
   public static class PartnerSubscriptionsStubRequest {
     private final String orgId;
     private final List<Contract> contracts;
@@ -191,7 +231,7 @@ public class PartnerApiStubs {
    * @return AWS contract response body map
    */
   private Map<String, Object> buildAwsContractBody(Contract contract) {
-    var body = new java.util.HashMap<String, Object>();
+    var body = new HashMap<String, Object>();
     body.put("rhAccountId", contract.getOrgId());
     body.put("sourcePartner", "aws_marketplace");
     body.put("entitlementDates", buildEntitlementDates(contract));
@@ -210,7 +250,7 @@ public class PartnerApiStubs {
             "vendorProductCode",
             contract.getProductCode(),
             "contracts",
-            java.util.List.of(buildContractDetails(contract))));
+            List.of(buildContractDetails(contract))));
     body.put("rhEntitlements", buildRhEntitlements(contract));
     return body;
   }
@@ -223,10 +263,10 @@ public class PartnerApiStubs {
    * @return Azure contract response body map
    */
   private Map<String, Object> buildAzureContractBody(Contract contract) {
-    var contractDetails = new java.util.HashMap<>(buildContractDetails(contract));
+    var contractDetails = new HashMap<>(buildContractDetails(contract));
     contractDetails.put("planId", contract.getPlanId());
 
-    var body = new java.util.HashMap<String, Object>();
+    var body = new HashMap<String, Object>();
     body.put("rhAccountId", contract.getOrgId());
     body.put("sourcePartner", "azure_marketplace");
     body.put("entitlementDates", buildEntitlementDates(contract));
@@ -249,7 +289,7 @@ public class PartnerApiStubs {
             "azureResourceId",
             contract.getResourceId(),
             "contracts",
-            java.util.List.of(contractDetails)));
+            List.of(contractDetails)));
     body.put("rhEntitlements", buildRhEntitlements(contract));
     return body;
   }
@@ -264,8 +304,8 @@ public class PartnerApiStubs {
   }
 
   /** Build common RH entitlements list. */
-  private java.util.List<Map<String, String>> buildRhEntitlements(Contract contract) {
-    return java.util.List.of(
+  private List<Map<String, String>> buildRhEntitlements(Contract contract) {
+    return List.of(
         Map.of(
             "sku",
             contract.getOffering().getSku(),

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.DateUtils.assertDatesAreEqual;
 
@@ -662,6 +663,142 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
         endDateBefore,
         contractsAfter.get(0).getEndDate(),
         "Azure contract end_date should be unchanged (not terminated)");
+  }
+
+  /** TC016 - Sync does not crash when upstream returns entitlement with null purchase. */
+  @TestPlanName("contracts-sync-TC016")
+  @Test
+  void shouldSkipEntitlementWithNullPurchaseAndSyncRemainingContracts() {
+    // Given: One valid AWS contract and one malformed entitlement with null purchase
+    String sku = RandomUtils.generateRandom();
+    Contract validContract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0), sku);
+    wiremock.forProductAPI().stubOfferingData(validContract.getOffering());
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(validContract);
+
+    var nullPurchaseEntitlement =
+        PartnerApiStubs.buildEntitlementWithNullPurchase(orgId, "aws_marketplace");
+    wiremock
+        .forPartnerAPI()
+        .stubPartnerSubscriptionsWithRawEntitlements(
+            orgId, List.of(validContract), List.of(nullPurchaseEntitlement));
+
+    // Sync offering to register product data
+    Response syncOffering = service.syncOffering(sku);
+    assertThat("Sync offering should succeed", syncOffering.statusCode(), is(HttpStatus.SC_OK));
+
+    // When: Sync contracts for the organization
+    Response syncResponse = service.syncContractsByOrg(orgId);
+
+    // Then: Sync succeeds — the valid contract is persisted, the bad one is skipped
+    assertThat("Sync should return OK", syncResponse.statusCode(), is(HttpStatus.SC_OK));
+    syncResponse
+        .then()
+        .body("status", equalTo(STATUS_SUCCESS))
+        .body("message", equalTo("Contracts Synced for " + orgId));
+
+    var contracts = service.getContractsByOrgId(orgId);
+    assertEquals(1, contracts.size(), "Only the valid contract should be persisted");
+    assertEquals(
+        validContract.getSubscriptionNumber(),
+        contracts.get(0).getSubscriptionNumber(),
+        "Persisted contract should be the valid one");
+  }
+
+  /**
+   * TC017 - Orphaned contract termination clears subscription's contract-provided state.
+   *
+   * <p>Reproduces SWATCH-4954: subscription had contract-provided capacity blocking subscription
+   * sync. After contract is orphaned and terminated, billing fields and measurements must be
+   * cleared so subscription sync can update it.
+   */
+  @TestPlanName("contracts-sync-TC017")
+  @Test
+  void shouldClearSubscriptionContractStateWhenContractIsOrphaned() {
+    // Given: An existing contract-enabled subscription with billing data and measurements
+    givenRosaContractIsCreated(10.0);
+
+    var subsBefore = service.getSubscriptionsByOrgId(orgId);
+    assertEquals(1, subsBefore.size(), "Should have one subscription");
+    assertNotNull(
+        subsBefore.get(0).getBillingProvider(),
+        "Subscription should have billing provider from contract");
+    assertFalse(
+        subsBefore.get(0).getMetrics().isEmpty(),
+        "Subscription should have measurements from contract");
+
+    // Given: Upstream now returns no valid contracts for this org
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId));
+
+    // When: Sync contracts
+    Response syncResponse = service.syncContractsByOrg(orgId);
+
+    // Then: Contract is orphaned and subscription contract state is cleared
+    assertThat("Sync should return OK", syncResponse.statusCode(), is(HttpStatus.SC_OK));
+
+    // Verify contract terminated
+    var contractsAfter = service.getContractsByOrgId(orgId);
+    assertEquals(1, contractsAfter.size(), "Contract should still exist (terminated, not deleted)");
+    assertNotNull(contractsAfter.get(0).getEndDate(), "Contract should be terminated");
+
+    // Verify subscription state cleared
+    var subsAfter = service.getSubscriptionsByOrgId(orgId);
+    assertEquals(1, subsAfter.size(), "Subscription should still exist");
+    assertNull(
+        subsAfter.get(0).getBillingProvider(),
+        "Subscription billingProvider should be cleared after contract termination");
+    assertTrue(
+        subsAfter.get(0).getMetrics().isEmpty(),
+        "Subscription measurements should be cleared after contract termination");
+  }
+
+  /**
+   * TC018 - Legitimate contract termination preserves subscription's contract-provided state.
+   *
+   * <p>Inverse of TC017: contract IS still in upstream (not orphaned) but with end_date in the
+   * past. Subscription billing state must be preserved.
+   */
+  @TestPlanName("contracts-sync-TC018")
+  @Test
+  void shouldPreserveSubscriptionBillingStateWhenContractIsLegitimatelyTerminated() {
+    // Given: A contract-enabled subscription with billing data and measurements
+    Contract contract = givenRosaContractIsCreated(10.0);
+
+    var subsBefore = service.getSubscriptionsByOrgId(orgId);
+    assertEquals(1, subsBefore.size(), "Should have one subscription");
+    assertNotNull(
+        subsBefore.get(0).getBillingProvider(),
+        "Subscription should have billing provider from contract");
+    assertFalse(
+        subsBefore.get(0).getMetrics().isEmpty(),
+        "Subscription should have measurements from contract");
+
+    // Given: Upstream now returns the same contract but with end_date in the past
+    Contract terminatedContract =
+        contract.toBuilder().endDate(OffsetDateTime.now().minusDays(1)).build();
+    wiremock
+        .forPartnerAPI()
+        .stubPartnerSubscriptions(forContractsInOrgId(orgId, terminatedContract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(terminatedContract);
+
+    // When: Sync contracts
+    Response syncResponse = service.syncContractsByOrg(orgId);
+
+    // Then: Sync succeeds and subscription billing state is preserved
+    assertThat("Sync should return OK", syncResponse.statusCode(), is(HttpStatus.SC_OK));
+    syncResponse
+        .then()
+        .body("status", equalTo(STATUS_SUCCESS))
+        .body("message", equalTo("Contracts Synced for " + orgId));
+
+    var subsAfter = service.getSubscriptionsByOrgId(orgId);
+    assertEquals(1, subsAfter.size(), "Subscription should still exist");
+    assertNotNull(
+        subsAfter.get(0).getBillingProvider(),
+        "Subscription billingProvider should be preserved after legitimate termination");
+    assertFalse(
+        subsAfter.get(0).getMetrics().isEmpty(),
+        "Subscription measurements should be preserved after legitimate termination");
   }
 
   protected String getContractUuidByProvider(String orgId, BillingProvider provider) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -43,6 +43,8 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Mapper(
     componentModel = "jakarta-cdi",
@@ -50,6 +52,8 @@ import org.mapstruct.Named;
     builder = @Builder(disableBuilder = true),
     uses = {ContractOfferingMapper.class})
 public interface ContractEntityMapper {
+
+  Logger log = LoggerFactory.getLogger(ContractEntityMapper.class);
 
   @Mapping(
       target = "subscriptionNumber",
@@ -108,6 +112,13 @@ public interface ContractEntityMapper {
   /** Extract billingProviderId from Partner Gateway API response */
   @Named("billingProviderId")
   default String extractBillingProviderId(PartnerEntitlementV1 entitlement) {
+    if (entitlement.getPurchase() == null
+        || entitlement.getPurchase().getVendorProductCode() == null) {
+      log.warn(
+          "Skipping entitlement with missing purchase data for org {}",
+          entitlement.getRhAccountId());
+      return null;
+    }
     var partner = entitlement.getSourcePartner();
     if (isAwsMarketplace(partner)) {
       return String.format(
@@ -116,11 +127,11 @@ public interface ContractEntityMapper {
           entitlement.getPartnerIdentities().getAwsCustomerId(),
           entitlement.getPartnerIdentities().getSellerAccountId());
     } else if (isAzureMarketplace(partner)) {
+      var contracts = entitlement.getPurchase().getContracts();
       var azurePlanId =
-          entitlement.getPurchase().getContracts().stream()
-              .map(SaasContractV1::getPlanId)
-              .findFirst()
-              .orElse("");
+          contracts != null
+              ? contracts.stream().map(SaasContractV1::getPlanId).findFirst().orElse("")
+              : "";
       var azureOfferId = entitlement.getPurchase().getVendorProductCode();
       var azureCustomerId = entitlement.getPartnerIdentities().getAzureCustomerId();
       var azureResourceId = entitlement.getPurchase().getAzureResourceId();

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -528,6 +528,10 @@ public class ContractService {
                   "Terminating subscription that no longer exists in upstream partner API: {}",
                   sub);
               sub.setEndDate(terminationDate);
+              sub.setBillingProvider(null);
+              sub.setBillingProviderId(null);
+              sub.setBillingAccountId(null);
+              sub.getSubscriptionMeasurements().clear();
               subscriptionRepository.persist(sub);
             });
   }
@@ -580,8 +584,13 @@ public class ContractService {
           String bpId = contractEntityMapper.extractBillingProviderId(entitlement);
           if (bpId != null) {
             upstreamBillingProviderIds.add(bpId);
+            tryUpsertPartnerContract(entitlement);
+          } else {
+            log.warn(
+                "Skipping entitlement with missing purchase data for org {}: {}",
+                orgId,
+                entitlement);
           }
-          tryUpsertPartnerContract(entitlement);
         }
       }
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -22,6 +22,8 @@ package com.redhat.swatch.contract.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.DimensionV1;
 import com.redhat.swatch.clients.rh.partner.gateway.api.model.PartnerEntitlementV1;
@@ -114,6 +116,55 @@ class ContractEntityMapperTest {
     assertEquals(
         "theAzureResourceId;thePlanId;theAzureOfferId;theAzureCustomerId;theClientId",
         entity.getBillingProviderId());
+  }
+
+  @Test
+  void testExtractBillingProviderIdReturnsNullWhenPurchaseIsNull() {
+    entitlement = new PartnerEntitlementV1();
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AWS.getCode());
+    entitlement.setPartnerIdentities(new PartnerIdentityV1());
+
+    assertNull(
+        mapper.extractBillingProviderId(entitlement), "Should return null when purchase is null");
+  }
+
+  @Test
+  void testExtractBillingProviderIdReturnsNullWhenPurchaseIsNullForAzure() {
+    entitlement = new PartnerEntitlementV1();
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
+    entitlement.setPartnerIdentities(new PartnerIdentityV1());
+
+    assertNull(
+        mapper.extractBillingProviderId(entitlement),
+        "Should return null when purchase is null for Azure");
+  }
+
+  @Test
+  void testExtractBillingProviderIdReturnsNullWhenVendorProductCodeIsNull() {
+    entitlement = new PartnerEntitlementV1();
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
+    entitlement.setPurchase(new PurchaseV1());
+    entitlement.setPartnerIdentities(new PartnerIdentityV1());
+
+    assertNull(
+        mapper.extractBillingProviderId(entitlement),
+        "Should return null when vendorProductCode is null");
+  }
+
+  @Test
+  void testExtractBillingProviderIdHandlesNullContractsInAzurePurchase() {
+    entitlement = new PartnerEntitlementV1();
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AZURE.getCode());
+    var purchase = new PurchaseV1();
+    purchase.setVendorProductCode("test-offer");
+    purchase.setAzureResourceId("test-resource");
+    entitlement.setPurchase(purchase);
+    entitlement.setPartnerIdentities(new PartnerIdentityV1());
+
+    String result = mapper.extractBillingProviderId(entitlement);
+    assertNotNull(result, "Should not throw NPE when Azure contracts list is null");
+    assertTrue(
+        result.contains(";;"), "planId should default to empty string when contracts list is null");
   }
 
   private void givenContractWithPlanId(String planId) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4954

## Description
When partner Gateway returns entitlements with a null purchase field, it causes an NPE in extractBillingProviderId() that crashed the entire org sync. Also, orphaned contract termination didn't clear the linked subscription's billing fields, leaving SubscriptionSyncService treating it as contract-provided and skipping it indefinitely.

## Testing
Unit and component tests included

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. podman compose up -d
2. make build component test swatch-contracts
