### PR TITLE
SWATCH-4868: Add test property file entry to enable wiremock

### DIFF
--- a/swatch-metrics/ct/resources/test.properties
+++ b/swatch-metrics/ct/resources/test.properties
@@ -1,2 +1,2 @@
 swatch.component-tests.services.kafkaBridge.log.enabled=false
-
+swatch.component-tests.services.wiremock.log.enabled=false


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4868

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The wiremock service was not being accessed in the component tests for swatch-metrics. The file test.properties needs the 'swatch.component-tests.services.wiremock.log.enabled=false' entry for it to happen.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. See the konflux tekton test for swatch-metrics. The wiremock service will show as loaded and the test will succeed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test configuration updated to disable additional service logging (WireMock) alongside existing Kafka Bridge logging suppression, reducing noise during component tests and making test output cleaner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->