### PR TITLE
swatch-4952: Add parameters USER_OPTS_APPEND to the clowdapp.yaml

### DIFF
--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -203,6 +205,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: USER_OPTS_APPEND
+              value: ${USER_OPTS_APPEND}
             - name: QUARKUS_LAUNCH_DEVMODE
               value: ${QUARKUS_LAUNCH_DEVMODE}
             - name: LOGGING_LEVEL_ROOT

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -307,6 +309,8 @@ objects:
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}
+              - name: USER_OPTS_APPEND
+                value: ${USER_OPTS_APPEND}
               - name: QUARKUS_LAUNCH_DEVMODE
                 value: ${QUARKUS_LAUNCH_DEVMODE}
               - name: LOGGING_LEVEL_ROOT

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -188,6 +190,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: USER_OPTS_APPEND
+              value: ${USER_OPTS_APPEND}
             - name: QUARKUS_LAUNCH_DEVMODE
               value: ${QUARKUS_LAUNCH_DEVMODE}
             - name: LOGGING_LEVEL_ROOT

--- a/swatch-metrics/deploy/clowdapp.yaml
+++ b/swatch-metrics/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: ENV_NAME
@@ -237,6 +239,8 @@ objects:
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}
+              - name: USER_OPTS_APPEND
+                value: ${USER_OPTS_APPEND}
               - name: QUARKUS_LAUNCH_DEVMODE
                 value: ${QUARKUS_LAUNCH_DEVMODE}
               - name: LOGGING_HEC_ENABLED
@@ -478,6 +482,8 @@ objects:
             env:
               - name: JAVA_DEBUG
                 value: ${JAVA_DEBUG}
+              - name: USER_OPTS_APPEND
+                value: ${USER_OPTS_APPEND}
               - name: LOGGING_HEC_ENABLED
                 value: ${LOGGING_HEC_ENABLED}
               - name: LOGGING_NAMESPACE

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -145,6 +147,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: USER_OPTS_APPEND
+              value: ${USER_OPTS_APPEND}
             - name: QUARKUS_LAUNCH_DEVMODE
               value: ${QUARKUS_LAUNCH_DEVMODE}
             - name: LOGGING_LEVEL_ROOT

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -138,6 +140,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: USER_OPTS_APPEND
+              value: ${USER_OPTS_APPEND}
             - name: QUARKUS_LAUNCH_DEVMODE
               value: ${QUARKUS_LAUNCH_DEVMODE}
             - name: LOGGING_LEVEL_ROOT

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -7,6 +7,8 @@ parameters:
   - name: JAVA_DEBUG
     # Set to "true" to enable remote debugging
     value: ''
+  - name: USER_OPTS_APPEND
+    value: ''
   - name: QUARKUS_LAUNCH_DEVMODE
     value: ''
   - name: IMAGE_PULL_SECRET
@@ -154,6 +156,8 @@ objects:
           env:
             - name: JAVA_DEBUG
               value: ${JAVA_DEBUG}
+            - name: USER_OPTS_APPEND
+              value: ${USER_OPTS_APPEND}
             - name: QUARKUS_LAUNCH_DEVMODE
               value: ${QUARKUS_LAUNCH_DEVMODE}
             - name: LOGGING_LEVEL_ROOT


### PR DESCRIPTION
Jira issue: SWATCH-4952

## Description
Adding USER_OPTS_APPEND to the services in clowder.  These are now being used in app-interface/data/services/insights/rhsm/cicd/deploy-clowder.yml#L254/ to limit the container memory, for: swatch-utilization and swatch-producer-azure.

##Testing
1. Deploy to ephemeral
1. oc get pod swatch-utilization...  -o jsonpath='{.spec.containers[*].env[*]}' | jq