### PR TITLE
SWATCH-4796: Reset deduplication when custom threshold changes

### DIFF
--- a/docs/integration-test-plans/Notification Service Integration Test Plan.md
+++ b/docs/integration-test-plans/Notification Service Integration Test Plan.md
@@ -77,21 +77,6 @@ Limitation:
    - Deduplication fires for identical `product + metric + SLA + usage` combo.
    - A new notification is produced when SLA changes and when usage changes, confirming both are part of the deduplication key.
 
-## stage-notification-deduplication-TC003
-
-1. **Description:** Exercises the **preferences_hash** element of the deduplication key for custom threshold notifications. Updating the custom utilization threshold changes the `preferences_hash` embedded in the event, causing the deduplication key to differ so the user is re-notified even if the same utilization level was already notified this month.
-2. **Setup:**
-   - The organization is opted-in for custom threshold notifications (`exceeded-custom-utilization-threshold` event type).
-   - The organization has set a custom threshold at a value below current usage (e.g., 80% with usage at 85%).
-   - The organization has already received a custom threshold notification this calendar month.
-3. **Actions and Verifications (in sequence):**
-   1. Trigger the utilization sync job → verify first custom threshold notification is received with a non-null `preferences_hash` in the context.
-   2. Trigger the utilization sync job again (same usage, same threshold) → assert **no new notification** is received (deduplication suppresses the duplicate).
-   3. Update the custom threshold to a different value that is still below current usage (e.g., 79%) → trigger the sync → verify **a new notification is received** and its `preferences_hash` differs from the first notification's hash.
-4. **Expected Result:**
-   - Deduplication suppresses notifications when the custom threshold configuration is unchanged.
-   - A new notification is delivered after the threshold is updated, confirming that the `preferences_hash` change resets the deduplication key.
-
 ## test_over_usage_notification_requires_payg_sla_aligned_with_offering
 
 1. **Description:** Over-usage notifications for PAYG products require that the SLA of the PAYG usage aligns with the contract offering's SLA. Usage at a mismatched SLA tier must not trigger an alert, even if the volume exceeds capacity.

--- a/docs/integration-test-plans/Notification Service Integration Test Plan.md
+++ b/docs/integration-test-plans/Notification Service Integration Test Plan.md
@@ -77,6 +77,21 @@ Limitation:
    - Deduplication fires for identical `product + metric + SLA + usage` combo.
    - A new notification is produced when SLA changes and when usage changes, confirming both are part of the deduplication key.
 
+## stage-notification-deduplication-TC003
+
+1. **Description:** Exercises the **preferences_hash** element of the deduplication key for custom threshold notifications. Updating the custom utilization threshold changes the `preferences_hash` embedded in the event, causing the deduplication key to differ so the user is re-notified even if the same utilization level was already notified this month.
+2. **Setup:**
+   - The organization is opted-in for custom threshold notifications (`exceeded-custom-utilization-threshold` event type).
+   - The organization has set a custom threshold at a value below current usage (e.g., 80% with usage at 85%).
+   - The organization has already received a custom threshold notification this calendar month.
+3. **Actions and Verifications (in sequence):**
+   1. Trigger the utilization sync job → verify first custom threshold notification is received with a non-null `preferences_hash` in the context.
+   2. Trigger the utilization sync job again (same usage, same threshold) → assert **no new notification** is received (deduplication suppresses the duplicate).
+   3. Update the custom threshold to a different value that is still below current usage (e.g., 79%) → trigger the sync → verify **a new notification is received** and its `preferences_hash` differs from the first notification's hash.
+4. **Expected Result:**
+   - Deduplication suppresses notifications when the custom threshold configuration is unchanged.
+   - A new notification is delivered after the threshold is updated, confirming that the `preferences_hash` change resets the deduplication key.
+
 ## test_over_usage_notification_requires_payg_sla_aligned_with_offering
 
 1. **Description:** Over-usage notifications for PAYG products require that the SLA of the PAYG usage aligns with the contract offering's SLA. Usage at a mismatched SLA tier must not trigger an alert, even if the volume exceeds capacity.

--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -501,7 +501,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Wait for notification message on notifications topic
     - Verify notification payload
 - **Expected Result**:
-    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_modified_hash)
+    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and preferences_hash)
     - Notification action `severity` is `MODERATE`
 
 **custom-threshold-TC002 - Notification sent when utilization is exactly at custom threshold**
@@ -516,7 +516,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Wait for notification message on notifications topic
     - Verify notification payload
 - **Expected Result**:
-    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_modified_hash)
+    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and preferences_hash)
     - Notification action `severity` is `MODERATE`
     - Notification is sent (threshold comparison uses greater-than-or-equal)
 

--- a/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
+++ b/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
@@ -86,7 +86,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
             FULL_CAPACITY,
             null,
             null);
-    thenLastModifiedHashShouldBePresent(notification);
+    thenPreferencesHashShouldBePresent(notification);
   }
 
   @TestPlanName("custom-threshold-TC002")
@@ -108,7 +108,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
             FULL_CAPACITY,
             null,
             null);
-    thenLastModifiedHashShouldBePresent(notification);
+    thenPreferencesHashShouldBePresent(notification);
   }
 
   @TestPlanName("custom-threshold-TC003")
@@ -145,15 +145,17 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     whenUtilizationEventIsReceived();
 
-    thenThresholdNotificationShouldBeSent(
-        CUSTOM_THRESHOLD_EVENT_TYPE,
-        Severity.MODERATE,
-        utilizationSummary.getProductId(),
-        metricId,
-        USAGE_OVER_CAPACITY,
-        FULL_CAPACITY,
-        null,
-        null);
+    var customNotification =
+        thenThresholdNotificationShouldBeSent(
+            CUSTOM_THRESHOLD_EVENT_TYPE,
+            Severity.MODERATE,
+            utilizationSummary.getProductId(),
+            metricId,
+            USAGE_OVER_CAPACITY,
+            FULL_CAPACITY,
+            null,
+            null);
+    thenPreferencesHashShouldBePresent(customNotification);
     thenThresholdNotificationShouldBeSent(
         DEFAULT_THRESHOLD_EVENT_TYPE,
         Severity.IMPORTANT,
@@ -175,14 +177,9 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
     kafkaBridge.produceKafkaMessage(UTILIZATION, utilizationSummary);
   }
 
-  private void thenLastModifiedHashShouldBePresent(Action notification) {
+  private void thenPreferencesHashShouldBePresent(Action notification) {
     assertThat(
-        notification
-            .getEvents()
-            .get(0)
-            .getPayload()
-            .getAdditionalProperties()
-            .get("last_modified_hash"),
+        notification.getContext().getAdditionalProperties().get("preferences_hash"),
         notNullValue());
   }
 }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
@@ -40,7 +40,9 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.inject.Inject;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.UUID;
@@ -81,7 +83,7 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
     return false;
   }
 
-  protected abstract Optional<Event> evaluateThreshold(
+  protected abstract Optional<HandlerEvent> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement);
 
   protected abstract String eventType();
@@ -90,14 +92,10 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
 
   protected abstract String metricName();
 
-  protected Event buildEvent(double utilizationPercent) {
-    var event = new Event();
-    event.setMetadata(new Metadata());
-    event.setPayload(
-        new Payload.PayloadBuilder()
-            .withAdditionalProperty(
-                "utilization_percentage", String.format(PERCENT_FORMAT, utilizationPercent))
-            .build());
+  protected HandlerEvent buildEvent(double utilizationPercent) {
+    var event = new HandlerEvent();
+    event.addPayloadProperty(
+        "utilization_percentage", String.format(PERCENT_FORMAT, utilizationPercent));
     return event;
   }
 
@@ -156,7 +154,7 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
       MetricId metricId,
       String eventType,
       Severity severity,
-      Event event) {
+      HandlerEvent event) {
     var action = new Action();
     action.setBundle(BUNDLE);
     action.setApplication(APPLICATION);
@@ -164,14 +162,27 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
     action.setOrgId(payload.getOrgId());
     action.setTimestamp(LocalDateTime.now());
     action.setId(UUID.randomUUID());
-    action.setEvents(List.of(event));
+    action.setEvents(List.of(buildNotificationEvent(event)));
     action.setContext(buildContext(payload, metricId, event));
     action.setRecipients(List.of(buildRecipient()));
     action.setSeverity(severity.name());
     return action;
   }
 
-  private Context buildContext(UtilizationSummary payload, MetricId metricId, Event event) {
+  private Event buildNotificationEvent(HandlerEvent handlerEvent) {
+    Event event = new Event();
+    event.setMetadata(handlerEvent.metadata);
+
+    Payload.PayloadBuilder builder = new Payload.PayloadBuilder();
+    for (Map.Entry<String, String> entry : handlerEvent.payload.entrySet()) {
+      builder.withAdditionalProperty(entry.getKey(), entry.getValue());
+    }
+
+    event.setPayload(builder.build());
+    return event;
+  }
+
+  private Context buildContext(UtilizationSummary payload, MetricId metricId, HandlerEvent event) {
     Context.ContextBuilder builder =
         (Context.ContextBuilder)
             new Context.ContextBuilder()
@@ -188,14 +199,11 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
       builder.withAdditionalProperty("billing_account_id", payload.getBillingAccountId());
     }
 
-    addAdditionalContextProperties(builder, payload, metricId, event);
+    for (Map.Entry<String, String> entry : event.context.entrySet()) {
+      builder.withAdditionalProperty(entry.getKey(), entry.getValue());
+    }
 
     return builder.build();
-  }
-
-  protected void addAdditionalContextProperties(
-      Context.ContextBuilder builder, UtilizationSummary payload, MetricId metricId, Event event) {
-    // Default: no additional properties
   }
 
   protected void sendNotification(
@@ -203,7 +211,7 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
       MetricId metricId,
       String eventType,
       Severity severity,
-      Event event,
+      HandlerEvent event,
       String metricName) {
     var action = buildNotificationAction(payload, metricId, eventType, severity, event);
     incrementCounter(payload, metricId, metricName);
@@ -253,5 +261,19 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
     recipient.setIgnoreUserPreferences(IGNORE_USER_PREFERENCES);
     recipient.setUsers(List.of());
     return recipient;
+  }
+
+  protected static class HandlerEvent {
+    private final Metadata metadata = new Metadata();
+    private final Map<String, String> payload = new HashMap<>();
+    private final Map<String, String> context = new HashMap<>();
+
+    public void addPayloadProperty(String key, String value) {
+      payload.put(key, value);
+    }
+
+    public void addContextProperty(String key, String value) {
+      context.put(key, value);
+    }
   }
 }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/BaseThresholdUtilizationHandlerService.java
@@ -165,17 +165,18 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
     action.setTimestamp(LocalDateTime.now());
     action.setId(UUID.randomUUID());
     action.setEvents(List.of(event));
-    action.setContext(buildContext(payload, metricId));
+    action.setContext(buildContext(payload, metricId, event));
     action.setRecipients(List.of(buildRecipient()));
     action.setSeverity(severity.name());
     return action;
   }
 
-  private Context buildContext(UtilizationSummary payload, MetricId metricId) {
-    var builder =
-        new Context.ContextBuilder()
-            .withAdditionalProperty("product_id", payload.getProductId())
-            .withAdditionalProperty("metric_id", metricId.getValue());
+  private Context buildContext(UtilizationSummary payload, MetricId metricId, Event event) {
+    Context.ContextBuilder builder =
+        (Context.ContextBuilder)
+            new Context.ContextBuilder()
+                .withAdditionalProperty("product_id", payload.getProductId())
+                .withAdditionalProperty("metric_id", metricId.getValue());
 
     if (isServiceLevelSet(payload.getSla())) {
       builder.withAdditionalProperty("service_level", payload.getSla().value());
@@ -183,8 +184,18 @@ public abstract class BaseThresholdUtilizationHandlerService implements Utilizat
     if (isUsageSet(payload.getUsage())) {
       builder.withAdditionalProperty("usage", payload.getUsage().value());
     }
+    if (payload.getBillingAccountId() != null && !payload.getBillingAccountId().isEmpty()) {
+      builder.withAdditionalProperty("billing_account_id", payload.getBillingAccountId());
+    }
+
+    addAdditionalContextProperties(builder, payload, metricId, event);
 
     return builder.build();
+  }
+
+  protected void addAdditionalContextProperties(
+      Context.ContextBuilder builder, UtilizationSummary payload, MetricId metricId, Event event) {
+    // Default: no additional properties
   }
 
   protected void sendNotification(

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -20,7 +20,9 @@
  */
 package com.redhat.swatch.utilization.service;
 
+import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.utilization.model.Measurement;
 import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
@@ -37,6 +39,7 @@ public class CustomThresholdUtilizationHandlerService
     extends BaseThresholdUtilizationHandlerService {
 
   public static final String CUSTOM_THRESHOLD_METRIC = "swatch_utilization_custom_threshold";
+  public static final String PREFERENCES_HASH = "preferences_hash";
 
   static final String EVENT_TYPE = "exceeded-custom-utilization-threshold";
 
@@ -77,8 +80,10 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      String lastModifiedHash = hashLastModified(preference.getLastModified().toInstant());
-      event.getPayload().getAdditionalProperties().put("last_modified_hash", lastModifiedHash);
+      event
+          .getMetadata()
+          .getAdditionalProperties()
+          .put(LAST_MODIFIED_HASH, hashLastModified(preference.getLastModified().toInstant()));
       return Optional.of(event);
     }
 
@@ -98,6 +103,15 @@ public class CustomThresholdUtilizationHandlerService
   @Override
   protected String metricName() {
     return CUSTOM_THRESHOLD_METRIC;
+  }
+
+  @Override
+  protected void addAdditionalContextProperties(
+      Context.ContextBuilder builder, UtilizationSummary payload, MetricId metricId, Event event) {
+    String hash = (String) event.getMetadata().getAdditionalProperties().get(LAST_MODIFIED_HASH);
+    if (hash != null) {
+      builder.withAdditionalProperty(LAST_MODIFIED_HASH, hash);
+    }
   }
 
   static String hashLastModified(Instant lastModified) {

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -20,9 +20,6 @@
  */
 package com.redhat.swatch.utilization.service;
 
-import com.redhat.cloud.notifications.ingress.Context;
-import com.redhat.cloud.notifications.ingress.Event;
-import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.utilization.model.Measurement;
 import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
@@ -47,7 +44,7 @@ public class CustomThresholdUtilizationHandlerService
   @Inject CustomThresholdValidator customThresholdValidator;
 
   @Override
-  protected Optional<Event> evaluateThreshold(
+  protected Optional<HandlerEvent> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement) {
     var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
     // In SWATCH-4990, we need to remove this condition, so all orgs are opted in.
@@ -80,10 +77,8 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      event
-          .getMetadata()
-          .getAdditionalProperties()
-          .put(LAST_MODIFIED_HASH, hashLastModified(preference.getLastModified().toInstant()));
+      event.addContextProperty(
+          PREFERENCES_HASH, hashLastModified(preference.getLastModified().toInstant()));
       return Optional.of(event);
     }
 
@@ -103,15 +98,6 @@ public class CustomThresholdUtilizationHandlerService
   @Override
   protected String metricName() {
     return CUSTOM_THRESHOLD_METRIC;
-  }
-
-  @Override
-  protected void addAdditionalContextProperties(
-      Context.ContextBuilder builder, UtilizationSummary payload, MetricId metricId, Event event) {
-    String hash = (String) event.getMetadata().getAdditionalProperties().get(LAST_MODIFIED_HASH);
-    if (hash != null) {
-      builder.withAdditionalProperty(LAST_MODIFIED_HASH, hash);
-    }
   }
 
   static String hashLastModified(Instant lastModified) {

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
@@ -20,7 +20,6 @@
  */
 package com.redhat.swatch.utilization.service;
 
-import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.swatch.utilization.model.Measurement;
 import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
@@ -37,7 +36,7 @@ public class OverThresholdUtilizationHandlerService extends BaseThresholdUtiliza
   static final String EVENT_TYPE = "exceeded-utilization-threshold";
 
   @Override
-  protected Optional<Event> evaluateThreshold(
+  protected Optional<HandlerEvent> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement) {
     double overUsageThreshold = getOverUsageThresholdForProduct(payload.getProductId());
     if (overUsageThreshold < 0.0) {

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
@@ -22,9 +22,11 @@ package com.redhat.swatch.utilization.service;
 
 import static com.redhat.swatch.utilization.service.CustomThresholdUtilizationHandlerService.CUSTOM_THRESHOLD_METRIC;
 import static com.redhat.swatch.utilization.service.CustomThresholdUtilizationHandlerService.EVENT_TYPE;
+import static com.redhat.swatch.utilization.service.CustomThresholdUtilizationHandlerService.PREFERENCES_HASH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
@@ -45,6 +47,7 @@ import io.micrometer.core.instrument.search.Search;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -230,7 +233,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
   }
 
   @Test
-  void shouldIncludeLastModifiedHashInPayload() {
+  void shouldIncludePreferencesHashInContext() {
     givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
@@ -240,16 +243,37 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
     var captor = ArgumentCaptor.forClass(Action.class);
     verify(notificationsProducer, times(1)).produce(captor.capture());
-    Action action = captor.getValue();
-
-    var eventPayload = action.getEvents().get(0).getPayload().getAdditionalProperties();
-    String expectedHash =
-        CustomThresholdUtilizationHandlerService.hashLastModified(LAST_MODIFIED.toInstant());
-    assertEquals(expectedHash, eventPayload.get("last_modified_hash"));
+    var context = captor.getValue().getContext().getAdditionalProperties();
+    assertNotNull(context.get(PREFERENCES_HASH), PREFERENCES_HASH + " must be present in context");
   }
 
   @Test
-  void shouldProduceDifferentHash_whenLastModifiedChanges() {
+  void shouldProduceSameHash_whenThresholdUnchanged() {
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
+    UtilizationSummary summary =
+        givenUtilizationSummary(
+            PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
+    whenCheckSummary(summary);
+
+    var captor = ArgumentCaptor.forClass(Action.class);
+    verify(notificationsProducer, times(1)).produce(captor.capture());
+    String firstHash =
+        (String) captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH);
+
+    Mockito.reset(notificationsProducer);
+    whenCheckSummary(summary);
+
+    verify(notificationsProducer, times(1)).produce(captor.capture());
+    String secondHash =
+        (String) captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH);
+
+    assertNotNull(firstHash);
+    assertNotNull(secondHash);
+    assertEquals(firstHash, secondHash, "Same preference state should produce same hash");
+  }
+
+  @Test
+  void shouldProduceDifferentHash_whenPreferenceIsUpdated() {
     var later = OffsetDateTime.of(2026, 4, 21, 10, 0, 0, 0, ZoneOffset.UTC);
 
     givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
@@ -261,14 +285,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
     var captor = ArgumentCaptor.forClass(Action.class);
     verify(notificationsProducer, times(1)).produce(captor.capture());
     String firstHash =
-        (String)
-            captor
-                .getValue()
-                .getEvents()
-                .get(0)
-                .getPayload()
-                .getAdditionalProperties()
-                .get("last_modified_hash");
+        (String) captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH);
 
     Mockito.reset(notificationsProducer);
     givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, later);
@@ -276,18 +293,11 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
     verify(notificationsProducer, times(1)).produce(captor.capture());
     String secondHash =
-        (String)
-            captor
-                .getValue()
-                .getEvents()
-                .get(0)
-                .getPayload()
-                .getAdditionalProperties()
-                .get("last_modified_hash");
+        (String) captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH);
 
     assertNotNull(firstHash);
     assertNotNull(secondHash);
-    assertNotEquals(firstHash, secondHash);
+    assertNotEquals(firstHash, secondHash, "Updated preference should produce a different hash");
   }
 
   @Test
@@ -441,6 +451,25 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID, sla, usage);
     assertEquals(EXPECTED_SINGLE_INCREMENT, count);
+  }
+
+  @Test
+  void hashLastModified_shouldProduceConsistentResults() {
+    Instant timestamp = Instant.parse("2026-05-27T14:30:00Z");
+    String hash1 = CustomThresholdUtilizationHandlerService.hashLastModified(timestamp);
+    String hash2 = CustomThresholdUtilizationHandlerService.hashLastModified(timestamp);
+
+    assertEquals(hash1, hash2, "Same timestamp should always produce same hash");
+  }
+
+  @Test
+  void hashLastModified_shouldProduceLowercaseHexString() {
+    Instant timestamp = Instant.parse("2026-05-27T14:30:00Z");
+    String hash = CustomThresholdUtilizationHandlerService.hashLastModified(timestamp);
+
+    assertNotNull(hash);
+    assertEquals(64, hash.length(), "SHA-256 hash should be 64 hex characters");
+    assertTrue(hash.matches("^[a-f0-9]+$"), "Hash should be lowercase hexadecimal");
   }
 
   // Helper methods

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerServiceTest.java
@@ -125,7 +125,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -139,7 +139,7 @@ class OverThresholdUtilizationHandlerServiceTest {
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -170,7 +170,7 @@ class OverThresholdUtilizationHandlerServiceTest {
                         .withUnlimited(false)));
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - each measurement creates its own counter, check cores counter
     double coresCount = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -210,7 +210,7 @@ class OverThresholdUtilizationHandlerServiceTest {
                         .withUnlimited(false)));
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - only instance hours should be incremented
     double coresCount = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -231,7 +231,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     verify(notificationsProducer, times(1))
@@ -246,7 +246,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     var captor = ArgumentCaptor.forClass(Action.class);
@@ -265,7 +265,7 @@ class OverThresholdUtilizationHandlerServiceTest {
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     verify(notificationsProducer, never()).produce(any(Action.class));
@@ -293,7 +293,7 @@ class OverThresholdUtilizationHandlerServiceTest {
                         .withUnlimited(false)));
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - should send one notification per measurement
     verify(notificationsProducer, times(2))
@@ -312,7 +312,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_PRODUCT_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - should NOT increment because 7% < 8% product threshold
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -337,7 +337,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_ABOVE_DEFAULT_THRESHOLD);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - should increment because 6% > 5% default threshold
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -362,7 +362,7 @@ class OverThresholdUtilizationHandlerServiceTest {
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, usage);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then - should NOT increment because negative threshold disables detection
     double count = getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID);
@@ -421,7 +421,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             .withUsage(usage);
 
     // When
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     // Then
     var captor = ArgumentCaptor.forClass(Action.class);
@@ -443,7 +443,7 @@ class OverThresholdUtilizationHandlerServiceTest {
     UtilizationSummary summary =
         givenUtilizationSummary(NON_PAYG_PRODUCT_ID, SOCKETS_METRIC_ID, 2.0, 1.0, 31.0);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, never()).produce(any(Action.class));
   }
@@ -454,7 +454,7 @@ class OverThresholdUtilizationHandlerServiceTest {
     UtilizationSummary summary =
         givenUtilizationSummary(NON_PAYG_PRODUCT_ID, SOCKETS_METRIC_ID, 2.0, 3.0, 93.0);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, times(1))
         .produce(argThat(action -> EVENT_TYPE.equals(action.getEventType())));
@@ -467,7 +467,7 @@ class OverThresholdUtilizationHandlerServiceTest {
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, 4.0, USAGE_EXCEEDING_THRESHOLD);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, times(1))
         .produce(argThat(action -> EVENT_TYPE.equals(action.getEventType())));
@@ -480,7 +480,7 @@ class OverThresholdUtilizationHandlerServiceTest {
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_MIXED_PRODUCT_ID, MANAGED_NODES_METRIC_ID, 10.0, 5.0, 150.0);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, never()).produce(any(Action.class));
   }
@@ -497,7 +497,7 @@ class OverThresholdUtilizationHandlerServiceTest {
             4.0,
             USAGE_EXCEEDING_THRESHOLD);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, times(1))
         .produce(argThat(action -> EVENT_TYPE.equals(action.getEventType())));
@@ -509,7 +509,7 @@ class OverThresholdUtilizationHandlerServiceTest {
     UtilizationSummary summary =
         givenUtilizationSummary(NON_PAYG_PRODUCT_ID, "Unknown-metric", 2.0, 1.0, 500.0);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, never()).produce(any(Action.class));
   }
@@ -520,7 +520,7 @@ class OverThresholdUtilizationHandlerServiceTest {
     UtilizationSummary summary =
         givenUtilizationSummary("totally-unknown-product", SOCKETS_METRIC_ID, 2.0, 1.0, 500.0);
 
-    whenCheckSummary(summary);
+    whenHandleSummary(summary);
 
     verify(notificationsProducer, never()).produce(any(Action.class));
   }
@@ -547,7 +547,7 @@ class OverThresholdUtilizationHandlerServiceTest {
                     .withUnlimited(false)));
   }
 
-  private void whenCheckSummary(UtilizationSummary summary) {
+  private void whenHandleSummary(UtilizationSummary summary) {
     for (Measurement measurement : summary.getMeasurements()) {
       service.handle(summary, measurement);
     }


### PR DESCRIPTION
Jira issue: [SWATCH-4796](https://redhat.atlassian.net/browse/SWATCH-4796)

## Description

When an org admin updates their custom utilization threshold, the deduplication
logic in notifications-backend should treat the next notification as a new event,
so the user is re-notified

- Adds `billing_account_id` to the notification event context. This field was already part of the deduplication key in notifications-backend but was never being sent, causing events for different billing accounts to collide in the
  dedup table.
- Adds a `preferences_hash` (SHA-256 of `OrgUtilizationPreference.lastUpdated`)   to the event context for `exceeded-custom-utilization-threshold` events only.   When the threshold changes, `lastUpdated` changes, the hash changes, and the  deduplication key in notifications-backend becomes distinct — resetting
  deduplication for that org.



[SWATCH-4796]: https://redhat.atlassian.net/browse/SWATCH-4796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ