### PR TITLE
SWATCH-5008 Calculate HBI staleness from last_check_in instead of stale_timestamp

### DIFF
--- a/bin/insert-mock-hosts
+++ b/bin/insert-mock-hosts
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+from datetime import datetime
 import json
 import os
 import subprocess
@@ -66,6 +67,9 @@ class DatabaseContext:
         if not is_guest:
             hypervisor_uuid = None
 
+        # Use current timestamp if last_seen not provided so hosts appear fresh
+        timestamp = last_seen or datetime.now().isoformat()
+
         # Build rhsm facts with optional SLA and usage
         rhsm_facts = {
             'orgId': org_id,
@@ -81,8 +85,9 @@ class DatabaseContext:
             'account': account,
             'display_name': display_name or insights_id,
             'org_id': org,
-            'created_on': last_seen or '1993-03-26',
-            'modified_on': last_seen or '1993-03-26',
+            'created_on': timestamp,
+            'modified_on': timestamp,
+            'last_check_in': timestamp,
             'facts': json.dumps({'rhsm': rhsm_facts}),
             'insights_id': insights_id,
             'subscription_manager_id': subscription_manager_id or str(uuid.uuid4()),
@@ -152,6 +157,9 @@ class DatabaseContext:
         # Create account_service record (only for tally database)
         self._create_account_service(account, 'HBI_HOST', org)
 
+        # Use current timestamp if last_seen not provided so hosts appear fresh
+        timestamp = last_seen or datetime.now().isoformat()
+
         host_fields = {
             'id': host_id,
             'instance_id': inventory_id,
@@ -164,7 +172,7 @@ class DatabaseContext:
             'hypervisor_uuid': hypervisor_uuid or None,
             'hardware_type': hardware_type or 'PHYSICAL',
             'num_of_guests': num_of_guests,
-            'last_seen': last_seen or '1993-03-26',
+            'last_seen': timestamp,
             'is_unmapped_guest': is_unmapped_guest or False,
             'is_hypervisor': is_hypervisor or False,
             'cloud_provider': cloud_provider or None,
@@ -349,6 +357,9 @@ parser.add_argument('--metric_id',
 parser.add_argument('--inventory-id',
                     default=None,
                     help='Set the inventory_id for the inserted hosts')
+parser.add_argument('--last-seen',
+                    default=None,
+                    help='Set the last_seen/last_check_in timestamp for inserted hosts (ISO 8601 format, e.g., 2026-05-26T15:00:00-03:00). Defaults to current time.')
 
 args = parser.parse_args()
 if args.is_hbi:
@@ -394,7 +405,7 @@ for i in range(args.num_accounts):
     for i in range(args.num_aws):
         generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='VIRTUALIZED', measurement_type='AWS',
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests, last_seen=args.last_seen,
                       cloud_provider='AWS', is_marketplace=args.is_marketplace, conversions_activity=args.conversions_activity,
                       host_type=args.host_type, billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
                       metric_id=args.metric_id)
@@ -402,7 +413,7 @@ for i in range(args.num_accounts):
     for i in range(args.num_gcp):
         generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='VIRTUALIZED', measurement_type='GOOGLE',
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests, last_seen=args.last_seen,
                       cloud_provider='GCP', is_marketplace=args.is_marketplace, conversions_activity=args.conversions_activity, host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
                       metric_id=args.metric_id)
@@ -410,7 +421,7 @@ for i in range(args.num_accounts):
     for i in range(args.num_physical):
         generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
                       product=args.product, sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                      is_hbi=args.is_hbi, num_of_guests=args.num_guests,
+                      is_hbi=args.is_hbi, num_of_guests=args.num_guests, last_seen=args.last_seen,
                       is_marketplace=args.is_marketplace, conversions_activity=args.conversions_activity,
                       host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
@@ -421,7 +432,7 @@ for i in range(args.num_accounts):
         hypervisor = generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='VIRTUAL',
                                    product=args.product,
                                    sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets,
-                                   is_hypervisor=True, is_hbi=args.is_hbi,
+                                   is_hypervisor=True, is_hbi=args.is_hbi, last_seen=args.last_seen,
                                    is_marketplace=args.is_marketplace, conversions_activity=args.conversions_activity,
                                    host_type=args.host_type,
                                    billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
@@ -431,7 +442,7 @@ for i in range(args.num_accounts):
             generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='PHYSICAL', measurement_type='PHYSICAL',
                           product=args.product,
                           sla=args.sla, usage=args.usage, cores=args.cores, sockets=args.sockets, is_hypervisor=True,
-                          is_hbi=args.is_hbi,
+                          is_hbi=args.is_hbi, last_seen=args.last_seen,
                           is_marketplace=args.is_marketplace, conversions_activity=args.conversions_activity,
                           host_type=args.host_type,
                           billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,
@@ -453,7 +464,7 @@ for i in range(args.num_accounts):
         generate_host(inventory_id=args.inventory_id, account_number=account, org_id=args.org, hardware_type='VIRTUALIZED', is_guest=True,
                       product=args.product, sla=args.sla, usage=args.usage, hypervisor_uuid=hypervisor_uuid,
                       cores=args.cores, sockets=args.sockets, is_unmapped_guest=create_unmapped,
-                      skip_buckets=skip_buckets, is_hbi=args.is_hbi,
+                      skip_buckets=skip_buckets, is_hbi=args.is_hbi, last_seen=args.last_seen,
                       is_marketplace=args.is_marketplace,  conversions_activity=args.conversions_activity,
                       host_type=args.host_type,
                       billing_provider=args.billing_provider, billing_account_id=args.billing_account_id,

--- a/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/subscriptions/ApplicationProperties.java
@@ -97,6 +97,15 @@ public class ApplicationProperties {
   private int cullingOffsetDays = 14;
 
   /**
+   * The time to add to a host's last_check_in to calculate its effective stale_timestamp. This
+   * should match HBI's CONVENTIONAL_TIME_TO_STALE_SECONDS default (29 hours) for orgs without
+   * custom staleness configuration. HBI no longer writes the stale_timestamp column (as of May
+   * 2026), so we calculate it from last_check_in + this offset.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  private Duration stalenessOffset = Duration.ofHours(29);
+
+  /**
    * Offsets the range to look at metrics to account for delay in prometheus having metrics
    * available
    */

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryDatabaseOperations.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.ApplicationProperties;
 import org.candlepin.subscriptions.inventory.db.model.InventoryHostFacts;
 import org.candlepin.subscriptions.tally.OrgHostsData;
 import org.springframework.stereotype.Component;
@@ -35,16 +36,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class InventoryDatabaseOperations {
 
   private final InventoryRepository repo;
+  private final int stalenessOffsetSeconds;
 
-  public InventoryDatabaseOperations(InventoryRepository inventoryRepository) {
+  public InventoryDatabaseOperations(
+      InventoryRepository inventoryRepository, ApplicationProperties props) {
     this.repo = inventoryRepository;
+    this.stalenessOffsetSeconds = (int) props.getStalenessOffset().toSeconds();
   }
 
   @Transactional(value = "inventoryTransactionManager", readOnly = true)
   public void processHost(
       String orgId, int culledOffsetDays, Consumer<InventoryHostFacts> consumer) {
     try (Stream<InventoryHostFacts> hostFactStream =
-        repo.getFacts(List.of(orgId), culledOffsetDays)) {
+        repo.getFacts(List.of(orgId), culledOffsetDays, stalenessOffsetSeconds)) {
       hostFactStream.forEach(consumer::accept);
     }
   }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/InventoryRepository.java
@@ -45,10 +45,14 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
         @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
   Stream<InventoryHostFacts> streamFacts(
-      @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);
+      @Param("orgId") String orgId,
+      @Param("culledOffsetDays") Integer culledOffsetDays,
+      @Param("stalenessOffsetSeconds") Integer stalenessOffsetSeconds);
 
-  default Stream<InventoryHostFacts> getFacts(Collection<String> orgIds, Integer culledOffsetDays) {
-    return orgIds.stream().flatMap(orgId -> streamFacts(orgId, culledOffsetDays));
+  default Stream<InventoryHostFacts> getFacts(
+      Collection<String> orgIds, Integer culledOffsetDays, Integer stalenessOffsetSeconds) {
+    return orgIds.stream()
+        .flatMap(orgId -> streamFacts(orgId, culledOffsetDays, stalenessOffsetSeconds));
   }
 
   /**
@@ -88,10 +92,11 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
         h.subscription_manager_id as subscription_manager_id
         from hosts h
         inner join system_profiles_static sps on h.id = sps.host_id
+        left join hbi.staleness s on h.org_id = s.org_id
         where h.org_id=:orgId
            and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
            and (sps.host_type IS NULL OR sps.host_type <> 'edge')
-           and NOW() < h.stale_timestamp + make_interval(days => :culledOffsetDays)
+           and h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, :stalenessOffsetSeconds)) > NOW() - make_interval(days => :culledOffsetDays)
         -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
         order by subscription_manager_id, h.id, h.org_id
       """)
@@ -101,5 +106,7 @@ public interface InventoryRepository extends Repository<InventoryHost, UUID> {
         @QueryHint(name = HINT_READ_ONLY, value = "true")
       })
   Stream<String> streamActiveSubscriptionManagerIds(
-      @Param("orgId") String orgId, @Param("culledOffsetDays") Integer culledOffsetDays);
+      @Param("orgId") String orgId,
+      @Param("culledOffsetDays") Integer culledOffsetDays,
+      @Param("stalenessOffsetSeconds") Integer stalenessOffsetSeconds);
 }

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHost.java
@@ -77,7 +77,6 @@ import lombok.Setter;
             @ColumnResult(name = "insights_id"),
             @ColumnResult(name = "provider_id"),
             @ColumnResult(name = "cloud_provider"),
-            @ColumnResult(name = "stale_timestamp", type = OffsetDateTime.class),
             @ColumnResult(name = "hardware_subman_id")
           })
     })
@@ -128,7 +127,6 @@ import lombok.Setter;
         rhsm_products.products,
         qpc_prods.qpc_products,
         system_profile.system_profile_product_ids,
-        h.stale_timestamp,
         coalesce(
             h.facts->'satellite'->>'virtual_host_uuid',
             sps.virtual_host_uuid::text,
@@ -140,6 +138,7 @@ import lombok.Setter;
         from hosts h
         inner join system_profiles_static sps on h.org_id = sps.org_id and h.id = sps.host_id
         left join system_profiles_dynamic spd on h.org_id = spd.org_id and h.id = spd.host_id
+        left join hbi.staleness s on h.org_id = s.org_id
         cross join lateral (
             select string_agg(items, ',') as products
             from jsonb_array_elements_text(h.facts->'rhsm'->'RH_PROD') as items) rhsm_products
@@ -152,7 +151,7 @@ import lombok.Setter;
         where h.org_id=:orgId
            and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
            and (sps.host_type IS NULL OR sps.host_type <> 'edge')
-           and h.stale_timestamp > NOW() - make_interval(days => :culledOffsetDays)
+           and h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, :stalenessOffsetSeconds)) > NOW() - make_interval(days => :culledOffsetDays)
         -- NOTE: ordering is crucial for correct streaming reconciliation of HBI data
         order by hardware_subman_id, any_hypervisor_uuid, inventory_id, h.org_id
     """,

--- a/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
+++ b/src/main/java/org/candlepin/subscriptions/inventory/db/model/InventoryHostFacts.java
@@ -65,7 +65,6 @@ public class InventoryHostFacts {
   private String syspurposeUnits;
   private String billingModel;
   private String cloudProvider;
-  private OffsetDateTime staleTimestamp;
   private String hardwareSubmanId;
 
   public InventoryHostFacts() {
@@ -111,7 +110,6 @@ public class InventoryHostFacts {
       String insightsId,
       String providerId,
       String cloudProvider,
-      OffsetDateTime staleTimestamp,
       String hardwareSubmanId) {
     this.inventoryId = inventoryId;
     this.modifiedOn = modifiedOn;
@@ -146,7 +144,6 @@ public class InventoryHostFacts {
     this.providerId = providerId;
     this.billingModel = billingModel;
     this.cloudProvider = cloudProvider;
-    this.staleTimestamp = staleTimestamp;
     this.hardwareSubmanId = hardwareSubmanId;
   }
 

--- a/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollector.java
@@ -66,6 +66,7 @@ public class InventoryAccountUsageCollector {
   private final HostRepository hostRepository;
   private final EntityManager entityManager;
   private final int culledOffsetDays;
+  private final int stalenessOffsetSeconds;
   private final Long hbiReconciliationFlushInterval;
   private final InventorySwatchDataCollator collator;
 
@@ -85,6 +86,7 @@ public class InventoryAccountUsageCollector {
     this.entityManager = entityManager;
     this.tallyBucketRepository = tallyBucketRepository;
     this.culledOffsetDays = props.getCullingOffsetDays();
+    this.stalenessOffsetSeconds = (int) props.getStalenessOffset().toSeconds();
     this.hbiReconciliationFlushInterval = props.getHbiReconciliationFlushInterval();
   }
 
@@ -134,6 +136,7 @@ public class InventoryAccountUsageCollector {
         collator.collateData(
             orgId,
             culledOffsetDays,
+            stalenessOffsetSeconds,
             (hbiSystem, swatchSystem, hypervisorData, iterationCount) -> {
               reconcileHbiSystemWithSwatchSystem(
                   hbiSystem, swatchSystem, hypervisorData, applicableProducts, detachHosts);

--- a/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollator.java
@@ -85,15 +85,18 @@ public class InventorySwatchDataCollator {
    *
    * @param orgId orgId to operate on
    * @param culledOffsetDays number of days before a system is considered culled by HBI
+   * @param stalenessOffsetSeconds seconds to add to last_check_in to calculate stale_timestamp
    * @param processor delegate that implements the Processor functional interface, to be called for
    *     each iteration.
    * @return the number of unique inventory IDs processed.
    */
-  public int collateData(String orgId, int culledOffsetDays, Processor processor) {
+  public int collateData(
+      String orgId, int culledOffsetDays, int stalenessOffsetSeconds, Processor processor) {
     Stream<InventoryHostFacts> inventorySystemStream =
-        inventoryRepository.streamFacts(orgId, culledOffsetDays);
+        inventoryRepository.streamFacts(orgId, culledOffsetDays, stalenessOffsetSeconds);
     Stream<String> activeSubmanIdStream =
-        inventoryRepository.streamActiveSubscriptionManagerIds(orgId, culledOffsetDays);
+        inventoryRepository.streamActiveSubscriptionManagerIds(
+            orgId, culledOffsetDays, stalenessOffsetSeconds);
     Stream<Host> swatchSystemStream = hostRepository.streamHbiHostsByOrgId(orgId);
 
     /*

--- a/src/main/resources/application-worker.yaml
+++ b/src/main/resources/application-worker.yaml
@@ -26,6 +26,8 @@ rhsm-subscriptions:
         connection-timeout: ${INVENTORY_DATABASE_CONNECTION_TIMEOUT_MS:30000}
         maximum-pool-size: ${INVENTORY_DATABASE_MAX_POOL_SIZE:10}
         auto-commit: false  # required to enable cursor-based streaming in native queries
+  culling-offset-days: ${CULLING_OFFSET_DAYS:14}
+  staleness-offset: ${STALENESS_OFFSET:29h}
   account-list-resource-location: ${ACCOUNT_LIST_RESOURCE_LOCATION:}
   event-retention-policy:
     eventRetentionDuration: ${EVENT_RECORD_RETENTION:P6M}

--- a/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
+++ b/src/test/java/org/candlepin/subscriptions/inventory/db/InventoryRepositoryIT.java
@@ -79,6 +79,7 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   private static final Set<Map<String, String>> INSTALLED_PRODUCTS =
       Set.of(Map.of("id", "d1"), Map.of("id", "d2"));
   private static final int CUT_OFF_DAYS = 3;
+  private static final int STALENESS_OFFSET_SECONDS = 104400;
 
   @Autowired InventoryRepository repository;
 
@@ -90,10 +91,11 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   @Transactional
   @Test
   void testStreamFacts() { // NOSONAR
-    assertEquals(0, repository.streamFacts(ORG_ID, CUT_OFF_DAYS).count());
+    assertEquals(0, repository.streamFacts(ORG_ID, CUT_OFF_DAYS, STALENESS_OFFSET_SECONDS).count());
 
     UUID expectedHostId = givenHost();
-    List<InventoryHostFacts> facts = repository.streamFacts(ORG_ID, CUT_OFF_DAYS).toList();
+    List<InventoryHostFacts> facts =
+        repository.streamFacts(ORG_ID, CUT_OFF_DAYS, STALENESS_OFFSET_SECONDS).toList();
     assertEquals(1, facts.size());
     InventoryHostFacts fact = facts.get(0);
     assertEquals(expectedHostId, fact.getInventoryId());
@@ -144,11 +146,17 @@ class InventoryRepositoryIT implements ExtendWithInventoryService, ExtendWithSwa
   @Transactional
   @Test
   void testStreamActiveSubscriptionManagerIds() {
-    assertEquals(0, repository.streamActiveSubscriptionManagerIds(ORG_ID, CUT_OFF_DAYS).count());
+    assertEquals(
+        0,
+        repository
+            .streamActiveSubscriptionManagerIds(ORG_ID, CUT_OFF_DAYS, STALENESS_OFFSET_SECONDS)
+            .count());
 
     givenHost();
     List<String> actual =
-        repository.streamActiveSubscriptionManagerIds(ORG_ID, CUT_OFF_DAYS).toList();
+        repository
+            .streamActiveSubscriptionManagerIds(ORG_ID, CUT_OFF_DAYS, STALENESS_OFFSET_SECONDS)
+            .toList();
     assertEquals(1, actual.size());
     assertEquals(SUBSCRIPTION_MANAGER_ID, actual.get(0));
   }

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorReconcileTest.java
@@ -82,7 +82,7 @@ class InventoryAccountUsageCollectorReconcileTest {
         ArgumentCaptor.forClass(InventorySwatchDataCollator.Processor.class);
 
     when(props.getHbiReconciliationFlushInterval()).thenReturn(2L);
-    when(collator.collateData(any(), anyInt(), captor.capture())).thenReturn(5);
+    when(collator.collateData(any(), anyInt(), anyInt(), captor.capture())).thenReturn(5);
     when(factNormalizer.normalize(any(), any())).thenReturn(new NormalizedFacts());
 
     var collector = setupCollector();

--- a/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventoryAccountUsageCollectorTallyTest.java
@@ -116,7 +116,8 @@ class InventoryAccountUsageCollectorTallyTest {
         hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(hypervisor));
     whenProcessHost(NON_RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
 
@@ -139,7 +140,8 @@ class InventoryAccountUsageCollectorTallyTest {
         hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(hypervisor));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(hypervisor));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -162,7 +164,8 @@ class InventoryAccountUsageCollectorTallyTest {
     expectedHypervisorMap.put(guest.getHypervisorUuid(), guest.getHypervisorUuid());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(guest));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -183,7 +186,8 @@ class InventoryAccountUsageCollectorTallyTest {
     expectedHypervisorMap.put(guest.getHypervisorUuid(), null);
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(guest));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(guest));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -208,7 +212,8 @@ class InventoryAccountUsageCollectorTallyTest {
     host.setSystemProfileSockets(3);
     mockReportedHypervisors(ORG_ID, new HashMap<>());
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -242,8 +247,10 @@ class InventoryAccountUsageCollectorTallyTest {
     host3.setSystemProfileSockets(2);
 
     mockReportedHypervisors(List.of(orgId1, orgId2), new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
-    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host3));
 
     whenProcessHost(RHEL_PRODUCTS, orgId1);
     whenProcessHost(RHEL_PRODUCTS, orgId2);
@@ -286,7 +293,8 @@ class InventoryAccountUsageCollectorTallyTest {
     host2.setSystemProfileSockets(10);
 
     mockReportedHypervisors(ORG_ID, new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host1, host2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -324,7 +332,8 @@ class InventoryAccountUsageCollectorTallyTest {
     host2.setSystemProfileSockets(10);
 
     mockReportedHypervisors(ORG_ID, new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host1, host2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -380,8 +389,10 @@ class InventoryAccountUsageCollectorTallyTest {
         createSystemProfileHost(orgId2, List.of(TEST_PRODUCT_ID), 2, 6, OffsetDateTime.now());
 
     mockReportedHypervisors(List.of(orgId1, orgId2), new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
-    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3));
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host3));
 
     whenProcessHost(RHEL_PRODUCTS, orgId1);
     whenProcessHost(RHEL_PRODUCTS, orgId2);
@@ -422,7 +433,8 @@ class InventoryAccountUsageCollectorTallyTest {
 
     mockReportedHypervisors(ORG_ID, new HashMap<>());
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(h1, h2));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(h1, h2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -462,8 +474,10 @@ class InventoryAccountUsageCollectorTallyTest {
     expectedHypervisorMap.put(host4.getSubscriptionManagerId(), null);
     mockReportedHypervisors(orgIds, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt())).thenReturn(Stream.of(host1, host2));
-    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt())).thenReturn(Stream.of(host3, host4));
+    when(inventoryRepo.getFacts(eq(List.of(orgId1)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host1, host2));
+    when(inventoryRepo.getFacts(eq(List.of(orgId2)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host3, host4));
 
     whenProcessHost(RHEL_PRODUCTS, orgId1);
     whenProcessHost(RHEL_PRODUCTS, orgId2);
@@ -515,7 +529,7 @@ class InventoryAccountUsageCollectorTallyTest {
         hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
         .thenReturn(Stream.of(hypervisor, guest1, guest2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
@@ -551,7 +565,7 @@ class InventoryAccountUsageCollectorTallyTest {
         hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
         .thenReturn(Stream.of(hypervisor, guest1, guest2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
@@ -582,7 +596,7 @@ class InventoryAccountUsageCollectorTallyTest {
         hypervisor.getSubscriptionManagerId(), hypervisor.getSubscriptionManagerId());
     mockReportedHypervisors(ORG_ID, expectedHypervisorMap);
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt()))
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
         .thenReturn(Stream.of(hypervisor, guest1, guest2));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
@@ -622,7 +636,8 @@ class InventoryAccountUsageCollectorTallyTest {
     host.setSystemProfileSockets(3);
 
     mockReportedHypervisors(ORG_ID, new HashMap<>());
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt())).thenReturn(Stream.of(host));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), anyInt(), anyInt()))
+        .thenReturn(Stream.of(host));
 
     whenProcessHost(RHEL_PRODUCTS, ORG_ID);
     mockBucketRepositoryFromAccountService();
@@ -656,7 +671,7 @@ class InventoryAccountUsageCollectorTallyTest {
             AccountServiceInventoryId.builder().orgId(ORG_ID).serviceType("HBI_HOST").build()))
         .thenReturn(Optional.of(accountServiceInventory));
 
-    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), any())).thenReturn(Stream.of(host));
+    when(inventoryRepo.getFacts(eq(List.of(ORG_ID)), any(), any())).thenReturn(Stream.of(host));
 
     whenProcessHost(accountServiceInventory, RHEL_PRODUCTS, ORG_ID);
 

--- a/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/InventorySwatchDataCollatorTest.java
@@ -52,12 +52,12 @@ class InventorySwatchDataCollatorTest {
 
   @Test
   void testCollatorDoesNothingWithNoData() {
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of());
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of());
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     verifyNoInteractions(processor);
     assertEquals(0, iterations);
@@ -67,12 +67,12 @@ class InventorySwatchDataCollatorTest {
   void testCollatorWorksWithOnlyHbiData() {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
     assertEquals(1, iterations);
@@ -80,7 +80,7 @@ class InventorySwatchDataCollatorTest {
 
   @Test
   void testCollatorWorksWithOnlySwatchData() {
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of());
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of());
 
     Host swatchSystem = new Host();
     swatchSystem.setInventoryId("123e4567-e89b-12d3-a456-426614174000");
@@ -88,7 +88,7 @@ class InventorySwatchDataCollatorTest {
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     verify(processor).accept(null, swatchSystem, new OrgHostsData("placeholder"), 1);
     assertEquals(1, iterations);
@@ -98,7 +98,7 @@ class InventorySwatchDataCollatorTest {
   void testCollatorProcessesSameInventoryIdTogetherInOneIteration() {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
 
     Host swatchSystem = new Host();
     swatchSystem.setInventoryId("123e4567-e89b-12d3-a456-426614174000");
@@ -106,7 +106,7 @@ class InventorySwatchDataCollatorTest {
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     verify(processor).accept(hbiSystem, swatchSystem, new OrgHostsData("placeholder"), 1);
     assertEquals(1, iterations);
@@ -116,7 +116,7 @@ class InventorySwatchDataCollatorTest {
   void testCollatorProcessesDifferentInventoryIdsInSeparateIterations() {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
 
     Host swatchSystem = new Host();
     swatchSystem.setInventoryId("223e4567-e89b-12d3-a456-426614174000");
@@ -124,7 +124,7 @@ class InventorySwatchDataCollatorTest {
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
     verify(processor).accept(null, swatchSystem, new OrgHostsData("placeholder"), 2);
@@ -136,14 +136,14 @@ class InventorySwatchDataCollatorTest {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
     hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
-    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any(), any()))
         .thenReturn(Stream.of("223e4567-e89b-12d3-a456-426614174000"));
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
         ArgumentCaptor.forClass(OrgHostsData.class);
@@ -164,14 +164,14 @@ class InventorySwatchDataCollatorTest {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
     hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
-    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any(), any()))
         .thenReturn(Stream.of((String) null));
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    collator.collateData("foo", 7, processor);
+    collator.collateData("foo", 7, 104400, processor);
     verify(processor).accept(hbiSystem, null, new OrgHostsData("placeholder"), 1);
   }
 
@@ -180,14 +180,14 @@ class InventorySwatchDataCollatorTest {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
     hbiSystem.setSatelliteHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
-    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any(), any()))
         .thenReturn(Stream.of("223e4567-e89b-12d3-a456-426614174000"));
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
         ArgumentCaptor.forClass(OrgHostsData.class);
@@ -208,14 +208,14 @@ class InventorySwatchDataCollatorTest {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
     hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
-    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any(), any()))
         .thenReturn(Stream.of("323e4567-e89b-12d3-a456-426614174000"));
     when(hostRepository.streamHbiHostsByOrgId(any())).thenReturn(Stream.of());
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
         ArgumentCaptor.forClass(OrgHostsData.class);
@@ -230,8 +230,8 @@ class InventorySwatchDataCollatorTest {
     InventoryHostFacts hbiSystem = new InventoryHostFacts();
     hbiSystem.setInventoryId(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
     hbiSystem.setHypervisorUuid("223e4567-e89b-12d3-a456-426614174000");
-    when(inventoryRepository.streamFacts(any(), any())).thenReturn(Stream.of(hbiSystem));
-    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any()))
+    when(inventoryRepository.streamFacts(any(), any(), any())).thenReturn(Stream.of(hbiSystem));
+    when(inventoryRepository.streamActiveSubscriptionManagerIds(any(), any(), any()))
         .thenReturn(
             Stream.of(
                 "123e4567-e89b-12d3-a456-426614174000",
@@ -241,7 +241,7 @@ class InventorySwatchDataCollatorTest {
 
     InventorySwatchDataCollator collator =
         new InventorySwatchDataCollator(inventoryRepository, hostRepository);
-    var iterations = collator.collateData("foo", 7, processor);
+    var iterations = collator.collateData("foo", 7, 104400, processor);
 
     ArgumentCaptor<OrgHostsData> orgHostsDataArgumentCaptor =
         ArgumentCaptor.forClass(OrgHostsData.class);

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySnapshotControllerIT.java
@@ -254,7 +254,7 @@ class TallySnapshotControllerIT implements ExtendWithSwatchDatabase, ExtendWithE
     host.setSyspurposeSla(sla);
 
     inventoryHosts.add(host);
-    when(inventoryRepository.streamFacts(eq(ORG_ID), any()))
+    when(inventoryRepository.streamFacts(eq(ORG_ID), any(), any()))
         .thenAnswer(i -> inventoryHosts.stream());
 
     return inventoryId;

--- a/src/test/java/org/candlepin/subscriptions/test/ExtendWithInventoryService.java
+++ b/src/test/java/org/candlepin/subscriptions/test/ExtendWithInventoryService.java
@@ -70,7 +70,7 @@ public interface ExtendWithInventoryService {
       Map<String, Object> canonicalFacts,
       Map<String, Object> systemProfileFacts,
       String reporter,
-      OffsetDateTime staleTimestamp,
+      OffsetDateTime lastCheckIn,
       OffsetDateTime createdOn,
       OffsetDateTime modifiedOn) {
     ObjectMapper objectMapper = new ObjectMapper();
@@ -88,7 +88,7 @@ public interface ExtendWithInventoryService {
             "system_profile_facts",
             "reporter",
             "groups",
-            "stale_timestamp",
+            "last_check_in",
             "created_on",
             "modified_on"
           },
@@ -102,7 +102,7 @@ public interface ExtendWithInventoryService {
             objectMapper.writeValueAsString(systemProfileFacts),
             reporter,
             "{}",
-            staleTimestamp.toString(),
+            lastCheckIn.toString(),
             createdOn.toString(),
             modifiedOn.toString()
           });

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -88,6 +88,8 @@ parameters:
     value: '2'
   - name: HOST_LAST_SYNC_THRESHOLD
     value: 30h
+  - name: STALENESS_OFFSET
+    value: 29h
   - name: PURGE_SNAPSHOT_SCHEDULE
     value: 0 3 * * *
   - name: CAPTURE_SNAPSHOT_SCHEDULE
@@ -641,6 +643,8 @@ objects:
               value: ${USE_CPU_SYSTEM_FACTS_TO_ALL_PRODUCTS}
             - name: HOST_LAST_SYNC_THRESHOLD
               value: ${HOST_LAST_SYNC_THRESHOLD}
+            - name: STALENESS_OFFSET
+              value: ${STALENESS_OFFSET}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL


### PR DESCRIPTION
Jira issue: SWATCH-5008

## Description
HBI deprecated the stale_timestamp column on May 21, 2026. Hosts created
after this date have NULL in this column, causing the tally query WHERE
clause "stale_timestamp > NOW() - 14 days" to evaluate to FALSE and
incorrectly filter out valid hosts. This caused new hosts to be omitted
during the nightly tally process in stage. It also has the potential
to delete swatch hosts that should have been retained.

Changes:
- Update InventoryHost query to calculate staleness from last_check_in
  plus staleness offset instead of relying on stale_timestamp column
- Add LEFT JOIN to hbi.staleness table to retrieve per-org
  conventional_time_to_stale values
  * The hbi.staleness table stores one staleness configuration per org
    (enforced by unique constraint on org_id)
  * conventional_time_to_stale represents the time from last_check_in
    until a host becomes "stale" (default: 104400 seconds / 29 hours)
  * Orgs can customize this value via HBI's staleness API
  * Query uses coalesce(s.conventional_time_to_stale, :stalenessOffsetSeconds)
    to fall back to configured default when org has no custom staleness
  * This allows the query to automatically respect org-specific staleness
    configurations without code changes
- Add staleness-offset configuration parameter (default: 29h) to
  application-worker.yaml following HBI's default
- Add STALENESS_OFFSET environment variable to clowdapp.yaml
- Update InventoryRepository.streamFacts() and
  streamActiveSubscriptionManagerIds() to accept stalenessOffsetSeconds
  parameter
- Update InventorySwatchDataCollator.collateData() to read staleness
  offset from configuration and pass to repository methods

The new query calculates staleness as:
  last_check_in + staleness_offset > NOW() - culling_offset

This ensures hosts with NULL stale_timestamp are correctly included based
on their calculated staleness, and the query automatically adapts to
org-specific staleness configurations when present.


# How To Test
⚠️ **I had claude help with generating test steps for this. I've verified them myself, but I could have missed something. Any discrepancies should be manually verified.**

## Setup: Create Test Data in HBI DB
⚠️ **You'll need the changes to the `insert-mock-hosts` script that were made in this PR to create the test data.**

### Step 1: Drop NOT NULL Constraint

Drop the stale_timestamp constraint (local testing only - simulates HBI schema after May 21, 2026):

```bash
psql -h localhost insights insights <<'EOF'
ALTER TABLE hbi.hosts ALTER COLUMN stale_timestamp DROP NOT NULL;
EOF
```

### Step 2: Create and Configure Test Scenarios

Create hosts one at a time with sleep delays to ensure distinct `created_on` timestamps:

```bash
# Scenario 1: Legacy host, 21 days old (should be filtered)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 21),
    stale_timestamp = (NOW() - make_interval(days => 21)) + make_interval(secs => 104400)
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 2: NULL stale_timestamp, 20 days old (should be filtered)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 20),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 3: NULL stale_timestamp, 15 days 5 hours old (should be filtered)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 15, hours => 5),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 4: NULL stale_timestamp, 12 days old (should be included)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 12),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 5: Legacy host, 2 days old (should be included)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 2),
    stale_timestamp = (NOW() - make_interval(days => 2)) + make_interval(secs => 104400)
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 6: NULL stale_timestamp, 1 day old (PRIMARY FIX - should be included)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 1),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 7: Legacy host, 3 hours old (will become stale later)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(hours => 3),
    stale_timestamp = (NOW() - make_interval(hours => 3)) + make_interval(secs => 104400)
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

# Scenario 8: NULL stale_timestamp, 1 hour old (will become stale later)
bin/insert-mock-hosts --hbi --org 999888777 --num-physical 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(hours => 1),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888777' ORDER BY created_on DESC LIMIT 1);
EOF

echo "Created and configured 8 test scenarios"
```

**What this does:**
- Creates 8 hosts sequentially with 1-second delays between each
- Ensures distinct `created_on` timestamps for reliable ordering
- `ORDER BY created_on DESC LIMIT 1` selects the most recently created host
- **Scenarios 1, 5, 7:** `stale_timestamp = last_check_in + 29h` (simulates legacy hosts)
- **Scenarios 2, 3, 4, 6, 8:** `stale_timestamp = NULL` (simulates hosts created after May 21, 2026)

### Step 3: Verify HBI Host State

Run this query to verify all hosts were created correctly:

```bash
psql -h localhost insights insights <<'EOF'
SELECT 
    ROW_NUMBER() OVER (ORDER BY created_on ASC) as scenario,
    EXTRACT(days FROM (NOW() - h.last_check_in)) as days_since_checkin,
    CASE WHEN h.stale_timestamp IS NULL THEN 'NULL' ELSE 'POPULATED' END as stale_ts,
    h.last_check_in + make_interval(secs => 104400) > NOW() - make_interval(days => 14) as should_be_included,
    CASE ROW_NUMBER() OVER (ORDER BY created_on ASC)
        WHEN 1 THEN 'Scenario 1: Legacy, old (won''t be tallied)'
        WHEN 2 THEN 'Scenario 2: NULL, old (won''t be tallied)'
        WHEN 3 THEN 'Scenario 3: NULL, at boundary (won''t be tallied)'
        WHEN 4 THEN 'Scenario 4: NULL, well inside boundary (will be tallied)'
        WHEN 5 THEN 'Scenario 5: Legacy, recent (will be tallied)'
        WHEN 6 THEN 'Scenario 6: NULL, recent (PRIMARY FIX - will be tallied)'
        WHEN 7 THEN 'Scenario 7: Legacy, fresh (will be tallied, will become stale)'
        WHEN 8 THEN 'Scenario 8: NULL, fresh (will be tallied, will become stale)'
    END as description
FROM hbi.hosts h
WHERE h.org_id = '999888777'
ORDER BY created_on ASC;
EOF
```

**Expected Results (ordered oldest to newest):**

| scenario | days_since_checkin | stale_ts | should_be_included | description |
|----------|-------------------|----------|-------------------|-------------|
| 1 | ~21 | POPULATED | false | Scenario 1: Legacy, old (won't be tallied) |
| 2 | ~20 | NULL | false | Scenario 2: NULL, old (won't be tallied) |
| 3 | ~15.2 | NULL | false | Scenario 3: NULL, at boundary (won't be tallied) |
| 4 | ~12 | NULL | true | Scenario 4: NULL, well inside boundary (will be tallied) |
| 5 | ~2 | POPULATED | true | Scenario 5: Legacy, recent (will be tallied) |
| 6 | ~1 | NULL | true | Scenario 6: NULL, recent (PRIMARY FIX - will be tallied) |
| 7 | ~0.13 | POPULATED | true | Scenario 7: Legacy, fresh (will be tallied) |
| 8 | ~0.04 | NULL | true | Scenario 8: NULL, fresh (will be tallied) |

**Confirm:** All 8 hosts are present in HBI database. Hosts with `should_be_included = true` will be tallied and created in swatch DB. Hosts with `should_be_included = false` will not be queried by the tally process and will not be created in swatch DB.

---

## Reproduce: Demonstrate the Bug on Main Branch

### Step 4: Checkout Main Branch

```bash
git checkout main
```

### Step 5: Redeploy Application

Redeploy the application with the main branch code to use the OLD query logic.

### Step 6: Test OLD Query Behavior

Run the old query logic to see what hosts will be returned (replicates the WHERE clause from main branch):

```bash
psql -h localhost insights insights <<'EOF'
-- OLD QUERY: Uses stale_timestamp column directly (NULL comparison fails)
WITH numbered_hosts AS (
  SELECT 
    h.*,
    ROW_NUMBER() OVER (ORDER BY h.created_on ASC) as scenario_num
  FROM hbi.hosts h
  WHERE h.org_id = '999888777'
)
SELECT 
    nh.id,
    EXTRACT(days FROM (NOW() - nh.last_check_in)) as days_since_checkin,
    nh.created_on,
    nh.stale_timestamp,
    CONCAT('Scenario ', nh.scenario_num) as scenario
FROM numbered_hosts nh
INNER JOIN hbi.system_profiles_static sps ON nh.org_id = sps.org_id AND nh.id = sps.host_id
WHERE (nh.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR nh.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
  AND (sps.host_type IS NULL OR sps.host_type <> 'edge')
  -- OLD QUERY WHERE CLAUSE: Uses stale_timestamp column
  AND nh.stale_timestamp > NOW() - make_interval(days => 14)
ORDER BY nh.scenario_num ASC;
EOF
```

**Expected Results (Main Branch - OLD QUERY):**

| scenario | days_since_checkin | stale_timestamp | description |
|----------|-------------------|-----------------|-------------|
| Scenario 5 | ~2 | POPULATED | Legacy host, 2 days old |
| Scenario 7 | ~0.13 | POPULATED | Legacy host, 3 hours old |

- **Only 2 hosts returned** (Scenarios 5 and 7 - both have POPULATED stale_timestamp)
- **Scenarios 4, 6, 8 incorrectly missing** (NULL stale_timestamp causes FALSE comparison even though they're within the window)
- Scenarios 1, 2, 3 correctly not returned (too old, outside 14-day window)

**Bug:** Hosts with NULL stale_timestamp are not returned by the query even though their calculated staleness is within the 14-day window.

### Step 7: Run Nightly Tally (Main Branch)

Run the nightly tally process for org `999888777`. The tally will use the OLD query logic.
```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/999888777" x-rh-swatch-psk:placeholder
```

### Step 8: Verify Swatch Database (Main Branch)

Check which hosts were processed and retained:

```bash
psql -h localhost rhsm-subscriptions rhsm-subscriptions <<'EOF'
SELECT org_id, inventory_id, COUNT(*) as host_count
FROM hosts 
WHERE org_id = '999888777'
GROUP BY org_id, inventory_id
ORDER BY inventory_id;
EOF
```

**Expected Results (Main Branch):**
- Only **2 hosts** present (Scenarios 5 and 7 - legacy hosts with populated stale_timestamp)
- Cross-reference inventory_id with the id from OLD query results above

**This demonstrates the bug:** Valid hosts with NULL stale_timestamp (Scenarios 4, 6, 8) were never queried by the tally process and therefore not created in swatch DB.

---

## Verify: Confirm the Fix on PR Branch

### Step 9: Clear Swatch Database

Before switching branches, clear the swatch database tables to start fresh:

```bash
psql -h localhost rhsm-subscriptions rhsm-subscriptions <<'EOF'
truncate hosts cascade;
truncate tally_snapshots cascade;
EOF

echo "Cleared swatch database"
```

**Important:** Do NOT delete from HBI database - leave the 8 test hosts intact.

### Step 10: Checkout PR Branch

```bash
git checkout SWATCH-5008-fix-hbi-query
```

### Step 11: Redeploy Application

Redeploy the application with the PR branch code to use the NEW query logic.

### Step 12: Test NEW Query Behavior

Run the new query logic to see what hosts are returned when all hosts are still fresh:

```bash
psql -h localhost insights insights <<'EOF'
-- NEW QUERY: Calculates staleness from last_check_in + staleness_offset
WITH numbered_hosts AS (
  SELECT 
    h.*,
    ROW_NUMBER() OVER (ORDER BY h.created_on ASC) as scenario_num
  FROM hbi.hosts h
  WHERE h.org_id = '999888777'
)
SELECT 
    nh.id,
    EXTRACT(days FROM (NOW() - nh.last_check_in)) as days_since_checkin,
    nh.created_on,
    nh.stale_timestamp,
    s.conventional_time_to_stale,
    nh.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) as calculated_stale_time,
    CONCAT('Scenario ', nh.scenario_num) as scenario
FROM numbered_hosts nh
INNER JOIN hbi.system_profiles_static sps ON nh.org_id = sps.org_id AND nh.id = sps.host_id
LEFT JOIN hbi.staleness s ON nh.org_id = s.org_id
WHERE (nh.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR nh.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
  AND (sps.host_type IS NULL OR sps.host_type <> 'edge')
  -- NEW QUERY WHERE CLAUSE: Calculates staleness from last_check_in + staleness_offset
  AND nh.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) > NOW() - make_interval(days => 14)
ORDER BY nh.scenario_num ASC;
EOF
```

**Expected Results (PR Branch - NEW QUERY with fresh hosts):**

| scenario | days_since_checkin | stale_timestamp | description |
|----------|-------------------|-----------------|-------------|
| Scenario 4 | ~12 | NULL | NULL stale_timestamp, well inside boundary ✓ |
| Scenario 5 | ~2 | POPULATED | Legacy host, backward compatibility ✓ |
| Scenario 6 | ~1 | NULL | PRIMARY FIX - NULL stale_timestamp, recent ✓ |
| Scenario 7 | ~0.13 | POPULATED | Legacy host, fresh ✓ |
| Scenario 8 | ~0.04 | NULL | NULL stale_timestamp, fresh ✓ |

- **5 hosts returned** (Scenarios 4, 5, 6, 7, 8)
- Scenarios 1, 2, 3 correctly not returned (too old, outside 14-day window)

**Fix confirmed:** Hosts with NULL stale_timestamp (4, 6, 8) are now correctly returned based on calculated staleness

### Step 13: Run Nightly Tally (PR Branch - First Run)

Run the nightly tally process for org `999888777`. The tally will use the NEW query logic.

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/999888777" x-rh-swatch-psk:placeholder
```

### Step 14: Verify Swatch Database (PR Branch - After First Tally)

Check which hosts were processed and retained:

```bash
psql -h localhost rhsm-subscriptions rhsm-subscriptions <<'EOF'
SELECT org_id, inventory_id, COUNT(*) as host_count
FROM hosts 
WHERE org_id = '999888777'
GROUP BY org_id, inventory_id
ORDER BY inventory_id;
EOF
```

**Expected Results (PR Branch - after first tally):**
- **5 hosts** created in swatch DB (Scenarios 4, 5, 6, 7, 8)
- All hosts with `last_check_in + 29h > NOW() - 14 days` are correctly tallied and created
- Hosts with NULL stale_timestamp are correctly created (Scenarios 4, 6, 8)

**This confirms the fix works for fresh hosts.**

### Step 15: Make Scenarios 7 and 8 Stale

Update the fresh hosts (Scenarios 7 and 8) to make them stale, simulating hosts that have aged out:

```bash
psql -h localhost insights insights <<'EOF'
BEGIN;

-- Make Scenario 7 stale: Set last_check_in to 25 days ago (7th host by creation order)
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 25),
    stale_timestamp = (NOW() - make_interval(days => 25)) + make_interval(secs => 104400)
WHERE id = (
  SELECT id FROM hbi.hosts 
  WHERE org_id = '999888777' 
  ORDER BY created_on ASC 
  LIMIT 1 OFFSET 6
);

-- Make Scenario 8 stale: Set last_check_in to 22 days ago (8th host by creation order)
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 22),
    stale_timestamp = NULL
WHERE id = (
  SELECT id FROM hbi.hosts 
  WHERE org_id = '999888777' 
  ORDER BY created_on ASC 
  LIMIT 1 OFFSET 7
);

COMMIT;
EOF

echo "Made scenarios 7 and 8 stale"
```

### Step 16: Test NEW Query Behavior (After Making Hosts Stale)

Verify scenarios 7 and 8 are now filtered out:

```bash
psql -h localhost insights insights <<'EOF'
SELECT 
    ROW_NUMBER() OVER (ORDER BY created_on ASC) as scenario,
    h.id,
    EXTRACT(days FROM (NOW() - h.last_check_in)) as days_since_checkin,
    CASE WHEN h.stale_timestamp IS NULL THEN 'NULL' ELSE 'POPULATED' END as stale_ts,
    h.last_check_in + make_interval(secs => 104400) > NOW() - make_interval(days => 14) as should_be_included
FROM hbi.hosts h
WHERE h.org_id = '999888777'
ORDER BY created_on ASC;
EOF
```

**Expected:** Scenarios 7 and 8 now have `should_be_included = false` (will not be returned by the NEW query, and therefore will be deleted from swatch DB on next tally run).

### Step 17: Run Nightly Tally (PR Branch - Second Run)

Run the tally again to test that stale hosts are correctly deleted:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/999888777" x-rh-swatch-psk:placeholder
```

### Step 18: Verify Swatch Database (PR Branch - After Second Tally)

Check that scenarios 7 and 8 were deleted:

```bash
psql -h localhost rhsm-subscriptions rhsm-subscriptions <<'EOF'
SELECT org_id, inventory_id, COUNT(*) as host_count
FROM hosts 
WHERE org_id = '999888777'
GROUP BY org_id, inventory_id
ORDER BY inventory_id;
EOF
```

**Expected Results (PR Branch - after second tally):**
- **3 hosts** present (Scenarios 4, 5, and 6)
- Scenarios 7 and 8 correctly deleted (no longer in HBI query results)

**This confirms deletion works correctly:** 
- Valid hosts with NULL stale_timestamp remain (Scenarios 4, 6)
- Stale hosts (both NULL and populated stale_timestamp) are correctly deleted (Scenarios 7, 8 removed)

---

## Additional Test: Custom Staleness Configuration

This test verifies the query correctly uses org-specific `conventional_time_to_stale` values from the `hbi.staleness` table instead of the hardcoded default (104400 seconds / 29 hours).

### Step 19: Create Custom Staleness Configuration

Insert a custom staleness value for a different org (999888778) with a 6-hour (21600 seconds) staleness offset:

```bash
psql -h localhost insights insights <<'EOF'
INSERT INTO hbi.staleness (id, org_id, conventional_time_to_stale, conventional_time_to_stale_warning, conventional_time_to_delete, created_on, modified_on)
VALUES (gen_random_uuid(), '999888778', 21600, 604800, 2592000, NOW(), NOW())
ON CONFLICT (org_id) DO UPDATE SET 
  conventional_time_to_stale = 21600,
  modified_on = NOW();
EOF
```

**What this does:** Sets org `999888778` to use a 6-hour (21600 seconds) staleness offset instead of the default 29-hour offset. The other fields use HBI defaults: `conventional_time_to_stale_warning = 604800` (7 days), `conventional_time_to_delete = 2592000` (30 days). 

**Effective inclusion window calculation:** Hosts are included when `last_check_in + staleness_offset > NOW() - 14 days`. Rearranging: a host at age X is included when `X < 14 days + staleness_offset`. With a 6-hour offset, hosts up to ~14.25 days old are included (narrower than the default ~15.2 days with 29h offset).

### Step 20: Create Test Hosts for Custom Staleness Org

Create 3 hosts with varying ages to test the custom staleness window:

```bash
# Host 1: 15 days old (should NOT be tallied - outside 14.25-day window)
bin/insert-mock-hosts --hbi --org 999888778 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 15),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888778' ORDER BY created_on DESC LIMIT 1);
EOF

# Host 2: 10 days old (should be tallied - inside 14.25-day window)
bin/insert-mock-hosts --hbi --org 999888778 --num-physical 1 && sleep 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 10),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888778' ORDER BY created_on DESC LIMIT 1);
EOF

# Host 3: 2 days old (should be tallied - fresh)
bin/insert-mock-hosts --hbi --org 999888778 --num-physical 1 && \
psql -h localhost insights insights <<'EOF'
UPDATE hbi.hosts 
SET last_check_in = NOW() - make_interval(days => 2),
    stale_timestamp = NULL
WHERE id = (SELECT id FROM hbi.hosts WHERE org_id = '999888778' ORDER BY created_on DESC LIMIT 1);
EOF

echo "Created 3 test hosts for custom staleness org"
```

### Step 21: Verify Custom Staleness is Used

Run the NEW query logic against org `999888778` to verify it uses the custom 6-hour staleness value:

```bash
psql -h localhost insights insights <<'EOF'
-- NEW QUERY with custom staleness configuration
WITH numbered_hosts AS (
  SELECT 
    h.*,
    ROW_NUMBER() OVER (ORDER BY h.created_on ASC) as host_num
  FROM hbi.hosts h
  WHERE h.org_id = '999888778'
)
SELECT 
    CONCAT('Host ', nh.host_num) as host,
    EXTRACT(days FROM (NOW() - nh.last_check_in)) as days_since_checkin,
    s.conventional_time_to_stale as custom_staleness_offset,
    nh.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) as calculated_stale_time,
    nh.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) > NOW() - make_interval(days => 14) as will_be_included
FROM numbered_hosts nh
INNER JOIN hbi.system_profiles_static sps ON nh.org_id = sps.org_id AND nh.id = sps.host_id
LEFT JOIN hbi.staleness s ON nh.org_id = s.org_id
WHERE (nh.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR nh.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
  AND (sps.host_type IS NULL OR sps.host_type <> 'edge')
ORDER BY nh.host_num ASC;
EOF
```

**Expected Results:**

| host | days_since_checkin | custom_staleness_offset | calculated_stale_time | will_be_included |
|------|-------------------|-------------------------|----------------------|------------------|
| Host 1 | 15 | 21600 | (timestamp) | f |
| Host 2 | 10 | 21600 | (timestamp) | t |
| Host 3 | 2 | 21600 | (timestamp) | t |

**Verify:**
- All 3 hosts shown (Step 21 query doesn't filter, it shows `will_be_included` for each)
- `custom_staleness_offset = 21600` (not NULL, not 104400) for all hosts
- `calculated_stale_time` = `last_check_in + 6 hours` for each host
- Host 1 has `will_be_included = f` (15 days old exceeds the 14.25-day cutoff)
- Hosts 2 and 3 have `will_be_included = t` (within the 14.25-day window)

### Step 22: Test NEW Query Returns Only Valid Hosts

Run the actual NEW query WHERE clause to verify correct filtering:

```bash
psql -h localhost insights insights <<'EOF'
-- NEW QUERY: Only hosts that pass ALL WHERE clauses from actual swatch query
SELECT 
    ROW_NUMBER() OVER (ORDER BY h.created_on ASC) as host_num,
    h.id,
    EXTRACT(days FROM (NOW() - h.last_check_in)) as days_since_checkin,
    s.conventional_time_to_stale as custom_staleness_offset
FROM hbi.hosts h
INNER JOIN hbi.system_profiles_static sps ON h.org_id = sps.org_id AND h.id = sps.host_id
LEFT JOIN hbi.system_profiles_dynamic spd ON h.org_id = spd.org_id AND h.id = spd.host_id
LEFT JOIN hbi.staleness s ON h.org_id = s.org_id
WHERE h.org_id = '999888778'
  AND (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')
  AND (sps.host_type IS NULL OR sps.host_type <> 'edge')
  AND h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) > NOW() - make_interval(days => 14)
ORDER BY h.created_on ASC;
EOF
```

**Expected Results:**

| host_num | days_since_checkin | custom_staleness_offset |
|----------|-------------------|-------------------------|
| 2 | ~10 | 21600 |
| 3 | ~2 | 21600 |

- **Only 2 hosts returned** (host_num 2 and 3)
- Host 1 (host_num 1) correctly filtered out (15 days old exceeds the 14.25-day effective window with 6h offset)
- Both returned hosts show `custom_staleness_offset = 21600`, confirming the custom value is used

**This confirms:** The query correctly uses org-specific staleness values from `hbi.staleness` table and applies different inclusion windows based on those values.

### Step 23: Run Nightly Tally for Custom Staleness Org

Run the tally process for org `999888778`:

```
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/999888778" x-rh-swatch-psk:placeholder
```

### Step 24: Verify Swatch Database for Custom Staleness Org

Check which hosts were created in swatch DB:

```bash
psql -h localhost rhsm-subscriptions rhsm-subscriptions <<'EOF'
SELECT org_id, inventory_id, COUNT(*) as host_count
FROM hosts 
WHERE org_id = '999888778'
GROUP BY org_id, inventory_id
ORDER BY inventory_id;
EOF
```

**Expected Results:**
- **2 hosts** created in swatch DB (Hosts 2 and 3 from HBI query)
- Host 1 not created (correctly filtered by custom 14.25-day window)
- Cross-reference inventory_id with the id from Step 22 query results

**This confirms:** The tally process correctly applies custom staleness offsets per org, resulting in different inclusion behavior compared to the default 29-hour offset. The shorter 6-hour offset creates a narrower window (14.25 days) compared to the default (15.2 days).
