### PR TITLE
SWATCH-4962: Add component tests for category-filtered tally report has_data

### DIFF
--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -241,16 +241,15 @@ Test cases should be testable locally and in deployed environments.
 
 The tally report filtering test cases are organized into two component test files:
 
-- **TallyReportFiltersPaygTest.java** - Contains 20 test cases (TC001-TC023, excluding TC009, TC010, TC015, TC024) covering PAYG (Pay-As-You-Go) scenarios:
+- **TallyReportFiltersPaygTest.java** - Contains 20 test cases (TC001-TC023, excluding TC009, TC010, TC024) covering PAYG (Pay-As-You-Go) scenarios:
   - TC001-TC008: Basic filtering by granularity, SLA, usage, billing provider, and billing account ID
   - TC011-TC014: Validation errors and metadata verification
   - TC016-TC023: Daily granularity filtering, monthly/quarterly/yearly granularity support
   - Product: RHEL for x86 ELS PAYG (supports hourly granularity)
 
-- **TallyReportFiltersEdgeCaseTest.java** - Contains 4 test cases for edge cases requiring special event patterns:
+- **TallyReportFiltersEdgeCaseTest.java** - Contains 3 test cases for edge cases requiring special event patterns:
   - TC009: Multiple events aggregation with same filter attributes
   - TC010: Three distinct SLA values filtering
-  - TC015: Data gaps with hasData field
   - TC024: Billing account change for same instance
   - Product: RHEL for x86 ELS PAYG (supports hourly granularity)
 
@@ -498,26 +497,6 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API properly handles EMPTY enum values in filters
     - EMPTY is treated as a valid filter value distinct from null
 
-**tally-report-filters-TC015 - Data gaps indicated by hasData field**
-
-- **Description**: Verify that an unfiltered hourly tally report sets has_data per bucket.
-- **Setup**:
-    - Organization is opted in
-    - Premium payg events created at hour 0 (value 10.0) and hour 2 (value 20.0)
-    - Four-hour range where hours 1 and 3 have no events
-    - Hourly tally is performed
-- **Action**:
-    - Request unfiltered hourly tally report for the 4-hour range (no category filter)
-- **Verification**:
-    - Response data contains data points for each hour in the range
-    - Hour 0: value=10, has_data=true
-    - Hour 2: value=20, has_data=true
-    - Gap hours 1 and 3: value=0, has_data=false
-    - No data point in the range has value=0 and has_data=true
-- **Expected Result**:
-    - Event hours report has_data=true with the expected tallied values
-    - Gap-filled hours without a snapshot for that period report value=0 and has_data=false
-
 **tally-report-filters-TC016 - All data returned when no optional filters applied**
 
 - **Description**: Verify that tally report API returns all event data aggregated when querying without optional filter parameters
@@ -736,6 +715,26 @@ All test files use `@BeforeAll` to create test data once and share it across all
 - **Expected Result**:
     - Existing zero-value measurements for the filtered category are treated as present (has_data=true)
     - Categories that did not contribute at that hour still report has_data=false with value=0
+
+**tally-report-has-data-TC003 - Data gaps indicated by hasData field**
+
+- **Description**: Verify that an unfiltered hourly tally report sets has_data per bucket.
+- **Setup**:
+    - Organization is opted in
+    - Premium payg events created at hour 0 (value 10.0) and hour 2 (value 20.0)
+    - Four-hour range where hours 1 and 3 have no events
+    - Hourly tally is performed
+- **Action**:
+    - Request unfiltered hourly tally report for the 4-hour range (no category filter)
+- **Verification**:
+    - Response data contains data points for each hour in the range
+    - Hour 0: value=10, has_data=true
+    - Hour 2: value=20, has_data=true
+    - Gap hours 1 and 3: value=0, has_data=false
+    - No data point in the range has value=0 and has_data=true
+- **Expected Result**:
+    - Event hours report has_data=true with the expected tallied values
+    - Gap-filled hours without a snapshot for that period report value=0 and has_data=false
 
 ## Summary Messages Separated By Attribute Value
 

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -697,6 +697,49 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Daily reports correctly attribute measurements to respective billing accounts when an instance changes billing account ID
     - Total aggregated value equals the sum of individual billing account values
 
+## Report Has Data Based on Category
+
+**tally-report-has-data-TC001 - has_data matches category contribution**
+
+- **Description**: Verify that hourly tally reports with a category filter set has_data from that category’s measurements only—not from snapshot presence or other hardware categories. Covers gap hours, contributing cloud usage, and muted categories when only cloud PAYG usage exists.
+- **Setup**:
+    - Organization is opted in
+    - Cloud PAYG event published at hour T−2 (relative to current UTC hour) with vCPUs=8.0, sla=PREMIUM
+    - No event at gap hour T−4; no events at other hours in the queried range except T−2
+    - Hourly tally is performed until category=cloud at T−2 shows value>0 and has_data=true
+- **Action**:
+    - Configure primary row searches feature flag (enabled, then disabled via parameterization)
+    - Request hourly tally report for product tag and vCPUs metric with category set to each of physical, virtual, hypervisor, and cloud over range T−6 through end of T−2
+    - Request category=cloud report and inspect gap hour T−4 and event hour T−2
+    - Request physical, virtual, and hypervisor reports at event hour T−2
+- **Verification**:
+    - For every category in the range, no data point has value=0 and has_data=true unless that category contributed measurements
+    - At gap hour T−4, category=cloud has value=0 and has_data=false
+    - At event hour T−2, category=cloud has value=8 and has_data=true
+    - At event hour T−2, physical, virtual, and hypervisor each have value=0 and has_data=false
+- **Expected Result**:
+    - has_data reflects category-specific measurement presence per bucket
+    - Gap-filled hours report has_data=false even when value=0
+    - Non-contributing categories do not report has_data=true when a cloud-only snapshot exists
+
+**tally-report-has-data-TC002 - Zero-value category measurements still report has_data**
+
+- **Description**: Verify that a zero-quantity measurement for a contributing category still returns has_data=true with value=0, and that other categories at the same hour remain has_data=false when only cloud contributed.
+- **Setup**:
+    - Organization is opted in
+    - CLOUD PAYG event published at hour T−6 (relative to current UTC hour) with vCPUs=0.0, sla=PREMIUM
+    - Hourly tally is performed until category=cloud at T−6 shows value=0 and has_data=true
+- **Action**:
+    - Configure primary row searches feature flag (enabled, then disabled via parameterization)
+    - Request hourly tally report for product tag and vCPUs metric with category=cloud for hour T−6 only
+    - Request hourly reports with category physical, virtual, and hypervisor for the same hour
+- **Verification**:
+    - At event hour T−6, category=cloud has value=0 and has_data=true
+    - At event hour T−6, physical, virtual, and hypervisor each have value=0 and has_data=false
+- **Expected Result**:
+    - Existing zero-value measurements for the filtered category are treated as present (has_data=true)
+    - Categories that did not contribute at that hour still report has_data=false with value=0
+
 ## Summary Messages Separated By Attribute Value
 
 **tally-summary-by-attributes-TC001 - Tally summary separates measurements by SLA**

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -500,24 +500,23 @@ All test files use `@BeforeAll` to create test data once and share it across all
 
 **tally-report-filters-TC015 - Data gaps indicated by hasData field**
 
-- **Description**: Verify that tally report data points correctly indicate gaps in time series data using the hasData field
+- **Description**: Verify that an unfiltered hourly tally report sets has_data per bucket.
 - **Setup**:
     - Organization is opted in
-    - Event created at hour 0 (value 10.0)
-    - Event created at hour 2 (value 20.0)
-    - Hour 1 has no events (gap)
+    - Premium payg events created at hour 0 (value 10.0) and hour 2 (value 20.0)
+    - Four-hour range where hours 1 and 3 have no events
     - Hourly tally is performed
 - **Action**:
-    - Request tally report for 4-hour range covering all hours
+    - Request unfiltered hourly tally report for the 4-hour range (no category filter)
 - **Verification**:
-    - Response data contains data points
-    - Data points have hasData field populated
-    - At least one data point has hasData=true where events occurred
-    - hasData field indicates presence/absence of actual event data
+    - Response data contains data points for each hour in the range
+    - Hour 0: value=10, has_data=true
+    - Hour 2: value=20, has_data=true
+    - Gap hours 1 and 3: value=0, has_data=false
+    - No data point in the range has value=0 and has_data=true
 - **Expected Result**:
-    - API populates hasData field in data points
-    - hasData field accurately reflects whether events existed for that time period
-    - Time series gaps are identifiable via hasData field
+    - Event hours report has_data=true with the expected tallied values
+    - Gap-filled hours without a snapshot for that period report value=0 and has_data=false
 
 **tally-report-filters-TC016 - All data returned when no optional filters applied**
 
@@ -701,14 +700,13 @@ All test files use `@BeforeAll` to create test data once and share it across all
 
 **tally-report-has-data-TC001 - has_data matches category contribution**
 
-- **Description**: Verify that hourly tally reports with a category filter set has_data from that category’s measurements only—not from snapshot presence or other hardware categories. Covers gap hours, contributing cloud usage, and muted categories when only cloud PAYG usage exists.
+- **Description**: Verify that hourly tally reports with a category filter set has_data from that category’s measurements only, not from snapshot presence or other hardware categories.
 - **Setup**:
     - Organization is opted in
-    - Cloud PAYG event published at hour T−2 (relative to current UTC hour) with vCPUs=8.0, sla=PREMIUM
+    - Cloud payg event published at hour T−2 (relative to current UTC hour) with vCPUs=8.0, sla=Premium
     - No event at gap hour T−4; no events at other hours in the queried range except T−2
     - Hourly tally is performed until category=cloud at T−2 shows value>0 and has_data=true
 - **Action**:
-    - Configure primary row searches feature flag (enabled, then disabled via parameterization)
     - Request hourly tally report for product tag and vCPUs metric with category set to each of physical, virtual, hypervisor, and cloud over range T−6 through end of T−2
     - Request category=cloud report and inspect gap hour T−4 and event hour T−2
     - Request physical, virtual, and hypervisor reports at event hour T−2
@@ -724,13 +722,12 @@ All test files use `@BeforeAll` to create test data once and share it across all
 
 **tally-report-has-data-TC002 - Zero-value category measurements still report has_data**
 
-- **Description**: Verify that a zero-quantity measurement for a contributing category still returns has_data=true with value=0, and that other categories at the same hour remain has_data=false when only cloud contributed.
+- **Description**: Verify that a zero-quantity measurement for a contributing category still returns has_data=true with value=0 and that other categories at the same hour remain has_data=false when only cloud contributed.
 - **Setup**:
     - Organization is opted in
-    - CLOUD PAYG event published at hour T−6 (relative to current UTC hour) with vCPUs=0.0, sla=PREMIUM
+    - Cloud payg event published at hour T−6 (relative to current UTC hour) with vCPUs=0.0, sla=Premium
     - Hourly tally is performed until category=cloud at T−6 shows value=0 and has_data=true
 - **Action**:
-    - Configure primary row searches feature flag (enabled, then disabled via parameterization)
     - Request hourly tally report for product tag and vCPUs metric with category=cloud for hour T−6 only
     - Request hourly reports with category physical, virtual, and hypervisor for the same hour
 - **Verification**:

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -137,27 +137,21 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
 
     thenNoSnapshotGapBucket(pointForHour(cloudReport, gapHour), gapHour);
     thenCategoryHasMeasurementBucket(
-        pointForHour(cloudReport, positiveEventHourStart),
-        8,
-        positiveEventHourStart,
-        "cloud");
+        pointForHour(cloudReport, positiveEventHourStart), 8, positiveEventHourStart, "cloud");
 
     for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
       TallyReportData mutedReport =
           fetchCategoryHourlyReport(
               firstOrgId, mutedCategory, positiveRangeStart, positiveEventHourEnd);
       thenMutedCategoryAtSnapshotHour(
-          pointForHour(mutedReport, positiveEventHourStart),
-          mutedCategory,
-          positiveEventHourStart);
+          pointForHour(mutedReport, positiveEventHourStart), mutedCategory, positiveEventHourStart);
     }
   }
 
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-has-data-TC002")
-  void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(
-      boolean primaryRowSearches) {
+  void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(boolean primaryRowSearches) {
     // Given: Zero cloud PAYG is published and tallied
     givenFeatureFlagIsConfigured(primaryRowSearches);
     String orgId = RandomUtils.generateRandom();
@@ -330,8 +324,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     assertNotNull(report.getData(), "report data");
     return report.getData().stream()
         .filter(
-            point ->
-                point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
+            point -> point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
         .findFirst()
         .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
   }
@@ -343,9 +336,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     }
     return report.getData().stream()
         .filter(
-            point ->
-                point.getDate() != null
-                    && startOfUtcHour(point.getDate()).isEqual(hourStart))
+            point -> point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
         .anyMatch(
             point ->
                 point.getValue() != null
@@ -360,12 +351,10 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     }
     return report.getData().stream()
         .filter(
-            point ->
-                point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
+            point -> point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
         .anyMatch(
             point ->
-                intValueOrZero(point.getValue()) == 0
-                    && Boolean.TRUE.equals(point.getHasData()));
+                intValueOrZero(point.getValue()) == 0 && Boolean.TRUE.equals(point.getHasData()));
   }
 
   private static boolean hasMisleadingZeroWithHasData(TallyReportData report) {

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -56,7 +56,6 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
   private static final Duration PIPELINE_POLL_INTERVAL = Duration.ofSeconds(2);
 
   private static String firstOrgId;
-  private static String secondOrgId;
 
   /** Cloud usage hour and surrounding range for gap assertions. */
   private static OffsetDateTime positiveEventHourStart;
@@ -102,21 +101,21 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
             .timeoutMessage(
                 "Category=cloud metric=%s must materialize positive usage at %s.",
                 METRIC_ID, positiveEventHourStart));
+  }
 
-    secondOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
-    service.createOptInConfig(secondOrgId);
-    publishCloudPaygEvent(secondOrgId, zeroEventHourStart, 0.0f);
+  private void awaitCloudZeroMeasurementReady(String orgId) {
     AwaitilityUtils.untilAsserted(
         () -> {
-          service.performHourlyTallyForOrg(secondOrgId);
+          service.performHourlyTallyForOrg(orgId);
           if (!zeroMeasurementForHour(
-              getCategoryHourlyReport(secondOrgId, "cloud", zeroEventHourStart, zeroEventHourEnd),
+              getCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd),
               zeroEventHourStart)) {
             throw new AssertionError(
-                "PAYG fixtures not ready for org "
-                    + secondOrgId
-                    + " at zero hour "
-                    + zeroEventHourStart);
+                "PAYG zero-quantity cloud measurement not ready for org "
+                    + orgId
+                    + " at "
+                    + zeroEventHourStart
+                    + " (expected value=0, has_data=true on category=cloud)");
           }
         },
         AwaitilitySettings.using(PIPELINE_POLL_INTERVAL, PIPELINE_WAIT_TIMEOUT)
@@ -291,15 +290,20 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
   void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(boolean primaryRowSearches) {
     givenFeatureFlagIsConfigured(primaryRowSearches);
 
+    String orgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+    service.createOptInConfig(orgId);
+    publishCloudPaygEvent(orgId, zeroEventHourStart, 0.0f);
+    awaitCloudZeroMeasurementReady(orgId);
+
     TallyReportData cloudReport =
-        getCategoryHourlyReport(secondOrgId, "cloud", zeroEventHourStart, zeroEventHourEnd);
+        getCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd);
 
     assertCategoryHasMeasurementBucket(
         pointForHour(cloudReport, zeroEventHourStart), 0, zeroEventHourStart, "cloud");
 
     for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
       TallyReportData mutedReport =
-          getCategoryHourlyReport(secondOrgId, mutedCategory, zeroEventHourStart, zeroEventHourEnd);
+          getCategoryHourlyReport(orgId, mutedCategory, zeroEventHourStart, zeroEventHourEnd);
       assertMutedCategoryAtSnapshotHour(
           pointForHour(mutedReport, zeroEventHourStart), mutedCategory, zeroEventHourStart);
     }

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -148,6 +148,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     }
   }
 
+  /*
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-has-data-TC002")
@@ -174,6 +175,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
           pointForHour(mutedReport, zeroEventHourStart), mutedCategory, zeroEventHourStart);
     }
   }
+  */
 
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.tally.test.model.ServiceLevelType;
+import com.redhat.swatch.tally.test.model.TallyReportData;
+import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.candlepin.subscriptions.json.Event;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
+
+  private static final String PRODUCT_ID = RHEL_FOR_X86_ELS_PAYG.productId();
+  private static final String PRODUCT_TAG = RHEL_FOR_X86_ELS_PAYG.productTag();
+  private static final String METRIC_ID = RHEL_FOR_X86_ELS_PAYG.metricIds().get(0);
+
+  private static final Duration PIPELINE_WAIT_TIMEOUT = Duration.ofSeconds(120);
+  private static final Duration PIPELINE_POLL_INTERVAL = Duration.ofSeconds(2);
+
+  private static String firstOrgId;
+  private static String secondOrgId;
+
+  /** Cloud usage hour and surrounding range for gap assertions. */
+  private static OffsetDateTime positiveEventHourStart;
+
+  private static OffsetDateTime positiveEventHourEnd;
+  private static OffsetDateTime positiveRangeStart;
+  private static OffsetDateTime gapHour;
+
+  /** Separate hour for zero-quantity cloud usage. */
+  private static OffsetDateTime zeroEventHourStart;
+
+  private static OffsetDateTime zeroEventHourEnd;
+
+  @BeforeAll
+  static void setupCategoryHasDataPaygEvents() {
+    OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+    positiveEventHourStart = base.minusHours(2);
+    positiveEventHourEnd = positiveEventHourStart.plusHours(1).minusNanos(1);
+    positiveRangeStart = positiveEventHourStart.minusHours(4);
+    gapHour = positiveEventHourStart.minusHours(2);
+
+    zeroEventHourStart = base.minusHours(6);
+    zeroEventHourEnd = zeroEventHourStart.plusHours(1).minusNanos(1);
+
+    firstOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+    service.createOptInConfig(firstOrgId);
+    publishCloudPaygEvent(firstOrgId, positiveEventHourStart, 8.0f);
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          service.performHourlyTallyForOrg(firstOrgId);
+          if (!usagePositiveForHour(
+              getCategoryHourlyReport(
+                  firstOrgId, "cloud", positiveEventHourStart, positiveEventHourEnd),
+              positiveEventHourStart)) {
+            throw new AssertionError(
+                "PAYG fixtures not ready for org "
+                    + firstOrgId
+                    + " at positive hour "
+                    + positiveEventHourStart);
+          }
+        },
+        AwaitilitySettings.using(PIPELINE_POLL_INTERVAL, PIPELINE_WAIT_TIMEOUT)
+            .timeoutMessage(
+                "Category=cloud metric=%s must materialize positive usage at %s.",
+                METRIC_ID, positiveEventHourStart));
+
+    secondOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+    service.createOptInConfig(secondOrgId);
+    publishCloudPaygEvent(secondOrgId, zeroEventHourStart, 0.0f);
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          service.performHourlyTallyForOrg(secondOrgId);
+          if (!zeroMeasurementForHour(
+              getCategoryHourlyReport(secondOrgId, "cloud", zeroEventHourStart, zeroEventHourEnd),
+              zeroEventHourStart)) {
+            throw new AssertionError(
+                "PAYG fixtures not ready for org "
+                    + secondOrgId
+                    + " at zero hour "
+                    + zeroEventHourStart);
+          }
+        },
+        AwaitilitySettings.using(PIPELINE_POLL_INTERVAL, PIPELINE_WAIT_TIMEOUT)
+            .timeoutMessage(
+                "Category=cloud metric=%s must materialize value=0 with has_data=true at %s.",
+                METRIC_ID, zeroEventHourStart));
+  }
+
+  private static void publishCloudPaygEvent(
+      String orgId, OffsetDateTime hourStart, float metricValue) {
+    kafkaBridge.produceKafkaMessage(
+        SWATCH_SERVICE_INSTANCE_INGRESS,
+        helpers.createPaygEventWithTimestamp(
+            orgId,
+            UUID.randomUUID().toString(),
+            hourStart.toString(),
+            UUID.randomUUID().toString(),
+            METRIC_ID,
+            metricValue,
+            Event.Sla.PREMIUM,
+            Event.HardwareType.CLOUD,
+            PRODUCT_ID,
+            PRODUCT_TAG));
+  }
+
+  private static Map<String, Object> hourlyQueryParams(
+      OffsetDateTime beginning, OffsetDateTime ending, String category) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("granularity", "Hourly");
+    params.put("beginning", beginning.toString());
+    params.put("ending", ending.toString());
+    params.put("sla", ServiceLevelType.PREMIUM.toString());
+    params.put("category", category);
+    return params;
+  }
+
+  private static TallyReportData getCategoryHourlyReport(
+      String orgId, String category, OffsetDateTime beginning, OffsetDateTime ending) {
+    return service.getTallyReportData(
+        orgId, PRODUCT_TAG, METRIC_ID, hourlyQueryParams(beginning, ending, category));
+  }
+
+  private static OffsetDateTime startOfUtcHour(OffsetDateTime t) {
+    return t.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+  }
+
+  private static TallyReportDataPoint pointForHour(
+      TallyReportData report, OffsetDateTime hourStart) {
+    assertNotNull(report.getData(), "report data");
+    return report.getData().stream()
+        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
+  }
+
+  private static boolean hasMisleadingZeroWithHasData(TallyReportData report) {
+    return report.getData().stream()
+        .anyMatch(
+            p -> p.getValue() != null && p.getValue() == 0 && Boolean.TRUE.equals(p.getHasData()));
+  }
+
+  private static boolean usagePositiveForHour(TallyReportData report, OffsetDateTime hourStart) {
+    if (report.getData() == null || report.getData().isEmpty()) {
+      return false;
+    }
+    return report.getData().stream()
+        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
+        .anyMatch(
+            p -> p.getValue() != null && p.getValue() > 0 && Boolean.TRUE.equals(p.getHasData()));
+  }
+
+  private static boolean zeroMeasurementForHour(TallyReportData report, OffsetDateTime hourStart) {
+    if (report.getData() == null || report.getData().isEmpty()) {
+      return false;
+    }
+    return report.getData().stream()
+        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
+        .anyMatch(p -> intValueOrZero(p.getValue()) == 0 && Boolean.TRUE.equals(p.getHasData()));
+  }
+
+  private static int intValueOrZero(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  /** No snapshot/measurements for the period — gap-filled bucket. */
+  private static void assertNoSnapshotGapBucket(TallyReportDataPoint point, OffsetDateTime hour) {
+    assertEquals(
+        0,
+        intValueOrZero(point.getValue()),
+        "Gap hour " + hour + " must have value 0 when no events exist for that hour");
+    assertFalse(
+        Boolean.TRUE.equals(point.getHasData()),
+        "Gap hour " + hour + " must have has_data=false when no snapshot exists: " + point);
+  }
+
+  /** Category contributed measurements for the period. */
+  private static void assertCategoryHasMeasurementBucket(
+      TallyReportDataPoint point, int expectedValue, OffsetDateTime hour, String category) {
+    assertEquals(
+        expectedValue,
+        intValueOrZero(point.getValue()),
+        "category=" + category + " hour " + hour + " expected value");
+    assertTrue(
+        Boolean.TRUE.equals(point.getHasData()),
+        "category="
+            + category
+            + " hour "
+            + hour
+            + " must have has_data=true when measurements exist: "
+            + point);
+  }
+
+  /** Snapshot exists from other categories but this category did not contribute. */
+  private static void assertMutedCategoryAtSnapshotHour(
+      TallyReportDataPoint point, String category, OffsetDateTime hour) {
+    assertEquals(
+        0,
+        intValueOrZero(point.getValue()),
+        "category="
+            + category
+            + " hour "
+            + hour
+            + " must have value 0 with no category contribution");
+    assertFalse(
+        Boolean.TRUE.equals(point.getHasData()),
+        "category="
+            + category
+            + " hour "
+            + hour
+            + " must have has_data=false when snapshot exists "
+            + "but this category has no measurements: "
+            + point);
+  }
+
+  @ParameterizedTest(name = "primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-has-data-TC001")
+  void shouldIndicateHasDataMatchesCategoryContribution(boolean primaryRowSearches) {
+    givenFeatureFlagIsConfigured(primaryRowSearches);
+
+    for (String category : List.of("physical", "virtual", "hypervisor", "cloud")) {
+      TallyReportData report =
+          getCategoryHourlyReport(firstOrgId, category, positiveRangeStart, positiveEventHourEnd);
+
+      assertFalse(
+          hasMisleadingZeroWithHasData(report),
+          "Category="
+              + category
+              + " must not return value=0 with has_data=true when that category contributed nothing.");
+    }
+
+    TallyReportData cloudReport =
+        getCategoryHourlyReport(firstOrgId, "cloud", positiveRangeStart, positiveEventHourEnd);
+
+    assertNoSnapshotGapBucket(pointForHour(cloudReport, gapHour), gapHour);
+
+    assertCategoryHasMeasurementBucket(
+        pointForHour(cloudReport, positiveEventHourStart), 8, positiveEventHourStart, "cloud");
+
+    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
+      TallyReportData mutedReport =
+          getCategoryHourlyReport(
+              firstOrgId, mutedCategory, positiveRangeStart, positiveEventHourEnd);
+      assertMutedCategoryAtSnapshotHour(
+          pointForHour(mutedReport, positiveEventHourStart), mutedCategory, positiveEventHourStart);
+    }
+  }
+
+  @ParameterizedTest(name = "primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-has-data-TC002")
+  void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(boolean primaryRowSearches) {
+    givenFeatureFlagIsConfigured(primaryRowSearches);
+
+    TallyReportData cloudReport =
+        getCategoryHourlyReport(secondOrgId, "cloud", zeroEventHourStart, zeroEventHourEnd);
+
+    assertCategoryHasMeasurementBucket(
+        pointForHour(cloudReport, zeroEventHourStart), 0, zeroEventHourStart, "cloud");
+
+    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
+      TallyReportData mutedReport =
+          getCategoryHourlyReport(secondOrgId, mutedCategory, zeroEventHourStart, zeroEventHourEnd);
+      assertMutedCategoryAtSnapshotHour(
+          pointForHour(mutedReport, zeroEventHourStart), mutedCategory, zeroEventHourStart);
+    }
+  }
+}

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -30,6 +30,7 @@ import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.tally.test.model.ServiceLevelType;
 import com.redhat.swatch.tally.test.model.TallyReportData;
 import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
@@ -56,21 +57,20 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
   private static final Duration PIPELINE_POLL_INTERVAL = Duration.ofSeconds(2);
 
   private static String firstOrgId;
-
-  /** Cloud usage hour and surrounding range for gap assertions. */
   private static OffsetDateTime positiveEventHourStart;
-
   private static OffsetDateTime positiveEventHourEnd;
   private static OffsetDateTime positiveRangeStart;
   private static OffsetDateTime gapHour;
-
-  /** Separate hour for zero-quantity cloud usage. */
   private static OffsetDateTime zeroEventHourStart;
-
   private static OffsetDateTime zeroEventHourEnd;
 
+  private static String dataGapOrgId;
+  private static OffsetDateTime dataGapBaseTime;
+  private static OffsetDateTime dataGapRangeBeginning;
+  private static OffsetDateTime dataGapRangeEnding;
+
   @BeforeAll
-  static void setupCategoryHasDataPaygEvents() {
+  static void givenCategoryHasDataPaygScenariosReady() {
     OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
     positiveEventHourStart = base.minusHours(2);
     positiveEventHourEnd = positiveEventHourStart.plusHours(1).minusNanos(1);
@@ -80,14 +80,14 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     zeroEventHourStart = base.minusHours(6);
     zeroEventHourEnd = zeroEventHourStart.plusHours(1).minusNanos(1);
 
-    firstOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+    firstOrgId = RandomUtils.generateRandom();
     service.createOptInConfig(firstOrgId);
-    publishCloudPaygEvent(firstOrgId, positiveEventHourStart, 8.0f);
+    givenCloudPaygEventPublished(firstOrgId, positiveEventHourStart, 8.0f);
     AwaitilityUtils.untilAsserted(
         () -> {
           service.performHourlyTallyForOrg(firstOrgId);
-          if (!usagePositiveForHour(
-              getCategoryHourlyReport(
+          if (!cloudUsagePositiveForHour(
+              fetchCategoryHourlyReport(
                   firstOrgId, "cloud", positiveEventHourStart, positiveEventHourEnd),
               positiveEventHourStart)) {
             throw new AssertionError(
@@ -101,30 +101,118 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
             .timeoutMessage(
                 "Category=cloud metric=%s must materialize positive usage at %s.",
                 METRIC_ID, positiveEventHourStart));
+
+    dataGapBaseTime = base.minusHours(10);
+    dataGapRangeBeginning = dataGapBaseTime;
+    dataGapRangeEnding = dataGapBaseTime.plusHours(4).minusNanos(1);
+    dataGapOrgId = RandomUtils.generateRandom();
+    service.createOptInConfig(dataGapOrgId);
+    givenCloudPaygEventPublished(dataGapOrgId, dataGapBaseTime, 10.0f);
+    givenCloudPaygEventPublished(dataGapOrgId, dataGapBaseTime.plusHours(2), 20.0f);
+    service.performHourlyTallyForOrg(dataGapOrgId);
   }
 
-  private void awaitCloudZeroMeasurementReady(String orgId) {
-    AwaitilityUtils.untilAsserted(
-        () -> {
-          service.performHourlyTallyForOrg(orgId);
-          if (!zeroMeasurementForHour(
-              getCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd),
-              zeroEventHourStart)) {
-            throw new AssertionError(
-                "PAYG zero-quantity cloud measurement not ready for org "
-                    + orgId
-                    + " at "
-                    + zeroEventHourStart
-                    + " (expected value=0, has_data=true on category=cloud)");
-          }
-        },
-        AwaitilitySettings.using(PIPELINE_POLL_INTERVAL, PIPELINE_WAIT_TIMEOUT)
-            .timeoutMessage(
-                "Category=cloud metric=%s must materialize value=0 with has_data=true at %s.",
-                METRIC_ID, zeroEventHourStart));
+  @ParameterizedTest(name = "primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-has-data-TC001")
+  void shouldIndicateHasDataMatchesCategoryContribution(boolean primaryRowSearches) {
+    // Given: Positive cloud PAYG is tallied and the primary-row flag is configured
+    givenFeatureFlagIsConfigured(primaryRowSearches);
+
+    // When: Hourly category reports are fetched for the event window
+    TallyReportData cloudReport =
+        fetchCategoryHourlyReport(firstOrgId, "cloud", positiveRangeStart, positiveEventHourEnd);
+
+    // Then: No category reports value=0 with has_data=true without contributing
+    for (String category : List.of("physical", "virtual", "hypervisor", "cloud")) {
+      TallyReportData report =
+          fetchCategoryHourlyReport(firstOrgId, category, positiveRangeStart, positiveEventHourEnd);
+      assertFalse(
+          hasMisleadingZeroWithHasData(report),
+          "Category="
+              + category
+              + " must not return value=0 with has_data=true when that category "
+              + "contributed nothing.");
+    }
+
+    thenNoSnapshotGapBucket(pointForHour(cloudReport, gapHour), gapHour);
+    thenCategoryHasMeasurementBucket(
+        pointForHour(cloudReport, positiveEventHourStart),
+        8,
+        positiveEventHourStart,
+        "cloud");
+
+    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
+      TallyReportData mutedReport =
+          fetchCategoryHourlyReport(
+              firstOrgId, mutedCategory, positiveRangeStart, positiveEventHourEnd);
+      thenMutedCategoryAtSnapshotHour(
+          pointForHour(mutedReport, positiveEventHourStart),
+          mutedCategory,
+          positiveEventHourStart);
+    }
   }
 
-  private static void publishCloudPaygEvent(
+  @ParameterizedTest(name = "primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-has-data-TC002")
+  void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(
+      boolean primaryRowSearches) {
+    // Given: Zero cloud PAYG is published and tallied
+    givenFeatureFlagIsConfigured(primaryRowSearches);
+    String orgId = RandomUtils.generateRandom();
+    service.createOptInConfig(orgId);
+    givenCloudPaygEventPublished(orgId, zeroEventHourStart, 0.0f);
+    givenZeroCloudMeasurementReadyForOrg(orgId);
+
+    // When: Hourly category reports are fetched for the zero event hour
+    TallyReportData cloudReport =
+        fetchCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd);
+
+    // Then: Cloud reports zero with has_data=true; muted categories report has_data=false
+    thenCategoryHasMeasurementBucket(
+        pointForHour(cloudReport, zeroEventHourStart), 0, zeroEventHourStart, "cloud");
+
+    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
+      TallyReportData mutedReport =
+          fetchCategoryHourlyReport(orgId, mutedCategory, zeroEventHourStart, zeroEventHourEnd);
+      thenMutedCategoryAtSnapshotHour(
+          pointForHour(mutedReport, zeroEventHourStart), mutedCategory, zeroEventHourStart);
+    }
+  }
+
+  @ParameterizedTest(name = "primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-has-data-TC003")
+  void shouldIndicateDataGapsWithHasDataField(boolean primaryRowSearches) {
+    // Given: Events at hours 0 and 2 are tallied; hours 1 and 3 are gaps
+    givenFeatureFlagIsConfigured(primaryRowSearches);
+
+    // When: Unfiltered hourly report is fetched for the four-hour range
+    TallyReportData response =
+        AwaitilityUtils.until(
+            () ->
+                fetchUnfilteredHourlyReport(
+                    dataGapOrgId, dataGapRangeBeginning, dataGapRangeEnding),
+            data -> data.getData() != null && !data.getData().isEmpty());
+
+    OffsetDateTime hour0 = dataGapBaseTime;
+    OffsetDateTime hour1 = hour0.plusHours(1);
+    OffsetDateTime hour2 = hour0.plusHours(2);
+    OffsetDateTime hour3 = hour0.plusHours(3);
+
+    // Then: Event hours report usage; gap hours report value=0 and has_data=false
+    thenCategoryHasMeasurementBucket(pointForHour(response, hour0), 10, hour0, "report");
+    thenCategoryHasMeasurementBucket(pointForHour(response, hour2), 20, hour2, "report");
+    thenNoSnapshotGapBucket(pointForHour(response, hour1), hour1);
+    thenNoSnapshotGapBucket(pointForHour(response, hour3), hour3);
+
+    assertFalse(
+        hasMisleadingZeroWithHasData(response),
+        "Unfiltered report must not pair value=0 with has_data=true on gap-filled hours");
+  }
+
+  private static void givenCloudPaygEventPublished(
       String orgId, OffsetDateTime hourStart, float metricValue) {
     kafkaBridge.produceKafkaMessage(
         SWATCH_SERVICE_INSTANCE_INGRESS,
@@ -141,67 +229,28 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
             PRODUCT_TAG));
   }
 
-  private static Map<String, Object> hourlyQueryParams(
-      OffsetDateTime beginning, OffsetDateTime ending, String category) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("granularity", "Hourly");
-    params.put("beginning", beginning.toString());
-    params.put("ending", ending.toString());
-    params.put("sla", ServiceLevelType.PREMIUM.toString());
-    params.put("category", category);
-    return params;
+  private static void givenZeroCloudMeasurementReadyForOrg(String orgId) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          service.performHourlyTallyForOrg(orgId);
+          if (!cloudZeroMeasurementForHour(
+              fetchCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd),
+              zeroEventHourStart)) {
+            throw new AssertionError(
+                "PAYG zero-quantity cloud measurement not ready for org "
+                    + orgId
+                    + " at "
+                    + zeroEventHourStart
+                    + " (expected value=0, has_data=true on category=cloud)");
+          }
+        },
+        AwaitilitySettings.using(PIPELINE_POLL_INTERVAL, PIPELINE_WAIT_TIMEOUT)
+            .timeoutMessage(
+                "Category=cloud metric=%s must materialize value=0 with has_data=true at %s.",
+                METRIC_ID, zeroEventHourStart));
   }
 
-  private static TallyReportData getCategoryHourlyReport(
-      String orgId, String category, OffsetDateTime beginning, OffsetDateTime ending) {
-    return service.getTallyReportData(
-        orgId, PRODUCT_TAG, METRIC_ID, hourlyQueryParams(beginning, ending, category));
-  }
-
-  private static OffsetDateTime startOfUtcHour(OffsetDateTime t) {
-    return t.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
-  }
-
-  private static TallyReportDataPoint pointForHour(
-      TallyReportData report, OffsetDateTime hourStart) {
-    assertNotNull(report.getData(), "report data");
-    return report.getData().stream()
-        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
-        .findFirst()
-        .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
-  }
-
-  private static boolean hasMisleadingZeroWithHasData(TallyReportData report) {
-    return report.getData().stream()
-        .anyMatch(
-            p -> p.getValue() != null && p.getValue() == 0 && Boolean.TRUE.equals(p.getHasData()));
-  }
-
-  private static boolean usagePositiveForHour(TallyReportData report, OffsetDateTime hourStart) {
-    if (report.getData() == null || report.getData().isEmpty()) {
-      return false;
-    }
-    return report.getData().stream()
-        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
-        .anyMatch(
-            p -> p.getValue() != null && p.getValue() > 0 && Boolean.TRUE.equals(p.getHasData()));
-  }
-
-  private static boolean zeroMeasurementForHour(TallyReportData report, OffsetDateTime hourStart) {
-    if (report.getData() == null || report.getData().isEmpty()) {
-      return false;
-    }
-    return report.getData().stream()
-        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
-        .anyMatch(p -> intValueOrZero(p.getValue()) == 0 && Boolean.TRUE.equals(p.getHasData()));
-  }
-
-  private static int intValueOrZero(Integer value) {
-    return value == null ? 0 : value;
-  }
-
-  /** No snapshot/measurements for the period — gap-filled bucket. */
-  private static void assertNoSnapshotGapBucket(TallyReportDataPoint point, OffsetDateTime hour) {
+  private static void thenNoSnapshotGapBucket(TallyReportDataPoint point, OffsetDateTime hour) {
     assertEquals(
         0,
         intValueOrZero(point.getValue()),
@@ -211,8 +260,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
         "Gap hour " + hour + " must have has_data=false when no snapshot exists: " + point);
   }
 
-  /** Category contributed measurements for the period. */
-  private static void assertCategoryHasMeasurementBucket(
+  private static void thenCategoryHasMeasurementBucket(
       TallyReportDataPoint point, int expectedValue, OffsetDateTime hour, String category) {
     assertEquals(
         expectedValue,
@@ -228,8 +276,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
             + point);
   }
 
-  /** Snapshot exists from other categories but this category did not contribute. */
-  private static void assertMutedCategoryAtSnapshotHour(
+  private static void thenMutedCategoryAtSnapshotHour(
       TallyReportDataPoint point, String category, OffsetDateTime hour) {
     assertEquals(
         0,
@@ -250,62 +297,86 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
             + point);
   }
 
-  @ParameterizedTest(name = "primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-has-data-TC001")
-  void shouldIndicateHasDataMatchesCategoryContribution(boolean primaryRowSearches) {
-    givenFeatureFlagIsConfigured(primaryRowSearches);
-
-    for (String category : List.of("physical", "virtual", "hypervisor", "cloud")) {
-      TallyReportData report =
-          getCategoryHourlyReport(firstOrgId, category, positiveRangeStart, positiveEventHourEnd);
-
-      assertFalse(
-          hasMisleadingZeroWithHasData(report),
-          "Category="
-              + category
-              + " must not return value=0 with has_data=true when that category contributed nothing.");
-    }
-
-    TallyReportData cloudReport =
-        getCategoryHourlyReport(firstOrgId, "cloud", positiveRangeStart, positiveEventHourEnd);
-
-    assertNoSnapshotGapBucket(pointForHour(cloudReport, gapHour), gapHour);
-
-    assertCategoryHasMeasurementBucket(
-        pointForHour(cloudReport, positiveEventHourStart), 8, positiveEventHourStart, "cloud");
-
-    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
-      TallyReportData mutedReport =
-          getCategoryHourlyReport(
-              firstOrgId, mutedCategory, positiveRangeStart, positiveEventHourEnd);
-      assertMutedCategoryAtSnapshotHour(
-          pointForHour(mutedReport, positiveEventHourStart), mutedCategory, positiveEventHourStart);
-    }
+  private static TallyReportData fetchCategoryHourlyReport(
+      String orgId, String category, OffsetDateTime beginning, OffsetDateTime ending) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("granularity", "Hourly");
+    params.put("beginning", beginning.toString());
+    params.put("ending", ending.toString());
+    params.put("sla", ServiceLevelType.PREMIUM.toString());
+    params.put("category", category);
+    return service.getTallyReportData(orgId, PRODUCT_TAG, METRIC_ID, params);
   }
 
-  @ParameterizedTest(name = "primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-has-data-TC002")
-  void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(boolean primaryRowSearches) {
-    givenFeatureFlagIsConfigured(primaryRowSearches);
+  private static TallyReportData fetchUnfilteredHourlyReport(
+      String orgId, OffsetDateTime beginning, OffsetDateTime ending) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("granularity", "Hourly");
+    params.put("beginning", beginning.toString());
+    params.put("ending", ending.toString());
+    return service.getTallyReportData(orgId, PRODUCT_TAG, METRIC_ID, params);
+  }
 
-    String orgId = String.valueOf(10000 + (int) (Math.random() * 90000));
-    service.createOptInConfig(orgId);
-    publishCloudPaygEvent(orgId, zeroEventHourStart, 0.0f);
-    awaitCloudZeroMeasurementReady(orgId);
+  private static OffsetDateTime startOfUtcHour(OffsetDateTime timestamp) {
+    return timestamp.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+  }
 
-    TallyReportData cloudReport =
-        getCategoryHourlyReport(orgId, "cloud", zeroEventHourStart, zeroEventHourEnd);
+  private static int intValueOrZero(Integer value) {
+    return value == null ? 0 : value;
+  }
 
-    assertCategoryHasMeasurementBucket(
-        pointForHour(cloudReport, zeroEventHourStart), 0, zeroEventHourStart, "cloud");
+  private static TallyReportDataPoint pointForHour(
+      TallyReportData report, OffsetDateTime hourStart) {
+    assertNotNull(report.getData(), "report data");
+    return report.getData().stream()
+        .filter(
+            point ->
+                point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
+  }
 
-    for (String mutedCategory : List.of("physical", "virtual", "hypervisor")) {
-      TallyReportData mutedReport =
-          getCategoryHourlyReport(orgId, mutedCategory, zeroEventHourStart, zeroEventHourEnd);
-      assertMutedCategoryAtSnapshotHour(
-          pointForHour(mutedReport, zeroEventHourStart), mutedCategory, zeroEventHourStart);
+  private static boolean cloudUsagePositiveForHour(
+      TallyReportData report, OffsetDateTime hourStart) {
+    if (report.getData() == null || report.getData().isEmpty()) {
+      return false;
     }
+    return report.getData().stream()
+        .filter(
+            point ->
+                point.getDate() != null
+                    && startOfUtcHour(point.getDate()).isEqual(hourStart))
+        .anyMatch(
+            point ->
+                point.getValue() != null
+                    && point.getValue() > 0
+                    && Boolean.TRUE.equals(point.getHasData()));
+  }
+
+  private static boolean cloudZeroMeasurementForHour(
+      TallyReportData report, OffsetDateTime hourStart) {
+    if (report.getData() == null || report.getData().isEmpty()) {
+      return false;
+    }
+    return report.getData().stream()
+        .filter(
+            point ->
+                point.getDate() != null && startOfUtcHour(point.getDate()).isEqual(hourStart))
+        .anyMatch(
+            point ->
+                intValueOrZero(point.getValue()) == 0
+                    && Boolean.TRUE.equals(point.getHasData()));
+  }
+
+  private static boolean hasMisleadingZeroWithHasData(TallyReportData report) {
+    if (report.getData() == null) {
+      return false;
+    }
+    return report.getData().stream()
+        .anyMatch(
+            point ->
+                point.getValue() != null
+                    && point.getValue() == 0
+                    && Boolean.TRUE.equals(point.getHasData()));
   }
 }

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
@@ -112,8 +112,10 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
             20.0f,
             30.0f);
 
-    givenPaygEventPublished(threeSlaTest.timestamp(), threeSlaTest.premiumValue(), Event.Sla.PREMIUM);
-    givenPaygEventPublished(threeSlaTest.timestamp(), threeSlaTest.standardValue(), Event.Sla.STANDARD);
+    givenPaygEventPublished(
+        threeSlaTest.timestamp(), threeSlaTest.premiumValue(), Event.Sla.PREMIUM);
+    givenPaygEventPublished(
+        threeSlaTest.timestamp(), threeSlaTest.standardValue(), Event.Sla.STANDARD);
     givenPaygEventPublished(
         threeSlaTest.timestamp(), threeSlaTest.selfSupportValue(), Event.Sla.SELF_SUPPORT);
 

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
@@ -22,6 +22,7 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
@@ -30,6 +31,7 @@ import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.tally.test.model.ServiceLevelType;
 import com.redhat.swatch.tally.test.model.TallyReportData;
+import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -202,6 +204,23 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
     kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
   }
 
+  private static OffsetDateTime startOfUtcHour(OffsetDateTime t) {
+    return t.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+  }
+
+  private static TallyReportDataPoint pointForHour(
+      TallyReportData report, OffsetDateTime hourStart) {
+    assertNotNull(report.getData(), "report data");
+    return report.getData().stream()
+        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
+  }
+
+  private static int intValueOrZero(Integer value) {
+    return value == null ? 0 : value;
+  }
+
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
   @TestPlanName("tally-report-filters-TC009")
@@ -278,14 +297,44 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
 
     assertNotNull(response.getData(), "Response data should not be null");
 
-    long pointsWithData =
-        response.getData().stream()
-            .filter(point -> Boolean.TRUE.equals(point.getHasData()))
-            .count();
+    OffsetDateTime hour0 = dataGapTest.baseTime();
+    OffsetDateTime hour1 = hour0.plusHours(1);
+    OffsetDateTime hour2 = hour0.plusHours(2);
+    OffsetDateTime hour3 = hour0.plusHours(3);
 
+    // Hours with PREMIUM events after tally: has_data=true and matching values.
+    TallyReportDataPoint hour0Point = pointForHour(response, hour0);
+    assertEquals(10, intValueOrZero(hour0Point.getValue()), "hour 0 value");
     assertTrue(
-        pointsWithData > 0,
-        "Should have at least one data point with hasData=true where events occurred");
+        Boolean.TRUE.equals(hour0Point.getHasData()),
+        "hour 0 must have has_data=true where events occurred");
+
+    TallyReportDataPoint hour2Point = pointForHour(response, hour2);
+    assertEquals(20, intValueOrZero(hour2Point.getValue()), "hour 2 value");
+    assertTrue(
+        Boolean.TRUE.equals(hour2Point.getHasData()),
+        "hour 2 must have has_data=true where events occurred");
+
+    // Gap hours (no events): gap-filled buckets must be value=0 and has_data=false.
+    for (OffsetDateTime gapHour : List.of(hour1, hour3)) {
+      TallyReportDataPoint gapPoint = pointForHour(response, gapHour);
+      assertEquals(
+          0,
+          intValueOrZero(gapPoint.getValue()),
+          "Gap hour " + gapHour + " must have value 0 with no snapshot for that period");
+      assertFalse(
+          Boolean.TRUE.equals(gapPoint.getHasData()),
+          "Gap hour " + gapHour + " must have has_data=false with no measurements: " + gapPoint);
+    }
+
+    assertFalse(
+        response.getData().stream()
+            .anyMatch(
+                p ->
+                    p.getValue() != null
+                        && p.getValue() == 0
+                        && Boolean.TRUE.equals(p.getHasData())),
+        "Unfiltered report must not pair value=0 with has_data=true on gap-filled hours");
   }
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
@@ -22,16 +22,12 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
-import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.tally.test.model.ServiceLevelType;
 import com.redhat.swatch.tally.test.model.TallyReportData;
-import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -47,8 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Edge case tests requiring special event patterns.
  *
  * <p>Tests: - TC009: Multiple events aggregation (same filter attributes) - TC010: Three distinct
- * SLA values - TC015: Data gaps with hasData field - TC024: Billing account change for same
- * instance
+ * SLA values - TC024: Billing account change for same instance
  */
 public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
   private static String testOrgId;
@@ -71,13 +66,6 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
       float standardValue,
       float selfSupportValue) {}
 
-  record DataGapScenario(
-      OffsetDateTime baseTime,
-      OffsetDateTime beginning,
-      OffsetDateTime ending,
-      float valueAtHour0,
-      float valueAtHour2) {}
-
   record BillingAccountChangeScenario(
       String instanceId,
       String billingAccount1,
@@ -91,12 +79,11 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
 
   private static AggregationScenario aggregationTest;
   private static ThreeSlaScenario threeSlaTest;
-  private static DataGapScenario dataGapTest;
   private static BillingAccountChangeScenario billingChangeTest;
 
   @BeforeAll
-  static void setupEdgeCaseEvents() {
-    testOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+  static void givenEdgeCasePaygEventsPublished() {
+    testOrgId = RandomUtils.generateRandom();
     service.createOptInConfig(testOrgId);
 
     // TC009: Multiple events with same filter attributes (aggregation)
@@ -110,7 +97,7 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
             List.of(15.0f, 25.0f, 10.0f));
 
     for (float value : aggregationTest.valuesToAggregate()) {
-      publishEvent(aggregationTest.timestamp(), value, Event.Sla.PREMIUM);
+      givenPaygEventPublished(aggregationTest.timestamp(), value, Event.Sla.PREMIUM);
     }
 
     // TC010: Three distinct SLA values
@@ -125,20 +112,10 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
             20.0f,
             30.0f);
 
-    publishEvent(threeSlaTest.timestamp(), threeSlaTest.premiumValue(), Event.Sla.PREMIUM);
-    publishEvent(threeSlaTest.timestamp(), threeSlaTest.standardValue(), Event.Sla.STANDARD);
-    publishEvent(threeSlaTest.timestamp(), threeSlaTest.selfSupportValue(), Event.Sla.SELF_SUPPORT);
-
-    // TC015: Data gaps with hasData field
-    OffsetDateTime gapBaseTime =
-        OffsetDateTime.now(ZoneOffset.UTC).minusHours(10).truncatedTo(ChronoUnit.HOURS);
-    dataGapTest =
-        new DataGapScenario(
-            gapBaseTime, gapBaseTime, gapBaseTime.plusHours(4).minusNanos(1), 10.0f, 20.0f);
-
-    publishEvent(dataGapTest.baseTime(), dataGapTest.valueAtHour0(), Event.Sla.PREMIUM);
-    publishEvent(
-        dataGapTest.baseTime().plusHours(2), dataGapTest.valueAtHour2(), Event.Sla.PREMIUM);
+    givenPaygEventPublished(threeSlaTest.timestamp(), threeSlaTest.premiumValue(), Event.Sla.PREMIUM);
+    givenPaygEventPublished(threeSlaTest.timestamp(), threeSlaTest.standardValue(), Event.Sla.STANDARD);
+    givenPaygEventPublished(
+        threeSlaTest.timestamp(), threeSlaTest.selfSupportValue(), Event.Sla.SELF_SUPPORT);
 
     // TC024: Billing account change for same instance
     OffsetDateTime changeTime = OffsetDateTime.now(ZoneOffset.UTC).minusHours(3);
@@ -154,14 +131,14 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
             5.0f,
             8.0f);
 
-    publishEvent(
+    givenPaygEventPublished(
         billingChangeTest.instanceId(),
         billingChangeTest.firstEventTime(),
         billingChangeTest.firstEventValue(),
         Event.Sla.PREMIUM,
         billingChangeTest.billingAccount1());
 
-    publishEvent(
+    givenPaygEventPublished(
         billingChangeTest.instanceId(),
         billingChangeTest.secondEventTime(),
         billingChangeTest.secondEventValue(),
@@ -171,13 +148,109 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
     service.performHourlyTallyForOrg(testOrgId);
   }
 
-  // Overloaded publishEvent methods - basic case with random instance, no billing account
-  private static void publishEvent(OffsetDateTime timestamp, float value, Event.Sla sla) {
-    publishEvent(UUID.randomUUID().toString(), timestamp, value, sla, null);
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-filters-TC009")
+  void shouldAggregateMultipleEventsWithSameFilters(boolean enablePrimaryRowSearches) {
+    // Given: Three PREMIUM events at the same hour are tallied
+    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
+
+    Map<String, Object> queryParams =
+        Map.of(
+            "granularity", "Hourly",
+            "beginning", aggregationTest.beginning().toString(),
+            "ending", aggregationTest.ending().toString(),
+            "sla", ServiceLevelType.PREMIUM.toString());
+
+    // When: Hourly report is fetched for that hour with SLA=PREMIUM
+    TallyReportData response =
+        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams);
+
+    // Then: Values aggregate to 50 (15+25+10)
+    double total =
+        response.getData() == null
+            ? 0.0
+            : response.getData().stream().mapToInt(d -> d.getValue()).sum();
+
+    assertEquals(50.0, total, 0.0001, "Should aggregate all three PREMIUM events (15+25+10)");
   }
 
-  // With specific instance ID and billing account
-  private static void publishEvent(
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-filters-TC010")
+  void shouldFilterWithThreeDistinctSlaValues(boolean enablePrimaryRowSearches) {
+    // Given: Three SLA events at the same hour are tallied
+    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
+
+    Map<String, Object> queryParams =
+        Map.of(
+            "granularity", "Hourly",
+            "beginning", threeSlaTest.beginning().toString(),
+            "ending", threeSlaTest.ending().toString(),
+            "sla", ServiceLevelType.SELF_SUPPORT.toString());
+
+    // When: Hourly report is fetched with SLA=SELF_SUPPORT
+    TallyReportData response =
+        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams);
+
+    // Then: Only the Self-Support event is included (30)
+    double total =
+        response.getData() == null
+            ? 0.0
+            : response.getData().stream().mapToInt(d -> d.getValue()).sum();
+
+    assertEquals(30.0, total, 0.0001, "Self-Support SLA should total 30");
+  }
+
+  @ParameterizedTest(name = "with primaryRowSearches={0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-report-filters-TC024")
+  void shouldTrackBillingAccountChangeForSameInstance(boolean enablePrimaryRowSearches) {
+    // Given: Same instance reported usage under two billing accounts
+    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
+
+    Map<String, Object> queryParams1 =
+        Map.of(
+            "granularity", "Daily",
+            "beginning", billingChangeTest.beginning().toString(),
+            "ending", billingChangeTest.ending().toString(),
+            "billing_account_id", billingChangeTest.billingAccount1());
+
+    // When: Daily reports are fetched per billing account
+    TallyReportData response1 =
+        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams1);
+
+    double account1Total =
+        response1.getData() == null
+            ? 0.0
+            : response1.getData().stream().mapToInt(d -> d.getValue()).sum();
+
+    Map<String, Object> queryParams2 =
+        Map.of(
+            "granularity", "Daily",
+            "beginning", billingChangeTest.beginning().toString(),
+            "ending", billingChangeTest.ending().toString(),
+            "billing_account_id", billingChangeTest.billingAccount2());
+
+    TallyReportData response2 =
+        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams2);
+
+    double account2Total =
+        response2.getData() == null
+            ? 0.0
+            : response2.getData().stream().mapToInt(d -> d.getValue()).sum();
+
+    // Then: Each billing account total matches its event
+    assertEquals(5.0, account1Total, 0.0001, "Billing account 1 should total 5");
+    assertEquals(8.0, account2Total, 0.0001, "Billing account 2 should total 8");
+  }
+
+  private static void givenPaygEventPublished(
+      OffsetDateTime timestamp, float value, Event.Sla sla) {
+    givenPaygEventPublished(UUID.randomUUID().toString(), timestamp, value, sla, null);
+  }
+
+  private static void givenPaygEventPublished(
       String instanceId,
       OffsetDateTime timestamp,
       float value,
@@ -202,178 +275,5 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
     }
 
     kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
-  }
-
-  private static OffsetDateTime startOfUtcHour(OffsetDateTime t) {
-    return t.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
-  }
-
-  private static TallyReportDataPoint pointForHour(
-      TallyReportData report, OffsetDateTime hourStart) {
-    assertNotNull(report.getData(), "report data");
-    return report.getData().stream()
-        .filter(p -> p.getDate() != null && startOfUtcHour(p.getDate()).isEqual(hourStart))
-        .findFirst()
-        .orElseThrow(() -> new AssertionError("No data point for hour " + hourStart));
-  }
-
-  private static int intValueOrZero(Integer value) {
-    return value == null ? 0 : value;
-  }
-
-  @ParameterizedTest(name = "with primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC009")
-  void shouldAggregateMultipleEventsWithSameFilters(boolean enablePrimaryRowSearches) {
-    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
-
-    Map<String, Object> queryParams =
-        Map.of(
-            "granularity", "Hourly",
-            "beginning", aggregationTest.beginning().toString(),
-            "ending", aggregationTest.ending().toString(),
-            "sla", ServiceLevelType.PREMIUM.toString());
-
-    TallyReportData response =
-        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams);
-
-    // Debug: Print response data to understand what we're getting
-    if (response.getData() != null) {
-      System.out.println("Response data points: " + response.getData().size());
-      response
-          .getData()
-          .forEach(d -> System.out.println("  Date: " + d.getDate() + ", Value: " + d.getValue()));
-    }
-
-    double total =
-        response.getData() == null
-            ? 0.0
-            : response.getData().stream().mapToInt(d -> d.getValue()).sum();
-
-    System.out.println("Total: " + total + ", Expected: 50.0");
-    assertEquals(50.0, total, 0.0001, "Should aggregate all three PREMIUM events (15+25+10)");
-  }
-
-  @ParameterizedTest(name = "with primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC010")
-  void shouldFilterWithThreeDistinctSlaValues(boolean enablePrimaryRowSearches) {
-    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
-
-    Map<String, Object> queryParams =
-        Map.of(
-            "granularity", "Hourly",
-            "beginning", threeSlaTest.beginning().toString(),
-            "ending", threeSlaTest.ending().toString(),
-            "sla", ServiceLevelType.SELF_SUPPORT.toString());
-
-    TallyReportData response =
-        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams);
-
-    double total =
-        response.getData() == null
-            ? 0.0
-            : response.getData().stream().mapToInt(d -> d.getValue()).sum();
-
-    assertEquals(30.0, total, 0.0001, "Self-Support SLA should total 30");
-  }
-
-  @ParameterizedTest(name = "with primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC015")
-  void shouldIndicateDataGapsWithHasDataField(boolean enablePrimaryRowSearches) {
-    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
-
-    Map<String, Object> queryParams =
-        Map.of(
-            "granularity", "Hourly",
-            "beginning", dataGapTest.beginning().toString(),
-            "ending", dataGapTest.ending().toString());
-
-    TallyReportData response =
-        AwaitilityUtils.until(
-            () -> service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams),
-            data -> data.getData() != null && !data.getData().isEmpty());
-
-    assertNotNull(response.getData(), "Response data should not be null");
-
-    OffsetDateTime hour0 = dataGapTest.baseTime();
-    OffsetDateTime hour1 = hour0.plusHours(1);
-    OffsetDateTime hour2 = hour0.plusHours(2);
-    OffsetDateTime hour3 = hour0.plusHours(3);
-
-    // Hours with PREMIUM events after tally: has_data=true and matching values.
-    TallyReportDataPoint hour0Point = pointForHour(response, hour0);
-    assertEquals(10, intValueOrZero(hour0Point.getValue()), "hour 0 value");
-    assertTrue(
-        Boolean.TRUE.equals(hour0Point.getHasData()),
-        "hour 0 must have has_data=true where events occurred");
-
-    TallyReportDataPoint hour2Point = pointForHour(response, hour2);
-    assertEquals(20, intValueOrZero(hour2Point.getValue()), "hour 2 value");
-    assertTrue(
-        Boolean.TRUE.equals(hour2Point.getHasData()),
-        "hour 2 must have has_data=true where events occurred");
-
-    // Gap hours (no events): gap-filled buckets must be value=0 and has_data=false.
-    for (OffsetDateTime gapHour : List.of(hour1, hour3)) {
-      TallyReportDataPoint gapPoint = pointForHour(response, gapHour);
-      assertEquals(
-          0,
-          intValueOrZero(gapPoint.getValue()),
-          "Gap hour " + gapHour + " must have value 0 with no snapshot for that period");
-      assertFalse(
-          Boolean.TRUE.equals(gapPoint.getHasData()),
-          "Gap hour " + gapHour + " must have has_data=false with no measurements: " + gapPoint);
-    }
-
-    assertFalse(
-        response.getData().stream()
-            .anyMatch(
-                p ->
-                    p.getValue() != null
-                        && p.getValue() == 0
-                        && Boolean.TRUE.equals(p.getHasData())),
-        "Unfiltered report must not pair value=0 with has_data=true on gap-filled hours");
-  }
-
-  @ParameterizedTest(name = "with primaryRowSearches={0}")
-  @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC024")
-  void shouldTrackBillingAccountChangeForSameInstance(boolean enablePrimaryRowSearches) {
-    givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
-
-    Map<String, Object> queryParams1 =
-        Map.of(
-            "granularity", "Daily",
-            "beginning", billingChangeTest.beginning().toString(),
-            "ending", billingChangeTest.ending().toString(),
-            "billing_account_id", billingChangeTest.billingAccount1());
-
-    TallyReportData response1 =
-        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams1);
-
-    double account1Total =
-        response1.getData() == null
-            ? 0.0
-            : response1.getData().stream().mapToInt(d -> d.getValue()).sum();
-
-    Map<String, Object> queryParams2 =
-        Map.of(
-            "granularity", "Daily",
-            "beginning", billingChangeTest.beginning().toString(),
-            "ending", billingChangeTest.ending().toString(),
-            "billing_account_id", billingChangeTest.billingAccount2());
-
-    TallyReportData response2 =
-        service.getTallyReportData(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams2);
-
-    double account2Total =
-        response2.getData() == null
-            ? 0.0
-            : response2.getData().stream().mapToInt(d -> d.getValue()).sum();
-
-    assertEquals(5.0, account1Total, 0.0001, "Billing account 1 should total 5");
-    assertEquals(8.0, account2Total, 0.0001, "Billing account 2 should total 8");
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-4962

## Description
Reproduces bug from SWATCH-4962. These tests check that changes in [PR-6128](https://github.com/RedHatInsights/rhsm-subscriptions/pull/6128) work to fix it. Only payg component tests included.

## Testing
IQE Test MR (non-payg tests): https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1513

### Setup
1. Clean before running tests:
```
./mvnw clean install -DskipTests
```
2. Bring up services:
```
podman compose up -d
```

### Steps
1. Run new has_data tests in TallyReportCategoryHasDataPaygTest:
```
./mvnw clean install -Pcomponent-tests -pl swatch-tally/ct -am -Dtest=tests.TallyReportCategoryHasDataPaygTest -Dsurefire.failIfNoSpecifiedTests=false
```

### Verification
1. All new/updated tests listed above pass (3 tests, 6 runs total).
