### PR TITLE
Add Liquibase precondition on index existence

### DIFF
--- a/src/main/resources/liquibase/202605151359-host-tally-buckets-partial-index.xml
+++ b/src/main/resources/liquibase/202605151359-host-tally-buckets-partial-index.xml
@@ -6,6 +6,11 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
 
   <changeSet id="202605151359-01" author="awood" dbms="postgresql">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists tableName="host_tally_buckets" indexName="host_tally_buckets_is_primary_idx"/>
+      </not>
+    </preConditions>
     <sql>
       CREATE INDEX host_tally_buckets_is_primary_idx ON host_tally_buckets (
         product_id


### PR DESCRIPTION
Jira issue: None

## Description
Add a condition that will skip the index creation if it already exists (in production due to an out-of-band migration, for example)

## Testing
1. Checkout `main`.
2. Run `make build swatch-tally`.
3. Verify the index `host_tally_buckets_is_primary_idx` exists.
    ```
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c '\d host_tally_buckets'
    ```
3. Delete the record of that changeset having run
    ```
    psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "delete from databasechangelog where id='202605151359-01'"                                                 
    ```
4. Run `make swatch-tally` again.  Deployment will fail due to the index already existing.
5. Checkout this branch.
6. Run `make build swatch-tally`.
7. Verify deployment completes successfully.
