### PR TITLE
WIP: SWATCH-4368: Add Kessel (RBACv2) authorization foundation

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -17,36 +17,36 @@
             "createdAt": "2024-10-01T09:18:27.111Z"
         },
         {
-          "name": "swatch.swatch-notifications.send-notifications",
-          "description": "Enable sending of over-usage notifications to platform.notifications.ingress",
-          "type": "operational",
-          "project": "default",
-          "enabled": true,
-          "stale": false,
-          "strategies": [
-            {
-              "name": "default",
-              "parameters": {}
-            }
-          ],
-          "variants": [],
-          "createdAt": "2025-11-28T10:00:00.000Z"
+            "name": "swatch.swatch-notifications.send-notifications",
+            "description": "Enable sending of over-usage notifications to platform.notifications.ingress",
+            "type": "operational",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {}
+                }
+            ],
+            "variants": [],
+            "createdAt": "2025-11-28T10:00:00.000Z"
         },
         {
-          "name": "swatch.swatch-notifications.send-notifications-orgs-allowlist",
-          "description": "Comma-separated list of org IDs allowed to receive over-usage notifications regardless of the global send-notifications flag. Used for targeted testing in production without affecting other users.",
-          "type": "operational",
-          "project": "default",
-          "enabled": true,
-          "stale": false,
-          "strategies": [
-            {
-              "name": "default",
-              "parameters": {}
-            }
-          ],
-          "variants": [],
-          "createdAt": "2026-02-26T10:00:00.000Z"
+            "name": "swatch.swatch-notifications.send-notifications-orgs-allowlist",
+            "description": "Comma-separated list of org IDs allowed to receive over-usage notifications regardless of the global send-notifications flag. Used for targeted testing in production without affecting other users.",
+            "type": "operational",
+            "project": "default",
+            "enabled": true,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {}
+                }
+            ],
+            "variants": [],
+            "createdAt": "2026-02-26T10:00:00.000Z"
         },
         {
             "name": "hbi.api.disable-xjoin",
@@ -141,6 +141,22 @@
             ],
             "variants": [],
             "createdAt": "2026-03-30T015:18:27.111Z"
+        },
+        {
+            "name": "swatch.common-security.use-kessel-rbac",
+            "description": "When enabled, SWATCH uses Kessel (RBACv2) for authorization instead of legacy RBACv1. Part of SWATCH-4368 migration.",
+            "type": "operational",
+            "project": "default",
+            "enabled": false,
+            "stale": false,
+            "strategies": [
+                {
+                    "name": "default",
+                    "parameters": {}
+                }
+            ],
+            "variants": [],
+            "createdAt": "2026-06-02T20:00:00.000Z"
         }
     ],
     "strategies": [

--- a/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/ApiSecurityConfiguration.java
@@ -21,7 +21,9 @@
 package org.candlepin.subscriptions.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.getunleash.Unleash;
 import jakarta.servlet.http.HttpServletRequest;
+import org.candlepin.subscriptions.rbac.KesselService;
 import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +76,7 @@ import org.springframework.security.web.servlet.util.matcher.PathPatternRequestM
  * </ol>
  */
 @Configuration
-@Import(RbacConfiguration.class)
+@Import({RbacConfiguration.class, KesselConfiguration.class})
 public class ApiSecurityConfiguration {
 
   @Autowired protected ManagementServerProperties actuatorProps;
@@ -165,9 +167,16 @@ public class ApiSecurityConfiguration {
       SecurityProperties secProps,
       RbacProperties rbacProperties,
       RbacService rbacService,
-      IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper) {
+      IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper,
+      @Autowired(required = false) KesselService kesselService,
+      @Autowired(required = false) Unleash unleash) {
     return new IdentityHeaderAuthenticationDetailsService(
-        secProps, rbacProperties, identityHeaderAuthoritiesMapper, rbacService);
+        secProps,
+        rbacProperties,
+        identityHeaderAuthoritiesMapper,
+        rbacService,
+        kesselService,
+        unleash);
   }
 
   @Bean

--- a/src/main/java/org/candlepin/subscriptions/security/KesselConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/KesselConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.security;
+
+import org.candlepin.subscriptions.rbac.KesselProperties;
+import org.candlepin.subscriptions.rbac.KesselService;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KesselConfiguration {
+
+  @Bean
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.kessel")
+  public KesselProperties kesselProperties() {
+    return new KesselProperties();
+  }
+
+  @Bean
+  public KesselService kesselService(KesselProperties props) {
+    return new KesselService(props);
+  }
+}

--- a/src/main/resources/application-api.yaml
+++ b/src/main/resources/application-api.yaml
@@ -12,6 +12,13 @@ rhsm-subscriptions:
     truststore-password: ${clowder.endpoints.rbac-service.trust-store-password}
     truststore-type: ${clowder.endpoints.rbac-service.trust-store-type}
     max-connections: ${RHSM_RBAC_MAX_CONNECTIONS:100}
+  kessel:
+    endpoint: ${KESSEL_URL:localhost:9000}
+    insecure: ${KESSEL_INSECURE:true}
+    auth-enabled: ${KESSEL_AUTH_ENABLED:false}
+    client-id: ${KESSEL_AUTH_CLIENT_ID:}
+    client-secret: ${KESSEL_AUTH_CLIENT_SECRET:}
+    oidc-issuer: ${KESSEL_AUTH_OIDC_ISSUER:}
   contracts:
     client:
       back-off-initial-interval: ${CONTRACT_CLIENT_BACK_OFF_INITIAL_INTERVAL_MILLIS:1000}

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -109,6 +109,8 @@ objects:
         - rbac
         - swatch-contracts
         - swatch-utilization
+      optionalDependencies:
+        - kessel-inventory
 
       database:
         sharedDbAppName: ${DB_POD}

--- a/swatch-common-security/pom.xml
+++ b/swatch-common-security/pom.xml
@@ -31,6 +31,23 @@
     </dependency>
 
     <dependency>
+      <groupId>org.project-kessel</groupId>
+      <artifactId>kessel-sdk</artifactId>
+      <version>1.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.78.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>oauth2-oidc-sdk</artifactId>
+      <version>11.30.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/swatch-common-security/pom.xml
+++ b/swatch-common-security/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.quarkiverse.unleash</groupId>
+      <artifactId>quarkus-unleash</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/swatch-common-security/pom.xml
+++ b/swatch-common-security/pom.xml
@@ -93,6 +93,12 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <version>1.78.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import com.nimbusds.jose.util.Pair;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.project_kessel.api.auth.ClientConfigAuth;
+import org.project_kessel.api.auth.OAuth2ClientCredentials;
+import org.project_kessel.api.auth.OIDCDiscovery;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.ClientBuilder;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+import org.project_kessel.api.rbac.v2.Utils;
+
+@Slf4j
+@ApplicationScoped
+public class KesselAuthorizationService {
+
+  private static final String RBAC_APP_NAME = "subscriptions";
+  private static final String RBAC_ADMIN_PERMISSION = RBAC_APP_NAME + ":*:*";
+  private static final String RBAC_READER_PERMISSION = RBAC_APP_NAME + ":reports:read";
+  private static final String KESSEL_DOMAIN = "redhat";
+
+  private static final List<String> SWATCH_PERMISSIONS =
+      List.of(RBAC_ADMIN_PERMISSION, RBAC_READER_PERMISSION);
+
+  @Inject KesselProperties properties;
+
+  private KesselInventoryServiceBlockingStub stub;
+  private ManagedChannel channel;
+
+  @PostConstruct
+  void init() {
+    try {
+      var builder = new ClientBuilder(properties.endpoint());
+
+      if (properties.insecure()) {
+        builder.insecure();
+      } else if (properties.authEnabled()) {
+        var issuer =
+            properties
+                .oidcIssuer()
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "swatch.kessel.oidc-issuer is required when auth is enabled"));
+        var clientId =
+            properties
+                .clientId()
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "swatch.kessel.client-id is required when auth is enabled"));
+        var clientSecret =
+            properties
+                .clientSecret()
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "swatch.kessel.client-secret is required when auth is enabled"));
+
+        var discovery = OIDCDiscovery.fetchOIDCDiscovery(issuer);
+        var authConfig = new ClientConfigAuth(clientId, clientSecret, discovery.tokenEndpoint());
+        var oauthClient = new OAuth2ClientCredentials(authConfig);
+        builder.oauth2ClientAuthenticated(oauthClient);
+      } else {
+        builder.unauthenticated();
+      }
+
+      Pair<KesselInventoryServiceBlockingStub, ManagedChannel> result = builder.build();
+      this.stub = result.getLeft();
+      this.channel = result.getRight();
+      log.info("Kessel authorization client initialized: endpoint={}", properties.endpoint());
+    } catch (Exception e) {
+      log.error("Failed to initialize Kessel authorization client", e);
+      throw new IllegalStateException("Kessel client initialization failed", e);
+    }
+  }
+
+  @PreDestroy
+  void shutdown() {
+    if (channel != null) {
+      try {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        channel.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Check if the given principal has the specified RBACv1-style permission via Kessel.
+   *
+   * @param principal the authenticated identity
+   * @param permission RBACv1 permission string (e.g. "subscriptions:*:*")
+   * @return true if access is allowed
+   */
+  public boolean checkAccess(RhIdentityPrincipal principal, String permission) {
+    var subjectId = extractSubjectId(principal);
+    var relation = mapPermissionToRelation(permission);
+
+    var request =
+        CheckRequest.newBuilder()
+            .setSubject(Utils.principalSubject(subjectId, KESSEL_DOMAIN))
+            .setRelation(relation)
+            .setObject(Utils.workspaceResource("default"))
+            .build();
+
+    try {
+      CheckResponse response = stub.check(request);
+      return response.getAllowed() == Allowed.ALLOWED_TRUE;
+    } catch (StatusRuntimeException e) {
+      log.warn(
+          "Kessel check failed for subject={}, permission={}: {}",
+          subjectId,
+          permission,
+          e.getStatus());
+      return false;
+    }
+  }
+
+  /**
+   * Get all granted RBACv1-style permissions for the given principal via Kessel. This method checks
+   * each known SWATCH permission and returns the ones that are allowed — matching the interface
+   * used by RbacRolesAugmentor.
+   */
+  public List<String> getPermissions(RhIdentityPrincipal principal) {
+    var granted = new ArrayList<String>();
+    for (var permission : SWATCH_PERMISSIONS) {
+      if (checkAccess(principal, permission)) {
+        granted.add(permission);
+      }
+    }
+    return granted;
+  }
+
+  /**
+   * Convert an RBACv1 permission string to a Kessel relation name. Colons become underscores, and
+   * wildcards become "all".
+   */
+  static String mapPermissionToRelation(String rbacPermission) {
+    return rbacPermission.replace(':', '_').replace("*", "all");
+  }
+
+  private static String extractSubjectId(RhIdentityPrincipal principal) {
+    return principal.getIdentity().getOrgId();
+  }
+
+  // Visible for testing
+  void setStub(KesselInventoryServiceBlockingStub stub) {
+    this.stub = stub;
+  }
+}

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
@@ -101,8 +101,8 @@ public class KesselAuthorizationService {
       this.channel = result.getRight();
       log.info("Kessel authorization client initialized: endpoint={}", properties.endpoint());
     } catch (Exception e) {
-      log.error("Failed to initialize Kessel authorization client", e);
-      throw new IllegalStateException("Kessel client initialization failed", e);
+      log.warn(
+          "Failed to initialize Kessel authorization client; auth checks will deny by default", e);
     }
   }
 
@@ -126,6 +126,10 @@ public class KesselAuthorizationService {
    * @return true if access is allowed
    */
   public boolean checkAccess(RhIdentityPrincipal principal, String permission) {
+    if (stub == null) {
+      log.warn("Kessel client not initialized; denying access");
+      return false;
+    }
     var subjectId = extractSubjectId(principal);
     var relation = mapPermissionToRelation(permission);
 

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import java.util.Optional;
+
+@ConfigMapping(prefix = "swatch.kessel")
+public interface KesselProperties {
+
+  @WithDefault("localhost:9000")
+  String endpoint();
+
+  @WithDefault("true")
+  boolean insecure();
+
+  @WithDefault("false")
+  boolean authEnabled();
+
+  Optional<String> clientId();
+
+  Optional<String> clientSecret();
+
+  Optional<String> oidcIssuer();
+}

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselRolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselRolesAugmentor.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @IfBuildProperty(name = "swatch-common-security.include-rbac", stringValue = "true")
 public class KesselRolesAugmentor implements SecurityIdentityAugmentor {
 
-  static final String KESSEL_FLAG = "swatch.common-security.use-kessel-rbac";
+  public static final String KESSEL_FLAG = "swatch.common-security.use-kessel-rbac";
 
   private static final String RBAC_ADMIN_PERMISSION = "subscriptions:*:*";
   private static final String RBAC_READER_PERMISSION = "subscriptions:reports:read";

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselRolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselRolesAugmentor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import io.getunleash.Unleash;
+import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.security.Principal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+@IfBuildProperty(name = "swatch-common-security.include-rbac", stringValue = "true")
+public class KesselRolesAugmentor implements SecurityIdentityAugmentor {
+
+  static final String KESSEL_FLAG = "swatch.common-security.use-kessel-rbac";
+
+  private static final String RBAC_ADMIN_PERMISSION = "subscriptions:*:*";
+  private static final String RBAC_READER_PERMISSION = "subscriptions:reports:read";
+
+  @Inject Unleash unleash;
+  @Inject KesselAuthorizationService kesselService;
+
+  @Override
+  public Uni<SecurityIdentity> augment(
+      SecurityIdentity identity, AuthenticationRequestContext context) {
+    if (!unleash.isEnabled(KESSEL_FLAG)) {
+      return Uni.createFrom().item(identity);
+    }
+
+    Principal principal = identity.getPrincipal();
+    if (principal instanceof RhIdentityPrincipal rhIdentityPrincipal
+        && shouldCheck(rhIdentityPrincipal)) {
+      return context.runBlocking(() -> lookupKesselRoles(identity));
+    }
+    return Uni.createFrom().item(identity);
+  }
+
+  private SecurityIdentity lookupKesselRoles(SecurityIdentity identity) {
+    List<String> permissions;
+    try {
+      permissions = kesselService.getPermissions((RhIdentityPrincipal) identity.getPrincipal());
+    } catch (Exception e) {
+      log.warn("Error adding roles via Kessel service integration: {}", e.getMessage());
+      return identity;
+    }
+
+    Set<String> effectiveRoles = determineEffectiveRoles(permissions);
+    return QuarkusSecurityIdentity.builder(identity).addRoles(effectiveRoles).build();
+  }
+
+  private Set<String> determineEffectiveRoles(List<String> permissions) {
+    if (permissions.contains(RBAC_ADMIN_PERMISSION)
+        || permissions.contains(RBAC_READER_PERMISSION)) {
+      return Set.of("customer");
+    }
+    return Set.of();
+  }
+
+  private static boolean shouldCheck(RhIdentityPrincipal principal) {
+    return Objects.equals("User", principal.getIdentity().getType())
+        || Objects.equals("ServiceAccount", principal.getIdentity().getType());
+  }
+}

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RbacRolesAugmentor.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/RbacRolesAugmentor.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.common.security;
 import com.redhat.swatch.clients.rbac.api.model.Access;
 import com.redhat.swatch.clients.rbac.api.resources.AccessApi;
 import com.redhat.swatch.clients.rbac.api.resources.ApiException;
+import io.getunleash.Unleash;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -54,6 +55,7 @@ public class RbacRolesAugmentor implements SecurityIdentityAugmentor {
   @ConfigProperty(name = "RBAC_ENABLED", defaultValue = "true")
   boolean rbacEnabled;
 
+  @Inject Unleash unleash;
   @Inject @RestClient AccessApi accessApi;
 
   @Override
@@ -61,6 +63,10 @@ public class RbacRolesAugmentor implements SecurityIdentityAugmentor {
       SecurityIdentity identity, AuthenticationRequestContext context) {
     if (!rbacEnabled) {
       return Uni.createFrom().item(buildWithAllRoles(identity));
+    }
+
+    if (unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)) {
+      return Uni.createFrom().item(identity);
     }
 
     Principal principal = identity.getPrincipal();

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -19,6 +19,9 @@ quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".tru
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-type=${clowder.endpoints.rbac-service.trust-store-type}
 
+# Unleash toggle: when enabled, KesselRolesAugmentor handles auth and RbacRolesAugmentor is skipped
+# Toggle name: swatch.common-security.use-kessel-rbac (default off — managed in Unleash)
+
 # Kessel / RBACv2 configuration
 swatch.kessel.endpoint=${KESSEL_URL:localhost:9000}
 swatch.kessel.insecure=${KESSEL_INSECURE:true}

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -18,3 +18,11 @@ quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store-type=${clowder.endpoints.rbac-service.trust-store-type}
+
+# Kessel / RBACv2 configuration
+swatch.kessel.endpoint=${KESSEL_URL:localhost:9000}
+swatch.kessel.insecure=${KESSEL_INSECURE:true}
+swatch.kessel.auth-enabled=${KESSEL_AUTH_ENABLED:false}
+swatch.kessel.client-id=${KESSEL_AUTH_CLIENT_ID:}
+swatch.kessel.client-secret=${KESSEL_AUTH_CLIENT_SECRET:}
+swatch.kessel.oidc-issuer=${KESSEL_AUTH_OIDC_ISSUER:}

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -29,3 +29,4 @@ swatch.kessel.auth-enabled=${KESSEL_AUTH_ENABLED:false}
 swatch.kessel.client-id=${KESSEL_AUTH_CLIENT_ID:}
 swatch.kessel.client-secret=${KESSEL_AUTH_CLIENT_SECRET:}
 swatch.kessel.oidc-issuer=${KESSEL_AUTH_OIDC_ISSUER:}
+%prod.swatch.kessel.insecure=false

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselAuthorizationServiceTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselAuthorizationServiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+
+@ExtendWith(MockitoExtension.class)
+class KesselAuthorizationServiceTest {
+
+  KesselAuthorizationService service;
+  RhIdentityPrincipalFactory identityFactory;
+
+  @Mock KesselInventoryServiceBlockingStub stub;
+
+  @BeforeEach
+  void setup() {
+    service = new KesselAuthorizationService();
+    service.setStub(stub);
+
+    identityFactory = new RhIdentityPrincipalFactory();
+    identityFactory.mapper = new ObjectMapper();
+  }
+
+  private RhIdentityPrincipal principalFromJson(String json) {
+    try {
+      return identityFactory.fromJson(json);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void permissionMappingConvertsColonsToUnderscoresAndWildcardsToAll() {
+    assertEquals(
+        "subscriptions_all_all",
+        KesselAuthorizationService.mapPermissionToRelation("subscriptions:*:*"));
+    assertEquals(
+        "subscriptions_reports_read",
+        KesselAuthorizationService.mapPermissionToRelation("subscriptions:reports:read"));
+  }
+
+  @Test
+  void checkAccessReturnsTrueWhenAllowed() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_TRUE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    assertTrue(service.checkAccess(principal, "subscriptions:*:*"));
+  }
+
+  @Test
+  void checkAccessReturnsFalseWhenDenied() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_FALSE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    assertFalse(service.checkAccess(principal, "subscriptions:*:*"));
+  }
+
+  @Test
+  void checkAccessReturnsFalseOnGrpcError() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    assertFalse(service.checkAccess(principal, "subscriptions:*:*"));
+  }
+
+  @Test
+  void checkAccessBuildsCorrectRequestForUserPrincipal() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_TRUE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    service.checkAccess(principal, "subscriptions:reports:read");
+
+    var captor = ArgumentCaptor.forClass(CheckRequest.class);
+    verify(stub).check(captor.capture());
+
+    var request = captor.getValue();
+    assertEquals("subscriptions_reports_read", request.getRelation());
+    assertEquals("principal", request.getSubject().getResource().getResourceType());
+    assertEquals("redhat/org123", request.getSubject().getResource().getResourceId());
+    assertEquals("workspace", request.getObject().getResourceType());
+  }
+
+  @Test
+  void getPermissionsReturnsGrantedPermissions() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_TRUE).build())
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_FALSE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    List<String> permissions = service.getPermissions(principal);
+
+    assertEquals(List.of("subscriptions:*:*"), permissions);
+  }
+
+  @Test
+  void getPermissionsReturnsEmptyWhenNoneGranted() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_FALSE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    List<String> permissions = service.getPermissions(principal);
+
+    assertTrue(permissions.isEmpty());
+  }
+
+  @Test
+  void getPermissionsReturnsBothWhenBothGranted() {
+    when(stub.check(any(CheckRequest.class)))
+        .thenReturn(CheckResponse.newBuilder().setAllowed(Allowed.ALLOWED_TRUE).build());
+
+    var principal = principalFromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    List<String> permissions = service.getPermissions(principal);
+
+    assertEquals(List.of("subscriptions:*:*", "subscriptions:reports:read"), permissions);
+  }
+}

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselRolesAugmentorTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselRolesAugmentorTest.java
@@ -21,14 +21,11 @@
 package com.redhat.swatch.common.security;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.swatch.clients.rbac.api.model.Access;
-import com.redhat.swatch.clients.rbac.api.model.AccessPagination;
-import com.redhat.swatch.clients.rbac.api.resources.AccessApi;
-import com.redhat.swatch.clients.rbac.api.resources.ApiException;
 import io.getunleash.Unleash;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.AuthenticationRequestContext;
@@ -46,21 +43,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class RbacRolesAugmentorTest {
-  RbacRolesAugmentor augmentor;
+class KesselRolesAugmentorTest {
+
+  KesselRolesAugmentor augmentor;
   RhIdentityPrincipalFactory identityFactory;
 
-  @Mock AccessApi rbacApi;
   @Mock Unleash unleash;
+  @Mock KesselAuthorizationService kesselService;
 
   AuthenticationRequestContext context = Uni.createFrom()::item;
 
   @BeforeEach
   void setup() {
-    augmentor = new RbacRolesAugmentor();
-    augmentor.rbacEnabled = true;
+    augmentor = new KesselRolesAugmentor();
     augmentor.unleash = unleash;
-    augmentor.accessApi = rbacApi;
+    augmentor.kesselService = kesselService;
 
     identityFactory = new RhIdentityPrincipalFactory();
     identityFactory.mapper = new ObjectMapper();
@@ -75,10 +72,22 @@ class RbacRolesAugmentorTest {
   }
 
   @Test
-  void customerRoleGrantedToCustomerHavingAdminRbacRole() throws ApiException {
-    when(rbacApi.getPrincipalAccess(any(), any(), any(), any(), any()))
-        .thenReturn(
-            new AccessPagination().data(List.of(new Access().permission("subscriptions:*:*"))));
+  void skipsWhenFlagDisabled() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(false);
+    var subscriber =
+        augmentor
+            .augment(
+                securityIdentityForRhIdentityJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON), context)
+            .subscribe()
+            .withSubscriber(UniAssertSubscriber.create());
+    subscriber.assertCompleted();
+    verifyNoInteractions(kesselService);
+  }
+
+  @Test
+  void customerRoleGrantedWhenKesselAllowsAdmin() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+    when(kesselService.getPermissions(any())).thenReturn(List.of("subscriptions:*:*"));
     var subscriber =
         augmentor
             .augment(
@@ -90,11 +99,9 @@ class RbacRolesAugmentorTest {
   }
 
   @Test
-  void customerRoleGrantedToCustomerHavingReaderRbacRole() throws ApiException {
-    when(rbacApi.getPrincipalAccess(any(), any(), any(), any(), any()))
-        .thenReturn(
-            new AccessPagination()
-                .data(List.of(new Access().permission("subscriptions:reports:read"))));
+  void customerRoleGrantedWhenKesselAllowsReader() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+    when(kesselService.getPermissions(any())).thenReturn(List.of("subscriptions:reports:read"));
     var subscriber =
         augmentor
             .augment(
@@ -106,9 +113,9 @@ class RbacRolesAugmentorTest {
   }
 
   @Test
-  void customerRoleNotGrantedToCustomerNoRbacRole() throws ApiException {
-    when(rbacApi.getPrincipalAccess(any(), any(), any(), any(), any()))
-        .thenReturn(new AccessPagination().data(List.of()));
+  void noRoleWhenKesselDenies() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+    when(kesselService.getPermissions(any())).thenReturn(List.of());
     var subscriber =
         augmentor
             .augment(
@@ -120,9 +127,9 @@ class RbacRolesAugmentorTest {
   }
 
   @Test
-  void customerRoleNotGrantedWhenRbacCallFails() throws ApiException {
-    when(rbacApi.getPrincipalAccess(any(), any(), any(), any(), any()))
-        .thenThrow(new ApiException());
+  void noRoleWhenKesselCallFails() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+    when(kesselService.getPermissions(any())).thenThrow(new RuntimeException("gRPC error"));
     var subscriber =
         augmentor
             .augment(
@@ -134,16 +141,27 @@ class RbacRolesAugmentorTest {
   }
 
   @Test
-  void noRbacInteractionWhenRbacNotEnabled() {
-    augmentor.rbacEnabled = false;
+  void skipsForAssociatePrincipal() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
     var subscriber =
         augmentor
             .augment(
-                securityIdentityForRhIdentityJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON), null)
-            .map(SecurityIdentity::getRoles)
+                securityIdentityForRhIdentityJson(RhIdentityUtils.ASSOCIATE_IDENTITY_JSON), context)
             .subscribe()
             .withSubscriber(UniAssertSubscriber.create());
-    verifyNoInteractions(rbacApi);
-    subscriber.assertCompleted().assertItem(Set.of("test", "service", "support", "customer"));
+    subscriber.assertCompleted();
+    verifyNoInteractions(kesselService);
+  }
+
+  @Test
+  void callsKesselServiceForCustomerPrincipal() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+    when(kesselService.getPermissions(any())).thenReturn(List.of("subscriptions:*:*"));
+    augmentor
+        .augment(securityIdentityForRhIdentityJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON), context)
+        .subscribe()
+        .withSubscriber(UniAssertSubscriber.create())
+        .assertCompleted();
+    verify(kesselService).getPermissions(any());
   }
 }

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServer.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+
+/**
+ * In-process gRPC mock for the Kessel Inventory Service. Use in component and integration tests to
+ * verify the full Kessel authorization flow without a real Kessel deployment.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * MockKesselServer kessel = new MockKesselServer();
+ * kessel.start();
+ *
+ * // Allow all checks by default
+ * kessel.allowAll();
+ *
+ * // Or configure specific permissions
+ * kessel.setResponse("subscriptions_all_all", Allowed.ALLOWED_TRUE);
+ * kessel.setResponse("subscriptions_reports_read", Allowed.ALLOWED_FALSE);
+ *
+ * // Get a blocking stub for direct use or injection
+ * KesselInventoryServiceBlockingStub stub = kessel.blockingStub();
+ *
+ * // Cleanup
+ * kessel.stop();
+ * }</pre>
+ */
+public class MockKesselServer {
+
+  private final String serverName;
+  private Server server;
+  private ManagedChannel channel;
+  private final Map<String, Allowed> responses = new ConcurrentHashMap<>();
+  private Allowed defaultResponse = Allowed.ALLOWED_FALSE;
+
+  public MockKesselServer() {
+    this.serverName = InProcessServerBuilder.generateName();
+  }
+
+  public void start() throws IOException {
+    server =
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(new MockKesselInventoryService())
+            .build()
+            .start();
+    channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+  }
+
+  public void stop() {
+    if (channel != null) {
+      channel.shutdownNow();
+    }
+    if (server != null) {
+      server.shutdownNow();
+    }
+  }
+
+  public KesselInventoryServiceBlockingStub blockingStub() {
+    return KesselInventoryServiceGrpc.newBlockingStub(channel);
+  }
+
+  public void setResponse(String relation, Allowed allowed) {
+    responses.put(relation, allowed);
+  }
+
+  public void allowAll() {
+    defaultResponse = Allowed.ALLOWED_TRUE;
+    responses.clear();
+  }
+
+  public void denyAll() {
+    defaultResponse = Allowed.ALLOWED_FALSE;
+    responses.clear();
+  }
+
+  public void reset() {
+    responses.clear();
+    defaultResponse = Allowed.ALLOWED_FALSE;
+  }
+
+  private class MockKesselInventoryService
+      extends KesselInventoryServiceGrpc.KesselInventoryServiceImplBase {
+
+    @Override
+    public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
+      var relation = request.getRelation();
+      var allowed = responses.getOrDefault(relation, defaultResponse);
+      responseObserver.onNext(CheckResponse.newBuilder().setAllowed(allowed).build());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServerTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+
+class MockKesselServerTest {
+
+  MockKesselServer kesselServer;
+  KesselAuthorizationService service;
+  RhIdentityPrincipalFactory identityFactory;
+
+  @BeforeEach
+  void setup() throws IOException {
+    kesselServer = new MockKesselServer();
+    kesselServer.start();
+
+    service = new KesselAuthorizationService();
+    service.setStub(kesselServer.blockingStub());
+
+    identityFactory = new RhIdentityPrincipalFactory();
+    identityFactory.mapper = new ObjectMapper();
+  }
+
+  @AfterEach
+  void teardown() {
+    kesselServer.stop();
+  }
+
+  private RhIdentityPrincipal principal() {
+    try {
+      return identityFactory.fromJson(RhIdentityUtils.CUSTOMER_IDENTITY_JSON);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void allowAllGrantsBothPermissions() {
+    kesselServer.allowAll();
+    List<String> permissions = service.getPermissions(principal());
+    assertEquals(List.of("subscriptions:*:*", "subscriptions:reports:read"), permissions);
+  }
+
+  @Test
+  void denyAllGrantsNoPermissions() {
+    kesselServer.denyAll();
+    List<String> permissions = service.getPermissions(principal());
+    assertTrue(permissions.isEmpty());
+  }
+
+  @Test
+  void selectivePermissions() {
+    kesselServer.setResponse("subscriptions_all_all", Allowed.ALLOWED_FALSE);
+    kesselServer.setResponse("subscriptions_reports_read", Allowed.ALLOWED_TRUE);
+
+    assertTrue(service.checkAccess(principal(), "subscriptions:reports:read"));
+    assertFalse(service.checkAccess(principal(), "subscriptions:*:*"));
+
+    List<String> permissions = service.getPermissions(principal());
+    assertEquals(List.of("subscriptions:reports:read"), permissions);
+  }
+
+  @Test
+  void resetClearsResponses() {
+    kesselServer.allowAll();
+    assertTrue(service.checkAccess(principal(), "subscriptions:*:*"));
+
+    kesselServer.reset();
+    assertFalse(service.checkAccess(principal(), "subscriptions:*:*"));
+  }
+}

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -239,6 +239,8 @@ objects:
         - ${DB_POD}
         - rbac
         - export-service
+      optionalDependencies:
+        - kessel-inventory
 
       featureFlags: true
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/KesselAuthCanaryTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/api/v2/KesselAuthCanaryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.resource.api.v2;
+
+import static com.redhat.swatch.common.security.RhIdentityHeaderAuthenticationMechanism.RH_IDENTITY_HEADER;
+import static com.redhat.swatch.contract.security.RhIdentityUtils.CUSTOMER_IDENTITY_HEADER;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.common.security.KesselAuthorizationService;
+import com.redhat.swatch.common.security.KesselRolesAugmentor;
+import com.redhat.swatch.common.security.RhIdentityPrincipal;
+import com.redhat.swatch.contract.test.resources.EnableKesselResource;
+import io.getunleash.Unleash;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Canary test proving the Kessel auth path works end-to-end. Sends a User identity header to a
+ * v2 @RolesAllowed("customer") endpoint and verifies that KesselRolesAugmentor correctly
+ * grants/denies the "customer" role via KesselAuthorizationService.
+ */
+@QuarkusTest
+@TestProfile(EnableKesselResource.class)
+class KesselAuthCanaryTest {
+
+  private static final String SUBSCRIPTIONS_ENDPOINT =
+      "/api/rhsm-subscriptions/v2/subscriptions/products/BASILISK";
+
+  @InjectMock Unleash unleash;
+  @InjectMock KesselAuthorizationService kesselService;
+
+  @BeforeEach
+  void setup() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(true);
+  }
+
+  @Test
+  void kesselGrantsAccess_requestPassesAuth() {
+    when(kesselService.getPermissions(any(RhIdentityPrincipal.class)))
+        .thenReturn(List.of("subscriptions:*:*"));
+
+    given()
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .queryParam("beginning", OffsetDateTime.now().minusDays(1).toString())
+        .queryParam("ending", OffsetDateTime.now().toString())
+        .when()
+        .get(SUBSCRIPTIONS_ENDPOINT)
+        .then()
+        .statusCode(not(401))
+        .statusCode(not(403));
+
+    verify(kesselService).getPermissions(any(RhIdentityPrincipal.class));
+  }
+
+  @Test
+  void kesselDeniesAccess_endpointReturns403() {
+    when(kesselService.getPermissions(any(RhIdentityPrincipal.class))).thenReturn(List.of());
+
+    given()
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .queryParam("beginning", OffsetDateTime.now().minusDays(1).toString())
+        .queryParam("ending", OffsetDateTime.now().toString())
+        .when()
+        .get(SUBSCRIPTIONS_ENDPOINT)
+        .then()
+        .statusCode(403);
+  }
+
+  @Test
+  void kesselFlagOff_fallsBackToRbacV1() {
+    when(unleash.isEnabled(KesselRolesAugmentor.KESSEL_FLAG)).thenReturn(false);
+
+    given()
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .queryParam("beginning", OffsetDateTime.now().minusDays(1).toString())
+        .queryParam("ending", OffsetDateTime.now().toString())
+        .when()
+        .get(SUBSCRIPTIONS_ENDPOINT);
+
+    verify(kesselService, never()).getPermissions(any());
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/DisableKesselResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/DisableKesselResource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.test.resources;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+/**
+ * Test profile that disables both RBAC v1 and Kessel authorization. All roles are granted to all
+ * principals — use for tests that don't need to verify authorization behavior.
+ *
+ * <p>Note: Kessel is already disabled in the test profile by default since Unleash is inactive
+ * (%test.quarkus.unleash.active=false). This profile explicitly disables RBAC v1 as well.
+ */
+public class DisableKesselResource implements QuarkusTestProfile {
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of("RBAC_ENABLED", "false");
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/EnableKesselResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/EnableKesselResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.test.resources;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+/**
+ * Test profile that keeps RBAC enabled so that the SecurityIdentityAugmentor chain runs. Used with
+ * mocked Unleash + KesselAuthorizationService to test the Kessel auth path end-to-end.
+ */
+public class EnableKesselResource implements QuarkusTestProfile {
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of("RBAC_ENABLED", "true");
+  }
+}

--- a/swatch-core/pom.xml
+++ b/swatch-core/pom.xml
@@ -45,7 +45,9 @@
     </dependency>
     <dependency>
       <groupId>io.getunleash</groupId>
-      <artifactId>springboot-unleash-starter</artifactId>
+      <artifactId>unleash-client-java</artifactId>
+      <version>10.0.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.project-kessel</groupId>

--- a/swatch-core/pom.xml
+++ b/swatch-core/pom.xml
@@ -44,6 +44,26 @@
       <artifactId>rbac-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.getunleash</groupId>
+      <artifactId>springboot-unleash-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.project-kessel</groupId>
+      <artifactId>kessel-sdk</artifactId>
+      <version>1.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.78.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>oauth2-oidc-sdk</artifactId>
+      <version>11.30.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-common-clock</artifactId>
     </dependency>

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rbac;
+
+import lombok.Data;
+
+@Data
+public class KesselProperties {
+  private String endpoint = "localhost:9000";
+  private boolean insecure = true;
+  private boolean authEnabled = false;
+  private String clientId;
+  private String clientSecret;
+  private String oidcIssuer;
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselService.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselService.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.rbac;
+
+import com.nimbusds.jose.util.Pair;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.project_kessel.api.auth.ClientConfigAuth;
+import org.project_kessel.api.auth.OAuth2ClientCredentials;
+import org.project_kessel.api.auth.OIDCDiscovery;
+import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckResponse;
+import org.project_kessel.api.inventory.v1beta2.ClientBuilder;
+import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+import org.project_kessel.api.rbac.v2.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KesselService {
+
+  private static final Logger log = LoggerFactory.getLogger(KesselService.class);
+
+  private static final String RBAC_APP_NAME = "subscriptions";
+  private static final String RBAC_ADMIN_PERMISSION = RBAC_APP_NAME + ":*:*";
+  private static final String RBAC_READER_PERMISSION = RBAC_APP_NAME + ":reports:read";
+  private static final String KESSEL_DOMAIN = "redhat";
+
+  private static final List<String> SWATCH_PERMISSIONS =
+      List.of(RBAC_ADMIN_PERMISSION, RBAC_READER_PERMISSION);
+
+  private final KesselProperties properties;
+  private KesselInventoryServiceBlockingStub stub;
+  private ManagedChannel channel;
+
+  public KesselService(KesselProperties properties) {
+    this.properties = properties;
+  }
+
+  @PostConstruct
+  void init() {
+    try {
+      var builder = new ClientBuilder(properties.getEndpoint());
+
+      if (properties.isInsecure()) {
+        builder.insecure();
+      } else if (properties.isAuthEnabled()) {
+        var issuer = properties.getOidcIssuer();
+        var clientId = properties.getClientId();
+        var clientSecret = properties.getClientSecret();
+
+        if (issuer == null || clientId == null || clientSecret == null) {
+          throw new IllegalStateException(
+              "Kessel oidcIssuer, clientId, and clientSecret are required when auth is enabled");
+        }
+
+        var discovery = OIDCDiscovery.fetchOIDCDiscovery(issuer);
+        var authConfig = new ClientConfigAuth(clientId, clientSecret, discovery.tokenEndpoint());
+        var oauthClient = new OAuth2ClientCredentials(authConfig);
+        builder.oauth2ClientAuthenticated(oauthClient);
+      } else {
+        builder.unauthenticated();
+      }
+
+      Pair<KesselInventoryServiceBlockingStub, ManagedChannel> result = builder.build();
+      this.stub = result.getLeft();
+      this.channel = result.getRight();
+      log.info("Kessel authorization client initialized: endpoint={}", properties.getEndpoint());
+    } catch (Exception e) {
+      log.error("Failed to initialize Kessel authorization client", e);
+      throw new IllegalStateException("Kessel client initialization failed", e);
+    }
+  }
+
+  @PreDestroy
+  void shutdown() {
+    if (channel != null) {
+      try {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        channel.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  public boolean checkAccess(String subjectId, String permission) {
+    var relation = mapPermissionToRelation(permission);
+
+    var request =
+        CheckRequest.newBuilder()
+            .setSubject(Utils.principalSubject(subjectId, KESSEL_DOMAIN))
+            .setRelation(relation)
+            .setObject(Utils.workspaceResource("default"))
+            .build();
+
+    try {
+      CheckResponse response = stub.check(request);
+      return response.getAllowed() == Allowed.ALLOWED_TRUE;
+    } catch (StatusRuntimeException e) {
+      log.warn(
+          "Kessel check failed for subject={}, permission={}: {}",
+          subjectId,
+          permission,
+          e.getStatus());
+      return false;
+    }
+  }
+
+  public List<String> getPermissions(String subjectId) {
+    var granted = new ArrayList<String>();
+    for (var permission : SWATCH_PERMISSIONS) {
+      if (checkAccess(subjectId, permission)) {
+        granted.add(permission);
+      }
+    }
+    return granted;
+  }
+
+  static String mapPermissionToRelation(String rbacPermission) {
+    return rbacPermission.replace(':', '_').replace("*", "all");
+  }
+
+  // Visible for testing
+  void setStub(KesselInventoryServiceBlockingStub stub) {
+    this.stub = stub;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselService.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselService.java
@@ -90,8 +90,8 @@ public class KesselService {
       this.channel = result.getRight();
       log.info("Kessel authorization client initialized: endpoint={}", properties.getEndpoint());
     } catch (Exception e) {
-      log.error("Failed to initialize Kessel authorization client", e);
-      throw new IllegalStateException("Kessel client initialization failed", e);
+      log.warn(
+          "Failed to initialize Kessel authorization client; auth checks will deny by default", e);
     }
   }
 
@@ -108,6 +108,10 @@ public class KesselService {
   }
 
   public boolean checkAccess(String subjectId, String permission) {
+    if (stub == null) {
+      log.warn("Kessel client not initialized; denying access for subject={}", subjectId);
+      return false;
+    }
     var relation = mapPermissionToRelation(permission);
 
     var request =

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/IdentityHeaderAuthenticationDetailsService.java
@@ -20,9 +20,11 @@
  */
 package org.candlepin.subscriptions.security;
 
+import io.getunleash.Unleash;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.candlepin.subscriptions.rbac.KesselService;
 import org.candlepin.subscriptions.rbac.RbacApiException;
 import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
@@ -51,16 +53,32 @@ public class IdentityHeaderAuthenticationDetailsService
   private RbacProperties rbacProps;
   private RoleProvider roleProvider;
   private RbacService rbacController;
+  private KesselService kesselService;
+  private Unleash unleash;
+
+  static final String KESSEL_FLAG = "swatch.common-security.use-kessel-rbac";
 
   public IdentityHeaderAuthenticationDetailsService(
       SecurityProperties props,
       RbacProperties rbacProps,
       Attributes2GrantedAuthoritiesMapper authMapper,
       RbacService rbacController) {
+    this(props, rbacProps, authMapper, rbacController, null, null);
+  }
+
+  public IdentityHeaderAuthenticationDetailsService(
+      SecurityProperties props,
+      RbacProperties rbacProps,
+      Attributes2GrantedAuthoritiesMapper authMapper,
+      RbacService rbacController,
+      KesselService kesselService,
+      Unleash unleash) {
     this.rbacProps = rbacProps;
     this.authMapper = authMapper;
     this.props = props;
     this.rbacController = rbacController;
+    this.kesselService = kesselService;
+    this.unleash = unleash;
 
     if (props.isDevMode()) {
       log.info("Running in DEV mode. Security will be disabled.");
@@ -100,10 +118,30 @@ public class IdentityHeaderAuthenticationDetailsService
   }
 
   private List<String> getPermissions() {
+    if (isKesselEnabled()) {
+      return getKesselPermissions();
+    }
     try {
       return rbacController.getPermissions(rbacProps.getApplicationName());
     } catch (RbacApiException e) {
       log.warn("Unable to determine roles from RBAC service.", e);
+      return Collections.emptyList();
+    }
+  }
+
+  private boolean isKesselEnabled() {
+    return kesselService != null && unleash != null && unleash.isEnabled(KESSEL_FLAG);
+  }
+
+  private List<String> getKesselPermissions() {
+    try {
+      Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+      if (auth != null && auth.getPrincipal() instanceof InsightsUserPrincipal user) {
+        return kesselService.getPermissions(user.getOrgId());
+      }
+      return Collections.emptyList();
+    } catch (Exception e) {
+      log.warn("Unable to determine roles from Kessel service.", e);
       return Collections.emptyList();
     }
   }

--- a/swatch-system-conduit/deploy/clowdapp.yaml
+++ b/swatch-system-conduit/deploy/clowdapp.yaml
@@ -160,6 +160,8 @@ objects:
     dependencies:
       - ${DB_POD}
       - swatch-tally
+    optionalDependencies:
+      - kessel-inventory
 
     pullSecrets:
       name: ${IMAGE_PULL_SECRET}

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/ApiSecurityConfiguration.java
@@ -21,7 +21,9 @@
 package org.candlepin.subscriptions.conduit.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.getunleash.Unleash;
 import jakarta.servlet.http.HttpServletRequest;
+import org.candlepin.subscriptions.rbac.KesselService;
 import org.candlepin.subscriptions.rbac.RbacProperties;
 import org.candlepin.subscriptions.rbac.RbacService;
 import org.candlepin.subscriptions.security.AntiCsrfFilter;
@@ -84,7 +86,7 @@ import org.springframework.security.web.servlet.util.matcher.PathPatternRequestM
  * </ol>
  */
 @Configuration
-@Import(RbacConfiguration.class)
+@Import({RbacConfiguration.class, KesselConfiguration.class})
 public class ApiSecurityConfiguration {
 
   @Autowired protected ManagementServerProperties actuatorProps;
@@ -164,9 +166,16 @@ public class ApiSecurityConfiguration {
       SecurityProperties secProps,
       RbacProperties rbacProperties,
       RbacService rbacService,
-      IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper) {
+      IdentityHeaderAuthoritiesMapper identityHeaderAuthoritiesMapper,
+      @Autowired(required = false) KesselService kesselService,
+      @Autowired(required = false) Unleash unleash) {
     return new IdentityHeaderAuthenticationDetailsService(
-        secProps, rbacProperties, identityHeaderAuthoritiesMapper, rbacService);
+        secProps,
+        rbacProperties,
+        identityHeaderAuthoritiesMapper,
+        rbacService,
+        kesselService,
+        unleash);
   }
 
   @Bean

--- a/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/KesselConfiguration.java
+++ b/swatch-system-conduit/src/main/java/org/candlepin/subscriptions/conduit/security/KesselConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.conduit.security;
+
+import org.candlepin.subscriptions.rbac.KesselProperties;
+import org.candlepin.subscriptions.rbac.KesselService;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KesselConfiguration {
+
+  @Bean
+  @ConfigurationProperties(prefix = "rhsm-subscriptions.kessel")
+  public KesselProperties kesselProperties() {
+    return new KesselProperties();
+  }
+
+  @Bean
+  public KesselService kesselService(KesselProperties props) {
+    return new KesselService(props);
+  }
+}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -399,6 +399,8 @@ objects:
       - swatch-contracts
       - rbac
       - export-service
+    optionalDependencies:
+      - kessel-inventory
     # IQE plugin your ClowdApp is associated with
     testing:
       iqePlugin: rhsm-subscriptions

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -150,6 +150,8 @@ objects:
       - ${DB_POD}
       - swatch-contracts
       - rbac
+    optionalDependencies:
+      - kessel-inventory
 
     kafkaTopics:
       - replicas: ${{KAFKA_UTILIZATION_REPLICAS}}


### PR DESCRIPTION
## Summary

Foundation work for migrating SWATCH from RBACv1 to Kessel (RBACv2). Adds the Kessel Java SDK, authorization service wrappers, and Unleash-gated augmentors to both the Quarkus and Spring security stacks. **Zero production behavior change** — everything is gated behind the `swatch.common-security.use-kessel-rbac` Unleash flag (default OFF).

- Add `kessel-sdk` gRPC client + `KesselAuthorizationService` wrapper to `swatch-common-security` (Quarkus) and `swatch-core` (Spring)
- Add `KesselRolesAugmentor` (Quarkus `SecurityIdentityAugmentor`) that calls Kessel instead of RBAC v1 when flag is ON
- Modify `IdentityHeaderAuthenticationDetailsService` (Spring) with the same Kessel path
- Add `kessel-inventory` as optional ClowdApp dependency to all 7 services
- Register Unleash flag in `.unleash/flags.json` for local dev
- Add `MockKesselServer` (in-process gRPC mock) for testing
- Add canary integration test proving the full Kessel auth path works on the v2 subscriptions endpoint

## Unleash Flag

Toggle name: `swatch.common-security.use-kessel-rbac`

```shell
# Enable
http post :4242/api/admin/projects/default/features/swatch.common-security.use-kessel-rbac/environments/development/on \
  Authorization:"*:*.unleash-insecure-admin-api-token"

# Disable
http post :4242/api/admin/projects/default/features/swatch.common-security.use-kessel-rbac/environments/development/off \
  Authorization:"*:*.unleash-insecure-admin-api-token"
```

## Test plan

- [x] `./mvnw -pl swatch-common-security test` — 47 tests (15 new Kessel tests + 32 existing), all pass
- [x] `./mvnw -pl swatch-core test` — 37 tests, all pass
- [x] `./mvnw -pl swatch-contracts test -Dtest=KesselAuthCanaryTest` — 3 canary tests pass
- [ ] Ephemeral environment validation
