### PR TITLE
Fix Mockito warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
     <sonar.branch.target>main</sonar.branch.target>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.java.binaries>${project.build.directory}</sonar.java.binaries>
+    <!-- Required for later late replacement of @{argLine} -->
+    <argLine/>
   </properties>
 
   <repositories>
@@ -383,6 +385,9 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire-plugin.version}</version>
           <configuration>
+            <argLine>
+              @{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            </argLine>
             <reportFormat>brief</reportFormat>
             <includes>
               <include>*Test.java</include>


### PR DESCRIPTION

Jira issue: None

## Description
This fixes a warning that has been popping up recently:

Mockito is currently self-attaching to enable the inline-mock-maker.
This will no longer work in future releases of the JDK. Please add
Mockito as an agent to your build as described in Mockito's
documentation:
https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3

We have to add the Java agent ourselves to the test JVM since Mockito
can no longer add the agent itself.

## Testing

### Steps
1. Run `./mvnw test -pl swatch-tally -Dtest=InstancesDataExporterServiceTest` on
   `main` and this branch.  On `main` you'll see the warning message, but not on
   this branch.
