### PR TITLE
SWATCH-4980: Enforce org-admin check on org preferences.

### DIFF
--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RhIdentityPrincipal.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RhIdentityPrincipal.java
@@ -71,6 +71,11 @@ public class RhIdentityPrincipal implements Principal {
     return Objects.equals("X509", getIdentity().getType());
   }
 
+  public boolean isOrgAdmin() {
+    User user = getIdentity().getUser();
+    return user != null && Boolean.TRUE.equals(user.getOrgAdmin());
+  }
+
   public String toString() {
     return getName();
   }

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
@@ -37,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
  * <li>service - granted to x-rh-swatch-psk authenticated principals
  * <li>support - granted to x-rh-identity authenticated principals when type is "Associate".
  * <li>test - granted to any authenticated principal when SWATCH_TEST_APIS_ENABLED is true.
+ * <li>admin - granted to x-rh-identity User principals when is_org_admin is true.
  */
 @Slf4j
 @ApplicationScoped
@@ -51,12 +52,15 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
     if (!identity.isAnonymous() && configuration.isTestApisEnabled()) {
       roles.add("test");
     }
-    if (principal instanceof RhIdentityPrincipal) {
-      if (((RhIdentityPrincipal) principal).isAssociate()) {
+    if (principal instanceof RhIdentityPrincipal rhIdentityPrincipal) {
+      if (rhIdentityPrincipal.isAssociate()) {
         roles.add("support");
       }
-      if ("X509".equals(((RhIdentityPrincipal) principal).getIdentity().getType())) {
+      if (rhIdentityPrincipal.isX509()) {
         roles.add("service");
+      }
+      if (rhIdentityPrincipal.isUser() && rhIdentityPrincipal.isOrgAdmin()) {
+        roles.add("admin");
       }
     }
     if (principal instanceof PskPrincipal) {

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RolesAugmentor.java
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
  * <li>service - granted to x-rh-swatch-psk authenticated principals
  * <li>support - granted to x-rh-identity authenticated principals when type is "Associate".
  * <li>test - granted to any authenticated principal when SWATCH_TEST_APIS_ENABLED is true.
- * <li>admin - granted to x-rh-identity User principals when is_org_admin is true.
+ * <li>org_admin - granted to x-rh-identity User principals when is_org_admin is true.
  */
 @Slf4j
 @ApplicationScoped
@@ -60,7 +60,7 @@ public class RolesAugmentor implements SecurityIdentityAugmentor {
         roles.add("service");
       }
       if (rhIdentityPrincipal.isUser() && rhIdentityPrincipal.isOrgAdmin()) {
-        roles.add("admin");
+        roles.add("org_admin");
       }
     }
     if (principal instanceof PskPrincipal) {

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/User.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/User.java
@@ -26,28 +26,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** DTO for the identity field of an x-rh-identity JSON document. */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Identity {
-  private String type;
-
-  public String getType() {
-    return type != null ? type : "User";
-  }
-
-  @JsonProperty("org_id")
-  private String orgId;
-
-  @JsonProperty("associate")
-  private SamlAssertions samlAssertions;
-
-  private X509Properties x509;
-
-  @JsonProperty("service_account")
-  private ServiceAccount serviceAccount;
-
-  private User user;
+public class User {
+  @JsonProperty("is_org_admin")
+  private Boolean orgAdmin;
 }

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityDeserializationTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityDeserializationTest.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.common.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -42,5 +43,13 @@ class RhIdentityDeserializationTest {
     var identity = identityFactory.fromHeader(RhIdentityUtils.X509_IDENTITY_HEADER);
     assertEquals("X509", identity.getIdentity().getType());
     assertEquals("CN=test.example.com", identity.getIdentity().getX509().getSubjectDn());
+  }
+
+  @Test
+  void shouldDeserializeOrgAdminUserHeader() throws Exception {
+    var identity = identityFactory.fromHeader(RhIdentityUtils.ORG_ADMIN_IDENTITY_HEADER);
+    assertEquals("User", identity.getIdentity().getType());
+    assertEquals("org123", identity.getIdentity().getOrgId());
+    assertTrue(identity.isOrgAdmin());
   }
 }

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityPrincipalTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityPrincipalTest.java
@@ -91,6 +91,32 @@ class RhIdentityPrincipalTest {
   }
 
   @Test
+  void testIsOrgAdminReturnsTrueWhenUserIsOrgAdmin() {
+    User user = User.builder().orgAdmin(true).build();
+    Identity identity = Identity.builder().type("User").orgId("123").user(user).build();
+    RhIdentityPrincipal principal = RhIdentityPrincipal.builder().identity(identity).build();
+
+    assertTrue(principal.isOrgAdmin());
+  }
+
+  @Test
+  void testIsOrgAdminReturnsFalseWhenUserIsNotOrgAdmin() {
+    User user = User.builder().orgAdmin(false).build();
+    Identity identity = Identity.builder().type("User").orgId("123").user(user).build();
+    RhIdentityPrincipal principal = RhIdentityPrincipal.builder().identity(identity).build();
+
+    assertFalse(principal.isOrgAdmin());
+  }
+
+  @Test
+  void testIsOrgAdminReturnsFalseWhenUserSubObjectAbsent() {
+    Identity identity = Identity.builder().type("User").orgId("123").build();
+    RhIdentityPrincipal principal = RhIdentityPrincipal.builder().identity(identity).build();
+
+    assertFalse(principal.isOrgAdmin());
+  }
+
+  @Test
   void testGetNameForDifferentTypes() {
     // Test name resolution for different identity types
 

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityUtils.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RhIdentityUtils.java
@@ -63,6 +63,21 @@ public class RhIdentityUtils {
 
   public static final String CUSTOMER_IDENTITY_HEADER = generateHeader(CUSTOMER_IDENTITY_JSON);
 
+  public static final String ORG_ADMIN_IDENTITY_JSON =
+      """
+            {
+              "identity": {
+                "type": "User",
+                "org_id": "org123",
+                "user": {
+                  "is_org_admin": true
+                }
+              }
+            }
+            """;
+
+  public static final String ORG_ADMIN_IDENTITY_HEADER = generateHeader(ORG_ADMIN_IDENTITY_JSON);
+
   static String generateHeader(String json) {
     return new String(
         Base64.getEncoder().encode(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RolesAugmentorTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RolesAugmentorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import java.io.IOException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RolesAugmentorTest {
+
+  RolesAugmentor augmentor;
+  RhIdentityPrincipalFactory identityFactory;
+
+  @Mock SecurityConfiguration configuration;
+
+  AuthenticationRequestContext context = Uni.createFrom()::item;
+
+  @BeforeEach
+  void setup() {
+    augmentor = new RolesAugmentor();
+    augmentor.configuration = configuration;
+
+    identityFactory = new RhIdentityPrincipalFactory();
+    identityFactory.mapper = new ObjectMapper();
+  }
+
+  private QuarkusSecurityIdentity securityIdentityForRhIdentityJson(String json) {
+    try {
+      return QuarkusSecurityIdentity.builder().setPrincipal(identityFactory.fromJson(json)).build();
+    } catch (IOException e) {
+      throw new AuthenticationFailedException(e);
+    }
+  }
+
+  @Test
+  void shouldGrantAdminRoleToOrgAdminUser() {
+    var subscriber =
+        augmentor
+            .augment(
+                securityIdentityForRhIdentityJson(RhIdentityUtils.ORG_ADMIN_IDENTITY_JSON), context)
+            .map(SecurityIdentity::getRoles)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+    subscriber.assertCompleted().assertItem(Set.of("admin"));
+  }
+
+  @Test
+  void shouldNotGrantAdminRoleToNonAdminUser() {
+    var subscriber =
+        augmentor
+            .augment(
+                securityIdentityForRhIdentityJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON), context)
+            .map(SecurityIdentity::getRoles)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+    subscriber.assertCompleted().assertItem(Set.of());
+  }
+}

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RolesAugmentorTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/RolesAugmentorTest.java
@@ -71,7 +71,7 @@ class RolesAugmentorTest {
             .map(SecurityIdentity::getRoles)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create());
-    subscriber.assertCompleted().assertItem(Set.of("admin"));
+    subscriber.assertCompleted().assertItem(Set.of("org_admin"));
   }
 
   @Test

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -20,6 +20,8 @@
  */
 package com.redhat.swatch.component.tests.utils;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 public final class SwatchUtils {
@@ -45,10 +47,20 @@ public final class SwatchUtils {
             + orgId
             + "\",\"issuer_dn\":\"CN=test-issuer\"}},"
             + "\"entitlements\":{\"rhel\":{\"is_entitled\":true}}}";
-    String rhId =
-        java.util.Base64.getEncoder()
-            .encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
 
+    return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
+  }
+
+  /** Returns headers for a User-type identity (Quarkus services). */
+  public static Map<String, String> securityHeadersWithUserRole(String orgId, boolean isOrgAdmin) {
+    String json =
+        "{\"identity\":{\"type\":\"User\",\"org_id\":\""
+            + orgId
+            + "\",\"user\":{\"is_org_admin\":"
+            + isOrgAdmin
+            + "}}}";
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
   }
 
@@ -69,7 +81,6 @@ public final class SwatchUtils {
             + orgId
             + "\"}"
             + "}}";
-    return java.util.Base64.getEncoder()
-        .encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -487,6 +487,47 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Response custom_threshold matches request value
     - Response last_modified is present for each successful POST
 
+**org-preferences-TC007 - Org admin can update custom threshold**
+
+- **Description**: Verify that an org admin (is_org_admin=true in x-rh-identity) can successfully update the custom threshold.
+- **Setup**:
+    - An organization has not configured any custom preferences
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with User-type identity where is_org_admin=true
+- **Verification**:
+    - Verify response status code is 200
+    - Verify response contains the persisted custom_threshold value
+- **Expected Result**:
+    - HTTP 200 response
+    - Custom threshold is updated successfully
+
+**org-preferences-TC008 - Non-admin user cannot update custom threshold**
+
+- **Description**: Verify that a regular user (is_org_admin=false in x-rh-identity) is rejected when attempting to update the custom threshold.
+- **Setup**:
+    - An organization has not configured any custom preferences
+- **Action**:
+    - Call POST /api/rhsm-subscriptions/v1/utilization/org-preferences with User-type identity where is_org_admin=false
+- **Verification**:
+    - Verify response status code is 403 Forbidden
+- **Expected Result**:
+    - HTTP 403 Forbidden
+    - Threshold is not updated
+
+**org-preferences-TC009 - Org admin from another organization cannot tamper with a different org's preferences**
+
+- **Description**: Verify that an admin from org A, when using their own x-rh-identity (org_id=A), can only update org A's preferences, not org B's. The endpoint is inherently safe from cross-org tampering because org_id is always extracted from the authenticated identity.
+- **Setup**:
+    - Org B has a custom threshold configured
+- **Action**:
+    - Org A admin calls POST /api/rhsm-subscriptions/v1/utilization/org-preferences using their own identity (org_id=A) with a different threshold value
+- **Verification**:
+    - Verify that org B's threshold is unchanged
+    - Verify that org A's threshold is updated
+- **Expected Result**:
+    - Org B's preferences remain unchanged (org A's identity cannot target org B)
+    - Org A's preferences are updated
+
 ## Custom Usage Threshold Notification
 
 **custom-threshold-TC001 - Detect custom threshold exceeded and send notification**

--- a/swatch-utilization/ct/java/api/UtilizationSwatchService.java
+++ b/swatch-utilization/ct/java/api/UtilizationSwatchService.java
@@ -21,6 +21,7 @@
 package api;
 
 import static com.redhat.swatch.component.tests.utils.SwatchUtils.securityHeadersWithServiceRole;
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.securityHeadersWithUserRole;
 import static org.apache.http.HttpStatus.SC_OK;
 
 import com.redhat.swatch.component.tests.api.SwatchService;
@@ -72,6 +73,31 @@ public class UtilizationSwatchService extends SwatchService {
     Objects.requireNonNull(request, "request must not be null");
 
     return updateOrgPreferences(orgId, request)
+        .then()
+        .statusCode(SC_OK)
+        .extract()
+        .as(OrgPreferencesResponse.class);
+  }
+
+  public Response updateOrgPreferencesAsUser(
+      String orgId, boolean isOrgAdmin, OrgPreferencesRequest request) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(request, "request must not be null");
+
+    return given()
+        .headers(securityHeadersWithUserRole(orgId, isOrgAdmin))
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when()
+        .post(ORG_PREFERENCES_ENDPOINT);
+  }
+
+  public OrgPreferencesResponse updateOrgPreferencesAsUserExpectSuccess(
+      String orgId, boolean isOrgAdmin, OrgPreferencesRequest request) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(request, "request must not be null");
+
+    return updateOrgPreferencesAsUser(orgId, isOrgAdmin, request)
         .then()
         .statusCode(SC_OK)
         .extract()

--- a/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesComponentTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import io.restassured.response.Response;
@@ -173,6 +174,66 @@ public class OrgPreferencesComponentTest extends BaseUtilizationComponentTest {
     // Then: Request is accepted and returns boundary value
     assertEquals(100, response.getCustomThreshold(), "Should accept threshold value 100");
     assertNotNull(response.getLastModified(), "POST response should contain last_modified");
+  }
+
+  @TestPlanName("org-preferences-TC007")
+  @Test
+  void shouldAllowOrgAdminToUpdatePreferences() {
+    // Given: An org admin user identity with a custom threshold
+    Integer customThreshold = 42;
+    OrgPreferencesRequest request = new OrgPreferencesRequest();
+    request.setCustomThreshold(customThreshold);
+
+    // When: Org admin updates the threshold
+    OrgPreferencesResponse body =
+        service.updateOrgPreferencesAsUserExpectSuccess(orgId, true, request);
+
+    // Then: Request succeeds
+    assertEquals(
+        customThreshold, body.getCustomThreshold(), "Response should contain updated threshold");
+  }
+
+  @TestPlanName("org-preferences-TC008")
+  @Test
+  void shouldRejectNonAdminUserFromUpdatingPreferences() {
+    // Given: A non-admin user identity
+    OrgPreferencesRequest request = new OrgPreferencesRequest();
+    request.setCustomThreshold(42);
+
+    // When: Non-admin user attempts to update the threshold
+    Response response = service.updateOrgPreferencesAsUser(orgId, false, request);
+
+    // Then: Request is rejected with 403 Forbidden
+    assertEquals(
+        HttpStatus.SC_FORBIDDEN,
+        response.statusCode(),
+        "Non-admin user should be rejected with 403");
+  }
+
+  @TestPlanName("org-preferences-TC009")
+  @Test
+  void shouldNotAffectAnotherOrgPreferencesWhenAdminUsesOwnIdentity() {
+    // Given: Org B has a custom threshold configured
+    String orgBId = RandomUtils.generateRandom();
+    Integer orgBThreshold = 30;
+    OrgPreferencesRequest orgBRequest = new OrgPreferencesRequest();
+    orgBRequest.setCustomThreshold(orgBThreshold);
+    service.updateOrgPreferencesAsUserExpectSuccess(orgBId, true, orgBRequest);
+
+    // When: Admin from org A (different org) updates their own threshold
+    Integer orgAThreshold = 55;
+    OrgPreferencesRequest orgARequest = new OrgPreferencesRequest();
+    orgARequest.setCustomThreshold(orgAThreshold);
+    service.updateOrgPreferencesAsUserExpectSuccess(orgId, true, orgARequest);
+
+    // Then: Org B's threshold is unchanged; org A's threshold is updated
+    OrgPreferencesResponse orgBPreferences = service.getOrgPreferencesExpectSuccess(orgBId);
+    assertEquals(
+        orgBThreshold, orgBPreferences.getCustomThreshold(), "Org B threshold should be unchanged");
+
+    OrgPreferencesResponse orgAPreferences = service.getOrgPreferencesExpectSuccess(orgId);
+    assertEquals(
+        orgAThreshold, orgAPreferences.getCustomThreshold(), "Org A threshold should be updated");
   }
 
   private OrgPreferencesResponse whenGetOrgPreferences() {

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
@@ -48,7 +48,7 @@ public class OrgPreferencesResource implements OrgPreferencesApi {
   }
 
   @Override
-  @RolesAllowed({"admin", "service"})
+  @RolesAllowed({"org_admin", "service"})
   public OrgPreferencesResponse updateOrgPreferences(
       String xRhIdentity, OrgPreferencesRequest orgPreferencesRequest) {
     String orgId = orgIdResolver.getOrgId(securityContext, httpHeaders);

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/OrgPreferencesResource.java
@@ -48,7 +48,7 @@ public class OrgPreferencesResource implements OrgPreferencesApi {
   }
 
   @Override
-  @RolesAllowed({"customer", "service"})
+  @RolesAllowed({"admin", "service"})
   public OrgPreferencesResponse updateOrgPreferences(
       String xRhIdentity, OrgPreferencesRequest orgPreferencesRequest) {
     String orgId = orgIdResolver.getOrgId(securityContext, httpHeaders);

--- a/swatch-utilization/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-utilization/src/main/resources/META-INF/openapi.yaml
@@ -16,6 +16,9 @@ paths:
       tags:
         - OrgPreferences
       operationId: getOrgPreferences
+      security:
+        - customer: []
+        - service: []
       summary: Get organization utilization preferences
       description: >-
         Retrieves the organization utilization preferences for the organization resolved
@@ -44,6 +47,9 @@ paths:
       tags:
         - OrgPreferences
       operationId: updateOrgPreferences
+      security:
+        - admin: []
+        - service: []
       summary: Update organization utilization preferences
       description: >-
         Accepts organization utilization preferences (for example custom over-usage threshold)
@@ -77,6 +83,22 @@ paths:
         "500":
           $ref: "../../../../../spec/error-responses.yaml#/$defs/InternalServerError"
 components:
+  securitySchemes:
+    customer:
+      type: apiKey
+      description: customer facing API
+      name: x-rh-identity
+      in: header
+    admin:
+      type: apiKey
+      description: API is available for org admin users
+      name: x-rh-identity
+      in: header
+    service:
+      type: apiKey
+      description: API is available for services
+      name: x-rh-swatch-psk
+      in: header
   schemas:
     OrgPreferencesRequest:
       type: object

--- a/swatch-utilization/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-utilization/src/main/resources/META-INF/openapi.yaml
@@ -48,7 +48,7 @@ paths:
         - OrgPreferences
       operationId: updateOrgPreferences
       security:
-        - admin: []
+        - org_admin: []
         - service: []
       summary: Update organization utilization preferences
       description: >-
@@ -89,9 +89,9 @@ components:
       description: customer facing API
       name: x-rh-identity
       in: header
-    admin:
+    org_admin:
       type: apiKey
-      description: API is available for org admin users
+      description: API is available for organization administrators (is_org_admin=true in x-rh-identity)
       name: x-rh-identity
       in: header
     service:

--- a/swatch-utilization/src/main/resources/application.properties
+++ b/swatch-utilization/src/main/resources/application.properties
@@ -27,8 +27,7 @@ ORG_PREFERENCE_DEFAULT_THRESHOLD=80
 
 # Public HTTP APIs use x-rh-identity; JAX-RS resources must opt in with roles.
 quarkus.security.deny-unannotated-members=true
-# Disable role checking in dev mode. Use QUARKUS_SECURITY_AUTH_ENABLED_IN_DEV_MODE=true to override.
-quarkus.security.auth.enabled-in-dev-mode=false
+quarkus.security.auth.enabled-in-dev-mode=true
 
 # dev-specific defaults; these can still be overridden by env var
 %dev.SERVER_PORT=8018

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import com.redhat.swatch.utilization.service.OrgPreferencesService;
@@ -38,7 +39,6 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class OrgPreferencesResourceTest {
   @InjectMock OrgPreferencesService orgPreferencesService;
 
   @Test
-  void getOrgPreferences_whenPreferencesExist_returnsPreferences() {
+  void getOrgPreferences_whenPreferencesExist_returnsPreferences() throws Exception {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(10);
     when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
@@ -71,7 +71,7 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void getOrgPreferences_whenPreferencesDoNotExist_returnsDefaultThreshold() {
+  void getOrgPreferences_whenPreferencesDoNotExist_returnsDefaultThreshold() throws Exception {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(80);
     when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
@@ -87,7 +87,7 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void updateOrgPreferences_whenPayloadValid_invokesServiceWithResolvedOrgId() {
+  void updateOrgPreferences_whenPayloadValid_invokesServiceWithResolvedOrgId() throws Exception {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(4);
     when(orgPreferencesService.updateOrgPreferences(eq(ORG_ID), any(OrgPreferencesRequest.class)))
@@ -106,7 +106,7 @@ class OrgPreferencesResourceTest {
   @ParameterizedTest
   @ValueSource(ints = {-1, 101})
   void updateOrgPreferences_whenThresholdOutOfRange_returnsBadRequestWithoutCallingService(
-      int invalidThreshold) {
+      int invalidThreshold) throws Exception {
     whenUpdateOrgPreferencesTo(invalidThreshold).statusCode(HttpStatus.SC_BAD_REQUEST);
 
     verify(orgPreferencesService, never())
@@ -114,27 +114,29 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void updateOrgPreferences_whenCustomThresholdMissing_returnsBadRequestWithoutCallingService() {
+  void updateOrgPreferences_whenCustomThresholdMissing_returnsBadRequestWithoutCallingService()
+      throws Exception {
     whenUpdateOrgPreferencesTo(null).statusCode(HttpStatus.SC_BAD_REQUEST);
 
     verify(orgPreferencesService, never())
         .updateOrgPreferences(anyString(), any(OrgPreferencesRequest.class));
   }
 
-  private static ValidatableResponse whenGetOrgPreferences() {
+  private static ValidatableResponse whenGetOrgPreferences() throws Exception {
     return given()
-        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID))
+        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, false))
         .when()
         .get(ORG_PREFERENCES_PATH)
         .then();
   }
 
-  private static ValidatableResponse whenUpdateOrgPreferencesTo(Integer customThreshold) {
+  private static ValidatableResponse whenUpdateOrgPreferencesTo(Integer customThreshold)
+      throws Exception {
     OrgPreferencesRequest request = new OrgPreferencesRequest();
     request.setCustomThreshold(customThreshold);
 
     return given()
-        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID))
+        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, true))
         .contentType(ContentType.JSON)
         .body(request)
         .when()
@@ -142,8 +144,12 @@ class OrgPreferencesResourceTest {
         .then();
   }
 
-  private static String base64UserIdentity(String orgId) {
-    String json = String.format("{\"identity\":{\"type\":\"User\",\"org_id\":\"%s\"}}", orgId);
-    return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+  private static String base64UserIdentity(String orgId, boolean isOrgAdmin) throws Exception {
+    var mapper = new ObjectMapper();
+    var root = mapper.createObjectNode();
+    var identity = root.putObject("identity");
+    identity.put("type", "User").put("org_id", orgId);
+    identity.putObject("user").put("is_org_admin", isOrgAdmin);
+    return Base64.getEncoder().encodeToString(mapper.writeValueAsBytes(root));
   }
 }

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
@@ -49,13 +49,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 class OrgPreferencesResourceTest {
 
   private static final String ORG_ID = "org123";
+  private static final boolean IS_ORG_ADMIN = true;
   private static final String ORG_PREFERENCES_PATH =
       "/api/rhsm-subscriptions/v1/utilization/org-preferences";
 
   @InjectMock OrgPreferencesService orgPreferencesService;
 
   @Test
-  void getOrgPreferences_whenPreferencesExist_returnsPreferences() throws Exception {
+  void getOrgPreferences_whenPreferencesExist_returnsPreferences() {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(10);
     when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
@@ -71,7 +72,7 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void getOrgPreferences_whenPreferencesDoNotExist_returnsDefaultThreshold() throws Exception {
+  void getOrgPreferences_whenPreferencesDoNotExist_returnsDefaultThreshold() {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(80);
     when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(expected);
@@ -87,7 +88,7 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void updateOrgPreferences_whenPayloadValid_invokesServiceWithResolvedOrgId() throws Exception {
+  void updateOrgPreferences_whenPayloadValid_invokesServiceWithResolvedOrgId() {
     var expected = new OrgPreferencesResponse();
     expected.setCustomThreshold(4);
     when(orgPreferencesService.updateOrgPreferences(eq(ORG_ID), any(OrgPreferencesRequest.class)))
@@ -106,7 +107,7 @@ class OrgPreferencesResourceTest {
   @ParameterizedTest
   @ValueSource(ints = {-1, 101})
   void updateOrgPreferences_whenThresholdOutOfRange_returnsBadRequestWithoutCallingService(
-      int invalidThreshold) throws Exception {
+      int invalidThreshold) {
     whenUpdateOrgPreferencesTo(invalidThreshold).statusCode(HttpStatus.SC_BAD_REQUEST);
 
     verify(orgPreferencesService, never())
@@ -114,29 +115,27 @@ class OrgPreferencesResourceTest {
   }
 
   @Test
-  void updateOrgPreferences_whenCustomThresholdMissing_returnsBadRequestWithoutCallingService()
-      throws Exception {
+  void updateOrgPreferences_whenCustomThresholdMissing_returnsBadRequestWithoutCallingService() {
     whenUpdateOrgPreferencesTo(null).statusCode(HttpStatus.SC_BAD_REQUEST);
 
     verify(orgPreferencesService, never())
         .updateOrgPreferences(anyString(), any(OrgPreferencesRequest.class));
   }
 
-  private static ValidatableResponse whenGetOrgPreferences() throws Exception {
+  private static ValidatableResponse whenGetOrgPreferences() {
     return given()
-        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, false))
+        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, !IS_ORG_ADMIN))
         .when()
         .get(ORG_PREFERENCES_PATH)
         .then();
   }
 
-  private static ValidatableResponse whenUpdateOrgPreferencesTo(Integer customThreshold)
-      throws Exception {
+  private static ValidatableResponse whenUpdateOrgPreferencesTo(Integer customThreshold) {
     OrgPreferencesRequest request = new OrgPreferencesRequest();
     request.setCustomThreshold(customThreshold);
 
     return given()
-        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, true))
+        .header(RH_IDENTITY_HEADER, base64UserIdentity(ORG_ID, IS_ORG_ADMIN))
         .contentType(ContentType.JSON)
         .body(request)
         .when()
@@ -144,12 +143,16 @@ class OrgPreferencesResourceTest {
         .then();
   }
 
-  private static String base64UserIdentity(String orgId, boolean isOrgAdmin) throws Exception {
-    var mapper = new ObjectMapper();
-    var root = mapper.createObjectNode();
-    var identity = root.putObject("identity");
-    identity.put("type", "User").put("org_id", orgId);
-    identity.putObject("user").put("is_org_admin", isOrgAdmin);
-    return Base64.getEncoder().encodeToString(mapper.writeValueAsBytes(root));
+  private static String base64UserIdentity(String orgId, boolean isOrgAdmin) {
+    try {
+      var mapper = new ObjectMapper();
+      var root = mapper.createObjectNode();
+      var identity = root.putObject("identity");
+      identity.put("type", "User").put("org_id", orgId);
+      identity.putObject("user").put("is_org_admin", isOrgAdmin);
+      return Base64.getEncoder().encodeToString(mapper.writeValueAsBytes(root));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4980

## Description
Enforces org-admin authorization on POST /api/rhsm-subscriptions/v1/utilization/org-preferences. Previously any authenticated user could update their org's custom utilization threshold. Now only org admins (is_org_admin: true in x-rh-identity) or service principals can write.


## Testing
podman compose up -d
make-build component-test swatch-utilization
Unit tests included
