### PR TITLE
SWATCH-4803: Add exception mapper in swatch-utilization to log client validation exceptions

### DIFF
--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/ConstraintViolationExceptionMapper.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/resources/ConstraintViolationExceptionMapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.resources;
+
+import com.redhat.swatch.utilization.openapi.model.Error;
+import com.redhat.swatch.utilization.openapi.model.Errors;
+import jakarta.annotation.Priority;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Provider
+@Priority(Priorities.USER)
+public class ConstraintViolationExceptionMapper
+    implements ExceptionMapper<ConstraintViolationException> {
+
+  static final String ERROR_TITLE = "Client request failed validation.";
+
+  @Override
+  public Response toResponse(ConstraintViolationException exception) {
+    String detail = formatDetail(exception);
+    log.warn("Client request failed validation: {}", detail);
+
+    Error error =
+        new Error()
+            .status(String.valueOf(Status.BAD_REQUEST.getStatusCode()))
+            .title(ERROR_TITLE)
+            .detail(detail);
+
+    return Response.status(Status.BAD_REQUEST)
+        .entity(new Errors().errors(List.of(error)))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  private static String formatDetail(ConstraintViolationException exception) {
+    if (exception.getConstraintViolations() == null
+        || exception.getConstraintViolations().isEmpty()) {
+      return exception.getMessage();
+    }
+    return exception.getConstraintViolations().stream()
+        .map(ConstraintViolationExceptionMapper::formatViolation)
+        .collect(Collectors.joining("; "));
+  }
+
+  private static String formatViolation(ConstraintViolation<?> violation) {
+    String path = violation.getPropertyPath().toString();
+    String message = violation.getMessage();
+    Object invalidValue = violation.getInvalidValue();
+    if (invalidValue != null) {
+      return path + ": rejected value " + invalidValue + " (" + message + ")";
+    }
+    return path + ": " + message;
+  }
+}

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/ConstraintViolationExceptionMapperTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/ConstraintViolationExceptionMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.utilization.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.utilization.openapi.model.Errors;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.junit.jupiter.api.Test;
+
+class ConstraintViolationExceptionMapperTest {
+
+  private static final Validator VALIDATOR =
+      Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void toResponse_includesRejectedValueInDetail() {
+    var request = new OrgPreferencesRequest().customThreshold(150);
+    var violations = VALIDATOR.validate(request);
+    var exception = new ConstraintViolationException(violations);
+
+    Response response = new ConstraintViolationExceptionMapper().toResponse(exception);
+
+    assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Errors errors = (Errors) response.getEntity();
+    assertEquals(
+        "customThreshold: rejected value 150 (must be less than or equal to 100)",
+        errors.getErrors().get(0).getDetail());
+    assertTrue(errors.getErrors().get(0).getDetail().contains("rejected value 150"));
+  }
+}

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/resources/OrgPreferencesResourceTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.utilization.resources;
 
 import static com.redhat.swatch.common.security.RhIdentityHeaderAuthenticationMechanism.RH_IDENTITY_HEADER;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,7 +108,9 @@ class OrgPreferencesResourceTest {
   @ValueSource(ints = {-1, 101})
   void updateOrgPreferences_whenThresholdOutOfRange_returnsBadRequestWithoutCallingService(
       int invalidThreshold) {
-    whenUpdateOrgPreferencesTo(invalidThreshold).statusCode(HttpStatus.SC_BAD_REQUEST);
+    whenUpdateOrgPreferencesTo(invalidThreshold)
+        .statusCode(HttpStatus.SC_BAD_REQUEST)
+        .body("errors[0].detail", containsString("rejected value " + invalidThreshold));
 
     verify(orgPreferencesService, never())
         .updateOrgPreferences(anyString(), any(OrgPreferencesRequest.class));


### PR DESCRIPTION
Jira issue: SWATCH-4803

## Description
Before these changes, the API worked correctly by validating and rejecting wrong requests, but the warnings were not printed into the service logs.

After these changes, we now capture the validation logs using the standard exception mapper and log a warning. Additionally, we also print the wrong value that caused the error in the validation.

## Testing
Updated `updateOrgPreferences_whenThresholdOutOfRange_returnsBadRequestWithoutCallingService` to validate the log. The log now contains:
```
2026-06-03 11:23:09,338 WARN  [com.redhat.swatch.utilization.resources.ConstraintViolationExceptionMapper] (executor-thread-1) Client request failed validation: updateOrgPreferences.orgPreferencesRequest.customThreshold: rejected value -1 (must be greater than or equal to 0)
```