### PR TITLE
Update swatch-system-conduit/ct/README.md to remove artemis and swatch-tally deployments

### DIFF
--- a/swatch-system-conduit/ct/README.md
+++ b/swatch-system-conduit/ct/README.md
@@ -33,7 +33,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-syst
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-system-conduit
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component swatch-system-conduit --remove-dependencies swatch-system-conduit/swatch-tally --no-remove-resources app:rhsm
 ```
 
 ### 2. Run Component Tests Against OpenShift


### PR DESCRIPTION
## Description
Changes:
- removing unnecessary `artemis` component 
- removing unnecessary `swatch-tally` dependency
- adding necessary `rhsm` component to setup the ephemeral resources like signalfx

## Testing
Running:
1.- `bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component swatch-system-conduit --remove-dependencies swatch-system-conduit/swatch-tally --no-remove-resources app:rhsm`
2.- `./mvnw clean install -Pcomponent-tests -pl swatch-system-conduit/ct -am -Dswatch.component-tests.global.target=openshift` should pass