### PR TITLE
SWATCH-4943: Update otel config to use swatch-otel-config-v1

### DIFF
--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -28,40 +28,7 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: swatch-traces-otel-config
-    data:
-      relay: |
-        extensions:
-          health_check:
-            endpoint: 0.0.0.0:13133
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: 0.0.0.0:4317
-              http:
-                endpoint: 0.0.0.0:4318
-        processors:
-          batch:
-        exporters:
-          debug:
-            verbosity: detailed
-        service:
-          extensions:
-            - health_check
-          pipelines:
-            traces:
-              receivers: [otlp]
-              processors: [batch]
-              exporters: [debug]
-          telemetry:
-            logs:
-              level: info
-
-  - apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: swatch-logging-otel-config
+      name: swatch-otel-config-v1
     data:
       relay: |
         extensions:
@@ -78,6 +45,14 @@ objects:
             protocol: rfc3164
             udp:
               listen_address: '0.0.0.0:54526'
+          filelog:
+            include:
+              - /logs/server.log
+            start_at: end
+            operators:
+              - type: json_parser
+                parse_from: body
+                parse_to: attributes
         processors:
           batch:
           transform/syslog:
@@ -86,6 +61,12 @@ objects:
               statements:
               - set(resource.attributes["host.name"], attributes["hostname"]) where attributes["hostname"] != nil
               - set(body, attributes["message"]) where attributes["message"] != nil
+          transform/file_logs:
+            log_statements:
+            - context: log
+              statements:
+              - set(body, attributes) where IsMap(attributes)
+              - keep_keys(body, ["message", "severity", "properties"])
         exporters:
           debug:
             verbosity: detailed
@@ -97,9 +78,13 @@ objects:
               receivers: [otlp]
               processors: [batch]
               exporters: [debug]
-            logs:
+            logs/syslog:
               receivers: [syslog]
               processors: [batch, transform/syslog]
+              exporters: [debug]
+            logs/file:
+              receivers: [filelog]
+              processors: [batch, transform/file_logs]
               exporters: [debug]
           telemetry:
             logs:

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -77,9 +77,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
-  - name: NGINX_OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-logging-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -300,6 +298,27 @@ objects:
                     value: '1024'
                   - name: SPLUNK_MEMORY_TOTAL_MIB
                     value: $(TRACES_MEMORY_TOTAL_MIB)
+                  - name: LOGGING_HEC_URL
+                    value: ${LOGGING_HEC_URL}
+                  - name: LOGGING_HEC_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-hec-external
+                        key: token
+                  - name: LOGGING_SOURCE
+                    value: ${LOGGING_SOURCE}
+                  - name: LOGGING_SOURCE_TYPE
+                    value: ${LOGGING_SOURCE_TYPE}
+                  - name: K8S_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                  - name: K8S_POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.name
         - name: nginx-proxy
           replicas: ${{REPLICAS}}
           webServices:
@@ -331,7 +350,7 @@ objects:
             sidecars:
               - name: otel-collector
                 enabled: true
-                configMap: ${NGINX_OTEL_SIDECAR_CONFIG_MAP}
+                configMap: ${OTEL_SIDECAR_CONFIG_MAP}
                 image: ${OTEL_SIDECAR_IMAGE}
                 envVars:
                   - name: ENV_NAME
@@ -365,6 +384,11 @@ objects:
                       fieldRef:
                         apiVersion: v1
                         fieldPath: metadata.namespace
+                  - name: K8S_POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.name
 
   - kind: Service
     apiVersion: v1

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -96,7 +96,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -318,6 +318,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
           volumes:
             - name: logs
               emptyDir:

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -135,7 +135,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -487,6 +487,27 @@ objects:
                   value: '1024'
                 - name: SPLUNK_MEMORY_TOTAL_MIB
                   value: $(TRACES_MEMORY_TOTAL_MIB)
+                - name: LOGGING_HEC_URL
+                  value: ${LOGGING_HEC_URL}
+                - name: LOGGING_HEC_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: splunk-hec-external
+                      key: token
+                - name: LOGGING_SOURCE
+                  value: ${LOGGING_SOURCE}
+                - name: LOGGING_SOURCE_TYPE
+                  value: ${LOGGING_SOURCE_TYPE}
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.name
             volumes:
               - name: logs
                 emptyDir:

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -111,7 +111,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -301,6 +301,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
           volumes:
             - name: logs
               emptyDir:

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -135,7 +135,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -215,6 +215,27 @@ objects:
                     value: '1024'
                   - name: SPLUNK_MEMORY_TOTAL_MIB
                     value: $(TRACES_MEMORY_TOTAL_MIB)
+                  - name: LOGGING_HEC_URL
+                    value: ${LOGGING_HEC_URL}
+                  - name: LOGGING_HEC_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-hec-external
+                        key: token
+                  - name: LOGGING_SOURCE
+                    value: ${LOGGING_SOURCE}
+                  - name: LOGGING_SOURCE_TYPE
+                    value: ${LOGGING_SOURCE_TYPE}
+                  - name: K8S_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                  - name: K8S_POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.name
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}
@@ -437,6 +458,27 @@ objects:
                     value: '1024'
                   - name: SPLUNK_MEMORY_TOTAL_MIB
                     value: $(TRACES_MEMORY_TOTAL_MIB)
+                  - name: LOGGING_HEC_URL
+                    value: ${LOGGING_HEC_URL}
+                  - name: LOGGING_HEC_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-hec-external
+                        key: token
+                  - name: LOGGING_SOURCE
+                    value: ${LOGGING_SOURCE_RHEL}
+                  - name: LOGGING_SOURCE_TYPE
+                    value: ${LOGGING_SOURCE_TYPE}
+                  - name: K8S_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                  - name: K8S_POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.name
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -68,7 +68,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -229,6 +229,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
           volumes:
             - name: logs
               emptyDir:

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -64,7 +64,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -222,6 +222,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
 
 - apiVersion: v1
   kind: Secret

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -124,7 +124,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -379,6 +379,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
 
     jobs:
       - name: sync

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -257,7 +257,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -716,6 +716,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
 
     jobs:
       - name: tally

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -58,7 +58,7 @@ parameters:
   - name: OTEL_SIDECAR_IMAGE
     value: quay.io/signalfx/splunk-otel-collector:0.140.0
   - name: OTEL_SIDECAR_CONFIG_MAP
-    value: swatch-traces-otel-config
+    value: swatch-otel-config-v1
   - name: OTEL_SIDECAR_TRACES_CONFIG
     value: '/etc/otelcol/relay'
   - name: OTEL_ENV_NAME
@@ -255,6 +255,27 @@ objects:
                 value: '1024'
               - name: SPLUNK_MEMORY_TOTAL_MIB
                 value: $(TRACES_MEMORY_TOTAL_MIB)
+              - name: LOGGING_HEC_URL
+                value: ${LOGGING_HEC_URL}
+              - name: LOGGING_HEC_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: splunk-hec-external
+                    key: token
+              - name: LOGGING_SOURCE
+                value: ${LOGGING_SOURCE}
+              - name: LOGGING_SOURCE_TYPE
+                value: ${LOGGING_SOURCE_TYPE}
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
           volumes:
             - name: logs
               emptyDir:


### PR DESCRIPTION
Jira issue: SWATCH-4943

## Description
The config map swatch-otel-config-v1 is now coming from https://gitlab.cee.redhat.com/rhsm/swatch-otel-config which already includes logging (via syslog + file) and traces. I configured the LOGGING properties as long with the TRACES properties, but the LOGGING is only enabled for swatch-api, for the rest, it will be ignored.

## Testing
CI should be passing. 
Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/189722.