### PR TITLE
SWATCH-4901: Use POST for internal RPC trigger endpoints

### DIFF
--- a/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
@@ -84,6 +84,6 @@ public class BillableUsageSwatchService extends SwatchService {
 
   /** Flush Kafka topics using internal API. */
   public void flushBillableUsageAggregationTopic() {
-    given().put(FLUSH_ENDPOINT).then().statusCode(HttpStatus.SC_OK);
+    given().post(FLUSH_ENDPOINT).then().statusCode(HttpStatus.SC_OK);
   }
 }

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -332,7 +332,7 @@ objects:
             - /usr/bin/bash
             - -c
             - >
-              /usr/bin/curl --fail -H "Origin: https://swatch-billable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/topics/flush"
+              /usr/bin/curl --fail -H "Origin: https://swatch-billable-usage-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-billable-usage-service:8000/api/swatch-billable-usage/internal/rpc/topics/flush"
           env:
             - name: SWATCH_SELF_PSK
               valueFrom:

--- a/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
@@ -89,7 +89,7 @@ paths:
         '500':
           $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance:
-    put:
+    post:
       description: Reset remittance_pending_value in Billable Usage Remittance table when it matches certain criteria
       summary: Update billable usage remittance records. Use org_ids to update by orgs, or billing_account_ids to update by billing accounts. Only one of these parameters should be specified at a time, do not provide both.
       operationId: resetBillableUsageRemittance
@@ -146,7 +146,7 @@ paths:
           $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
   /api/swatch-billable-usage/internal/rpc/topics/flush:
     description: Flush the billable usage aggregation topic to force publish aggregations that are stuck from low traffic.
-    put:
+    post:
       summary: Publishes messages to the billable-usage-aggregation-repartition topic for every partition in order to flush out stuck aggregations.
       operationId: flushBillableUsageAggregationTopic
       responses:

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/BillableUsageDeploymentTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/BillableUsageDeploymentTest.java
@@ -32,7 +32,7 @@ public class BillableUsageDeploymentTest {
   @Test
   void testTraceResponseHeader() {
     given()
-        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .post("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
         .then()
         .header(TRACE_RESPONSE_HEADER, startsWith("00-"));
   }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
@@ -157,7 +157,7 @@ class InternalBillableUsageResourceTest {
         .queryParam("org_ids", ORG_ID)
         .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
         .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
-        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .post("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
         .then()
         .statusCode(HttpStatus.SC_OK);
   }
@@ -170,7 +170,7 @@ class InternalBillableUsageResourceTest {
         .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
         .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
         .queryParam("billing_account_ids", String.format("%s_%s_ba", ORG_ID, PRODUCT_ID))
-        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .post("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
         .then()
         .statusCode(HttpStatus.SC_OK);
   }
@@ -184,7 +184,7 @@ class InternalBillableUsageResourceTest {
         .queryParam("start", OffsetDateTime.now().minusDays(5).toString())
         .queryParam("end", OffsetDateTime.now().plusDays(5).toString())
         .queryParam("billing_account_ids", String.format("%s_%s_ba", ORG_ID, PRODUCT_ID))
-        .put("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
+        .post("/api/swatch-billable-usage/internal/rpc/remittance/reset_billable_usage_remittance")
         .then()
         .statusCode(HttpStatus.SC_BAD_REQUEST);
   }

--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -904,9 +904,9 @@ This section verifies the automatic contract termination behavior when contracts
 - **Note:** This endpoint **SUPPORTS multiple subscriptions** via JSON array
 
 **subscriptions-sync-TC001 - Sync all subscriptions for enabled orgs**  
-- **Description**: Verify PUT /rpc/subscriptions/sync enqueues org subscriptions.  
+- **Description**: Verify POST /rpc/subscriptions/sync enqueues org subscriptions.  
 - **Setup**: Configure sync-enabled orgs.  
-- **Action:** PUT `/api/swatch-contracts/internal/rpc/subscriptions/sync`.  
+- **Action:** POST `/api/swatch-contracts/internal/rpc/subscriptions/sync`.  
 - **Verification**: Monitor sync queue.  
 - **Expected Result:**  
   - RpcResponse with success

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -88,7 +88,7 @@ public class ContractsSwatchService extends SwatchService {
     Objects.requireNonNull(sku, "sku must not be null");
 
     String endpoint = String.format(OFFERING_SYNC_ENDPOINT, sku);
-    return given().headers(SECURITY_HEADERS).when().put(endpoint);
+    return given().headers(SECURITY_HEADERS).when().post(endpoint);
   }
 
   public List<com.redhat.swatch.contract.test.model.Contract> getContracts(Contract contract) {
@@ -420,7 +420,7 @@ public class ContractsSwatchService extends SwatchService {
   }
 
   public Response syncAllSubscriptions() {
-    return given().headers(SECURITY_HEADERS).when().put(SYNC_ALL_SUBSCRIPTIONS_ENDPOINT);
+    return given().headers(SECURITY_HEADERS).when().post(SYNC_ALL_SUBSCRIPTIONS_ENDPOINT);
   }
 
   public SubscriptionResponse syncUmbSubscription(Subscription subscription) {
@@ -461,7 +461,7 @@ public class ContractsSwatchService extends SwatchService {
     Objects.requireNonNull(sku, "sku must not be null");
 
     String endpoint = String.format(FORCE_RECONCILE_OFFERING_ENDPOINT, sku);
-    return given().headers(SECURITY_HEADERS).when().put(endpoint);
+    return given().headers(SECURITY_HEADERS).when().post(endpoint);
   }
 
   private List<com.redhat.swatch.contract.test.model.Contract> getContracts(

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -507,7 +507,7 @@ objects:
               - /usr/bin/bash
               - -c
               - >
-                /usr/bin/curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-contracts-service:8000/api/swatch-contracts/internal/rpc/subscriptions/sync"
+                /usr/bin/curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-contracts-service:8000/api/swatch-contracts/internal/rpc/subscriptions/sync"
             env:
               - name: SWATCH_SELF_PSK
                 valueFrom:
@@ -532,7 +532,7 @@ objects:
               - /usr/bin/bash
               - -c
               - >
-                /usr/bin/curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X PUT "http://swatch-contracts-service:8000/api/swatch-contracts/internal/rpc/offerings/sync"
+                /usr/bin/curl --fail -H "Origin: https://swatch-contracts-service.redhat.com" -H "x-rh-swatch-psk: ${SWATCH_SELF_PSK}" -X POST "http://swatch-contracts-service:8000/api/swatch-contracts/internal/rpc/offerings/sync"
             env:
               - name: SWATCH_SELF_PSK
                 valueFrom:

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -449,7 +449,7 @@ paths:
         - service: [ ]
   /api/swatch-contracts/internal/rpc/subscriptions/sync:
     description: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
-    put:
+    post:
       summary: Enqueue all sync-enabled orgs to sync their subscriptions with upstream
       operationId: syncAllSubscriptions
       parameters:
@@ -671,7 +671,7 @@ paths:
         required: true
         schema:
           type: string
-    put:
+    post:
       summary: Sync an offering from the upstream source.
       operationId: syncOffering
       responses:
@@ -689,7 +689,7 @@ paths:
         - service: [ ]
   /api/swatch-contracts/internal/rpc/offerings/sync:
     description: Syncs all offerings not listed in deny list from the upstream source.
-    put:
+    post:
       summary: Syncs all offerings not listed in deny list from the upstream source.
       operationId: syncAllOfferings
       responses:
@@ -713,7 +713,7 @@ paths:
         required: true
         schema:
           type: string
-    put:
+    post:
       summary: Reconcile capacity for an offering from the upstream source.
       operationId: forceReconcileOffering
       responses:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -120,7 +120,7 @@ class ContractsResourceTest {
         given()
             .queryParams("forceSync", "false")
             .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-            .put("/api/swatch-contracts/internal/rpc/subscriptions/sync")
+            .post("/api/swatch-contracts/internal/rpc/subscriptions/sync")
             .then()
             .statusCode(200)
             .extract()
@@ -137,7 +137,7 @@ class ContractsResourceTest {
         given()
             .queryParams("forceSync", "true")
             .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-            .put("/api/swatch-contracts/internal/rpc/subscriptions/sync")
+            .post("/api/swatch-contracts/internal/rpc/subscriptions/sync")
             .then()
             .statusCode(200)
             .extract()
@@ -154,7 +154,7 @@ class ContractsResourceTest {
         given()
             .queryParams("forceSync", "false")
             .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-            .put("/api/swatch-contracts/internal/rpc/subscriptions/sync")
+            .post("/api/swatch-contracts/internal/rpc/subscriptions/sync")
             .then()
             .statusCode(200)
             .extract()
@@ -169,7 +169,7 @@ class ContractsResourceTest {
     OfferingResponse response =
         given()
             .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-            .put("/api/swatch-contracts/internal/rpc/offerings/sync")
+            .post("/api/swatch-contracts/internal/rpc/offerings/sync")
             .then()
             .statusCode(200)
             .extract()
@@ -184,7 +184,7 @@ class ContractsResourceTest {
     OfferingResponse response =
         given()
             .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-            .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", SKU))
+            .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", SKU))
             .then()
             .statusCode(200)
             .extract()
@@ -228,7 +228,7 @@ class ContractsResourceTest {
         .thenReturn(SyncResult.SKIPPED_NOT_FOUND);
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(404);
 
@@ -236,7 +236,7 @@ class ContractsResourceTest {
         .thenReturn(SyncResult.SKIPPED_DENYLISTED);
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(403);
 
@@ -250,7 +250,7 @@ class ContractsResourceTest {
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(404);
 
@@ -258,7 +258,7 @@ class ContractsResourceTest {
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(403);
 
@@ -266,7 +266,7 @@ class ContractsResourceTest {
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(400);
 
@@ -274,7 +274,7 @@ class ContractsResourceTest {
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(503);
 
@@ -282,7 +282,7 @@ class ContractsResourceTest {
     doThrow(rtex).when(offeringSyncService).syncOffering(any(String.class));
     given()
         .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
-        .put(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
+        .post(String.format("/api/swatch-contracts/internal/rpc/offerings/sync/%s", "TEST_SKU"))
         .then()
         .statusCode(500);
   }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: [SWATCH-4901](https://redhat.atlassian.net/browse/SWATCH-4901)

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
RPC command triggers in swatch-contracts and swatch-billable-usage used PUT, which implies idempotent resource replacement. Switch them to POST in OpenAPI, CronJob curls, tests, and CT clients.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Component tests:
```
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am
./mvnw clean install -Pcomponent-tests -pl swatch-billable-usage/ct -am
```
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1517

/use-iqe-image-tag=rhsm-subscriptions-34d724f0c9184959e64f3ca031201a341f9d822a

[SWATCH-4901]: https://redhat.atlassian.net/browse/SWATCH-4901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ