### PR TITLE
fix swatch-contracts component tests to wait for Unleash toggle propagation

### DIFF
--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -37,6 +37,20 @@ public class ContractsUnleashService extends UnleashService {
         AwaitilitySettings.defaults()
             .timeoutMessage(
                 "Unleash toggle '%s' should be enabled".formatted(PARTNER_GATEWAY_CONTRACTS)));
+    waitForUnleashPropagation();
+  }
+
+  /**
+   * Wait for swatch-contracts to pick up the toggle. The harness only checks Unleash admin; the
+   * service polls on {@code quarkus.unleash.fetch-toggles-interval} (1s in dev/ephemeral).
+   */
+  private void waitForUnleashPropagation() {
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for Unleash propagation", e);
+    }
   }
 
   public void disablePartnerGatewayContracts() {


### PR DESCRIPTION
## Description
- Wait 2s after enabling `enable-partner-gateway-contracts` so swatch-contracts picks up the toggle (`fetch-toggles-interval=1s` in ephemeral). Same pattern than in swatch-utilization.
- Fixes flaky `ContractsTerminationComponentTest` when the UMB consumer dropped messages before the pod saw the flag.
