### PR TITLE
SWATCH-5049: Expose public v2 OpenAPI from swatch-api.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,6 +16,8 @@
   <properties>
     <api_spec_v1>${project.basedir}/rhsm-subscriptions-api-v1-spec.yaml</api_spec_v1>
     <api_config_v1>${project.basedir}/rhsm-subscriptions-api-v1-config.json</api_config_v1>
+    <api_spec_v2>${project.basedir}/rhsm-subscriptions-api-v2-spec.yaml</api_spec_v2>
+    <api_config_v2>${project.basedir}/rhsm-subscriptions-api-v2-config.json</api_config_v2>
   </properties>
 
   <dependencies>
@@ -116,6 +118,68 @@
               </configOptions>
             </configuration>
           </execution>
+
+          <execution>
+            <id>generateApi_v2</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${api_spec_v2}</inputSpec>
+              <generatorName>jaxrs-spec</generatorName>
+              <configurationFile>${api_config_v2}</configurationFile>
+              <configOptions>
+                <sourceFolder>src/gen/java/main</sourceFolder>
+                <interfaceOnly>true</interfaceOnly>
+                <generatePom>false</generatePom>
+                <dateLibrary>java8</dateLibrary>
+                <useJakartaEe>true</useJakartaEe>
+                <useTags>true</useTags>
+              </configOptions>
+              <typeMappings>
+                <typeMapping>string+MetricId=MetricId</typeMapping>
+                <typeMapping>string+ProductId=ProductId</typeMapping>
+              </typeMappings>
+              <importMappings>
+                <importMapping>StreamingOutput=javax.ws.rs.core.StreamingOutput</importMapping>
+                <importMapping>MetricId=com.redhat.swatch.configuration.registry.MetricId
+                </importMapping>
+                <importMapping>ProductId=com.redhat.swatch.configuration.registry.ProductId
+                </importMapping>
+              </importMappings>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>generateApiDocs_v2</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <generatorName>html</generatorName>
+              <inputSpec>${api_spec_v2}</inputSpec>
+              <output>${project.build.directory}/docs</output>
+              <generateModelTests>false</generateModelTests>
+              <generateApiTests>false</generateApiTests>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>generateOpenApiJson_v2</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <generatorName>openapi</generatorName>
+              <inputSpec>${api_spec_v2}</inputSpec>
+              <output>${project.build.directory}/openapijson</output>
+              <generateModelTests>false</generateModelTests>
+              <generateApiTests>false</generateApiTests>
+              <configOptions>
+                <outputFileName>rhsm-subscriptions-api-v2-openapi.json</outputFileName>
+              </configOptions>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -148,6 +212,34 @@
               <output>${project.build.directory}/classes/swagger</output>
               <configOptions>
                 <outputFile>generated-api-spec-v1.json</outputFile>
+              </configOptions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-api-v2-spec-yaml</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${api_spec_v2}</inputSpec>
+              <language>openapi-yaml</language>
+              <output>${project.build.directory}/classes/swagger</output>
+              <configOptions>
+                <outputFile>generated-api-spec-v2.yaml</outputFile>
+              </configOptions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-api-v2-spec-json</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${api_spec_v2}</inputSpec>
+              <language>openapi</language>
+              <output>${project.build.directory}/classes/swagger</output>
+              <configOptions>
+                <outputFile>generated-api-spec-v2.json</outputFile>
               </configOptions>
             </configuration>
           </execution>

--- a/api/rhsm-subscriptions-api-v2-config.json
+++ b/api/rhsm-subscriptions-api-v2-config.json
@@ -1,0 +1,7 @@
+{
+  "modelPackage": "org.candlepin.subscriptions.utilization.api.v2.model",
+  "apiPackage": "org.candlepin.subscriptions.utilization.api.v2.resources",
+  "invokerPackage": "org.candlepin.subscriptions.utilization",
+  "groupId": "org.candlepin",
+  "artifactId": "rhsm-subscriptions"
+}

--- a/api/rhsm-subscriptions-api-v2-spec.yaml
+++ b/api/rhsm-subscriptions-api-v2-spec.yaml
@@ -1,0 +1,401 @@
+openapi: "3.0.2"
+info:
+  title: "rhsm-subscriptions-api"
+  description: "REST interface for the rhsm-subscriptions service. Please note any deprecated APIs. Our current deprecation policy is to keep deprecated APIs around for at least 6 months."
+  version: 2.0.0
+
+servers:
+  - url: /{PATH_PREFIX}/{APP_NAME}
+    variables:
+      PATH_PREFIX:
+        default: api
+      APP_NAME:
+        default: rhsm-subscriptions
+  - url: https://{HOSTNAME}/{PATH_PREFIX}/{APP_NAME}
+    variables:
+      HOSTNAME:
+        enum:
+          - qa.console.redhat.com
+          - stage.console.redhat.com
+          - console.redhat.com
+        default: console.redhat.com
+      PATH_PREFIX:
+        default: api
+      APP_NAME:
+        default: rhsm-subscriptions
+
+paths:
+  /v2/subscriptions/products/{product_id}:
+    description: "Operations for total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+    parameters:
+      - name: product_id
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ProductId"
+        description: "The ID for the product we wish to query"
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          minimum: 0
+        description: "The number of items to skip before starting to collect the result set"
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+        description: "The numbers of items to return"
+    get:
+      summary: "Returns the total capacity by SKU for all of the org's active subscriptions for given Swatch product ID."
+      operationId: getSkuCapacityReport
+      parameters:
+        - name: category
+          in: query
+          schema:
+            $ref: '#/components/schemas/ReportCategory'
+          description: 'The category to fetch data for'
+        - name: sla
+          in: query
+          schema:
+            $ref: '#/components/schemas/ServiceLevelType'
+          description: "Include only capacity for the specified service level."
+        - name: usage
+          in: query
+          schema:
+            $ref: '#/components/schemas/UsageType'
+          description: "Include only capacity for the specified usage level."
+        - name: billing_provider
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingProviderType'
+          description: "Include only report data matching the specified billing provider"
+        - name: billing_account_id
+          in: query
+          schema:
+            $ref: '#/components/schemas/BillingAccountId'
+          description: "Include only report data matching the specified billing account"
+        - name: beginning
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the start of the report period. Dates should be provided in ISO 8601
+                 format but the only accepted offset is UTC. E.g. 2017-07-21T17:32:28Z"
+        - name: ending
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: "Defines the end of the report period.  Defaults to the current time. Dates should
+                 be provided in UTC."
+        - name: metric_id
+          in: query
+          schema:
+            type: string
+          description: "Filter subscriptions to those that contribute to a specific unit of measure"
+        - name: sort
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkuCapacityReportSort"
+          description: "What property to sort by (optional)"
+        - name: dir
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+          description: "Which direction to sort by (default: asc)"
+      responses:
+        '200':
+          description: "The request for the account's subscription capacities was successful."
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/SkuCapacityReport"
+              example:
+                data:
+                  - sku: RH00011
+                    product_name: "Red Hat Enterprise Linux Server, Premium (Physical and 4 Virtual Nodes)(L3 Only)"
+                    service_level: Premium
+                    usage: Production
+                    subscriptions:
+                      - id: "1234567890"
+                        number: "1234567891"
+                      - id: "1234567892"
+                        number: "1234567893"
+                      - id: "1234567894"
+                        number: "1234567895"
+                    next_event_date: "2020-04-01T00:00:00Z"
+                    next_event_type: Subscription Begin
+                    quantity: 3
+                    measurements:
+                      - 42
+                      - null
+                      - 1
+                    category: HYPERVISOR
+                meta:
+                  count: 1
+                  measurements: [ "Cores", "Sockets", "Instance-hours" ]
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '403':
+          $ref: "#/components/responses/Forbidden"
+        '404':
+          $ref: "#/components/responses/ResourceNotFound"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+      tags:
+        - subscriptions
+  /v2/openapi.json:
+    get:
+      summary: "Get the OpenAPI spec in JSON format."
+      operationId: getOpenApiJson
+      tags:
+        - root
+      responses:
+        '200':
+          description: "The request to get the OpenAPI JSON was successful."
+          content:
+            application/json:
+              schema:
+                type: string
+  /v2/openapi.yaml:
+    get:
+      summary: "Get the OpenAPI spec in YAML format."
+      operationId: getOpenApiYaml
+      tags:
+        - root
+      responses:
+        '200':
+          description: "The request to get the OpenAPI YAML was successful."
+          content:
+            application/x-yaml:
+              schema:
+                type: string
+
+components:
+  responses:
+    BadRequest:
+      description: "The server could could not process the current request."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    Forbidden:
+      description: "The request was valid, but the request was refused by the server."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    ResourceNotFound:
+      description: "The requested resource was not found."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+    InternalServerError:
+      description: "An internal server error has occurred and is not recoverable."
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+
+  securitySchemes:
+    3ScaleIdentity:
+      type: apiKey
+      in: header
+      name: x-rh-identity
+      description: |
+        Base64-encoded JSON identity header provided by 3Scale. Contains an
+        account number of the user issuing the request. Format of the JSON:
+        ```
+        {
+            "identity": {
+                "account_number": "account123",
+                "type": "User",
+                "user" : {
+                    "is_org_admin": true
+                },
+                "internal" : {
+                    "org_id": "org123"
+                }
+            }
+        }
+        ```
+        Encoded (via `base64 -w0`):
+        `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImFjY291bnQxMjMiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsiaXNfb3JnX2FkbWluIjp0cnVlfSwiaW50ZXJuYWwiOnsib3JnX2lkIjoib3JnMTIzIn19fQo=`
+
+  schemas:
+    # Schemas ending in "Type" are intentionally named to prevent naming conflicts with db model classes
+    ServiceLevelType:
+      description: "Describes the service level that the report was made against. Not set if it
+          wasn't specified as a query parameter."
+      type: string
+      enum: [ "", Premium, Standard, Self-Support, _ANY ]
+    UsageType:
+      description: "Describes the usage that the report was made against. Not set if it wasn't
+          specified as a query parameter."
+      type: string
+      enum: [ "", Production, Development/Test, Disaster Recovery, _ANY ]
+    BillingProviderType:
+      type: string
+      enum: [ "", red hat, aws, gcp, azure, oracle, _ANY ]
+    ReportCategory:
+      type: string
+      enum:
+        - physical
+        - virtual
+        - cloud
+        - hypervisor
+    BillingAccountId:
+      type: string
+    SortDirection:
+      type: string
+      enum:
+        - asc
+        - desc
+    PageLinks:
+      properties:
+        first:
+          type: string
+        last:
+          type: string
+        previous:
+          type: string
+        next:
+          type: string
+      required:
+        - first
+        - last
+
+    SubscriptionType:
+      type: string
+      enum:
+        - On-demand
+        - Annual
+
+    SubscriptionEventType:
+      description: "The most immediate subscription event, such as a subscription beginning or ending."
+      type: string
+      enum:
+        - Subscription Start
+        - Subscription End
+
+    SkuCapacitySubscription:
+      properties:
+        id:
+          type: string
+        number:
+          type: string
+
+    SkuCapacity:
+      properties:
+        sku:
+          description: "The identifier for the offering."
+          type: string
+        product_name:
+          description: "The offering name."
+          type: string
+        service_level:
+          $ref: "#/components/schemas/ServiceLevelType"
+        usage:
+          $ref: "#/components/schemas/UsageType"
+        subscriptions:
+          description: "List of active subscriptions that contribute to the quantity and capacity totals."
+          type: array
+          items:
+            $ref: "#/components/schemas/SkuCapacitySubscription"
+        billing_account_id:
+          description: "The billing account ID."
+          type: string
+        billing_provider:
+          $ref: '#/components/schemas/BillingProviderType'
+        next_event_date:
+          description: "The most immediate date for a subscription event."
+          type: string
+          format: date-time
+        next_event_type:
+          $ref: "#/components/schemas/SubscriptionEventType"
+        quantity:
+          description: "The summed subscription quantities across the active subscriptions for the offering."
+          type: integer
+          format: int32
+        measurements:
+          description: >-
+            The summed standard capacity of the unit-of-measure of the active subscriptions for the offering. 
+            Must be in the same order as "measurements" in the meta.
+          type: array
+          items:
+            format: double
+            type: number
+        category:
+          $ref: '#/components/schemas/ReportCategory'
+        has_infinite_quantity:
+          description: "Denotes unlimited capacity for the offering when true."
+          type: boolean
+    SkuCapacityReportSort:
+      type: string
+      enum:
+        - sku
+        - service_level
+        - usage
+        - next_event_date
+        - next_event_type
+        - quantity
+        - product_name
+    SkuCapacityReport:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkuCapacity'
+        links:
+          $ref: "#/components/schemas/PageLinks"
+        meta:
+          type: object
+          properties:
+            count:
+              type: integer
+            product:
+              type: string
+            measurements:
+              type: array
+              items:
+                type: string
+            service_level:
+              $ref: '#/components/schemas/ServiceLevelType'
+            usage:
+              $ref: '#/components/schemas/UsageType'
+            subscription_type:
+              $ref: '#/components/schemas/SubscriptionType'
+            report_category:
+              $ref: '#/components/schemas/ReportCategory'
+          required:
+            - count
+            - product
+            - subscription_type
+    ProductId:
+      type: string
+      format: ProductId
+    Errors:
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/Error"
+    Error:
+      required:
+        - status
+        - code
+        - title
+      properties:
+        status:
+          type: string
+        code:
+          type: string
+        title:
+          type: string
+
+security:
+  - 3ScaleIdentity: []

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v2/OpenApiResourceV2.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v2/OpenApiResourceV2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.resource.api.v2;
+
+import lombok.AllArgsConstructor;
+import org.candlepin.subscriptions.resource.api.ApiSpecController;
+import org.candlepin.subscriptions.utilization.api.v2.resources.RootApi;
+import org.springframework.stereotype.Component;
+
+/** Serves the OpenAPI spec as /openapi.json and /openapi.yaml. */
+@Component
+@AllArgsConstructor
+public class OpenApiResourceV2 implements RootApi {
+  private final ApiSpecController controller;
+
+  @Override
+  public String getOpenApiJson() {
+    return controller.getOpenApiV2Json();
+  }
+
+  @Override
+  public String getOpenApiYaml() {
+    return controller.getOpenApiV2Yaml();
+  }
+}

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -87,6 +87,9 @@ public class ApiSecurityConfiguration {
         // Public v1 API specs (e.g. /api/rhsm-subscriptions/v1/openapi.yaml):
         "/api/rhsm-subscriptions/v1/*openapi.yaml",
         "/api/rhsm-subscriptions/v1/*openapi.json",
+        // Public v2 API specs (e.g. /api/rhsm-subscriptions/v2/openapi.yaml):
+        "/api/rhsm-subscriptions/v2/*openapi.yaml",
+        "/api/rhsm-subscriptions/v2/*openapi.json",
         "/api/rhsm-subscriptions/v1/version",
         "/api-docs/**",
         "/api/rhsm-subscriptions/*spec.yaml",


### PR DESCRIPTION
The v2 openapi URL was routed to swatch-api, which only serves the v1 spec and has no v2 handler, so unauthenticated requests were rejected and the API catalog could not load the document.

Serve the v2 public spec from swatch-contracts and route those requests through swatch-api nginx to the owning service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released API v2 with new SKU capacity report endpoint (`GET /v2/subscriptions/products/{product_id}`) supporting comprehensive filtering and pagination
  * Made OpenAPI specifications publicly accessible via JSON and YAML endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->