### PR TITLE
Fix DB warnings during test runs

### DIFF
--- a/swatch-core-test/src/main/resources/application-test-inventory.yaml
+++ b/swatch-core-test/src/main/resources/application-test-inventory.yaml
@@ -12,7 +12,6 @@ logging:
       candlepin: INFO
 spring:
   jpa:
-    database: postgresql
     properties:
       hibernate:
         jdbc:


### PR DESCRIPTION
Jira issue: None

## Description
The JDBC url in this test properties files is for HSQLDB, but the
database dialect is set to Postgresql.  This mismatch results in a lot
of errors ("user lacks privilege or object not found:
CLIENT_MIN_MESSAGES") as the Hibernate Postgresql dialect tries to set
some values that are not available in HSQLDB.  If we remove the explicit
dialect directive, Hibernate will autodetect what to use based on the
JDBC url.

## Testing

### Steps
1. Run InstancesDataExporterServiceTest on main and this branch

### Verification
1. You'll see warnings on main ("user lacks privilege or object not found:
   CLIENT_MIN_MESSAGES") but not on this branch.

