### PR TITLE
SWATCH-4952: fix USER_OPTS_APPEND  JVM heap limit being overwritten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ COPY --from=0 /stage/swatch-tally/target/javaagent/* /opt/
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 RUN chmod -R g=u /deployments
 
 USER default
@@ -72,6 +75,7 @@ USER default
 ## - Fix CVE-2024-31141: Disabling Kafka client config providers
 ## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
-ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.BootApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Wrapper script to combine Java options at runtime
+# This allows USER_OPTS_APPEND to be set at runtime while preserving
+# the Quarkus and internal options defined at build time.
+
+# Combine all OPTS variables into JAVA_OPTS_APPEND at runtime
+# If JAVA_OPTS_APPEND is already set externally, preserve it and add USER_OPTS_APPEND
+if [ -z "${JAVA_OPTS_APPEND:-}" ]; then
+  # Not set externally - build from component parts
+  JAVA_OPTS_APPEND="${QUARKUS_OPTS_APPEND:-} ${INTERNAL_OPTS_APPEND:-} ${USER_OPTS_APPEND:-}"
+else
+  # Already set externally - just append USER_OPTS_APPEND to it
+  JAVA_OPTS_APPEND="${JAVA_OPTS_APPEND} ${USER_OPTS_APPEND:-}"
+fi
+
+# Remove leading/trailing whitespace
+JAVA_OPTS_APPEND=$(echo "$JAVA_OPTS_APPEND" | xargs)
+
+# Export for run-java.sh to pick up
+export JAVA_OPTS_APPEND
+
+# Execute the base image's startup script
+exec /opt/jboss/container/java/run/run-java.sh

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -144,6 +144,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -154,5 +157,6 @@ EXPOSE 8080
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -143,6 +143,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -153,5 +156,6 @@ EXPOSE 8080
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -143,6 +143,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -153,5 +156,6 @@ EXPOSE 8080
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -145,6 +145,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -157,5 +160,6 @@ ENV AB_JOLOKIA_OFF=""
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -145,6 +145,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -157,5 +160,6 @@ ENV AB_JOLOKIA_OFF=""
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -145,6 +145,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -155,5 +158,6 @@ EXPOSE 8080
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -55,6 +55,10 @@ COPY --from=0 /stage/swatch-system-conduit/META-INF /deployments/META-INF
 COPY --from=0 /stage/swatch-system-conduit/BOOT-INF/classes /deployments/
 
 COPY --from=0 /stage/swatch-system-conduit/target/javaagent/* /opt/
+
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 RUN chmod -R g=u /deployments
 
 USER default
@@ -62,6 +66,7 @@ USER default
 ## - Fix CVE-2024-31141: Disabling Kafka client config providers
 ## - OmitStackTraceInFastThrow: disabling the optimization that eliminates the full exception stack trace
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
-ENV JAVA_OPTS_APPEND="$INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_MAIN_CLASS=org.candlepin.subscriptions.SystemConduitApplication
 ENV JAVA_LIB_DIR=/deployments/lib/*
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/swatch-utilization/src/main/docker/Dockerfile.jvm
+++ b/swatch-utilization/src/main/docker/Dockerfile.jvm
@@ -145,6 +145,9 @@ COPY --from=0 --chown=default:root --chmod=775 /stage/${PROJECT_NAME}/target/qua
 # Required by Red Hat OpenShift Software Certification Policy Guide
 COPY --from=0 /stage/LICENSE /licenses/
 
+# Copy shared entrypoint wrapper that combines JAVA_OPTS at runtime
+COPY --from=0 --chmod=755 /stage/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Used by Quarkus dev mode
 RUN chmod 775 /deployments /deployments/*
 
@@ -155,5 +158,6 @@ EXPOSE 8080
 ENV INTERNAL_OPTS_APPEND="-Dorg.apache.kafka.automatic.config.providers=none -XX:-OmitStackTraceInFastThrow"
 # Standard Quarkus JVM properties
 ENV QUARKUS_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
Jira issue: SWATCH-4952

## Description
`swatch-utilization-service` was running with a 640Mi heap instead of the intended 380Mi.  The deployment YAML set `USER_OPTS_APPEND=-Xmx380m -XX:MaxMetaspaceSize=256m`, but the JVM was ignoring it entirely, leaving MaxRAMPercentage=80.0 in effect against the 800Mi container limit.

The root cause: the Dockerfile baked JAVA_OPTS_APPEND at image build time:
`ENV JAVA_OPTS_APPEND="$QUARKUS_OPTS_APPEND $INTERNAL_OPTS_APPEND $USER_OPTS_APPEND"`
`$USER_OPTS_APPEND` always expands to empty at build time, so `JAVA_OPTS_APPEND` was frozen into the image without it.  Runtime values of `USER_OPTS_APPEND` were silently ignored.

## Approaches Considered
1. Set `JAVA_OPTS_APPEND` directly in deploy.yaml: Works but overrides the baked-in value, silently dropping the Quarkus and internal opts (`-Djava.util.logging.manager, -Dorg.apache.kafka.automatic.config.providers=none, -XX:-OmitStackTraceInFastThrow`).  Those would need to be duplicated into every deployment YAML, creating drift risk.

1. Duplicate all opts into `deploy.yaml`: Fragile: the security/CVE fixes in `INTERNAL_OPTS_APPEND` live in the Dockerfile; duplicating them into YAML creates two sources of truth that can get out of sync.

1. Create a shared swatch base image: Would cleanly centralize the entrypoint logic, but complicates the release pipeline.

1. Runtime entrypoint wrapper (implemented): A small `docker-entrypoint.sh` composes `JAVA_OPTS_APPEND` at container startup from the three component variables.  Each variable retains its natural ownership: Quarkus/internal opts stay in the Dockerfile, heap tuning stays in the deployment YAML.

## Solution
- Add `bin/docker-entrypoint.sh`: composes `JAVA_OPTS_APPEND` at runtime from `QUARKUS_OPTS_APPEND`, `INTERNAL_OPTS_APPEND`, and `USER_OPTS_APPEND`, then execs `run-java.sh`.
- Update all service `Dockerfile.jvm` files to COPY the script and set it as ENTRYPOINT; remove the build-time `JAVA_OPTS_APPEND` composition.

## Testing
1. build images and push to quay: `/bin/build-images.sh -t latest`
1. bonfire deploy using the new quay images
1. `oc exec -it swatch-utilization-service-(tab complete) -- jcmd 1 VM.flags | grep -E 'MaxHeapSize|MaxRAMPercentage'`