### PR TITLE
ci: replace quay.io/konflux-ci/appstudio-utils:latest to quay.io/konflux-ci/task-runner

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -136,7 +136,7 @@ spec:
             type: string
         steps:
           - name: check
-            image: quay.io/konflux-ci/appstudio-utils:latest
+            image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
             script: |
               #!/bin/bash
               FAILED=false
@@ -221,7 +221,7 @@ spec:
             description: "true if component tests should be skipped, false to run"
         steps:
           - name: check
-            image: quay.io/konflux-ci/appstudio-utils:latest
+            image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
             script: |
               #!/bin/bash
               set -euo pipefail
@@ -309,7 +309,7 @@ spec:
             description: Updated EXTRA_DEPLOY_ARGS with template ref if rhsm component is present
         steps:
           - name: update-args
-            image: quay.io/konflux-ci/appstudio-utils:latest
+            image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -286,7 +286,7 @@ spec:
             description: Updated EXTRA_DEPLOY_ARGS with template refs for all monorepo components
         steps:
           - name: build-args
-            image: quay.io/konflux-ci/appstudio-utils:latest
+            image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -943,7 +943,7 @@ spec:
             type: string
         steps:
           - name: check
-            image: quay.io/konflux-ci/appstudio-utils:latest
+            image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
             script: |
               #!/bin/bash
               FAILED=false

--- a/.tekton/tasks/extract-metadata.yaml
+++ b/.tekton/tasks/extract-metadata.yaml
@@ -33,7 +33,7 @@ spec:
       description: IQE image tag from PR body /use-iqe-image-tag=VALUE if present and valid; empty or XXX uses IQE_IMAGE_TAG_DEFAULT
   steps:
     - name: extract
-      image: quay.io/konflux-ci/appstudio-utils:latest
+      image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: EVENT_TYPE
           valueFrom:

--- a/.tekton/tasks/github-delete-comment.yaml
+++ b/.tekton/tasks/github-delete-comment.yaml
@@ -18,7 +18,7 @@ spec:
       default: "swatch-ci-github-token"
   steps:
     - name: delete-comments
-      image: quay.io/konflux-ci/appstudio-utils:latest
+      image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/.tekton/tasks/github-post-deploy-failure.yaml
+++ b/.tekton/tasks/github-post-deploy-failure.yaml
@@ -33,7 +33,7 @@ spec:
     - name: artifacts
   steps:
     - name: post-comment
-      image: quay.io/konflux-ci/appstudio-utils:latest
+      image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: GITHUB_TOKEN
           valueFrom:

--- a/.tekton/tasks/github-post-test-results.yaml
+++ b/.tekton/tasks/github-post-test-results.yaml
@@ -40,7 +40,7 @@ spec:
     - name: artifacts
   steps:
     - name: post-comment
-      image: quay.io/konflux-ci/appstudio-utils:latest
+      image: quay.io/konflux-ci/task-runner@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
       env:
         - name: GITHUB_TOKEN
           valueFrom:


### PR DESCRIPTION
## Description
The konflux team announced that they are deprecating `quay.io/konflux-ci/appstudio-utils:latest`. We need to use `quay.io/konflux-ci/task-runner` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI pipelines and Tekton tasks to use a pinned task-runner container image (replacing the previous unpinned utility image) for more consistent, reliable, and reproducible pipeline execution across component and integration tests, metadata extraction, and GitHub comment tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->