### PR TITLE
SWATCH-4943: Fix logging for Spring Boot services + remove unused SPLUNK_MEMORY_TOTAL_MIB

### DIFF
--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -296,8 +296,6 @@ objects:
                     value: ${OTEL_SIDECAR_TRACES_CONFIG}
                   - name: TRACES_MEMORY_TOTAL_MIB
                     value: '1024'
-                  - name: SPLUNK_MEMORY_TOTAL_MIB
-                    value: $(TRACES_MEMORY_TOTAL_MIB)
                   - name: LOGGING_HEC_URL
                     value: ${LOGGING_HEC_URL}
                   - name: LOGGING_HEC_TOKEN
@@ -366,8 +364,6 @@ objects:
                     value: ${OTEL_SIDECAR_TRACES_CONFIG}
                   - name: TRACES_MEMORY_TOTAL_MIB
                     value: '1024'
-                  - name: SPLUNK_MEMORY_TOTAL_MIB
-                    value: $(TRACES_MEMORY_TOTAL_MIB)
                   - name: LOGGING_HEC_URL
                     value: ${LOGGING_HEC_URL}
                   - name: LOGGING_HEC_TOKEN

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -316,8 +316,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -485,8 +485,6 @@ objects:
                   value: ${OTEL_SIDECAR_TRACES_CONFIG}
                 - name: TRACES_MEMORY_TOTAL_MIB
                   value: '1024'
-                - name: SPLUNK_MEMORY_TOTAL_MIB
-                  value: $(TRACES_MEMORY_TOTAL_MIB)
                 - name: LOGGING_HEC_URL
                   value: ${LOGGING_HEC_URL}
                 - name: LOGGING_HEC_TOKEN

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/logback/RhsmSplunkHecEventHeaderSerializer.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/logback/RhsmSplunkHecEventHeaderSerializer.java
@@ -46,7 +46,7 @@ public class RhsmSplunkHecEventHeaderSerializer implements EventHeaderSerializer
      * at a point in the startup lifecycle where putting it into a @Bean configurable via
      * application properties wasn't a straightforward solution.
      */
-    fields.put("namespace", System.getenv("SPLUNKMETA_namespace"));
+    fields.put("namespace", System.getenv("LOGGING_NAMESPACE"));
 
     return metadata;
   }

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -299,8 +299,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -213,8 +213,6 @@ objects:
                     value: ${OTEL_SIDECAR_TRACES_CONFIG}
                   - name: TRACES_MEMORY_TOTAL_MIB
                     value: '1024'
-                  - name: SPLUNK_MEMORY_TOTAL_MIB
-                    value: $(TRACES_MEMORY_TOTAL_MIB)
                   - name: LOGGING_HEC_URL
                     value: ${LOGGING_HEC_URL}
                   - name: LOGGING_HEC_TOKEN
@@ -456,8 +454,6 @@ objects:
                     value: ${OTEL_SIDECAR_TRACES_CONFIG}
                   - name: TRACES_MEMORY_TOTAL_MIB
                     value: '1024'
-                  - name: SPLUNK_MEMORY_TOTAL_MIB
-                    value: $(TRACES_MEMORY_TOTAL_MIB)
                   - name: LOGGING_HEC_URL
                     value: ${LOGGING_HEC_URL}
                   - name: LOGGING_HEC_TOKEN

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -227,8 +227,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -220,8 +220,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -377,8 +377,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -714,8 +714,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -253,8 +253,6 @@ objects:
                 value: ${OTEL_SIDECAR_TRACES_CONFIG}
               - name: TRACES_MEMORY_TOTAL_MIB
                 value: '1024'
-              - name: SPLUNK_MEMORY_TOTAL_MIB
-                value: $(TRACES_MEMORY_TOTAL_MIB)
               - name: LOGGING_HEC_URL
                 value: ${LOGGING_HEC_URL}
               - name: LOGGING_HEC_TOKEN


### PR DESCRIPTION
Jira issue: SWATCH-4943

## Changes:
- In https://github.com/RedHatInsights/rhsm-subscriptions/pull/6174, the property `SPLUNKMETA_namespace` was renamed to `LOGGING_NAMESPACE`, but we missed to also update RhsmSplunkHecEventHeaderSerializer.java to populate the namespace field. 
- Remove the unused property `SPLUNK_MEMORY_TOTAL_MIB`. 
