### PR TITLE
SWATCH-4803: Refactor custom threshold handler logic

### DIFF
--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -21,6 +21,7 @@
 package tests;
 
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContractsInOrgId;
+import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static java.util.Collections.disjoint;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -31,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static utils.DateUtils.assertDatesAreEqual;
 
 import api.PartnerApiStubs;
 import com.redhat.swatch.component.tests.api.TestPlanName;

--- a/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
@@ -21,6 +21,7 @@
 package tests;
 
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
+import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static domain.Contract.buildRosaContract;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -34,7 +35,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static utils.DateUtils.assertDatesAreEqual;
 
 import api.ContractsArtemisService;
 import com.redhat.swatch.component.tests.api.Artemis;

--- a/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
@@ -22,6 +22,7 @@ package tests;
 
 import static api.CanonicalMessageArtemisSender.SUBSCRIPTION_CHANNEL;
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
+import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static com.redhat.swatch.contract.product.umb.UmbSubscription.convertToUtc;
 import static domain.Contract.buildRosaContract;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static utils.DateUtils.assertDatesAreEqual;
 
 import api.ContractsArtemisService;
 import com.redhat.swatch.component.tests.api.Artemis;

--- a/swatch-contracts/ct/java/tests/SubscriptionsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsTerminationComponentTest.java
@@ -20,8 +20,8 @@
  */
 package tests;
 
+import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static utils.DateUtils.assertDatesAreEqual;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import domain.Subscription;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/DateUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/DateUtils.java
@@ -18,7 +18,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package utils;
+package com.redhat.swatch.component.tests.utils;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -403,11 +403,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify response status code is 200
     - Verify response contains custom_threshold field
-    - Verify response last_updated is absent (field omitted; org has no persisted preferences)
+    - Verify response last_modified is absent (field omitted; org has no persisted preferences)
 - **Expected Result**:
     - HTTP 200 response
     - Response contains custom_threshold matching system default (ORG_PREFERENCE_DEFAULT_THRESHOLD config property)
-    - last_updated is absent (omitted from response body)
+    - last_modified is absent (omitted from response body)
 
 **org-preferences-TC002 - Update organization threshold preferences**
 
@@ -419,11 +419,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify response status code is 200
     - Verify response contains the persisted custom_threshold value
-    - Verify response contains last_updated (UTC timestamp of persistence)
+    - Verify response contains last_modified (UTC timestamp of persistence)
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the value from request body
-    - Response last_updated is present and matches the value returned by subsequent GET
+    - Response last_modified is present and matches the value returned by subsequent GET
 
 **org-preferences-TC003 - Retrieve custom threshold after update**
 
@@ -436,11 +436,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify GET response status code is 200
     - Verify GET response contains the previously configured custom_threshold
-    - Verify GET response contains last_updated
+    - Verify GET response contains last_modified
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the value set in previous POST request (not the system default)
-    - Response last_updated is present
+    - Response last_modified is present
 
 **org-preferences-TC004 - Update existing custom threshold**
 
@@ -453,11 +453,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Call GET /api/rhsm-subscriptions/v1/utilization/org-preferences to verify
 - **Verification**:
     - Verify final GET response returns the updated threshold value
-    - Verify final GET response contains last_updated reflecting the latest update
+    - Verify final GET response contains last_modified reflecting the latest update
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the second POST request value (not the first)
-    - Response last_updated is present
+    - Response last_modified is present
 
 **org-preferences-TC005 - Reject invalid threshold values**
 
@@ -485,7 +485,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Expected Result**:
     - HTTP 200 response for both 0 and 100 threshold values
     - Response custom_threshold matches request value
-    - Response last_updated is present for each successful POST
+    - Response last_modified is present for each successful POST
 
 ## Custom Usage Threshold Notification
 
@@ -501,7 +501,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Wait for notification message on notifications topic
     - Verify notification payload
 - **Expected Result**:
-    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_updated_hash)
+    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_modified_hash)
     - Notification action `severity` is `MODERATE`
 
 **custom-threshold-TC002 - Notification sent when utilization is exactly at custom threshold**
@@ -516,7 +516,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Wait for notification message on notifications topic
     - Verify notification payload
 - **Expected Result**:
-    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_updated_hash)
+    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage and last_modified_hash)
     - Notification action `severity` is `MODERATE`
     - Notification is sent (threshold comparison uses greater-than-or-equal)
 

--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -403,9 +403,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify response status code is 200
     - Verify response contains custom_threshold field
+    - Verify response last_updated is absent (field omitted; org has no persisted preferences)
 - **Expected Result**:
     - HTTP 200 response
     - Response contains custom_threshold matching system default (ORG_PREFERENCE_DEFAULT_THRESHOLD config property)
+    - last_updated is absent (omitted from response body)
 
 **org-preferences-TC002 - Update organization threshold preferences**
 
@@ -417,9 +419,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify response status code is 200
     - Verify response contains the persisted custom_threshold value
+    - Verify response contains last_updated (UTC timestamp of persistence)
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the value from request body
+    - Response last_updated is present and matches the value returned by subsequent GET
 
 **org-preferences-TC003 - Retrieve custom threshold after update**
 
@@ -432,9 +436,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Verification**:
     - Verify GET response status code is 200
     - Verify GET response contains the previously configured custom_threshold
+    - Verify GET response contains last_updated
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the value set in previous POST request (not the system default)
+    - Response last_updated is present
 
 **org-preferences-TC004 - Update existing custom threshold**
 
@@ -447,9 +453,11 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Call GET /api/rhsm-subscriptions/v1/utilization/org-preferences to verify
 - **Verification**:
     - Verify final GET response returns the updated threshold value
+    - Verify final GET response contains last_updated reflecting the latest update
 - **Expected Result**:
     - HTTP 200 response
     - Response custom_threshold matches the second POST request value (not the first)
+    - Response last_updated is present
 
 **org-preferences-TC005 - Reject invalid threshold values**
 
@@ -477,6 +485,7 @@ Additional cases can be added under the same `utilization-notifications-featuref
 - **Expected Result**:
     - HTTP 200 response for both 0 and 100 threshold values
     - Response custom_threshold matches request value
+    - Response last_updated is present for each successful POST
 
 ## Custom Usage Threshold Notification
 

--- a/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
+++ b/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
@@ -86,7 +86,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
             FULL_CAPACITY,
             null,
             null);
-    thenLastUpdatedHashShouldBePresent(notification);
+    thenLastModifiedHashShouldBePresent(notification);
   }
 
   @TestPlanName("custom-threshold-TC002")
@@ -108,7 +108,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
             FULL_CAPACITY,
             null,
             null);
-    thenLastUpdatedHashShouldBePresent(notification);
+    thenLastModifiedHashShouldBePresent(notification);
   }
 
   @TestPlanName("custom-threshold-TC003")
@@ -175,14 +175,14 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
     kafkaBridge.produceKafkaMessage(UTILIZATION, utilizationSummary);
   }
 
-  private void thenLastUpdatedHashShouldBePresent(Action notification) {
+  private void thenLastModifiedHashShouldBePresent(Action notification) {
     assertThat(
         notification
             .getEvents()
             .get(0)
             .getPayload()
             .getAdditionalProperties()
-            .get("last_updated_hash"),
+            .get("last_modified_hash"),
         notNullValue());
   }
 }

--- a/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
@@ -20,8 +20,10 @@
  */
 package tests;
 
+import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
@@ -43,13 +45,15 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
     // When: Retrieving org preferences
     OrgPreferencesResponse response = whenGetOrgPreferences();
 
-    // Then: Response contains system default threshold
+    // Then: Response contains system default threshold and no last_updated
     assertNotNull(response, "Response should not be null");
     assertNotNull(response.getCustomThreshold(), "Custom threshold should not be null");
     assertEquals(
         DEFAULT_THRESHOLD,
         response.getCustomThreshold(),
         "Should return system default threshold when org has no custom preferences");
+    assertNull(
+        response.getLastUpdated(), "last_updated should be absent when using default threshold");
   }
 
   @TestPlanName("org-preferences-TC002")
@@ -67,11 +71,13 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         customThreshold,
         postResponse.getCustomThreshold(),
         "POST response should contain custom threshold");
+    assertNotNull(postResponse.getLastUpdated(), "POST response should contain last_updated");
 
     // Verify persistence by retrieving
     OrgPreferencesResponse getResponse = whenGetOrgPreferences();
     assertEquals(
         customThreshold, getResponse.getCustomThreshold(), "GET should return persisted value");
+    assertDatesAreEqual(postResponse.getLastUpdated(), getResponse.getLastUpdated());
   }
 
   @TestPlanName("org-preferences-TC003")
@@ -90,6 +96,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         customThreshold,
         response.getCustomThreshold(),
         "Should return custom threshold, not system default");
+    assertNotNull(response.getLastUpdated(), "Should return last_updated for configured org");
   }
 
   @TestPlanName("org-preferences-TC004")
@@ -109,6 +116,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         updatedThreshold,
         response.getCustomThreshold(),
         "Should return updated threshold, not initial threshold");
+    assertNotNull(response.getLastUpdated(), "Should return last_updated after update");
   }
 
   @TestPlanName("org-preferences-TC005")

--- a/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
@@ -45,7 +45,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
     // When: Retrieving org preferences
     OrgPreferencesResponse response = whenGetOrgPreferences();
 
-    // Then: Response contains system default threshold and no last_updated
+    // Then: Response contains system default threshold and no last_modified
     assertNotNull(response, "Response should not be null");
     assertNotNull(response.getCustomThreshold(), "Custom threshold should not be null");
     assertEquals(
@@ -53,7 +53,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         response.getCustomThreshold(),
         "Should return system default threshold when org has no custom preferences");
     assertNull(
-        response.getLastUpdated(), "last_updated should be absent when using default threshold");
+        response.getLastModified(), "last_modified should be absent when using default threshold");
   }
 
   @TestPlanName("org-preferences-TC002")
@@ -71,13 +71,13 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         customThreshold,
         postResponse.getCustomThreshold(),
         "POST response should contain custom threshold");
-    assertNotNull(postResponse.getLastUpdated(), "POST response should contain last_updated");
+    assertNotNull(postResponse.getLastModified(), "POST response should contain last_modified");
 
     // Verify persistence by retrieving
     OrgPreferencesResponse getResponse = whenGetOrgPreferences();
     assertEquals(
         customThreshold, getResponse.getCustomThreshold(), "GET should return persisted value");
-    assertDatesAreEqual(postResponse.getLastUpdated(), getResponse.getLastUpdated());
+    assertDatesAreEqual(postResponse.getLastModified(), getResponse.getLastModified());
   }
 
   @TestPlanName("org-preferences-TC003")
@@ -96,7 +96,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         customThreshold,
         response.getCustomThreshold(),
         "Should return custom threshold, not system default");
-    assertNotNull(response.getLastUpdated(), "Should return last_updated for configured org");
+    assertNotNull(response.getLastModified(), "Should return last_modified for configured org");
   }
 
   @TestPlanName("org-preferences-TC004")
@@ -116,7 +116,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
         updatedThreshold,
         response.getCustomThreshold(),
         "Should return updated threshold, not initial threshold");
-    assertNotNull(response.getLastUpdated(), "Should return last_updated after update");
+    assertNotNull(response.getLastModified(), "Should return last_modified after update");
   }
 
   @TestPlanName("org-preferences-TC005")
@@ -159,6 +159,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
 
     // Then: Request is accepted and returns boundary value
     assertEquals(0, response.getCustomThreshold(), "Should accept threshold value 0");
+    assertNotNull(response.getLastModified(), "POST response should contain last_modified");
   }
 
   @TestPlanName("org-preferences-TC006")
@@ -171,6 +172,7 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
 
     // Then: Request is accepted and returns boundary value
     assertEquals(100, response.getCustomThreshold(), "Should accept threshold value 100");
+    assertNotNull(response.getLastModified(), "POST response should contain last_modified");
   }
 
   private OrgPreferencesResponse whenGetOrgPreferences() {

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -26,7 +26,7 @@ import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -48,7 +48,7 @@ public class CustomThresholdUtilizationHandlerService
       double utilizationPercent, UtilizationSummary payload, Measurement measurement) {
     var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
     // In SWATCH-4990, we need to remove this condition, so all orgs are opted in.
-    if (preference.getLastUpdated() == null) {
+    if (preference.getLastModified() == null) {
       log.debug(
           "No org preference found for orgId={}, skipping custom threshold check",
           payload.getOrgId());
@@ -77,8 +77,8 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      String lastUpdatedHash = hashLastUpdated(preference.getLastUpdated());
-      event.getPayload().getAdditionalProperties().put("last_updated_hash", lastUpdatedHash);
+      String lastModifiedHash = hashLastModified(preference.getLastModified().toInstant());
+      event.getPayload().getAdditionalProperties().put("last_modified_hash", lastModifiedHash);
       return Optional.of(event);
     }
 
@@ -100,9 +100,8 @@ public class CustomThresholdUtilizationHandlerService
     return CUSTOM_THRESHOLD_METRIC;
   }
 
-  static String hashLastUpdated(OffsetDateTime lastUpdated) {
-    var instant = lastUpdated.toInstant();
-    String canonicalTimestamp = instant.getEpochSecond() + ":" + instant.getNano();
+  static String hashLastModified(Instant lastModified) {
+    String canonicalTimestamp = lastModified.getEpochSecond() + ":" + lastModified.getNano();
     return DigestUtils.sha256Hex(canonicalTimestamp);
   }
 }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -21,13 +21,12 @@
 package com.redhat.swatch.utilization.service;
 
 import com.redhat.cloud.notifications.ingress.Event;
-import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceRepository;
 import com.redhat.swatch.utilization.model.Measurement;
 import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -41,21 +40,31 @@ public class CustomThresholdUtilizationHandlerService
 
   static final String EVENT_TYPE = "exceeded-custom-utilization-threshold";
 
-  @Inject OrgUtilizationPreferenceRepository preferenceRepository;
+  @Inject OrgPreferencesService orgPreferencesService;
+  @Inject CustomThresholdValidator customThresholdValidator;
 
   @Override
   protected Optional<Event> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement) {
-    var preferenceOpt = preferenceRepository.getPreferences(payload.getOrgId());
-    if (preferenceOpt.isEmpty()) {
+    var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
+    // In SWATCH-4990, we need to remove this condition, so all orgs are opted in.
+    if (preference.getLastUpdated() == null) {
       log.debug(
           "No org preference found for orgId={}, skipping custom threshold check",
           payload.getOrgId());
       return Optional.empty();
     }
 
-    var preference = preferenceOpt.get();
     int threshold = preference.getCustomThreshold();
+    if (!customThresholdValidator.isValid(threshold)) {
+      int defaultThreshold = orgPreferencesService.getDefaultThreshold();
+      log.warn(
+          "Retrieved invalid custom threshold '{}'. OrgId: {}. Using default threshold '{}'.",
+          threshold,
+          payload.getOrgId(),
+          defaultThreshold);
+      threshold = defaultThreshold;
+    }
 
     if (utilizationPercent >= threshold) {
       log.info(
@@ -68,7 +77,7 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      String lastUpdatedHash = hashLastUpdated(preference.getLastModified());
+      String lastUpdatedHash = hashLastUpdated(preference.getLastUpdated());
       event.getPayload().getAdditionalProperties().put("last_updated_hash", lastUpdatedHash);
       return Optional.of(event);
     }
@@ -91,8 +100,9 @@ public class CustomThresholdUtilizationHandlerService
     return CUSTOM_THRESHOLD_METRIC;
   }
 
-  static String hashLastUpdated(Instant lastUpdated) {
-    String canonicalTimestamp = lastUpdated.getEpochSecond() + ":" + lastUpdated.getNano();
+  static String hashLastUpdated(OffsetDateTime lastUpdated) {
+    var instant = lastUpdated.toInstant();
+    String canonicalTimestamp = instant.getEpochSecond() + ":" + instant.getNano();
     return DigestUtils.sha256Hex(canonicalTimestamp);
   }
 }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdValidator.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdValidator.java
@@ -18,11 +18,21 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.utilization.data;
+package com.redhat.swatch.utilization.service;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.validation.Validator;
 
 @ApplicationScoped
-public class OrgUtilizationPreferenceRepository
-    implements PanacheRepositoryBase<OrgUtilizationPreferenceEntity, String> {}
+public class CustomThresholdValidator {
+
+  @Inject Validator validator;
+
+  public boolean isValid(int customThreshold) {
+    return validator
+        .validate(new OrgPreferencesRequest().customThreshold(customThreshold))
+        .isEmpty();
+  }
+}

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
@@ -26,6 +26,9 @@ import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -60,7 +63,7 @@ public class OrgPreferencesService {
     } else {
       var entity = entityOpt.get();
       response.setCustomThreshold(entity.getCustomThreshold());
-      response.setLastUpdated(entity.getLastUpdated());
+      response.setLastModified(toOffsetDateTime(entity.getLastModified()));
     }
     return response;
   }
@@ -74,10 +77,11 @@ public class OrgPreferencesService {
     log.info("Updating utilization preference orgId={}", orgId);
     var entity = getOrCreateOrgPreferenceEntity(orgId);
     entity.setCustomThreshold(request.getCustomThreshold());
-    repository.persist(entity);
+    // using persist and flush, so the current_modified column is populated
+    repository.persistAndFlush(entity);
     var response = new OrgPreferencesResponse();
     response.setCustomThreshold(entity.getCustomThreshold());
-    response.setLastUpdated(entity.getLastUpdated());
+    response.setLastModified(toOffsetDateTime(entity.getLastModified()));
     log.debug("Updated utilization preference '{}' to orgId={}", request, orgId);
     return response;
   }
@@ -91,5 +95,9 @@ public class OrgPreferencesService {
               entity.setOrgId(orgId);
               return entity;
             });
+  }
+
+  private static OffsetDateTime toOffsetDateTime(Instant instant) {
+    return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
   }
 }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
@@ -42,19 +42,25 @@ public class OrgPreferencesService {
     this.repository = repository;
   }
 
+  public int getDefaultThreshold() {
+    return defaultThreshold;
+  }
+
   /**
    * Retrieves preferences for the given organization. Returns default threshold from
    * ORG_PREFERENCE_DEFAULT_THRESHOLD property if not configured.
    */
   @Transactional
   public OrgPreferencesResponse getOrgPreferences(String orgId) {
-    log.info("Retrieving utilization preference for orgId={}", orgId);
+    log.debug("Retrieving utilization preference for orgId={}", orgId);
     var entityOpt = repository.findByIdOptional(orgId);
     var response = new OrgPreferencesResponse();
     if (entityOpt.isEmpty()) {
       response.setCustomThreshold(defaultThreshold);
     } else {
-      response.setCustomThreshold(entityOpt.get().getCustomThreshold());
+      var entity = entityOpt.get();
+      response.setCustomThreshold(entity.getCustomThreshold());
+      response.setLastUpdated(entity.getLastUpdated());
     }
     return response;
   }
@@ -70,7 +76,8 @@ public class OrgPreferencesService {
     entity.setCustomThreshold(request.getCustomThreshold());
     repository.persist(entity);
     var response = new OrgPreferencesResponse();
-    response.setCustomThreshold(request.getCustomThreshold());
+    response.setCustomThreshold(entity.getCustomThreshold());
+    response.setLastUpdated(entity.getLastUpdated());
     log.debug("Updated utilization preference '{}' to orgId={}", request, orgId);
     return response;
   }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OrgPreferencesService.java
@@ -77,7 +77,7 @@ public class OrgPreferencesService {
     log.info("Updating utilization preference orgId={}", orgId);
     var entity = getOrCreateOrgPreferenceEntity(orgId);
     entity.setCustomThreshold(request.getCustomThreshold());
-    // using persist and flush, so the current_modified column is populated
+    // using persist and flush, so the last_modified column is populated
     repository.persistAndFlush(entity);
     var response = new OrgPreferencesResponse();
     response.setCustomThreshold(entity.getCustomThreshold());

--- a/swatch-utilization/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-utilization/src/main/resources/META-INF/openapi.yaml
@@ -100,3 +100,9 @@ components:
           minimum: 0
           maximum: 100
           description: Persisted over-usage threshold margin as a whole-number percentage.
+        last_modified:
+          type: string
+          format: date-time
+          description: >-
+            UTC timestamp when preferences were last persisted. Omitted when the organization
+            has not configured custom preferences and the system default threshold is returned.

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
@@ -25,27 +25,28 @@ import static com.redhat.swatch.utilization.service.CustomThresholdUtilizationHa
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
-import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceEntity;
-import com.redhat.swatch.utilization.data.OrgUtilizationPreferenceRepository;
 import com.redhat.swatch.utilization.model.Measurement;
 import com.redhat.swatch.utilization.model.Severity;
 import com.redhat.swatch.utilization.model.UtilizationSummary;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.Search;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -61,7 +62,15 @@ import org.mockito.Mockito;
 
 @QuarkusTest
 class CustomThresholdUtilizationHandlerServiceTest {
-  private static MockedStatic<SubscriptionDefinition> subscriptionDefinition;
+
+  @Inject CustomThresholdUtilizationHandlerService service;
+
+  @Inject MeterRegistry meterRegistry;
+
+  @InjectMock NotificationsProducer notificationsProducer;
+  @InjectMock OrgPreferencesService orgPreferencesService;
+
+  static MockedStatic<SubscriptionDefinition> subscriptionDefinition;
 
   private static final String ORG_ID = "org123";
   private static final String PAYG_PRODUCT_ID = "rosa";
@@ -74,6 +83,8 @@ class CustomThresholdUtilizationHandlerServiceTest {
       MetricIdUtils.getInstanceHours().getValue();
   private static final double CAPACITY = 100.0;
   private static final int CUSTOM_THRESHOLD = 80;
+  private static final OffsetDateTime LAST_UPDATED =
+      OffsetDateTime.of(2026, 4, 20, 10, 0, 0, 0, ZoneOffset.UTC);
 
   private static final double USAGE_EXCEEDING_THRESHOLD = 85.0; // 85% > 80% threshold
   private static final double USAGE_AT_THRESHOLD = 80.0; // 80% == 80% threshold
@@ -83,12 +94,6 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   private static final double EXPECTED_SINGLE_INCREMENT = 1.0;
   private static final double EXPECTED_NO_CHANGE = 0.0;
-
-  @Inject CustomThresholdUtilizationHandlerService service;
-  @Inject OrgUtilizationPreferenceRepository preferenceRepository;
-  @Inject MeterRegistry meterRegistry;
-
-  @InjectMock NotificationsProducer notificationsProducer;
 
   @BeforeAll
   static void beforeAll() {
@@ -103,17 +108,15 @@ class CustomThresholdUtilizationHandlerServiceTest {
     subscriptionDefinition.close();
   }
 
-  @Transactional
   @BeforeEach
   void setUp() {
     meterRegistry.clear();
     subscriptionDefinition.reset();
-    preferenceRepository.deleteAll();
   }
 
   @Test
   void shouldSendNotification_whenUtilizationExceedsOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -127,7 +130,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUtilizationEqualsOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_AT_THRESHOLD);
 
@@ -140,7 +143,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldNotSendNotification_whenUtilizationBelowOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_THRESHOLD); // 70% < 80%
@@ -153,7 +156,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUsageAtFullCapacityAndAboveCustomThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_AT_FULL_CAPACITY);
 
@@ -166,7 +169,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUsageIsOverCapacity() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_OVER_CAPACITY);
 
@@ -178,7 +181,26 @@ class CustomThresholdUtilizationHandlerServiceTest {
   }
 
   @Test
+  void shouldSendNotification_whenStoredThresholdInvalid_usesDefaultThreshold() {
+    givenOrgPreference(ORG_ID, 150, LAST_UPDATED);
+    when(orgPreferencesService.getDefaultThreshold()).thenReturn(CUSTOM_THRESHOLD);
+    UtilizationSummary summary =
+        givenUtilizationSummary(
+            PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
+
+    whenCheckSummary(summary);
+
+    verify(notificationsProducer, times(1))
+        .produce(argThat(action -> EVENT_TYPE.equals(action.getEventType())));
+    verify(orgPreferencesService, atLeastOnce()).getDefaultThreshold();
+    assertEquals(EXPECTED_SINGLE_INCREMENT, getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID));
+  }
+
+  @Test
   void shouldNotSendNotification_whenNoOrgPreferenceExists() {
+    var response = new OrgPreferencesResponse();
+    response.setCustomThreshold(CUSTOM_THRESHOLD);
+    when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(response);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -191,7 +213,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseModerateSeverity() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -209,7 +231,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldIncludeLastUpdatedHashInPayload() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -220,13 +242,16 @@ class CustomThresholdUtilizationHandlerServiceTest {
     verify(notificationsProducer, times(1)).produce(captor.capture());
     Action action = captor.getValue();
 
-    var eventPayload = action.getEvents().getFirst().getPayload().getAdditionalProperties();
-    assertNotNull(eventPayload.get("last_updated_hash"));
+    var eventPayload = action.getEvents().get(0).getPayload().getAdditionalProperties();
+    String expectedHash = CustomThresholdUtilizationHandlerService.hashLastUpdated(LAST_UPDATED);
+    assertEquals(expectedHash, eventPayload.get("last_updated_hash"));
   }
 
   @Test
-  void shouldProduceDifferentHash_whenLastUpdatedChanges() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+  void shouldProduceDifferentHash_whenLastModifiedChanges() {
+    var later = OffsetDateTime.of(2026, 4, 21, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -239,13 +264,13 @@ class CustomThresholdUtilizationHandlerServiceTest {
             captor
                 .getValue()
                 .getEvents()
-                .getFirst()
+                .get(0)
                 .getPayload()
                 .getAdditionalProperties()
                 .get("last_updated_hash");
 
     Mockito.reset(notificationsProducer);
-    givenOrgPreferenceIsUpdated(ORG_ID, CUSTOM_THRESHOLD + 1);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, later);
     whenCheckSummary(summary);
 
     verify(notificationsProducer, times(1)).produce(captor.capture());
@@ -254,7 +279,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
             captor
                 .getValue()
                 .getEvents()
-                .getFirst()
+                .get(0)
                 .getPayload()
                 .getAdditionalProperties()
                 .get("last_updated_hash");
@@ -266,7 +291,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldIncludeUtilizationPercentageInPayload() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -277,14 +302,14 @@ class CustomThresholdUtilizationHandlerServiceTest {
     verify(notificationsProducer, times(1)).produce(captor.capture());
     Action action = captor.getValue();
 
-    var eventPayload = action.getEvents().getFirst().getPayload().getAdditionalProperties();
+    var eventPayload = action.getEvents().get(0).getPayload().getAdditionalProperties();
     String expectedPercent = String.format("%.2f", USAGE_EXCEEDING_THRESHOLD);
     assertEquals(expectedPercent, eventPayload.get("utilization_percentage"));
   }
 
   @Test
   void shouldUseCurrentTotal_forCounterMetric() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     // rosa / Cores: value=4 (hourly increment), currentTotal=85 (MTD total exceeds 80% of 100)
     UtilizationSummary summary =
         givenUtilizationSummary(
@@ -298,7 +323,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseValue_forGaugeMetric() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     // RHEL for x86 / Sockets: value=1 (50% of 2 capacity, below 80%), currentTotal=31 (accumulated
     // sum)
     UtilizationSummary summary =
@@ -312,7 +337,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldTriggerNotification_forGaugeMetric_whenValueExceedsThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     // RHEL for x86 / Sockets: value=9 (90% of 10 capacity, above 80%), currentTotal=270
     // (accumulated sum)
     UtilizationSummary summary =
@@ -327,7 +352,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseValue_forGaugeMetric_onPaygProduct() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     // ansible-aap-managed / Managed-nodes: value=5 (50% of 10, below 80%), currentTotal=150
     // (accumulated sum)
     UtilizationSummary summary =
@@ -342,7 +367,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseCurrentTotal_forCounterMetric_onPaygProduct() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     // ansible-aap-managed / Instance-hours: value=4 (hourly increment), currentTotal=85 (MTD, above
     // 80%)
     UtilizationSummary summary =
@@ -398,7 +423,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
       UtilizationSummary.Usage usage,
       String expectedServiceLevel,
       String expectedUsage) {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
     UtilizationSummary summary =
         givenUtilizationSummary(
                 PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD)
@@ -419,20 +444,11 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   // Helper methods
 
-  @Transactional
-  void givenOrgPreference(String orgId, int threshold) {
-    var entity = new OrgUtilizationPreferenceEntity();
-    entity.setOrgId(orgId);
-    entity.setCustomThreshold(threshold);
-    preferenceRepository.persist(entity);
-  }
-
-  @Transactional
-  void givenOrgPreferenceIsUpdated(String orgId, int threshold) {
-    var entity = preferenceRepository.getPreferences(orgId);
-    assertTrue(entity.isPresent());
-    entity.get().setCustomThreshold(threshold);
-    preferenceRepository.persist(entity.get());
+  private void givenOrgPreference(String orgId, int threshold, OffsetDateTime lastUpdated) {
+    var response = new OrgPreferencesResponse();
+    response.setCustomThreshold(threshold);
+    response.setLastUpdated(lastUpdated);
+    when(orgPreferencesService.getOrgPreferences(orgId)).thenReturn(response);
   }
 
   private UtilizationSummary givenUtilizationSummary(

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
@@ -83,7 +83,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
       MetricIdUtils.getInstanceHours().getValue();
   private static final double CAPACITY = 100.0;
   private static final int CUSTOM_THRESHOLD = 80;
-  private static final OffsetDateTime LAST_UPDATED =
+  private static final OffsetDateTime LAST_MODIFIED =
       OffsetDateTime.of(2026, 4, 20, 10, 0, 0, 0, ZoneOffset.UTC);
 
   private static final double USAGE_EXCEEDING_THRESHOLD = 85.0; // 85% > 80% threshold
@@ -116,7 +116,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUtilizationExceedsOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -130,7 +130,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUtilizationEqualsOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_AT_THRESHOLD);
 
@@ -143,7 +143,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldNotSendNotification_whenUtilizationBelowOrgThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_THRESHOLD); // 70% < 80%
@@ -156,7 +156,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUsageAtFullCapacityAndAboveCustomThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_AT_FULL_CAPACITY);
 
@@ -169,7 +169,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenUsageIsOverCapacity() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_OVER_CAPACITY);
 
@@ -182,7 +182,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldSendNotification_whenStoredThresholdInvalid_usesDefaultThreshold() {
-    givenOrgPreference(ORG_ID, 150, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, 150, LAST_MODIFIED);
     when(orgPreferencesService.getDefaultThreshold()).thenReturn(CUSTOM_THRESHOLD);
     UtilizationSummary summary =
         givenUtilizationSummary(
@@ -197,7 +197,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
   }
 
   @Test
-  void shouldNotSendNotification_whenNoOrgPreferenceExists() {
+  void shouldNotSendNotification_whenOrgHasNoPersistedPreferences() {
     var response = new OrgPreferencesResponse();
     response.setCustomThreshold(CUSTOM_THRESHOLD);
     when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(response);
@@ -213,7 +213,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseModerateSeverity() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -230,8 +230,8 @@ class CustomThresholdUtilizationHandlerServiceTest {
   }
 
   @Test
-  void shouldIncludeLastUpdatedHashInPayload() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+  void shouldIncludeLastModifiedHashInPayload() {
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -243,15 +243,16 @@ class CustomThresholdUtilizationHandlerServiceTest {
     Action action = captor.getValue();
 
     var eventPayload = action.getEvents().get(0).getPayload().getAdditionalProperties();
-    String expectedHash = CustomThresholdUtilizationHandlerService.hashLastUpdated(LAST_UPDATED);
-    assertEquals(expectedHash, eventPayload.get("last_updated_hash"));
+    String expectedHash =
+        CustomThresholdUtilizationHandlerService.hashLastModified(LAST_MODIFIED.toInstant());
+    assertEquals(expectedHash, eventPayload.get("last_modified_hash"));
   }
 
   @Test
   void shouldProduceDifferentHash_whenLastModifiedChanges() {
     var later = OffsetDateTime.of(2026, 4, 21, 10, 0, 0, 0, ZoneOffset.UTC);
 
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -267,7 +268,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
                 .get(0)
                 .getPayload()
                 .getAdditionalProperties()
-                .get("last_updated_hash");
+                .get("last_modified_hash");
 
     Mockito.reset(notificationsProducer);
     givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, later);
@@ -282,7 +283,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
                 .get(0)
                 .getPayload()
                 .getAdditionalProperties()
-                .get("last_updated_hash");
+                .get("last_modified_hash");
 
     assertNotNull(firstHash);
     assertNotNull(secondHash);
@@ -291,7 +292,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldIncludeUtilizationPercentageInPayload() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
@@ -309,7 +310,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseCurrentTotal_forCounterMetric() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     // rosa / Cores: value=4 (hourly increment), currentTotal=85 (MTD total exceeds 80% of 100)
     UtilizationSummary summary =
         givenUtilizationSummary(
@@ -323,7 +324,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseValue_forGaugeMetric() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     // RHEL for x86 / Sockets: value=1 (50% of 2 capacity, below 80%), currentTotal=31 (accumulated
     // sum)
     UtilizationSummary summary =
@@ -337,7 +338,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldTriggerNotification_forGaugeMetric_whenValueExceedsThreshold() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     // RHEL for x86 / Sockets: value=9 (90% of 10 capacity, above 80%), currentTotal=270
     // (accumulated sum)
     UtilizationSummary summary =
@@ -352,7 +353,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseValue_forGaugeMetric_onPaygProduct() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     // ansible-aap-managed / Managed-nodes: value=5 (50% of 10, below 80%), currentTotal=150
     // (accumulated sum)
     UtilizationSummary summary =
@@ -367,7 +368,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   @Test
   void shouldUseCurrentTotal_forCounterMetric_onPaygProduct() {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     // ansible-aap-managed / Instance-hours: value=4 (hourly increment), currentTotal=85 (MTD, above
     // 80%)
     UtilizationSummary summary =
@@ -423,7 +424,7 @@ class CustomThresholdUtilizationHandlerServiceTest {
       UtilizationSummary.Usage usage,
       String expectedServiceLevel,
       String expectedUsage) {
-    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_UPDATED);
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, LAST_MODIFIED);
     UtilizationSummary summary =
         givenUtilizationSummary(
                 PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD)
@@ -444,10 +445,10 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
   // Helper methods
 
-  private void givenOrgPreference(String orgId, int threshold, OffsetDateTime lastUpdated) {
+  private void givenOrgPreference(String orgId, int threshold, OffsetDateTime lastModified) {
     var response = new OrgPreferencesResponse();
     response.setCustomThreshold(threshold);
-    response.setLastUpdated(lastUpdated);
+    response.setLastModified(lastModified);
     when(orgPreferencesService.getOrgPreferences(orgId)).thenReturn(response);
   }
 

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdValidatorTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdValidatorTest.java
@@ -18,11 +18,31 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.utilization.data;
+package com.redhat.swatch.utilization.service;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
-import jakarta.enterprise.context.ApplicationScoped;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ApplicationScoped
-public class OrgUtilizationPreferenceRepository
-    implements PanacheRepositoryBase<OrgUtilizationPreferenceEntity, String> {}
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class CustomThresholdValidatorTest {
+
+  @Inject CustomThresholdValidator validator;
+
+  @Test
+  void isValid_acceptsBoundaryValues() {
+    assertTrue(validator.isValid(0));
+    assertTrue(validator.isValid(100));
+    assertTrue(validator.isValid(50));
+  }
+
+  @Test
+  void isValid_rejectsValuesOutsideRange() {
+    assertFalse(validator.isValid(-1));
+    assertFalse(validator.isValid(101));
+    assertFalse(validator.isValid(150));
+  }
+}

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
@@ -82,7 +82,7 @@ class OrgPreferencesServiceTest {
   }
 
   @Test
-  void whenPreferenceExists_updatesThresholdWithoutPersist() {
+  void whenPreferenceExists_updatesThreshold() {
     var existing = new OrgUtilizationPreferenceEntity();
     existing.setOrgId(ORG_ID);
     existing.setCustomThreshold(3);

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.utilization.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +31,8 @@ import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +41,7 @@ import org.mockito.ArgumentCaptor;
 class OrgPreferencesServiceTest {
 
   private static final String ORG_ID = "org-456";
+  private static final OffsetDateTime LAST_UPDATED = OffsetDateTime.now(ZoneOffset.UTC);
 
   @InjectMock OrgUtilizationPreferenceRepository repository;
 
@@ -48,20 +52,23 @@ class OrgPreferencesServiceTest {
     var entity = new OrgUtilizationPreferenceEntity();
     entity.setOrgId(ORG_ID);
     entity.setCustomThreshold(7);
+    entity.setLastUpdated(LAST_UPDATED);
     when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.of(entity));
 
     var response = service.getOrgPreferences(ORG_ID);
 
     assertEquals(7, response.getCustomThreshold());
+    assertEquals(LAST_UPDATED, response.getLastUpdated());
   }
 
   @Test
-  void getOrgPreferences_whenPreferenceDoesNotExist_returnsDefaultThreshold() {
+  void getOrgPreferences_whenPreferenceDoesNotExist_returnsDefaultThresholdWithoutLastUpdated() {
     when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.empty());
 
     var response = service.getOrgPreferences(ORG_ID);
 
     assertEquals(80, response.getCustomThreshold());
+    assertNull(response.getLastUpdated());
   }
 
   @Test

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/OrgPreferencesServiceTest.java
@@ -31,8 +31,6 @@ import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -41,7 +39,6 @@ import org.mockito.ArgumentCaptor;
 class OrgPreferencesServiceTest {
 
   private static final String ORG_ID = "org-456";
-  private static final OffsetDateTime LAST_UPDATED = OffsetDateTime.now(ZoneOffset.UTC);
 
   @InjectMock OrgUtilizationPreferenceRepository repository;
 
@@ -52,23 +49,21 @@ class OrgPreferencesServiceTest {
     var entity = new OrgUtilizationPreferenceEntity();
     entity.setOrgId(ORG_ID);
     entity.setCustomThreshold(7);
-    entity.setLastUpdated(LAST_UPDATED);
     when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.of(entity));
 
     var response = service.getOrgPreferences(ORG_ID);
 
     assertEquals(7, response.getCustomThreshold());
-    assertEquals(LAST_UPDATED, response.getLastUpdated());
   }
 
   @Test
-  void getOrgPreferences_whenPreferenceDoesNotExist_returnsDefaultThresholdWithoutLastUpdated() {
+  void getOrgPreferences_whenPreferenceDoesNotExist_returnsDefaultThresholdWithoutLastModified() {
     when(repository.findByIdOptional(ORG_ID)).thenReturn(Optional.empty());
 
     var response = service.getOrgPreferences(ORG_ID);
 
     assertEquals(80, response.getCustomThreshold());
-    assertNull(response.getLastUpdated());
+    assertNull(response.getLastModified());
   }
 
   @Test
@@ -81,7 +76,7 @@ class OrgPreferencesServiceTest {
 
     assertEquals(11, response.getCustomThreshold());
     var captor = ArgumentCaptor.forClass(OrgUtilizationPreferenceEntity.class);
-    verify(repository).persist(captor.capture());
+    verify(repository).persistAndFlush(captor.capture());
     assertEquals(ORG_ID, captor.getValue().getOrgId());
     assertEquals(11, captor.getValue().getCustomThreshold());
   }


### PR DESCRIPTION
Jira issue: SWATCH-4803

## Description
Refactors custom utilization threshold handling to go through `OrgPreferencesService` and treat persisted org preferences as opt-in via `last_updated`. 

These changes centralize the preference logic, align the notification handler with the API contract (`last_updated` = configured org), and hardens against corrupt threshold data in the database.

- Expose `last_updated` on org preferences GET/POST when the org has saved preferences; omit it when returning the system default.
- Validate stored thresholds (0–100); on invalid values, log a warning and evaluate notifications using `ORG_PREFERENCE_DEFAULT_THRESHOLD`.
- Update OpenAPI, component tests, unit tests, and TEST_PLAN for the new behavior.

