### PR TITLE
SWATCH-4857: Partial index on product_id in host_tally_buckets

### DIFF
--- a/src/main/resources/liquibase/202605151359-host-tally-buckets-partial-index.xml
+++ b/src/main/resources/liquibase/202605151359-host-tally-buckets-partial-index.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202605151359-01" author="awood" dbms="postgresql">
+    <sql>
+      CREATE INDEX host_tally_buckets_is_primary_idx ON host_tally_buckets (
+        product_id
+      ) WHERE is_primary = TRUE;
+    </sql>
+    <rollback>
+      <dropIndex tableName="host_tally_buckets" indexName="host_tally_buckets_is_primary_idx"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -209,5 +209,6 @@
     <include file="liquibase/202604151137-last-modified-on-hosts-instance-measurements-host-tally-buckets.xml"/>
     <include file="liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml"/>
     <include file="liquibase/202605111456-remove-last-modified-triggers.xml"/>
+    <include file="liquibase/202605151359-host-tally-buckets-partial-index.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
Jira issue: SWATCH-4857

## Description
Adds a partial index to the `product_id` column of `host_tally_buckets` where
`is_primary` is true.

## Testing
The testing steps for this are complex enough that I don't really expect anyone
to replicate it.  I will write up my procedure for future reference though.

Firstly, export the `account_services`, `hosts` and `host_tally_buckets` tables.  These 
last two tables are large enough that `gabi` times out, requiring an iterative approach to export.
I generated scripts that will export 5% of each table at a time.  They are pasted below:

<details>
<summary>fetch-hosts.sh</summary>

```shell
#!/usr/bin/env bash
# https://github.com/olivergondza/bash-strict-mode
set -eEuo pipefail
trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

GABI="${DIR}/gabi-wrap"
OUTPUT_DIR="${DIR}"
FINAL_CSV="${OUTPUT_DIR}/hosts.csv"
PERCENTILES=(5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95)
TOTAL_BLOCKS=$(( ${#PERCENTILES[@]} + 1 ))

echo "=== Finding non-numeric org_ids ==="
NON_NUMERIC=$("${GABI}" -q "select distinct org_id from hosts where org_id !~ '^\d+$'" \
    | tail -n +2 | sed 's/^[[:space:]]*"//; s/"[[:space:]]*$//')

if [[ -z "${NON_NUMERIC}" ]]; then
    NUMERIC_FILTER="true"
    echo "  None found"
else
    IN_LIST=$(echo "${NON_NUMERIC}" | sed "s/.*/'&'/" | paste -sd,)
    NUMERIC_FILTER="org_id NOT IN (${IN_LIST})"
    echo "  Filter: ${NUMERIC_FILTER}"
fi

echo ""

lo="0"

for block in $(seq 0 $((TOTAL_BLOCKS - 1))); do
    BLOCK_FILE="${OUTPUT_DIR}/hosts-block-${block}.csv"

    if [[ -f "${BLOCK_FILE}" ]]; then
        lines=$(wc -l < "${BLOCK_FILE}")
        echo "=== Block ${block}: already exists (${lines} lines), skipping ==="
        if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
            pct=${PERCENTILES[$block]}
            frac=$(printf '0.%02d' "$pct")
            echo -n "  p${pct} boundary... "
            lo=$("${GABI}" -q "select percentile_disc(${frac}) within group (order by org_id::bigint) from hosts where ${NUMERIC_FILTER}" \
                | tail -n 1 | tr -d '[:space:]"')
            echo "${lo}"
        fi
        continue
    fi

    if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
        pct=${PERCENTILES[$block]}
        frac=$(printf '0.%02d' "$pct")
        echo -n "  p${pct} boundary... "
        hi=$("${GABI}" -q "select percentile_disc(${frac}) within group (order by org_id::bigint) from hosts where ${NUMERIC_FILTER}" \
            | tail -n 1 | tr -d '[:space:]"')
        echo "${hi}"

        echo "=== Block ${block}: ${lo} <= org_id::bigint < ${hi} ==="
        query="select * from hosts where ${NUMERIC_FILTER} and org_id::bigint >= ${lo} and org_id::bigint < ${hi}"
    else
        echo "=== Block ${block}: org_id::bigint >= ${lo} ==="
        query="select * from hosts where ${NUMERIC_FILTER} and org_id::bigint >= ${lo}"
    fi

    "${GABI}" -q "${query}" > "${BLOCK_FILE}"
    lines=$(wc -l < "${BLOCK_FILE}")
    echo "  -> ${BLOCK_FILE} (${lines} lines)"
    echo ""

    if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
        lo="${hi}"
    fi
done

echo ""
echo "=== Concatenating into ${FINAL_CSV} ==="

head -n 1 "${OUTPUT_DIR}/hosts-block-0.csv" > "${FINAL_CSV}"

for i in $(seq 0 $((TOTAL_BLOCKS - 1))); do
    tail -n +2 "${OUTPUT_DIR}/hosts-block-${i}.csv" >> "${FINAL_CSV}"
done

total=$(wc -l < "${FINAL_CSV}")
echo "Done. ${FINAL_CSV} has ${total} lines (including header)."
```
</details>

<details>
<summary>fetch-htb.sh</summary>

```shell
#!/usr/bin/env bash
# https://github.com/olivergondza/bash-strict-mode
set -eEuo pipefail
trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

GABI="${DIR}/gabi-wrap"
OUTPUT_DIR="${DIR}"
FINAL_CSV="${OUTPUT_DIR}/host-tally-buckets.csv"
PERCENTILES=(5 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95)
TOTAL_BLOCKS=$(( ${#PERCENTILES[@]} + 1 ))

lo="00000000-0000-0000-0000-000000000000"

for block in $(seq 0 $((TOTAL_BLOCKS - 1))); do
    BLOCK_FILE="${OUTPUT_DIR}/host-tally-buckets-block-${block}.csv"

    if [[ -f "${BLOCK_FILE}" ]]; then
        lines=$(wc -l < "${BLOCK_FILE}")
        echo "=== Block ${block}: already exists (${lines} lines), skipping ==="
        # Derive the upper bound for the next iteration
        if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
            pct=${PERCENTILES[$block]}
            frac=$(printf '0.%02d' "$pct")
            echo -n "  p${pct} boundary... "
            lo=$("${GABI}" -q "select percentile_disc(${frac}) within group (order by host_id) from host_tally_buckets" \
                | tail -n 1 | tr -d '[:space:]"')
            echo "${lo}"
        fi
        continue
    fi

    if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
        pct=${PERCENTILES[$block]}
        frac=$(printf '0.%02d' "$pct")
        echo -n "  p${pct} boundary... "
        hi=$("${GABI}" -q "select percentile_disc(${frac}) within group (order by host_id) from host_tally_buckets" \
            | tail -n 1 | tr -d '[:space:]"')
        echo "${hi}"

        echo "=== Block ${block}: '${lo}' <= host_id < '${hi}' ==="
        query="select * from host_tally_buckets where host_id >= '${lo}' and host_id < '${hi}'"
    else
        echo "=== Block ${block}: host_id >= '${lo}' ==="
        query="select * from host_tally_buckets where host_id >= '${lo}'"
    fi

    "${GABI}" -q "${query}" > "${BLOCK_FILE}"
    lines=$(wc -l < "${BLOCK_FILE}")
    echo "  -> ${BLOCK_FILE} (${lines} lines)"
    echo ""

    if [[ ${block} -lt ${#PERCENTILES[@]} ]]; then
        lo="${hi}"
    fi
done

echo ""
echo "=== Concatenating into ${FINAL_CSV} ==="

head -n 1 "${OUTPUT_DIR}/host-tally-buckets-block-0.csv" > "${FINAL_CSV}"

for i in $(seq 0 $((TOTAL_BLOCKS - 1))); do
    tail -n +2 "${OUTPUT_DIR}/host-tally-buckets-block-${i}.csv" >> "${FINAL_CSV}"
done

total=$(wc -l < "${FINAL_CSV}")
echo "Done. ${FINAL_CSV} has ${total} lines (including header)."
```
</details>

After running those scripts, you will then need to drop the
`hosts_columns_id_unq` constraint on the `hosts` table.  Gabi outputs NULL
columns as an empty string.  Postgresql interprets NULL != NULL (thus not
violating the constraint) while "" == "" which does violate the constraint.

Import the `hosts.csv` and `host-tally-buckets.csv` files and then run the
script below to alter the `hypervisor_uuid` column to insert a random value for
rows that would otherwise violate the constraint.

<details>
<summary>fix-hosts.sh</summary>

```shell
#!/usr/bin/env bash
# https://github.com/olivergondza/bash-strict-mode
set -eEuo pipefail
trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

PSQL="psql -h localhost -U rhsm-subscriptions rhsm-subscriptions"

# Postgresql treats NULL != NULL, but Gabi exports NULL as the empty string
# so we end up with rows that suddenly violate the uniqueness constraint.

echo "=== Counting duplicate groups ==="
${PSQL} -c "
SELECT count(*) AS duplicate_rows FROM (
    SELECT ctid, row_number() OVER (
        PARTITION BY hypervisor_uuid, subscription_manager_id, inventory_id
        ORDER BY ctid
    ) AS rn
    FROM hosts
) dupes
WHERE rn > 1;
"

echo "=== Assigning random hypervisor_uuid to duplicates ==="
${PSQL} -c "
UPDATE hosts SET hypervisor_uuid = gen_random_uuid()::text
WHERE ctid IN (
    SELECT ctid FROM (
        SELECT ctid, row_number() OVER (
            PARTITION BY hypervisor_uuid, subscription_manager_id, inventory_id
            ORDER BY ctid
        ) AS rn
        FROM hosts
    ) dupes
    WHERE rn > 1
);
"

echo "=== Re-applying unique constraint ==="
${PSQL} -c "
ALTER TABLE public.hosts
ADD CONSTRAINT hosts_columns_id_unq
UNIQUE (hypervisor_uuid, subscription_manager_id, inventory_id);
"

echo "Done."
```
</details>

Put the `hosts_columns_id_unq` constraint back in place.

Now you need to populate the `is_primary` column correctly and then recreate all
the views to provide it.

<details>
<summary>populate-is-primary.sql</summary>

```sql
drop view tally_instance_non_payg_view;
drop view tally_instance_payg_view;
drop view tally_instance_view;

create view public.tally_instance_view
            (org_id, id, instance_id, display_name, host_billing_provider, host_billing_account_id,
             bucket_billing_provider, bucket_billing_account_id, last_seen, last_applied_event_record_date,
             num_of_guests, product_id, sla, usage, measurement_type, sockets, cores, subscription_manager_id,
             inventory_id, hypervisor_uuid, is_primary)
as
SELECT DISTINCT h.org_id,
    h.id,
    h.instance_id,
    h.display_name,
    h.billing_provider AS host_billing_provider,
    h.billing_account_id AS host_billing_account_id,
    b.billing_provider AS bucket_billing_provider,
    b.billing_account_id AS bucket_billing_account_id,
    h.last_seen,
    mhstd.max_last_applied_event_record_date AS last_applied_event_record_date,
    COALESCE(h.num_of_guests, 0) AS num_of_guests,
    b.product_id,
    b.sla,
    b.usage,
    COALESCE(b.measurement_type, 'EMPTY'::character varying) AS measurement_type,
    b.sockets,
    b.cores,
    h.subscription_manager_id,
    h.inventory_id,
    h.hypervisor_uuid,
    b.is_primary
FROM hosts h
         JOIN host_tally_buckets b ON h.id = b.host_id
         LEFT JOIN LATERAL ( SELECT max(host_tally_service_type.last_applied_event_record_date) AS max_last_applied_event_record_date
                             FROM host_tally_service_type
                             WHERE host_tally_service_type.host_id = h.id) mhstd ON true;

alter table public.tally_instance_view
    owner to "rhsm-subscriptions";

create view public.tally_instance_non_payg_view
            (org_id, id, instance_id, display_name, host_billing_provider, host_billing_account_id,
             bucket_billing_provider, bucket_billing_account_id, last_seen, last_applied_event_record_date,
             num_of_guests, product_id, sla, usage, measurement_type, sockets, cores, subscription_manager_id,
             inventory_id, hypervisor_uuid, metrics, is_primary)
as
SELECT DISTINCT v.org_id,
    v.id,
    v.instance_id,
    v.display_name,
    v.host_billing_provider,
    v.host_billing_account_id,
    v.bucket_billing_provider,
    v.bucket_billing_account_id,
    v.last_seen,
    v.last_applied_event_record_date,
    v.num_of_guests,
    v.product_id,
    v.sla,
    v.usage,
    v.measurement_type,
    v.sockets,
    v.cores,
    v.subscription_manager_id,
    v.inventory_id,
    v.hypervisor_uuid,
    jsonb_agg(jsonb_build_object('metric_id', m.metric_id, 'value', m.value)) AS metrics,
    v.is_primary
FROM tally_instance_view v
         LEFT JOIN instance_measurements m ON v.id = m.host_id
GROUP BY v.org_id, v.id, v.instance_id, v.display_name, v.host_billing_provider,
    v.host_billing_account_id, v.bucket_billing_provider, v.bucket_billing_account_id, v.last_seen,
    v.last_applied_event_record_date, v.num_of_guests, v.product_id, v.sla, v.usage,
    v.measurement_type, v.sockets, v.cores, v.subscription_manager_id, v.inventory_id,
    v.hypervisor_uuid, v.is_primary;

alter table public.tally_instance_non_payg_view
    owner to "rhsm-subscriptions";

create view public.tally_instance_payg_view
            (org_id, id, instance_id, display_name, host_billing_provider, host_billing_account_id,
             bucket_billing_provider, bucket_billing_account_id, last_seen, last_applied_event_record_date,
             num_of_guests, product_id, sla, usage, measurement_type, sockets, cores, subscription_manager_id,
             inventory_id, hypervisor_uuid, month, metrics, is_primary)
as
SELECT DISTINCT v.org_id,
    v.id,
    v.instance_id,
    v.display_name,
    v.host_billing_provider,
    v.host_billing_account_id,
    v.bucket_billing_provider,
    v.bucket_billing_account_id,
    v.last_seen,
    v.last_applied_event_record_date,
    v.num_of_guests,
    v.product_id,
    v.sla,
    v.usage,
    v.measurement_type,
    v.sockets,
    v.cores,
    v.subscription_manager_id,
    v.inventory_id,
    v.hypervisor_uuid,
    m.month,
    jsonb_agg(jsonb_build_object('metric_id', m.metric_id, 'value', m.value)) AS metrics,
    v.is_primary
FROM tally_instance_view v
         LEFT JOIN instance_monthly_totals m ON v.id = m.host_id
GROUP BY v.org_id, v.id, v.instance_id, v.display_name, v.host_billing_provider,
    v.host_billing_account_id, v.bucket_billing_provider, v.bucket_billing_account_id, v.last_seen,
    v.last_applied_event_record_date, v.num_of_guests, v.product_id, v.sla, v.usage,
    v.measurement_type, v.sockets, v.cores, v.subscription_manager_id, v.inventory_id,
    v.hypervisor_uuid, m.month, v.is_primary;

alter table public.tally_instance_payg_view
    owner to "rhsm-subscriptions";

-- non-payg
update host_tally_buckets set is_primary=true
where
    sla <> '_ANY'
  AND usage <> '_ANY'
  AND billing_provider = '_ANY'
  AND billing_account_id = '_ANY'
  AND product_id in (
                     'rhel-aus-addon',
                     'RHEL for ARM',
                     'RHEL for IBM Power',
                     'RHEL for IBM z',
                     'rhel-for-sap-x86',
                     'RHEL for x86',
                     'RHEL Workstation',
                     'RHEL Compute Node',
                     'rhel-for-x86-els-converted',
                     'rhel-for-x86-els-unconverted',
                     'rhel-for-x86-eus',
                     'rhel-for-x86-ha',
                     'rhel-for-x86-rs',
                     'Satellite Capsule',
                     'Satellite Server',
                     'OpenShift Container Platform');

-- payg
update host_tally_buckets set is_primary=true
where
    sla <> '_ANY'
  AND usage <> '_ANY'
  AND billing_provider <> '_ANY'
  AND billing_account_id <> '_ANY'
  AND product_id in (
                     'ansible-aap-managed',
                     'rhacm',
                     'rhacs',
                     'rhel-for-x86-els-payg',
                     'rhel-for-x86-els-payg-addon',
                     'rhosak',
                     'rosa',
                     'OpenShift-metrics',
                     'OpenShift-dedicated-metrics'
    );
```
</details>

Now run the script below.  Remarks follow.

<details>
<summary>htb-test.sh</summary>

```shell
#! /usr/bin/env bash
# https://github.com/olivergondza/bash-strict-mode
set -eEuo pipefail
trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

OUTPUT_DIR="${DIR}/index-test"
BEFORE_DIR="${OUTPUT_DIR}/before"
AFTER_IS_PRIMARY_DIR="${OUTPUT_DIR}/after-is-primary"
AFTER_HOSTID_PID_DIR="${OUTPUT_DIR}/after-hostid-pid"

if [ -d "$OUTPUT_DIR" ]; then
    echo >&2 "Error: ${OUTPUT_DIR} already exists"
    exit 1
fi

mkdir -p "$BEFORE_DIR" "$AFTER_IS_PRIMARY_DIR" "$AFTER_HOSTID_PID_DIR"

PSQL=(psql -h localhost -U rhsm-subscriptions rhsm-subscriptions)

ORGS=(
  # TODO: Add org IDs for the top 25 orgs based on the results of
  # select count(*), h.org_id from host_tally_buckets htb
  #   join hosts h on htb.host_id = h.id
  #   group by h.org_id order by count(*) desc limit 25;
)

PAYG_PRODUCTS=(
    "ansible-aap-managed"
    "rhacm"
    "rhacs"
    "rhel-for-x86-els-payg"
    "rhel-for-x86-els-payg-addon"
    "rhosak"
    "rosa"
    "OpenShift-metrics"
    "OpenShift-dedicated-metrics'"
)

NONPAYG_PRODUCTS=(
    "rhel-aus-addon"
    "RHEL for ARM"
    "RHEL for IBM Power"
    "RHEL for IBM z"
    "rhel-for-sap-x86"
    "RHEL for x86"
    "RHEL Workstation"
    "RHEL Compute Node"
    "rhel-for-x86-els-converted"
    "rhel-for-x86-els-unconverted"
    "rhel-for-x86-eus"
    "rhel-for-x86-ha"
    "rhel-for-x86-rs"
    "Satellite Capsule"
    "Satellite Server"
    "OpenShift Container Platform'"
)

PAYG_COLS="
tipv1_0.bucket_billing_account_id,
tipv1_0.bucket_billing_provider,
tipv1_0.instance_id,
tipv1_0.measurement_type,
tipv1_0.product_id,
tipv1_0.sla,
tipv1_0.usage,
tipv1_0.id,
tipv1_0.month,
tipv1_0.cores,
tipv1_0.display_name,
tipv1_0.host_billing_account_id,
tipv1_0.host_billing_provider,
tipv1_0.hypervisor_uuid,
tipv1_0.inventory_id,
tipv1_0.last_applied_event_record_date,
tipv1_0.last_seen,
tipv1_0.metrics,
tipv1_0.num_of_guests,
tipv1_0.org_id,
tipv1_0.sockets,
tipv1_0.subscription_manager_id"

NONPAYG_COLS="
tinpv1_0.bucket_billing_account_id,
tinpv1_0.bucket_billing_provider,
tinpv1_0.instance_id,
tinpv1_0.measurement_type,
tinpv1_0.product_id,
tinpv1_0.sla,
tinpv1_0.usage,
tinpv1_0.id,
tinpv1_0.cores,
tinpv1_0.display_name,
tinpv1_0.host_billing_account_id,
tinpv1_0.host_billing_provider,
tinpv1_0.hypervisor_uuid,
tinpv1_0.inventory_id,
tinpv1_0.last_applied_event_record_date,
tinpv1_0.last_seen,
tinpv1_0.metrics,
tinpv1_0.num_of_guests,
tinpv1_0.org_id,
tinpv1_0.sockets,
tinpv1_0.subscription_manager_id"

PAYG_CONTROL_FILTER="and tipv1_0.sla <> '_ANY'
and tipv1_0.usage <> '_ANY'
and tipv1_0.bucket_billing_provider <> '_ANY'
and tipv1_0.bucket_billing_account_id <> '_ANY'"

NONPAYG_CONTROL_FILTER="and tinpv1_0.sla <> '_ANY'
and tinpv1_0.usage <> '_ANY'
and tinpv1_0.bucket_billing_provider = '_ANY'
and tinpv1_0.bucket_billing_account_id = '_ANY'"

PAYG_IS_PRIMARY_FILTER="and is_primary = true"

NONPAYG_IS_PRIMARY_FILTER="and tinpv1_0.is_primary = true"

sanitize_filename() {
    echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -d "'"
}

sql_escape() {
    echo "${1//\'/\'\'}"
}

TOTAL=$(( ${#ORGS[@]} * (${#PAYG_PRODUCTS[@]} + ${#NONPAYG_PRODUCTS[@]}) * 4 ))
COUNT=0

run_explain() {
    local view="$1" cols="$2" alias="$3" filter="$4"
    local org="$5" product="$6" outfile="$7"
    local escaped
    escaped=$(sql_escape "$product")

    COUNT=$((COUNT + 1))
    printf "\r[%d/%d] %-70s" "$COUNT" "$TOTAL" "$(basename "$outfile")"

    "${PSQL[@]}" -t -A -c "
EXPLAIN (ANALYZE, COSTS, VERBOSE, BUFFERS, FORMAT JSON)
select ${cols}
from ${view} ${alias}
where ${alias}.org_id = '${org}'
and ${alias}.product_id = '${escaped}'
${filter};" > "$outfile"
}

run_phase() {
    local phase="$1" outdir="$2"
    local payg_filter="$3" nonpayg_filter="$4"

    for org in "${ORGS[@]}"; do
        for product in "${PAYG_PRODUCTS[@]}"; do
            local safe
            safe=$(sanitize_filename "$product")
            run_explain \
                "tally_instance_payg_view" "$PAYG_COLS" "tipv1_0" "$payg_filter" \
                "$org" "$product" \
                "${outdir}/${phase}-payg-${org}-${safe}.json"
        done
        for product in "${NONPAYG_PRODUCTS[@]}"; do
            local safe
            safe=$(sanitize_filename "$product")
            run_explain \
                "tally_instance_non_payg_view" "$NONPAYG_COLS" "tinpv1_0" "$nonpayg_filter" \
                "$org" "$product" \
                "${outdir}/${phase}-nonpayg-${org}-${safe}.json"
        done
    done
}

echo "Dropping indexes if they exist..."
"${PSQL[@]}" -c "DROP INDEX IF EXISTS host_tally_buckets_is_primary_idx;"
"${PSQL[@]}" -c "DROP INDEX IF EXISTS host_tally_buckets_host_id_product_id_idx;"

echo ""
echo "=== Phase 1: Control ==="
run_phase "control" "$BEFORE_DIR" "$PAYG_CONTROL_FILTER" "$NONPAYG_CONTROL_FILTER"

echo ""
echo "=== Phase 2: Unindexed ==="
run_phase "unindexed" "$BEFORE_DIR" "$PAYG_IS_PRIMARY_FILTER" "$NONPAYG_IS_PRIMARY_FILTER"

echo ""
echo "Creating index..."
"${PSQL[@]}" -c "CREATE INDEX host_tally_buckets_is_primary_idx ON host_tally_buckets(product_id) WHERE is_primary = true;"
"${PSQL[@]}" -c "ANALYZE host_tally_buckets;"

echo ""
echo "=== Phase 3: Indexed (is_primary) ==="
run_phase "indexed" "$AFTER_IS_PRIMARY_DIR" "$PAYG_IS_PRIMARY_FILTER" "$NONPAYG_IS_PRIMARY_FILTER"

echo ""
echo "Dropping is_primary index..."
"${PSQL[@]}" -c "DROP INDEX host_tally_buckets_is_primary_idx;"

echo ""
echo "Creating (host_id, product_id) index..."
"${PSQL[@]}" -c "CREATE INDEX host_tally_buckets_host_id_product_id_idx ON host_tally_buckets(host_id, product_id);"
"${PSQL[@]}" -c "ANALYZE host_tally_buckets;"

echo ""
echo "=== Phase 4: Indexed (host_id, product_id) ==="
run_phase "hostid-pid" "$AFTER_HOSTID_PID_DIR" "$PAYG_IS_PRIMARY_FILTER" "$NONPAYG_IS_PRIMARY_FILTER"

echo ""
echo "Cleaning up (host_id, product_id) index..."
"${PSQL[@]}" -c "DROP INDEX host_tally_buckets_host_id_product_id_idx;"

echo ""
echo "Done! Results in ${OUTPUT_DIR}"
```
</details>

The script generates PAYG and non-PAYG explain plans for four separate
conditions:
  * A control where `is_primary` is not used at all
  * No index changes to `host_tally_buckets` but using `is_primary`
  * A partial index on the `product_id` column where `is_primary` is true
  * An index on `host_id` and `product_id` as an experiment to see if a smaller
    index than the 7 column wide PK on `host_tally_buckets` would help.

The script generates 2500 explain plans which is way too much to digest without
some automation.

<details>
<summary>htb-analyze.py</summary>

```python
#!/usr/bin/env python3
import json
import os
import re
import statistics
import sys

SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
INDEX_TEST_DIR = os.path.join(SCRIPT_DIR, "index-test")
BEFORE_DIR = os.path.join(INDEX_TEST_DIR, "before")
AFTER_IS_PRIMARY_DIR = os.path.join(INDEX_TEST_DIR, "after-is-primary")
AFTER_HOSTID_PID_DIR = os.path.join(INDEX_TEST_DIR, "after-hostid-pid")
STATS_FILE = os.path.join(INDEX_TEST_DIR, "stats.txt")

MIN_CONTROL_TIME_MS = 200.0

ALL_PHASES = ("control", "unindexed", "indexed", "hostid-pid")

FILENAME_RE = re.compile(
    r"^(?P<phase>control|unindexed|indexed|hostid-pid)-(?P<type>payg|nonpayg)-(?P<org>\d+)-(?P<product>.+)\.json$"
)


def extract_total_time(filepath):
    with open(filepath) as f:
        data = json.load(f)
    plan = data[0]
    return plan["Planning Time"] + plan["Execution Time"]


def collect_results():
    results = {}
    dir_phase_map = [
        (BEFORE_DIR, ("control", "unindexed")),
        (AFTER_IS_PRIMARY_DIR, ("indexed",)),
        (AFTER_HOSTID_PID_DIR, ("hostid-pid",)),
    ]
    for dirname, phases in dir_phase_map:
        if not os.path.isdir(dirname):
            print(f"Directory not found: {dirname}", file=sys.stderr)
            sys.exit(1)
        for filename in os.listdir(dirname):
            m = FILENAME_RE.match(filename)
            if not m:
                continue
            phase = m.group("phase")
            if phase not in phases:
                continue
            qtype = m.group("type")
            org = m.group("org")
            product = m.group("product")
            key = (qtype, org, product)
            filepath = os.path.join(dirname, filename)
            try:
                total_time = extract_total_time(filepath)
            except (json.JSONDecodeError, KeyError, IndexError) as e:
                print(f"Skipping {filename}: {e}", file=sys.stderr)
                continue
            results.setdefault(key, {})[phase] = total_time
    return results


def filter_and_group(results):
    grouped = {"payg": [], "nonpayg": []}
    skipped = 0
    for (qtype, org, product), phases in results.items():
        if "control" not in phases:
            continue
        if phases["control"] < MIN_CONTROL_TIME_MS:
            skipped += 1
            continue
        if not all(p in phases for p in ALL_PHASES):
            continue
        grouped[qtype].append(phases)
    return grouped, skipped


def compute_stats(values):
    if not values:
        return {"mean": 0, "median": 0, "stddev": 0, "n": 0}
    return {
        "mean": statistics.mean(values),
        "median": statistics.median(values),
        "stddev": statistics.stdev(values) if len(values) > 1 else 0,
        "n": len(values),
    }


def pct_change(baseline, comparison):
    if baseline == 0:
        return 0
    return ((comparison - baseline) / baseline) * 100


def format_table(grouped):
    phase_labels = {
        "control": "control",
        "unindexed": "unindexed",
        "indexed": "idx:is_primary",
        "hostid-pid": "idx:hostid_pid",
    }
    lines = []
    header = (
        f"{'Category':<10} {'Phase':<16} {'N':>5} "
        f"{'Mean (ms)':>12} {'Median (ms)':>12} {'StdDev (ms)':>12} "
        f"{'vs Control':>12}"
    )
    separator = "-" * len(header)

    lines.append(separator)
    lines.append(header)
    lines.append(separator)

    for qtype in ("payg", "nonpayg"):
        entries = grouped[qtype]
        if not entries:
            lines.append(f"{qtype:<10} (no data above {MIN_CONTROL_TIME_MS}ms threshold)")
            lines.append(separator)
            continue

        phase_data = {}
        for phase in ALL_PHASES:
            values = [e[phase] for e in entries]
            phase_data[phase] = compute_stats(values)

        control_mean = phase_data["control"]["mean"]

        for phase in ALL_PHASES:
            s = phase_data[phase]
            change = pct_change(control_mean, s["mean"])
            change_str = "---" if phase == "control" else f"{change:+.1f}%"
            label = phase_labels[phase]
            lines.append(
                f"{qtype:<10} {label:<16} {s['n']:>5} "
                f"{s['mean']:>12.1f} {s['median']:>12.1f} {s['stddev']:>12.1f} "
                f"{change_str:>12}"
            )
        lines.append(separator)

    return "\n".join(lines)


def main():
    results = collect_results()
    total_tuples = len(results)
    grouped, skipped = filter_and_group(results)
    included = sum(len(v) for v in grouped.values())

    summary_lines = [
        "htb-index-test Results Analysis",
        f"Total tuples: {total_tuples}",
        f"Filtered out (control < {MIN_CONTROL_TIME_MS}ms): {skipped}",
        f"Included in stats: {included}",
        "",
    ]

    table = format_table(grouped)
    output = "\n".join(summary_lines) + table + "\n"

    print(output)
    with open(STATS_FILE, "w") as f:
        f.write(output)
    print(f"\nWritten to {STATS_FILE}")


if __name__ == "__main__":
    main()
```
</details>

The analysis script throws out any tuples where the control was less that 200ms.
Any query that's already that fast isn't really worth worrying about.

Here are the results

```
htb-index-test Results Analysis
Total tuples: 625
Filtered out (control < 200.0ms): 578
Included in stats: 47
-------------------------------------------------------------------------------------
Category   Phase                N    Mean (ms)  Median (ms)  StdDev (ms)   vs Control
-------------------------------------------------------------------------------------
payg       control             29       1451.8       1326.8        615.0          ---
payg       unindexed           29       1242.7       1103.7        584.9       -14.4%
payg       idx:is_primary      29       1133.4       1080.9        643.6       -21.9%
payg       idx:hostid_pid      29       1235.2       1085.4        595.3       -14.9%
-------------------------------------------------------------------------------------
nonpayg    control             18       1309.2       1501.7        577.6          ---
nonpayg    unindexed           18       1258.9       1362.3        420.9        -3.8%
nonpayg    idx:is_primary      18        946.4       1301.2        640.5       -27.7%
nonpayg    idx:hostid_pid      18       1239.6       1295.5        434.4        -5.3%
-------------------------------------------------------------------------------------
```


We can see that most of the tuples were filtered.  That's expected since many
product IDs are going to be unrepresented in our sample.  However, we see a
definite improvement in performance with the partial index on the `is_primary`
column.  I would not classify the results as "dramatic", but we certainly shave
off a few hundred milliseconds which, given the frequency of the query, will add
up over time.

Finally, we'll fetch the index's size with

```sql
SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass)) AS size
FROM pg_indexes where indexname = 'host_tally_buckets_is_primary_idx'
ORDER BY pg_relation_size(indexname::regclass) DESC;
```

and Postgresql shows the index to be 24MB which is very small compared to the
time savings we're getting.
