### PR TITLE
SWATCH-4943: Rename SPLUNK_OBSERVABILITY_ACCESS_TOKEN to TRACES_ACCESS_TOKEN

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -287,7 +287,7 @@ objects:
                     value: ${OTEL_ENV_NAME}
                   - name: K8S_CLUSTER_NAME
                     value: ${OTEL_K8S_CLUSTER_NAME}
-                  - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+                  - name: TRACES_ACCESS_TOKEN
                     valueFrom:
                       secretKeyRef:
                         name: ${OTEL_TRACES_TOKEN_SECRET_NAME}
@@ -357,7 +357,7 @@ objects:
                     value: ${OTEL_ENV_NAME}
                   - name: K8S_CLUSTER_NAME
                     value: ${OTEL_K8S_CLUSTER_NAME}
-                  - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+                  - name: TRACES_ACCESS_TOKEN
                     valueFrom:
                       secretKeyRef:
                         name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -307,7 +307,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -476,7 +476,7 @@ objects:
                   value: ${OTEL_ENV_NAME}
                 - name: K8S_CLUSTER_NAME
                   value: ${OTEL_K8S_CLUSTER_NAME}
-                - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+                - name: TRACES_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -290,7 +290,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -204,7 +204,7 @@ objects:
                     value: ${OTEL_ENV_NAME}
                   - name: K8S_CLUSTER_NAME
                     value: ${OTEL_K8S_CLUSTER_NAME}
-                  - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+                  - name: TRACES_ACCESS_TOKEN
                     valueFrom:
                       secretKeyRef:
                         name: ${OTEL_TRACES_TOKEN_SECRET_NAME}
@@ -447,7 +447,7 @@ objects:
                     value: ${OTEL_ENV_NAME}-rhel
                   - name: K8S_CLUSTER_NAME
                     value: ${OTEL_K8S_CLUSTER_NAME}
-                  - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+                  - name: TRACES_ACCESS_TOKEN
                     valueFrom:
                       secretKeyRef:
                         name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -218,7 +218,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -211,7 +211,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -368,7 +368,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -705,7 +705,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -244,7 +244,7 @@ objects:
                 value: ${OTEL_ENV_NAME}
               - name: K8S_CLUSTER_NAME
                 value: ${OTEL_K8S_CLUSTER_NAME}
-              - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+              - name: TRACES_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: ${OTEL_TRACES_TOKEN_SECRET_NAME}


### PR DESCRIPTION
Jira issue: SWATCH-4943

## Description
The clowdapp's were using the old env var which made the traces not working in stage. 