### PR TITLE
SWATCH-4858: Update swatch-tally to use is_primary views

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/configuration/UnleashConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/configuration/UnleashConfiguration.java
@@ -20,23 +20,20 @@
  */
 package org.candlepin.subscriptions.configuration;
 
-import io.getunleash.Unleash;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 
-/** Configuration class for Unleash feature flags. */
 @Configuration
-public class UnleashConfiguration {
-
-  /**
-   * Creates the FeatureFlags bean for managing feature toggles.
-   *
-   * @param unleash the Unleash client instance (optional)
-   * @return FeatureFlags service
-   */
-  @Bean
-  public FeatureFlags featureFlags(@Autowired(required = false) Unleash unleash) {
-    return new FeatureFlags(unleash);
-  }
-}
+@ComponentScan(
+    basePackages = "org.candlepin.subscriptions.configuration",
+    // Prevent TestConfiguration annotated classes from being picked up by ComponentScan
+    excludeFilters = {
+      @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+      @ComponentScan.Filter(
+          type = FilterType.CUSTOM,
+          classes = AutoConfigurationExcludeFilter.class)
+    })
+public class UnleashConfiguration {}

--- a/src/main/java/org/candlepin/subscriptions/configuration/UnleashFeatureFlags.java
+++ b/src/main/java/org/candlepin/subscriptions/configuration/UnleashFeatureFlags.java
@@ -21,46 +21,38 @@
 package org.candlepin.subscriptions.configuration;
 
 import io.getunleash.Unleash;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
 
-/**
- * Feature flags service for managing Unleash feature toggles in the Spring Boot application.
- *
- * <p>This class provides methods to check feature flag status using Unleash. Feature flags allow
- * runtime control of application features without redeployment.
- */
-@Slf4j
-public class FeatureFlags {
-
-  // Feature flag names
-  public static final String ENABLE_PRIMARY_ROW_SEARCHES =
-      "swatch.swatch-tally.enable-primary-row-searches";
+@Component
+@Primary
+public class UnleashFeatureFlags implements FeatureFlags {
 
   private final Unleash unleash;
 
-  public FeatureFlags(Unleash unleash) {
+  public UnleashFeatureFlags(@Autowired(required = false) Unleash unleash) {
     this.unleash = unleash;
   }
 
   /**
-   * Check if primary row searches are enabled.
+   * Wrapper to {@link Unleash#isEnabled(String, boolean)}; however, if Unleash is null the default
+   * will be returned instead of an NPE.
    *
-   * @return true if primary row searches feature flag is enabled
+   * @param featureName Unleash feature flag name.
+   * @param flagDefault default value for the feature flag.
+   * @return a boolean indicating whether the flag is enabled or not.
    */
-  public boolean isPrimaryRowSearchesEnabled() {
+  @Override
+  public boolean isEnabled(String featureName, boolean flagDefault) {
     if (unleash == null) {
-      return false; // Default to disabled when Unleash is not available
+      return flagDefault;
     }
-    return unleash.isEnabled(ENABLE_PRIMARY_ROW_SEARCHES);
+    return unleash.isEnabled(featureName, flagDefault);
   }
 
-  /**
-   * Check if a feature flag is enabled by name.
-   *
-   * @param featureName the feature flag name
-   * @return true if the feature flag is enabled
-   */
+  @Override
   public boolean isEnabled(String featureName) {
-    return unleash.isEnabled(featureName);
+    return isEnabled(featureName, false);
   }
 }

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
@@ -169,7 +169,7 @@ public class TallyResource implements TallyApi {
 
     // Execute query based on feature flag - each path returns unified result
     TallyQueryResult queryResult =
-        featureFlags.isPrimaryRowSearchesEnabled()
+        featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)
             ? executeAggregateQuery(reportCriteria, metricId, category)
             : executeSnapshotBasedQuery(reportCriteria, metricId, category);
     List<UnroundedTallyReportDataPoint> snaps = queryResult.dataPoints();

--- a/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/TallySummaryMapper.java
@@ -133,7 +133,7 @@ public class TallySummaryMapper {
     }
 
     // For all other cases (Ansible, or COUNTER metrics): use existing SQL logic
-    if (featureFlags.isPrimaryRowSearchesEnabled()) {
+    if (featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)) {
       gateOnAnyValues(snapshot);
       return snapshotRepository.sumMeasurementValueForPeriodWithPrimary(
           snapshot.getOrgId(),

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -126,7 +126,9 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
 
   private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
       ProductId productId) {
-    boolean usePrimary = featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    // TODO Enable with featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    //  for SWATCH-4862
+    boolean usePrimary = false;
     if (productId.isPayg()) {
       return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
     }

--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -41,7 +41,10 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
+import org.candlepin.subscriptions.db.TallyInstanceNonPaygPrimaryViewRepository;
 import org.candlepin.subscriptions.db.TallyInstanceNonPaygViewRepository;
+import org.candlepin.subscriptions.db.TallyInstancePaygPrimaryViewRepository;
 import org.candlepin.subscriptions.db.TallyInstancePaygViewRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
@@ -52,6 +55,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 // NOTE(khowell): this couples our export implementation to the v1 REST API
 import org.candlepin.subscriptions.utilization.api.v1.model.ReportCategory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.stereotype.Component;
 
@@ -94,8 +98,14 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
 
   private final TallyInstancePaygViewRepository paygViewRepository;
   private final TallyInstanceNonPaygViewRepository nonPaygViewRepository;
+
+  private final TallyInstancePaygPrimaryViewRepository paygPrimaryViewRepository;
+  private final TallyInstanceNonPaygPrimaryViewRepository nonPaygPrimaryViewRepository;
+
   private final InstancesJsonDataMapperService jsonDataMapperService;
   private final InstancesCsvDataMapperService csvDataMapperService;
+
+  private final FeatureFlags featureFlags;
 
   @Override
   public boolean handles(ExportServiceRequest request) {
@@ -105,12 +115,22 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
   @Override
   public Stream<TallyInstanceView> fetchData(ExportServiceRequest request) {
     log.debug("Fetching data for {}", request.getOrgId());
+
     var reportCriteria = extractExportFilter(request);
-    boolean isPayg = reportCriteria.getProductId().isPayg();
-    var repository = isPayg ? paygViewRepository : nonPaygViewRepository;
+    var repository = selectRepository(reportCriteria.getProductId());
+
     return repository
         .findBy(buildSearchSpecification(reportCriteria), FluentQuery.FetchableFluentQuery::stream)
         .map(TallyInstanceView.class::cast);
+  }
+
+  private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
+      ProductId productId) {
+    boolean usePrimary = featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    if (productId.isPayg()) {
+      return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
+    }
+    return usePrimary ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
   }
 
   @Override

--- a/src/main/resources/liquibase/202506191100-add-host-service-type-table.xml
+++ b/src/main/resources/liquibase/202506191100-add-host-service-type-table.xml
@@ -244,7 +244,7 @@
                       h.hypervisor_uuid
       from hosts h
              join host_tally_buckets b on h.id = b.host_id
-             inner join MaxHostServiceTypeDate mhstd ON h.id = mhstd.host_id
+             left join MaxHostServiceTypeDate mhstd ON h.id = mhstd.host_id
     </createView>
     <createView
       replaceIfExists="true"

--- a/src/main/resources/liquibase/202605191440-update-views-with-is-primary.xml
+++ b/src/main/resources/liquibase/202605191440-update-views-with-is-primary.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202605191440-01" author="awood" dbms="postgresql">
+    <createView viewName="tally_instance_primary_view" replaceIfExists="true">
+      SELECT DISTINCT
+        h.org_id,
+        h.id,
+        h.instance_id AS instance_id,
+        h.display_name,
+        h.billing_provider AS host_billing_provider,
+        h.billing_account_id AS host_billing_account_id,
+        b.billing_provider AS bucket_billing_provider,
+        b.billing_account_id AS bucket_billing_account_id,
+        h.last_seen,
+        mhstd.max_last_applied_event_record_date AS last_applied_event_record_date,
+        COALESCE(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        COALESCE(b.measurement_type, 'EMPTY') AS measurement_type,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id,
+        h.hypervisor_uuid
+      FROM hosts h
+        JOIN host_tally_buckets b ON h.id = b.host_id
+        LEFT JOIN LATERAL (
+          SELECT MAX(last_applied_event_record_date) AS max_last_applied_event_record_date
+          FROM host_tally_service_type
+          WHERE host_id = h.id
+        ) mhstd ON true
+      WHERE b.is_primary = true;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202605191440-02" author="awood" dbms="postgresql">
+    <createView viewName="tally_instance_non_payg_primary_view" replaceIfExists="true">
+      SELECT DISTINCT
+        v.*,
+        jsonb_agg(jsonb_build_object('metric_id', m.metric_id, 'value', m.value)) AS metrics
+      FROM tally_instance_primary_view v
+        LEFT JOIN instance_measurements m ON v.id = m.host_id
+      GROUP BY
+        v.org_id,
+        v.id,
+        v.instance_id,
+        v.display_name,
+        v.host_billing_provider,
+        v.host_billing_account_id,
+        v.bucket_billing_provider,
+        v.bucket_billing_account_id,
+        v.last_seen,
+        v.last_applied_event_record_date,
+        v.num_of_guests,
+        v.product_id,
+        v.sla,
+        v.usage,
+        v.measurement_type,
+        v.sockets,
+        v.cores,
+        v.subscription_manager_id,
+        v.inventory_id,
+        v.hypervisor_uuid;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202605191440-03" author="awood" dbms="postgresql">
+    <createView viewName="tally_instance_payg_primary_view" replaceIfExists="true">
+      SELECT DISTINCT
+        v.*,
+        m.month,
+        jsonb_agg(jsonb_build_object('metric_id', m.metric_id, 'value', m.value)) AS metrics
+      FROM tally_instance_primary_view v
+        LEFT JOIN instance_monthly_totals m ON v.id = m.host_id
+      GROUP BY
+        v.org_id,
+        v.id,
+        v.instance_id,
+        v.display_name,
+        v.host_billing_provider,
+        v.host_billing_account_id,
+        v.bucket_billing_provider,
+        v.bucket_billing_account_id,
+        v.last_seen,
+        v.last_applied_event_record_date,
+        v.num_of_guests,
+        v.product_id,
+        v.sla,
+        v.usage,
+        v.measurement_type,
+        v.sockets,
+        v.cores,
+        v.subscription_manager_id,
+        v.inventory_id,
+        v.hypervisor_uuid,
+        m.month;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202605191440-04" author="awood" dbms="hsqldb">
+    <createView viewName="tally_instance_primary_view">
+      WITH MaxHostServiceTypeDate AS (
+        SELECT host_id,
+          MAX(last_applied_event_record_date) AS max_last_applied_event_record_date
+        FROM host_tally_service_type
+        GROUP BY host_id
+      )
+      SELECT DISTINCT
+        h.org_id,
+        h.id,
+        h.instance_id as instance_id,
+        h.display_name,
+        h.billing_provider as host_billing_provider,
+        h.billing_account_id as host_billing_account_id,
+        b.billing_provider as bucket_billing_provider,
+        b.billing_account_id as bucket_billing_account_id,
+        h.last_seen,
+        mhstd.max_last_applied_event_record_date AS last_applied_event_record_date,
+        COALESCE(h.num_of_guests, 0) AS num_of_guests,
+        b.product_id,
+        b.sla,
+        b.usage,
+        COALESCE(b.measurement_type, 'EMPTY') AS measurement_type,
+        b.sockets,
+        b.cores,
+        h.subscription_manager_id,
+        h.inventory_id,
+        h.hypervisor_uuid
+        FROM hosts h
+          JOIN host_tally_buckets b ON h.id = b.host_id
+          LEFT JOIN MaxHostServiceTypeDate mhstd ON h.id = mhstd.host_id
+        WHERE b.is_primary = true;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202605191440-05" author="awood" dbms="hsqldb">
+    <createView viewName="tally_instance_non_payg_primary_view">
+      SELECT DISTINCT
+        v.*,
+        CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') AS metrics
+      FROM tally_instance_primary_view v
+        LEFT JOIN instance_measurements m ON v.id = m.host_id;
+    </createView>
+  </changeSet>
+
+  <changeSet id="202605191440-06" author="awood" dbms="hsqldb">
+    <createView viewName="tally_instance_payg_primary_view">
+      SELECT DISTINCT
+        v.*,
+        m.month,
+        CONCAT('[{"metric_id":"', m.metric_id, '","value":',m.value , '}]') AS metrics
+      FROM tally_instance_primary_view v
+        LEFT JOIN instance_monthly_totals m ON v.id = m.host_id
+    </createView>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -210,5 +210,6 @@
     <include file="liquibase/202604301200-add-is-primary-to-host-tally-buckets.xml"/>
     <include file="liquibase/202605111456-remove-last-modified-triggers.xml"/>
     <include file="liquibase/202605151359-host-tally-buckets-partial-index.xml"/>
+    <include file="liquibase/202605191440-update-views-with-is-primary.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.ProductId;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.db.model.AccountServiceInventory;
 import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
 import org.candlepin.subscriptions.db.model.BillingProvider;
@@ -51,6 +53,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -58,6 +61,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -76,6 +80,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
   private static final String BILLING_ACCOUNT_ID_ANY = "_ANY";
   private static final String DEFAULT_ORG_ID = "org123";
 
+  @MockitoBean FeatureFlags featureFlags;
   @Autowired private TallyInstanceViewRepository repo;
   @Autowired private HostRepository hostRepo;
   @Autowired private AccountServiceInventoryRepository accountServiceInventoryRepository;
@@ -110,607 +115,735 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     defaultHosts = persistHosts(host8, host9, host10);
   }
 
-  @Transactional
-  @ParameterizedTest
-  @MethodSource("instanceSortParams")
-  void canSortByInstanceBasedSortMethods(String sort) {
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            DEFAULT_ORG_ID,
-            ROSA,
-            ServiceLevel._ANY,
-            Usage._ANY,
-            "",
-            0,
-            0,
-            "2021-01",
-            MetricIdUtils.getCores(),
-            BillingProvider._ANY,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            2,
-            sort,
-            SortDirection.ASC);
+  abstract class FeatureFlagTests {
+    @Transactional
+    @ParameterizedTest
+    @MethodSource(
+        "org.candlepin.subscriptions.db.TallyInstanceViewRepositoryTest#instanceSortParams")
+    void canSortByInstanceBasedSortMethods(String sort) {
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              DEFAULT_ORG_ID,
+              ROSA,
+              ServiceLevel._ANY,
+              Usage._ANY,
+              "",
+              0,
+              0,
+              "2021-01",
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              2,
+              sort,
+              SortDirection.ASC);
 
-    assertEquals(2, results.getTotalElements());
-  }
+      assertEquals(2, results.getTotalElements());
+    }
 
-  @Transactional
-  @Test
-  void testCanSortByMetricsForNonPayg() {
-    // using instance hours, because sort by Cores and Sockets work and it's already covered by the
-    // previous test.
-    MetricId referenceMetricId = MetricIdUtils.getInstanceHours();
+    @Transactional
+    @Test
+    void testCanSortByMetricsForNonPayg() {
+      // using instance hours, because sort by Cores and Sockets work and it's already covered by
+      // the
+      // previous test.
+      MetricId referenceMetricId = MetricIdUtils.getInstanceHours();
 
-    // given two hosts with different values for Instance-Hours
-    var host1 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 5.0);
-    var host2 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 10.0);
+      // given two hosts with different values for Instance-Hours
+      var host1 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 5.0);
+      var host2 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 10.0);
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            DEFAULT_ORG_ID,
-            OPENSHIFT_CONTAINER_PLATFORM,
-            ServiceLevel._ANY,
-            Usage._ANY,
-            "",
-            0,
-            0,
-            "2021-01",
-            referenceMetricId,
-            BillingProvider._ANY,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            2,
-            referenceMetricId.toString(),
-            SortDirection.DESC);
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              DEFAULT_ORG_ID,
+              OPENSHIFT_CONTAINER_PLATFORM,
+              ServiceLevel._ANY,
+              Usage._ANY,
+              "",
+              0,
+              0,
+              "2021-01",
+              referenceMetricId,
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              2,
+              referenceMetricId.toString(),
+              SortDirection.DESC);
 
-    // host2 should be returned first because we ordered by Instance-Hours descending
-    assertEquals(host2.getInstanceId(), results.getContent().get(0).getKey().getInstanceId());
-    assertEquals(host1.getInstanceId(), results.getContent().get(1).getKey().getInstanceId());
-  }
+      // host2 should be returned first because we ordered by Instance-Hours descending
+      assertEquals(host2.getInstanceId(), results.getContent().get(0).getKey().getInstanceId());
+      assertEquals(host1.getInstanceId(), results.getContent().get(1).getKey().getInstanceId());
+    }
 
-  @Test
-  @Transactional
-  void testFilterByBillingModel() {
-    Host host1 = createHost("i1", "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+    @Test
+    @Transactional
+    void testFilterByBillingModel() {
+      Host host1 = createHost("i1", "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    Host host2 = createHost("i2", "a1");
-    host2.setBillingProvider(BillingProvider.AWS);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.AWS);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+      Host host2 = createHost("i2", "a1");
+      host2.setBillingProvider(BillingProvider.AWS);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.AWS);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    Host host3 = createHost("i3", "a1");
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.EMPTY);
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+      Host host3 = createHost("i3", "a1");
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.EMPTY);
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    persistHosts(host1, host2, host3);
+      persistHosts(host1, host2, host3);
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider.AWS,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(1L, results.getTotalElements());
-    assertEquals(BillingProvider.AWS, results.getContent().get(0).getHostBillingProvider());
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider.AWS,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(1L, results.getTotalElements());
+      assertEquals(BillingProvider.AWS, results.getContent().get(0).getHostBillingProvider());
 
-    Page<TallyInstanceView> allResults =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider._ANY,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(3L, allResults.getTotalElements());
-    Map<String, TallyInstanceView> hostToBill =
-        allResults.stream()
-            .collect(Collectors.toMap(t -> t.getKey().getInstanceId(), Function.identity()));
+      Page<TallyInstanceView> allResults =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(3L, allResults.getTotalElements());
+      Map<String, TallyInstanceView> hostToBill =
+          allResults.stream()
+              .collect(Collectors.toMap(t -> t.getKey().getInstanceId(), Function.identity()));
 
-    assertTrue(
-        hostToBill
-            .keySet()
-            .containsAll(
-                Arrays.asList(host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
-        "Result did not contain expected hosts!");
-    assertEquals(
-        BillingProvider.RED_HAT, hostToBill.get(host1.getInstanceId()).getHostBillingProvider());
-    assertEquals(
-        BillingProvider.AWS, hostToBill.get(host2.getInstanceId()).getHostBillingProvider());
-    assertEquals(
-        BillingProvider._ANY, hostToBill.get(host3.getInstanceId()).getHostBillingProvider());
-  }
+      assertTrue(
+          hostToBill
+              .keySet()
+              .containsAll(
+                  Arrays.asList(
+                      host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
+          "Result did not contain expected hosts!");
+      assertEquals(
+          BillingProvider.RED_HAT, hostToBill.get(host1.getInstanceId()).getHostBillingProvider());
+      assertEquals(
+          BillingProvider.AWS, hostToBill.get(host2.getInstanceId()).getHostBillingProvider());
+      assertEquals(
+          BillingProvider._ANY, hostToBill.get(host3.getInstanceId()).getHostBillingProvider());
+    }
 
-  @Test
-  @Transactional
-  void testSortByBillingProvider() {
-    Host host1 = createHost("i1", "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+    @Test
+    @Transactional
+    void testSortByBillingProvider() {
+      Host host1 = createHost("i1", "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    Host host2 = createHost("i2", "a1");
-    host2.setBillingProvider(BillingProvider.AWS);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.AWS);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+      Host host2 = createHost("i2", "a1");
+      host2.setBillingProvider(BillingProvider.AWS);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.AWS);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    Host host3 = createHost("i3", "a1");
-    host3.setBillingProvider(BillingProvider.EMPTY);
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.EMPTY);
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+      Host host3 = createHost("i3", "a1");
+      host3.setBillingProvider(BillingProvider.EMPTY);
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.EMPTY);
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    Host host4 = createHost("i4", "a1");
-    host4.setBillingProvider(BillingProvider.ORACLE);
-    addBucketToHost(
-        host4,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.ORACLE);
-    addBucketToHost(
-        host4,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+      Host host4 = createHost("i4", "a1");
+      host4.setBillingProvider(BillingProvider.ORACLE);
+      addBucketToHost(
+          host4,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.ORACLE);
+      addBucketToHost(
+          host4,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY);
 
-    persistHosts(host1, host2, host3, host4);
-    hostRepo.flush();
+      persistHosts(host1, host2, host3, host4);
+      hostRepo.flush();
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider._ANY,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_BILLING_PROVIDER,
-            SortDirection.DESC);
-    assertEquals(4L, results.getTotalElements());
-    assertEquals(BillingProvider.RED_HAT, results.getContent().get(0).getHostBillingProvider());
-    assertEquals(BillingProvider.ORACLE, results.getContent().get(1).getHostBillingProvider());
-    assertEquals(BillingProvider.AWS, results.getContent().get(2).getHostBillingProvider());
-    assertEquals(BillingProvider.EMPTY, results.getContent().get(3).getHostBillingProvider());
-  }
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_BILLING_PROVIDER,
+              SortDirection.DESC);
+      assertEquals(4L, results.getTotalElements());
+      assertEquals(BillingProvider.RED_HAT, results.getContent().get(0).getHostBillingProvider());
+      assertEquals(BillingProvider.ORACLE, results.getContent().get(1).getHostBillingProvider());
+      assertEquals(BillingProvider.AWS, results.getContent().get(2).getHostBillingProvider());
+      assertEquals(BillingProvider.EMPTY, results.getContent().get(3).getHostBillingProvider());
+    }
 
-  @Transactional
-  @Test
-  void testFilterByHardwareMeasurementTypes() {
-    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.RED_HAT);
+    @Transactional
+    @Test
+    void testFilterByHardwareMeasurementTypes() {
+      Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.RED_HAT);
 
-    Host host2 = createHost(UUID.randomUUID().toString(), "a1");
-    host2.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.VIRTUAL,
-        BillingProvider.RED_HAT);
+      Host host2 = createHost(UUID.randomUUID().toString(), "a1");
+      host2.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.VIRTUAL,
+          BillingProvider.RED_HAT);
 
-    Host host3 = createHost(UUID.randomUUID().toString(), "a1");
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.HYPERVISOR,
-        BillingProvider.RED_HAT);
+      Host host3 = createHost(UUID.randomUUID().toString(), "a1");
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.HYPERVISOR,
+          BillingProvider.RED_HAT);
 
-    persistHosts(host1, host2, host3);
+      persistHosts(host1, host2, host3);
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider.RED_HAT,
-            BILLING_ACCOUNT_ID_ANY,
-            List.of(HardwareMeasurementType.VIRTUAL),
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(1L, results.getTotalElements());
-    assertEquals(
-        HardwareMeasurementType.VIRTUAL, results.getContent().get(0).getKey().getMeasurementType());
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider.RED_HAT,
+              BILLING_ACCOUNT_ID_ANY,
+              List.of(HardwareMeasurementType.VIRTUAL),
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(1L, results.getTotalElements());
+      assertEquals(
+          HardwareMeasurementType.VIRTUAL,
+          results.getContent().get(0).getKey().getMeasurementType());
 
-    Page<TallyInstanceView> allResults =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider.RED_HAT,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(3L, allResults.getTotalElements());
-    Map<String, TallyInstanceView> hostToBill =
-        allResults.stream()
-            .collect(
-                Collectors.toMap(
-                    instance -> instance.getKey().getInstanceId(), Function.identity()));
-    assertTrue(
-        hostToBill
-            .keySet()
-            .containsAll(
-                Arrays.asList(host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
-        "Result did not contain expected hosts!");
-    assertEquals(
-        HardwareMeasurementType.PHYSICAL,
-        hostToBill.get(host1.getInstanceId()).getKey().getMeasurementType());
-    assertEquals(
-        HardwareMeasurementType.VIRTUAL,
-        hostToBill.get(host2.getInstanceId()).getKey().getMeasurementType());
-    assertEquals(
-        HardwareMeasurementType.HYPERVISOR,
-        hostToBill.get(host3.getInstanceId()).getKey().getMeasurementType());
-  }
+      Page<TallyInstanceView> allResults =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider.RED_HAT,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(3L, allResults.getTotalElements());
+      Map<String, TallyInstanceView> hostToBill =
+          allResults.stream()
+              .collect(
+                  Collectors.toMap(
+                      instance -> instance.getKey().getInstanceId(), Function.identity()));
+      assertTrue(
+          hostToBill
+              .keySet()
+              .containsAll(
+                  Arrays.asList(
+                      host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())),
+          "Result did not contain expected hosts!");
+      assertEquals(
+          HardwareMeasurementType.PHYSICAL,
+          hostToBill.get(host1.getInstanceId()).getKey().getMeasurementType());
+      assertEquals(
+          HardwareMeasurementType.VIRTUAL,
+          hostToBill.get(host2.getInstanceId()).getKey().getMeasurementType());
+      assertEquals(
+          HardwareMeasurementType.HYPERVISOR,
+          hostToBill.get(host3.getInstanceId()).getKey().getMeasurementType());
+    }
 
-  @Transactional
-  @Test
-  void testGetResultWithEmptyMeasurementType() {
-    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, null, BillingProvider.RED_HAT);
+    @Transactional
+    @Test
+    void testGetResultWithEmptyMeasurementType() {
+      Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, null, BillingProvider.RED_HAT);
 
-    persistHosts(host1);
+      persistHosts(host1);
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider.RED_HAT,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(1L, results.getTotalElements());
-    assertEquals(
-        HardwareMeasurementType.EMPTY, results.getContent().get(0).getKey().getMeasurementType());
-  }
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider.RED_HAT,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(1L, results.getTotalElements());
+      assertEquals(
+          HardwareMeasurementType.EMPTY, results.getContent().get(0).getKey().getMeasurementType());
+    }
 
-  @Transactional
-  @Test
-  void testFilterByCloudHardwareMeasurementTypes() {
-    Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.AWS,
-        BillingProvider.RED_HAT);
+    @Transactional
+    @Test
+    void testFilterByCloudHardwareMeasurementTypes() {
+      Host host1 = createHost(UUID.randomUUID().toString(), "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.AWS,
+          BillingProvider.RED_HAT);
 
-    Host host2 = createHost(UUID.randomUUID().toString(), "a1");
-    host2.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.AZURE,
-        BillingProvider.RED_HAT);
+      Host host2 = createHost(UUID.randomUUID().toString(), "a1");
+      host2.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.AZURE,
+          BillingProvider.RED_HAT);
 
-    Host host3 = createHost(UUID.randomUUID().toString(), "a1");
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.GOOGLE,
-        BillingProvider.RED_HAT);
+      Host host3 = createHost(UUID.randomUUID().toString(), "a1");
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.GOOGLE,
+          BillingProvider.RED_HAT);
 
-    Host host5 = createHost(UUID.randomUUID().toString(), "a1");
-    addBucketToHost(
-        host5,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.RED_HAT);
+      Host host5 = createHost(UUID.randomUUID().toString(), "a1");
+      addBucketToHost(
+          host5,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.RED_HAT);
 
-    persistHosts(host1, host2, host3, host5);
+      persistHosts(host1, host2, host3, host5);
 
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            BillingProvider.RED_HAT,
-            BILLING_ACCOUNT_ID_ANY,
-            HardwareMeasurementType.getCloudProviderTypes(),
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(3L, results.getTotalElements());
-    Map<String, TallyInstanceView> hostToBill =
-        results.stream()
-            .collect(Collectors.toMap(t -> t.getKey().getInstanceId(), Function.identity()));
-    assertTrue(
-        hostToBill
-            .keySet()
-            .containsAll(
-                Arrays.asList(
-                    host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())));
-  }
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider.RED_HAT,
+              BILLING_ACCOUNT_ID_ANY,
+              HardwareMeasurementType.getCloudProviderTypes(),
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(3L, results.getTotalElements());
+      Map<String, TallyInstanceView> hostToBill =
+          results.stream()
+              .collect(Collectors.toMap(t -> t.getKey().getInstanceId(), Function.identity()));
+      assertTrue(
+          hostToBill
+              .keySet()
+              .containsAll(
+                  Arrays.asList(
+                      host1.getInstanceId(), host2.getInstanceId(), host3.getInstanceId())));
+    }
 
-  @Test
-  @Transactional
-  void testFilterByMinCoresAndSockets() {
-    Host host1 = createBaseHost("i1", "a1");
-    host1.setBillingProvider(BillingProvider.RED_HAT);
-    addBucketToHost(
-        host1,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.RED_HAT,
-        0,
-        4);
-    host1.setMeasurement(MetricIdUtils.getCores().toString(), 4.0);
-    host1.setMeasurement(MetricIdUtils.getSockets().toString(), 0.0);
+    @Test
+    @Transactional
+    void testFilterByMinCoresAndSockets() {
+      Host host1 = createBaseHost("i1", "a1");
+      host1.setBillingProvider(BillingProvider.RED_HAT);
+      addBucketToHost(
+          host1,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.RED_HAT,
+          0,
+          4);
+      host1.setMeasurement(MetricIdUtils.getCores().toString(), 4.0);
+      host1.setMeasurement(MetricIdUtils.getSockets().toString(), 0.0);
 
-    Host host2 = createBaseHost("i2", "a1");
-    host2.setBillingProvider(BillingProvider.AWS);
-    addBucketToHost(
-        host2,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.AWS,
-        2,
-        0);
-    host2.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
-    host2.setMeasurement(MetricIdUtils.getCores().toString(), 0.0);
+      Host host2 = createBaseHost("i2", "a1");
+      host2.setBillingProvider(BillingProvider.AWS);
+      addBucketToHost(
+          host2,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.AWS,
+          2,
+          0);
+      host2.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
+      host2.setMeasurement(MetricIdUtils.getCores().toString(), 0.0);
 
-    Host host3 = createBaseHost("i3", "a1");
-    addBucketToHost(
-        host3,
-        RHEL,
-        ServiceLevel.PREMIUM,
-        Usage.PRODUCTION,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider.EMPTY,
-        2,
-        2);
-    host3.setMeasurement(MetricIdUtils.getCores().toString(), 2.0);
-    host3.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
+      Host host3 = createBaseHost("i3", "a1");
+      addBucketToHost(
+          host3,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider.EMPTY,
+          2,
+          2);
+      host3.setMeasurement(MetricIdUtils.getCores().toString(), 2.0);
+      host3.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
 
-    persistHosts(host1, host2, host3);
+      persistHosts(host1, host2, host3);
 
-    Page<TallyInstanceView> coresResults =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            1,
-            0,
-            null,
-            MetricIdUtils.getCores(),
-            null,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(2L, coresResults.getTotalElements());
-    List<String> coreResultsIds =
-        coresResults.stream().map(r -> r.getKey().getInstanceId()).toList();
-    assertTrue(coreResultsIds.containsAll(List.of(host1.getInstanceId(), host3.getInstanceId())));
+      Page<TallyInstanceView> coresResults =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              1,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              null,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(2L, coresResults.getTotalElements());
+      List<String> coreResultsIds =
+          coresResults.stream().map(r -> r.getKey().getInstanceId()).toList();
+      assertTrue(coreResultsIds.containsAll(List.of(host1.getInstanceId(), host3.getInstanceId())));
 
-    Page<TallyInstanceView> socketsResults =
-        repo.findAllBy(
-            "a1",
-            RHEL,
-            ServiceLevel.PREMIUM,
-            Usage.PRODUCTION,
-            "",
-            0,
-            1,
-            null,
-            MetricIdUtils.getSockets(),
-            null,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            SORT_BY_CORES,
-            SortDirection.ASC);
-    assertEquals(2L, socketsResults.getTotalElements());
-    List<String> socketsResultIds =
-        socketsResults.stream().map(r -> r.getKey().getInstanceId()).collect(Collectors.toList());
-    assertThat(socketsResultIds, containsInAnyOrder(host2.getInstanceId(), host3.getInstanceId()));
-  }
+      Page<TallyInstanceView> socketsResults =
+          repo.findAllBy(
+              "a1",
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage.PRODUCTION,
+              "",
+              0,
+              1,
+              null,
+              MetricIdUtils.getSockets(),
+              null,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(2L, socketsResults.getTotalElements());
+      List<String> socketsResultIds =
+          socketsResults.stream().map(r -> r.getKey().getInstanceId()).collect(Collectors.toList());
+      assertThat(
+          socketsResultIds, containsInAnyOrder(host2.getInstanceId(), host3.getInstanceId()));
+    }
 
-  @Transactional
-  @Test
-  void testWithoutAnyFilterForMetricId() {
-    Page<TallyInstanceView> results =
-        repo.findAllBy(
-            DEFAULT_ORG_ID,
-            ROSA,
-            ServiceLevel._ANY,
-            Usage._ANY,
-            null,
-            0,
-            0,
-            null,
-            null,
-            BillingProvider._ANY,
-            BILLING_ACCOUNT_ID_ANY,
-            null,
-            0,
-            10,
-            null,
-            null);
-    List<MetricId> validMetricsByProduct = getMetricIdsFromConfigForTag(ROSA.toString()).toList();
+    @Transactional
+    @Test
+    void testWithoutAnyFilterForMetricId() {
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              DEFAULT_ORG_ID,
+              ROSA,
+              ServiceLevel._ANY,
+              Usage._ANY,
+              null,
+              0,
+              0,
+              null,
+              null,
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              null,
+              null);
+      List<MetricId> validMetricsByProduct = getMetricIdsFromConfigForTag(ROSA.toString()).toList();
 
-    // to ensure we're using a product with two metrics
-    assertEquals(2, validMetricsByProduct.size());
-    assertEquals(defaultHosts.size(), (int) results.getTotalElements());
-    for (var host : defaultHosts) {
-      for (var metric : validMetricsByProduct) {
-        assertTrue(
-            results.stream().anyMatch(h -> h.getMetrics().containsKey(metric)),
-            "Metric " + metric + " not found in the host " + host.getInventoryId());
+      // to ensure we're using a product with two metrics
+      assertEquals(2, validMetricsByProduct.size());
+      assertEquals(defaultHosts.size(), (int) results.getTotalElements());
+      for (var host : defaultHosts) {
+        for (var metric : validMetricsByProduct) {
+          assertTrue(
+              results.stream().anyMatch(h -> h.getMetrics().containsKey(metric)),
+              "Metric " + metric + " not found in the host " + host.getInventoryId());
+        }
       }
+    }
+  }
+
+  @Nested
+  class WithPrimaryRowSearchesEnabled extends FeatureFlagTests {
+    @BeforeEach
+    void setup() {
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false))
+          .thenReturn(true);
+    }
+
+    @Test
+    @Transactional
+    void testNonPrimaryBucketIsExcluded() {
+      Host primaryHost = createHost("inv-primary", "org-primary");
+      addBucketToHost(
+          primaryHost,
+          RHEL,
+          ServiceLevel._ANY,
+          Usage._ANY,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY,
+          2,
+          4,
+          true);
+
+      Host nonPrimaryHost = createHost("inv-non-primary", "org-primary");
+      addBucketToHost(
+          nonPrimaryHost,
+          RHEL,
+          ServiceLevel._ANY,
+          Usage._ANY,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY,
+          2,
+          4,
+          false);
+
+      persistHosts(primaryHost, nonPrimaryHost);
+
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "org-primary",
+              RHEL,
+              ServiceLevel._ANY,
+              Usage._ANY,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(1L, results.getTotalElements());
+      assertEquals(
+          primaryHost.getInstanceId(), results.getContent().get(0).getKey().getInstanceId());
+    }
+  }
+
+  @Nested
+  class WithPrimaryRowSearchesDisabled extends FeatureFlagTests {
+    @BeforeEach
+    void setup() {
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false))
+          .thenReturn(false);
+    }
+
+    @Test
+    @Transactional
+    void testNonPrimaryBucketIsIncluded() {
+      Host primaryHost = createHost("inv-primary", "org-primary");
+      addBucketToHost(
+          primaryHost,
+          RHEL,
+          ServiceLevel._ANY,
+          Usage._ANY,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY,
+          2,
+          4,
+          true);
+
+      Host nonPrimaryHost = createHost("inv-non-primary", "org-primary");
+      addBucketToHost(
+          nonPrimaryHost,
+          RHEL,
+          ServiceLevel._ANY,
+          Usage._ANY,
+          HardwareMeasurementType.PHYSICAL,
+          BillingProvider._ANY,
+          2,
+          4,
+          false);
+
+      persistHosts(primaryHost, nonPrimaryHost);
+
+      Page<TallyInstanceView> results =
+          repo.findAllBy(
+              "org-primary",
+              RHEL,
+              ServiceLevel._ANY,
+              Usage._ANY,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              null,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+      assertEquals(2L, results.getTotalElements());
     }
   }
 
@@ -807,16 +940,32 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
       BillingProvider billingProvider,
       int sockets,
       int cores) {
-    host.addBucket(
-        productId.toString(),
-        sla,
-        usage,
-        billingProvider,
-        BILLING_ACCOUNT_ID_ANY,
-        true,
-        sockets,
-        cores,
-        measurementType);
+    addBucketToHost(
+        host, productId, sla, usage, measurementType, billingProvider, sockets, cores, true);
+  }
+
+  private void addBucketToHost(
+      Host host,
+      ProductId productId,
+      ServiceLevel sla,
+      Usage usage,
+      HardwareMeasurementType measurementType,
+      BillingProvider billingProvider,
+      int sockets,
+      int cores,
+      boolean primary) {
+    var bucket =
+        host.addBucket(
+            productId.toString(),
+            sla,
+            usage,
+            billingProvider,
+            BILLING_ACCOUNT_ID_ANY,
+            true,
+            sockets,
+            cores,
+            measurementType);
+    bucket.setPrimary(primary);
   }
 
   static String[] instanceSortParams() {

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -53,6 +53,7 @@ import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -736,6 +737,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     }
 
     @Test
+    @Disabled("Enable during SWATCH-4862")
     @Transactional
     void testNonPrimaryBucketIsExcluded() {
       Host primaryHost = createHost("inv-primary", "org-primary");

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
@@ -128,7 +128,7 @@ class TallyResourceTest {
   class WithPrimaryRowSearchesEnabled {
     @BeforeEach
     void setup() {
-      when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(true);
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(true);
     }
 
     @Test
@@ -1035,7 +1035,7 @@ class TallyResourceTest {
   class WithPrimaryRowSearchesDisabled {
     @BeforeEach
     void setup() {
-      when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
     }
 
     @Test

--- a/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/SnapshotSummaryProducerTest.java
@@ -114,7 +114,8 @@ class SnapshotSummaryProducerTest {
   @MockitoSettings(strictness = Strictness.LENIENT)
   @ValueSource(booleans = {true, false})
   void testProduceSummaryDaily(boolean isPrimaryRowSearch) {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(isPrimaryRowSearch);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))
+        .thenReturn(isPrimaryRowSearch);
     Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
     updateMap.put(
         "org1",
@@ -179,7 +180,8 @@ class SnapshotSummaryProducerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testProduceSummaryHourly(boolean isPrimaryRowSearch) {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(isPrimaryRowSearch);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))
+        .thenReturn(isPrimaryRowSearch);
     Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
     updateMap.put(
         "org1",
@@ -244,7 +246,8 @@ class SnapshotSummaryProducerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testProduceMultiGranularitySummaries(boolean isPrimaryRowSearch) {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(isPrimaryRowSearch);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))
+        .thenReturn(isPrimaryRowSearch);
     Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
     updateMap.put(
         "org1",
@@ -323,7 +326,8 @@ class SnapshotSummaryProducerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testProduceSummariesNoBilling(boolean isPrimaryRowSearch) {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(isPrimaryRowSearch);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))
+        .thenReturn(isPrimaryRowSearch);
     Map<String, List<TallySnapshot>> updateMap = new HashMap<>();
     updateMap.put(
         "org1",

--- a/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/TallySummaryMapperTest.java
@@ -69,7 +69,9 @@ class TallySummaryMapperTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testMapSnapshots(boolean isPrimaryRowSearch) {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(true);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))
+        .thenReturn(isPrimaryRowSearch);
+
     when(clock.startOfMonth(any(OffsetDateTime.class)))
         .thenAnswer(inv -> ((OffsetDateTime) inv.getArgument(0)).minusDays(10));
 
@@ -115,7 +117,7 @@ class TallySummaryMapperTest {
   @Test
   @MockitoSettings(strictness = Strictness.LENIENT)
   void testMapSnapshotsPrimayRowsWithAny() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(true);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(true);
     when(clock.startOfMonth(any(OffsetDateTime.class)))
         .thenAnswer(inv -> ((OffsetDateTime) inv.getArgument(0)).minusDays(10));
 
@@ -210,7 +212,7 @@ class TallySummaryMapperTest {
       if (!isNonAnsibleGauge) {
         // SQL call should be made for non-GAUGE or Ansible products
         sqlCallCount++;
-        if (featureFlags.isPrimaryRowSearchesEnabled()) {
+        if (featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)) {
           verify(snapshotRepository)
               .sumMeasurementValueForPeriodWithPrimary(
                   eq(expected.getOrgId()),
@@ -299,7 +301,7 @@ class TallySummaryMapperTest {
     } else {
       // All other metrics: use SQL query result (value * 2)
       expectedTotalValues.put(measurementKey, value * 2);
-      if (featureFlags.isPrimaryRowSearchesEnabled()) {
+      if ((featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES))) {
         when(snapshotRepository.sumMeasurementValueForPeriodWithPrimary(
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), eq(measurementKey)))
             .thenReturn(value * 2);
@@ -380,7 +382,7 @@ class TallySummaryMapperTest {
   @Test
   @MockitoSettings(strictness = Strictness.LENIENT)
   void testGetCurrentlyMeasuredTotalNonAnsibleGaugeMetricUsesEventValue() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
 
     String org = "O1";
     // RHEL is non-Ansible and has GAUGE metrics like "Sockets"
@@ -432,7 +434,7 @@ class TallySummaryMapperTest {
    */
   @Test
   void testGetCurrentlyMeasuredTotalCounterMetricUsesSqlQuery() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
 
     String org = "O1";
     // OpenShift-metrics is non-Ansible
@@ -484,7 +486,7 @@ class TallySummaryMapperTest {
    */
   @Test
   void testGetCurrentlyMeasuredTotalPaygProductCounterUsesSqlQuery() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
 
     String org = "O1";
     // ROSA is a PAYG product
@@ -536,7 +538,7 @@ class TallySummaryMapperTest {
    */
   @Test
   void testGetCurrentlyMeasuredTotalAnsibleGaugeMetricUsesSqlQuery() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
 
     String org = "O1";
     // Ansible product
@@ -586,7 +588,7 @@ class TallySummaryMapperTest {
    */
   @Test
   void testGetCurrentlyMeasuredTotalPrimaryRowSearchEnabledUsesPrimaryQuery() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(true);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(true);
 
     String org = "O1";
     String productId = "OpenShift-metrics";
@@ -647,7 +649,7 @@ class TallySummaryMapperTest {
    */
   @Test
   void testGetCurrentlyMeasuredTotalMixedGaugeAndCounter() {
-    when(featureFlags.isPrimaryRowSearchesEnabled()).thenReturn(false);
+    when(featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)).thenReturn(false);
 
     String org = "O1";
     String productId = "ansible-aap-managed";

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/configuration/FeatureFlags.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/configuration/FeatureFlags.java
@@ -18,18 +18,13 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.configuration;
 
-import java.util.UUID;
-import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+public interface FeatureFlags {
 
-/**
- * Provides access to TallyInstanceView database entities. This is a legacy class that will be
- * retired when the is_primary migration effort is complete
- */
-@Deprecated
-public interface TallyInstancePaygViewRepository
-    extends JpaRepository<TallyInstancePaygView, UUID>,
-        JpaSpecificationExecutor<TallyInstancePaygView> {}
+  String ENABLE_PRIMARY_ROW_SEARCHES = "swatch.swatch-tally.enable-primary-row-searches";
+
+  boolean isEnabled(String featureName);
+
+  boolean isEnabled(String featureName, boolean defaultWhenUnavailable);
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/configuration/StubFeatureFlags.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/configuration/StubFeatureFlags.java
@@ -18,18 +18,24 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.subscriptions.db;
+package org.candlepin.subscriptions.configuration;
 
-import java.util.UUID;
-import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Component;
 
 /**
- * Provides access to TallyInstanceView database entities. This is a legacy class that will be
- * retired when the is_primary migration effort is complete
+ * A stub implementation since both swatch-system-conduit and swatch-tally import swatch-core and we
+ * don't have Unleash functionality in swatch-system-conduit.
  */
-@Deprecated
-public interface TallyInstancePaygViewRepository
-    extends JpaRepository<TallyInstancePaygView, UUID>,
-        JpaSpecificationExecutor<TallyInstancePaygView> {}
+@Component
+public class StubFeatureFlags implements FeatureFlags {
+
+  @Override
+  public boolean isEnabled(String featureName) {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled(String featureName, boolean defaultWhenUnavailable) {
+    return defaultWhenUnavailable;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygPrimaryViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygPrimaryViewRepository.java
@@ -20,13 +20,13 @@
  */
 package org.candlepin.subscriptions.db;
 
-import java.util.UUID;
 import org.candlepin.subscriptions.db.model.TallyInstanceNonPaygPrimaryView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/** Provides access to TallyInstanceView database entities. */
+/** Provides access to {@link TallyInstanceNonPaygPrimaryView} database entities. */
 @SuppressWarnings({"linelength", "indentation"})
 public interface TallyInstanceNonPaygPrimaryViewRepository
-    extends JpaRepository<TallyInstanceNonPaygPrimaryView, UUID>,
+    extends JpaRepository<TallyInstanceNonPaygPrimaryView, TallyInstanceViewKey>,
         JpaSpecificationExecutor<TallyInstanceNonPaygPrimaryView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygPrimaryViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygPrimaryViewRepository.java
@@ -21,15 +21,12 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.UUID;
-import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
+import org.candlepin.subscriptions.db.model.TallyInstanceNonPaygPrimaryView;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/**
- * Provides access to TallyInstanceView database entities. This is a legacy class that will be
- * retired when the is_primary migration effort is complete
- */
-@Deprecated
-public interface TallyInstancePaygViewRepository
-    extends JpaRepository<TallyInstancePaygView, UUID>,
-        JpaSpecificationExecutor<TallyInstancePaygView> {}
+/** Provides access to TallyInstanceView database entities. */
+@SuppressWarnings({"linelength", "indentation"})
+public interface TallyInstanceNonPaygPrimaryViewRepository
+    extends JpaRepository<TallyInstanceNonPaygPrimaryView, UUID>,
+        JpaSpecificationExecutor<TallyInstanceNonPaygPrimaryView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import java.util.UUID;
 import org.candlepin.subscriptions.db.model.TallyInstanceNonPaygView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -31,5 +31,5 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
  */
 @Deprecated
 public interface TallyInstanceNonPaygViewRepository
-    extends JpaRepository<TallyInstanceNonPaygView, UUID>,
+    extends JpaRepository<TallyInstanceNonPaygView, TallyInstanceViewKey>,
         JpaSpecificationExecutor<TallyInstanceNonPaygView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceNonPaygViewRepository.java
@@ -25,8 +25,11 @@ import org.candlepin.subscriptions.db.model.TallyInstanceNonPaygView;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/** Provides access to TallyInstanceView database entities. */
-@SuppressWarnings({"linelength", "indentation"})
+/**
+ * Provides access to TallyInstanceView database entities. This is a legacy class that will be
+ * retired when the is_primary migration effort is complete
+ */
+@Deprecated
 public interface TallyInstanceNonPaygViewRepository
     extends JpaRepository<TallyInstanceNonPaygView, UUID>,
         JpaSpecificationExecutor<TallyInstanceNonPaygView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygPrimaryViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygPrimaryViewRepository.java
@@ -21,15 +21,12 @@
 package org.candlepin.subscriptions.db;
 
 import java.util.UUID;
-import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
+import org.candlepin.subscriptions.db.model.TallyInstancePaygPrimaryView;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/**
- * Provides access to TallyInstanceView database entities. This is a legacy class that will be
- * retired when the is_primary migration effort is complete
- */
-@Deprecated
-public interface TallyInstancePaygViewRepository
-    extends JpaRepository<TallyInstancePaygView, UUID>,
-        JpaSpecificationExecutor<TallyInstancePaygView> {}
+/** Provides access to TallyInstanceView database entities. */
+@SuppressWarnings({"linelength", "indentation"})
+public interface TallyInstancePaygPrimaryViewRepository
+    extends JpaRepository<TallyInstancePaygPrimaryView, UUID>,
+        JpaSpecificationExecutor<TallyInstancePaygPrimaryView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygPrimaryViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygPrimaryViewRepository.java
@@ -20,13 +20,13 @@
  */
 package org.candlepin.subscriptions.db;
 
-import java.util.UUID;
 import org.candlepin.subscriptions.db.model.TallyInstancePaygPrimaryView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-/** Provides access to TallyInstanceView database entities. */
+/** Provides access to {@link TallyInstancePaygPrimaryView} database entities. */
 @SuppressWarnings({"linelength", "indentation"})
 public interface TallyInstancePaygPrimaryViewRepository
-    extends JpaRepository<TallyInstancePaygPrimaryView, UUID>,
+    extends JpaRepository<TallyInstancePaygPrimaryView, TallyInstanceViewKey>,
         JpaSpecificationExecutor<TallyInstancePaygPrimaryView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstancePaygViewRepository.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.subscriptions.db;
 
-import java.util.UUID;
 import org.candlepin.subscriptions.db.model.TallyInstancePaygView;
+import org.candlepin.subscriptions.db.model.TallyInstanceViewKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -31,5 +31,5 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
  */
 @Deprecated
 public interface TallyInstancePaygViewRepository
-    extends JpaRepository<TallyInstancePaygView, UUID>,
+    extends JpaRepository<TallyInstancePaygView, TallyInstanceViewKey>,
         JpaSpecificationExecutor<TallyInstancePaygView> {}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -148,7 +148,9 @@ public class TallyInstanceViewRepository {
 
   private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
       ProductId productId) {
-    boolean usePrimary = featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    // TODO Enable with featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    //  for SWATCH-4862
+    boolean usePrimary = false;
     if (productId.isPayg()) {
       return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
     }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -50,6 +51,7 @@ import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 import org.hibernate.query.criteria.JpaOrder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -78,13 +80,18 @@ public class TallyInstanceViewRepository {
   private final TallyInstancePaygViewRepository paygViewRepository;
   private final TallyInstanceNonPaygViewRepository nonPaygViewRepository;
 
+  private final TallyInstancePaygPrimaryViewRepository paygPrimaryViewRepository;
+  private final TallyInstanceNonPaygPrimaryViewRepository nonPaygPrimaryViewRepository;
+
+  private final FeatureFlags featureFlags;
+
   /**
    * Find all Hosts by bucket criteria and return a page of TallyInstanceView objects. A
    * TallyInstanceView is a Host representation detailing what 'bucket' was applied to the current
    * daily snapshots.
    *
    * @param orgId The organization ID of the hosts to query (required).
-   * @param productId The bucket product ID to filter Host by (pass null to ignore).
+   * @param productId The bucket product ID to filter Host by (required).
    * @param sla The bucket service level to filter Hosts by (pass null to ignore).
    * @param usage The bucket usage to filter Hosts by (pass null to ignore).
    * @param displayNameSubstring Case-insensitive string to filter Hosts' display name by (pass null
@@ -113,7 +120,10 @@ public class TallyInstanceViewRepository {
       Integer limit,
       String sort,
       SortDirection dir) {
-    var repository = productId.isPayg() ? paygViewRepository : nonPaygViewRepository;
+
+    Objects.requireNonNull(productId, "productId must be provided");
+    var repository = selectRepository(productId);
+
     return (Page<TallyInstanceView>)
         repository.findAll(
             buildSearchSpecification(
@@ -134,6 +144,15 @@ public class TallyInstanceViewRepository {
                     .sortDirection(dir)
                     .build()),
             ResourceUtils.getPageable(offset, limit));
+  }
+
+  private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
+      ProductId productId) {
+    boolean usePrimary = featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES, false);
+    if (productId.isPayg()) {
+      return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
+    }
+    return usePrimary ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
   }
 
   static <T extends TallyInstanceView> Specification<T> socketsAndCoresGreaterThanOrEqualTo(

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygPrimaryView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygPrimaryView.java
@@ -23,6 +23,7 @@ package org.candlepin.subscriptions.db.model;
 import static java.util.Optional.ofNullable;
 
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -37,33 +38,28 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Immutable;
 
-/** This is a legacy class that will be retired when the is_primary migration effort is complete */
 @Setter
 @Getter
 @Entity
 @Immutable
-@Table(name = "tally_instance_payg_view")
-@Deprecated
-public class TallyInstancePaygView extends TallyInstanceView {
-
-  @Column(name = "month")
-  private String month;
-
+@Table(name = "tally_instance_non_payg_primary_view")
+public class TallyInstanceNonPaygPrimaryView extends TallyInstanceView {
   /** This is only used when filtering/sorting instances. */
   @ElementCollection(fetch = FetchType.LAZY)
   @CollectionTable(
-      name = "instance_monthly_totals",
-      joinColumns = {
-        @JoinColumn(name = "host_id", referencedColumnName = "id"),
-        @JoinColumn(name = "month", referencedColumnName = "month")
-      })
+      name = "instance_measurements",
+      joinColumns = @JoinColumn(name = "host_id", referencedColumnName = "id"))
   @MapKeyColumn(name = "metric_id")
   @Column(name = "value")
   private Map<String, Double> filteredMetrics = new HashMap<>();
 
   @Override
   public double getMetricValue(MetricId metricId) {
-    if (getMetrics().containsKey(metricId)) {
+    if (MetricIdUtils.getSockets().equals(metricId)) {
+      return Double.valueOf(ofNullable(getSockets()).orElse(0));
+    } else if (MetricIdUtils.getCores().equals(metricId)) {
+      return Double.valueOf(ofNullable(getCores()).orElse(0));
+    } else if (getMetrics().containsKey(metricId)) {
       return ofNullable(getMetrics().get(metricId)).orElse(0.0);
     }
 

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstanceNonPaygView.java
@@ -38,11 +38,13 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Immutable;
 
+/** This is a legacy class that will be retired when the is_primary migration effort is complete */
 @Setter
 @Getter
 @Entity
 @Immutable
 @Table(name = "tally_instance_non_payg_view")
+@Deprecated
 public class TallyInstanceNonPaygView extends TallyInstanceView {
 
   /** This is only used when filtering/sorting instances. */

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygPrimaryView.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancePaygPrimaryView.java
@@ -37,14 +37,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Immutable;
 
-/** This is a legacy class that will be retired when the is_primary migration effort is complete */
 @Setter
 @Getter
 @Entity
 @Immutable
-@Table(name = "tally_instance_payg_view")
-@Deprecated
-public class TallyInstancePaygView extends TallyInstanceView {
+@Table(name = "tally_instance_payg_primary_view")
+public class TallyInstancePaygPrimaryView extends TallyInstanceView {
 
   @Column(name = "month")
   private String month;


### PR DESCRIPTION
Jira issue: SWATCH-4858

## Description
Creates the `tally_instance` family of views but filtering on `is_primary=TRUE`
and then configures swatch-tally to use the views based on the value of the
feature flag.

## Testing

### Setup
1. Start with SQL logging turned on
    ```shell
    SPRING_JPA_SHOW_SQL=true SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL=true \
    LOGGING_LEVEL_ORG_HIBERNATE_ORM_JDBC_BIND=trace make build swatch-tally
    ```

### Steps
1. Do a GET on `/instances/products/` for an org to access the `tally_instance`
   views
    ```shell
    http localhost:8010/api/rhsm-subscriptions/v1/instances/products/RHEL%20for%20x86 \
    sla==Premium \
    usage==Production \
    beginning==2025-05-26T00:00:00.000Z \
    ending==2026-05-26T00:00:00.000Z \
    x-rh-identity:"$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"org123"}}}' | base64 -w 0)"
    ```
1. You'll see the select statement reads from `tally_instance_non_payg_view`
1. Turn on the `swatch.swatch-tally.enable-primary-row-searches` feature flag.
    ```shell
    http post :4242/api/admin/projects/default/features/swatch.swatch-tally.enable-primary-row-searches/environments/development/on Authorization:"*:*.unleash-insecure-admin-api-token"
    ```
1. Re-run the same GET to `/instances/products`.

### Verification
1.  This time you'll see that `tally_instance_non_payg_primary_view` is used.
