### PR TITLE
Use label of latest for Artemis service instead of git hash

### DIFF
--- a/config/artemis/docker-compose.yml
+++ b/config/artemis/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   artemis:
-    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/artemis
+    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/artemis:latest
     container_name: artemis
     ports:
       - "61616:61616"  # core messaging (TCP)


### PR DESCRIPTION
## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
There is a window after a new hash of the Artemis component is created, but the image is not in quay.io. This period lasts up to 10 minutes if the publish succeeds. As the Bonfire process is set to retrieve the Artemis hash from GitHub/GitLab without knowing if the image is available at quay.io, this can lead to a failure in creating the Ephemeral environments we use in the CI.

To remedy this, the tag of latest has been used to ensure that an image will always be returned.

## Testing

A successful run for this PR should prove the validity of this change. The following error should cease going forward:
```* ImagePullBackOff error for pod/artemis-service-79bcf4ccb4-9w59c (container 'artemis-service'): Back-off pulling image "quay.io/redhat-services-prod/rh-subs-watch-tenant/artemis:9a64e16": ErrImagePull: unable to pull image or OCI artifact: pull image err: initializing source docker://quay.io/redhat-services-prod/rh-subs-watch-tenant/artemis:9a64e16```
