### PR TITLE
SWATCH-3246: fix subscription configuration properties and add subscription sync component tests

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -923,6 +923,89 @@ This section verifies the automatic contract termination behavior when contracts
   - Subscription entity created  
   - SubscriptionResponse: "Success"
 
+**subscriptions-sync-TC003 - Empty upstream org subscription list**
+- **Description**: When IT subscription search returns an empty list, all subscription rows previously stored for the org are removed.
+- **Setup**:
+  - One active subscription stored for the org
+  - IT subscription search returns HTTP 200 with an empty list
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+- **Expected Results**:
+  - No subscription rows remain for the org
+
+**subscriptions-sync-TC004 - Upstream org subscription search failure**
+- **Description**: When IT subscription search fails, the previously stored subscriptions must remain unchanged.
+- **Setup**:
+  - One active subscription stored for the org
+  - IT subscription search returns an HTTP error code (bad gateway or internal server error)
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+- **Expected Results**:
+  - The stored subscription is still present and unchanged
+
+**subscriptions-sync-TC005 - Subscription missing from subscription search list**
+- **Description**: When IT subscription search returns only one subscription for the org, any DB row whose `subscription_id` is not in that response is removed. Covers partial upstream responses and renewal: only the replacement is returned, it has a different `subscription_id`, and its start date is after the expired row — so days in the report window before the replacement start lose the expired row’s capacity in the capacity API.
+- **Setup**:
+  - Subscription A stored for the org, recently expired but within the configured sync retention window
+  - Replacement subscription B (different subscription id) with a later start date
+  - IT subscription search returns only B
+  - Report window: last 30 days through today (daily granularity)
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+  - `GET /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}` for the report window (RHEL, Sockets)
+- **Expected Results**:
+  - Subscription A is absent
+  - Subscription B is present
+  - Capacity API: zero sockets on each day before B’s start date; B’s socket capacity on each day from B’s start through window end
+
+**subscriptions-sync-TC006 - Expired and replacement both returned from subscription search**
+- **Description**: When IT subscription search returns both the expired subscription and its replacement, both rows remain in SWATCH so the capacity API can still count the expired row for days when it was active within the report window.
+- **Setup**:
+  - Subscription A stored for the org, recently expired but within the configured sync retention window
+  - Replacement subscription B with a later start date
+  - IT subscription search returns both A and B
+  - Report window: last 30 days through today (daily granularity)
+  - **Segment dates depend on `SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN` and `SUBSCRIPTION_IGNORE_STARTING_LATER_THAN`**: A’s end date must be after `now minus SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN` and B’s start must be before `now plus SUBSCRIPTION_IGNORE_STARTING_LATER_THAN`, or `shouldSyncSub` filters the DTO and reconcile deletes the stored row. 
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+  - Capacity API for the report window (RHEL, Sockets)
+- **Expected Results**:
+  - Subscription A is present
+  - Subscription B is present
+  - Capacity API: A’s socket capacity on each day from window start through A’s end date; B’s socket capacity on each day from B’s start through window end
+
+**subscriptions-sync-TC007 - Subscription filtered because upstream start date is null**
+- **Description**: When IT subscription search returns a subscription with a null effective start date, `shouldSyncSub` rejects the DTO. The subscription id is not added to `seenIds`, and an existing row for that id is deleted on reconcile.
+- **Setup**:
+  - One active subscription stored for the org
+  - IT subscription search returns the same subscription id with no `effectiveStartDate`
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+- **Expected Results**:
+  - The stored subscription row is removed
+
+**subscriptions-sync-TC008 - Subscription filtered because upstream start date is too far in the future**
+- **Description**: When IT subscription search returns a subscription whose start date is beyond `SUBSCRIPTION_IGNORE_STARTING_LATER_THAN`, `shouldSyncSub` rejects the DTO. The subscription is not synced from upstream; an existing row for that id is deleted on reconcile.
+- **Setup**:
+  - One active subscription stored for the org
+  - IT subscription search returns the same subscription id with a start date more than `SUBSCRIPTION_IGNORE_STARTING_LATER_THAN` in the future.
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+- **Expected Results**:
+  - The stored subscription row is removed
+
 **subscriptions-termination-TC001** - **Terminate subscription with timestamp**  
 - **Description:** Verify manual subscription termination.  
 - **Setup:** Create an active subscription.  

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -218,17 +218,26 @@ public class ContractsSwatchService extends SwatchService {
   }
 
   public SkuCapacityReportV2 getSkuCapacityByProductIdForOrg(Product product, String orgId) {
+    return getSkuCapacityByProductIdForOrg(product, orgId, null, null);
+  }
+
+  public SkuCapacityReportV2 getSkuCapacityByProductIdForOrg(
+      Product product, String orgId, OffsetDateTime beginning, OffsetDateTime ending) {
     Objects.requireNonNull(product, "product id must not be null");
     Objects.requireNonNull(orgId, "org id must not be null");
 
-    return given()
-        .headers(securityHeadersWithServiceRole(orgId))
-        .accept("application/vnd.api+json")
-        .pathParam("product_id", product.getName())
-        .get(GET_SKU_ENDPOINT)
-        .then()
-        .extract()
-        .as(SkuCapacityReportV2.class);
+    var request =
+        given()
+            .headers(securityHeadersWithServiceRole(orgId))
+            .accept("application/vnd.api+json")
+            .pathParam("product_id", product.getName());
+    if (beginning != null) {
+      request = request.queryParam("beginning", beginning.toString());
+    }
+    if (ending != null) {
+      request = request.queryParam("ending", ending.toString());
+    }
+    return request.get(GET_SKU_ENDPOINT).then().extract().as(SkuCapacityReportV2.class);
   }
 
   public CapacityReportByMetricId getCapacityReportByMetricId(

--- a/swatch-contracts/ct/java/api/SearchApiStubs.java
+++ b/swatch-contracts/ct/java/api/SearchApiStubs.java
@@ -22,6 +22,7 @@ package api;
 
 import domain.Subscription;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,65 @@ public class SearchApiStubs {
    */
   public void stubSearchApiNotFound(String subscriptionNumber) {
     stubSubscriptionBySubscriptionNumber(subscriptionNumber, List.of());
+  }
+
+  public void stubSearchSubscriptionsByOrgId(String orgId, Subscription... subscriptions) {
+    var responseBody = Arrays.stream(subscriptions).map(this::mapToApiModel).toList();
+    wiremockService
+        .given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "GET",
+                    "urlPathPattern",
+                    String.format(
+                        "/mock/subscriptionApi/search/criteria;web_customer_id=%s/options;products=ALL;showExternalReferences=true.*",
+                        orgId)),
+                "response",
+                Map.of(
+                    "status",
+                    200,
+                    "headers",
+                    Map.of("Content-Type", "application/json"),
+                    "jsonBody",
+                    responseBody),
+                "priority",
+                9,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+
+  public void stubSearchSubscriptionsByOrgIdFailure(String orgId, int httpStatus) {
+    wiremockService
+        .given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "GET",
+                    "urlPathPattern",
+                    String.format(
+                        "/mock/subscriptionApi/search/criteria;web_customer_id=%s/options;products=ALL;showExternalReferences=true.*",
+                        orgId)),
+                "response",
+                Map.of("status", httpStatus),
+                "priority",
+                9,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
   }
 
   /**

--- a/swatch-contracts/ct/java/tests/SubscriptionsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsSyncComponentTest.java
@@ -23,17 +23,43 @@ package tests;
 import static com.redhat.swatch.component.tests.utils.Topics.ENABLED_ORGS;
 import static com.redhat.swatch.component.tests.utils.Topics.SUBSCRIPTION_SYNC_TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.component.tests.api.DefaultMessageValidator;
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.CapacityReportByMetricId;
+import com.redhat.swatch.contract.test.model.CapacitySnapshotByMetricId;
 import com.redhat.swatch.contract.test.model.EnabledOrgsRequest;
+import com.redhat.swatch.contract.test.model.EnabledOrgsResponse;
+import com.redhat.swatch.contract.test.model.GranularityType;
+import domain.Offering;
+import domain.Product;
 import domain.Subscription;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
+
+  private static final double SOCKETS_CAPACITY = 8.0;
+
+  private static final OffsetDateTime REPORT_START = clock.startOfToday().minusDays(30);
+  private static final OffsetDateTime REPORT_END = clock.endOfToday();
+  private static final OffsetDateTime ACTIVE_SUBSCRIPTION_START =
+      clock.startOfToday().minusDays(25);
+  private static final OffsetDateTime EXPIRED_SEGMENT_START = REPORT_START.minusMonths(1);
+  private static final OffsetDateTime EXPIRED_SEGMENT_END = clock.startOfToday().minusDays(15);
+  private static final OffsetDateTime REPLACEMENT_START = clock.startOfToday().minusDays(14);
 
   @BeforeAll
   static void subscribeToBillableUsageTopic() {
@@ -60,10 +86,270 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
     assertEquals("Success", response.getDetail());
   }
 
+  @TestPlanName("subscriptions-sync-TC003")
+  @Test
+  void shouldDeleteAllSubscriptionsWhenSubscriptionSearchReturnsEmpty() {
+    Subscription subscription = givenExistingSubscription(ACTIVE_SUBSCRIPTION_START, REPORT_END);
+
+    wiremock.forSearchApi().stubSearchSubscriptionsByOrgId(orgId);
+    whenSubscriptionSyncRunsForOrg();
+
+    thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+  }
+
+  @TestPlanName("subscriptions-sync-TC004")
+  @ParameterizedTest
+  @ValueSource(ints = {HttpStatus.SC_BAD_GATEWAY, HttpStatus.SC_INTERNAL_SERVER_ERROR})
+  void shouldNotDeleteSubscriptionsWhenSubscriptionSearchFails(int httpStatus) {
+    Subscription subscription = givenExistingSubscription(ACTIVE_SUBSCRIPTION_START, REPORT_END);
+
+    wiremock.forSearchApi().stubSearchSubscriptionsByOrgIdFailure(orgId, httpStatus);
+    whenSubscriptionSyncRunsForOrg();
+
+    thenSubscriptionIsPresent(subscription.getSubscriptionId());
+  }
+
+  @TestPlanName("subscriptions-sync-TC005")
+  @Test
+  void shouldDeleteOmittedSubscriptionAndDropPriorMonthCapacity() {
+    Subscription expiredSubscription =
+        givenExistingSubscription(EXPIRED_SEGMENT_START, EXPIRED_SEGMENT_END);
+    Subscription replacementSubscription =
+        givenReplacementSubscription(REPLACEMENT_START, REPORT_END);
+
+    whenSubscriptionSyncRunsWithUpstream(replacementSubscription);
+
+    thenSubscriptionIsAbsent(expiredSubscription.getSubscriptionId());
+    thenSubscriptionIsPresent(replacementSubscription.getSubscriptionId());
+    thenDailyCapacityShowsSocketsOnDaysInRange(REPORT_START, REPLACEMENT_START.minusDays(1), 0.0);
+    thenDailyCapacityShowsSocketsOnDaysInRange(REPLACEMENT_START, REPORT_END, SOCKETS_CAPACITY);
+  }
+
+  @TestPlanName("subscriptions-sync-TC006")
+  @Test
+  void shouldRetainPriorMonthCapacityWhenExpiredAndRenewalInIt() {
+    Subscription expiredSubscription =
+        givenExistingSubscription(EXPIRED_SEGMENT_START, EXPIRED_SEGMENT_END);
+    Subscription replacementSubscription =
+        givenReplacementSubscription(REPLACEMENT_START, REPORT_END);
+
+    whenSubscriptionSyncRunsWithUpstream(expiredSubscription, replacementSubscription);
+
+    thenSubscriptionIsPresent(expiredSubscription.getSubscriptionId());
+    thenSubscriptionIsPresent(replacementSubscription.getSubscriptionId());
+    thenDailyCapacityShowsSocketsOnDaysInRange(REPORT_START, EXPIRED_SEGMENT_END, SOCKETS_CAPACITY);
+    thenDailyCapacityShowsSocketsOnDaysInRange(REPLACEMENT_START, REPORT_END, SOCKETS_CAPACITY);
+  }
+
+  @TestPlanName("subscriptions-sync-TC007")
+  @Test
+  void shouldDeleteSubscriptionWhenUpstreamStartDateIsNull() {
+    Subscription subscription = givenExistingSubscription(ACTIVE_SUBSCRIPTION_START, REPORT_END);
+    Subscription upstreamWithNullStart = subscription.toBuilder().startDate(null).build();
+
+    whenSubscriptionSyncRunsWithUpstream(upstreamWithNullStart);
+
+    thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+  }
+
+  @TestPlanName("subscriptions-sync-TC008")
+  @Test
+  void shouldDeleteSubscriptionWhenUpstreamStartTooFarInFuture() {
+    Subscription subscription = givenExistingSubscription(ACTIVE_SUBSCRIPTION_START, REPORT_END);
+    // 61 days exceeds SUBSCRIPTION_IGNORE_STARTING_LATER_THAN (60d) threshold
+    OffsetDateTime farFutureStart = clock.now().plusDays(61);
+    Subscription upstreamFarFutureStart =
+        subscription.toBuilder()
+            .startDate(farFutureStart)
+            .endDate(farFutureStart.plusYears(1))
+            .build();
+
+    whenSubscriptionSyncRunsWithUpstream(upstreamFarFutureStart);
+
+    thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+  }
+
   private Subscription givenSubscription() {
     var subscription = Subscription.buildRhelSubscription(orgId, Map.of(SOCKETS, 1.0));
     wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(subscription);
     wiremock.forProductAPI().stubOfferingData(subscription.getOffering());
     return subscription;
+  }
+
+  private Subscription givenExistingSubscription(OffsetDateTime startDate, OffsetDateTime endDate) {
+    String seed = RandomUtils.generateRandom();
+    String sku = RandomUtils.generateRandom();
+    wiremock
+        .forProductAPI()
+        .stubOfferingData(Offering.buildRhelOffering(sku, 4.0, SOCKETS_CAPACITY));
+    assertEquals(
+        HttpStatus.SC_OK, service.syncOffering(sku).statusCode(), "Sync offering should succeed");
+
+    Subscription subscription =
+        Subscription.buildRhelSubscriptionUsingSku(orgId, Map.of(SOCKETS, SOCKETS_CAPACITY), sku)
+            .toBuilder()
+            .subscriptionId(seed)
+            .subscriptionNumber(seed)
+            .startDate(startDate)
+            .endDate(endDate)
+            .build();
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.saveSubscriptions(true, subscription).statusCode(),
+        "Creating subscription should succeed");
+    return subscription;
+  }
+
+  private Subscription givenReplacementSubscription(
+      OffsetDateTime replacementStartDate, OffsetDateTime replacementEnd) {
+    String seed = RandomUtils.generateRandom();
+    String replacementSku = RandomUtils.generateRandom();
+    wiremock
+        .forProductAPI()
+        .stubOfferingData(Offering.buildRhelOffering(replacementSku, 4.0, SOCKETS_CAPACITY));
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.syncOffering(replacementSku).statusCode(),
+        "Sync replacement offering should succeed");
+
+    return Subscription.buildRhelSubscriptionUsingSku(
+            orgId, Map.of(SOCKETS, SOCKETS_CAPACITY), replacementSku)
+        .toBuilder()
+        .subscriptionId(seed)
+        .subscriptionNumber(seed)
+        .startDate(replacementStartDate)
+        .endDate(replacementEnd)
+        .build();
+  }
+
+  private void whenSubscriptionSyncRunsForOrg() {
+    kafkaBridge.produceKafkaMessage(
+        SUBSCRIPTION_SYNC_TASK, new EnabledOrgsResponse().withOrgId(orgId));
+  }
+
+  private void whenSubscriptionSyncRunsWithUpstream(Subscription... upstreamSubscriptions) {
+    wiremock.forSearchApi().stubSearchSubscriptionsByOrgId(orgId, upstreamSubscriptions);
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(upstreamSubscriptions);
+    whenSubscriptionSyncRunsForOrg();
+  }
+
+  private CapacityReportByMetricId whenDailyCapacityReport() {
+    return service.getCapacityReportByMetricId(
+        Product.RHEL,
+        orgId,
+        SOCKETS.toString(),
+        REPORT_START,
+        REPORT_END,
+        GranularityType.DAILY,
+        null);
+  }
+
+  private void thenSubscriptionIsPresent(String subscriptionId) {
+    AwaitilityUtils.untilIsTrue(
+        () ->
+            service.getSubscriptionsByOrgId(orgId).stream()
+                .anyMatch(sub -> subscriptionId.equals(sub.getSubscriptionId())),
+        AwaitilitySettings.defaults()
+            .withService(service)
+            .timeoutMessage("Subscription " + subscriptionId + " should remain in DB"));
+  }
+
+  private void thenSubscriptionIsAbsent(String subscriptionId) {
+    AwaitilityUtils.untilIsTrue(
+        () ->
+            service.getSubscriptionsByOrgId(orgId).stream()
+                .noneMatch(sub -> subscriptionId.equals(sub.getSubscriptionId())),
+        AwaitilitySettings.defaults()
+            .withService(service)
+            .timeoutMessage("Subscription " + subscriptionId + " should be removed from DB"));
+  }
+
+  private void thenDailyCapacityShowsSocketsOnDaysInRange(
+      OffsetDateTime inclusiveFrom, OffsetDateTime inclusiveTo, double expectedSockets) {
+
+    AwaitilityUtils.untilIsTrue(
+        () -> {
+          CapacityReportByMetricId report = whenDailyCapacityReport();
+          return allDaysInRangeMatchCapacity(report, inclusiveFrom, inclusiveTo, expectedSockets);
+        },
+        AwaitilitySettings.defaults()
+            .withService(service)
+            .timeoutMessage(
+                "Capacity API daily report should show "
+                    + expectedSockets
+                    + " sockets from "
+                    + inclusiveFrom
+                    + " through "
+                    + inclusiveTo));
+    assertDailyCapacitySocketsInDateRange(
+        whenDailyCapacityReport(), inclusiveFrom, inclusiveTo, expectedSockets);
+  }
+
+  private boolean allDaysInRangeMatchCapacity(
+      CapacityReportByMetricId report,
+      OffsetDateTime inclusiveFrom,
+      OffsetDateTime inclusiveTo,
+      double expectedSockets) {
+    for (OffsetDateTime day = inclusiveFrom.toLocalDate().atStartOfDay().atOffset(ZoneOffset.UTC);
+        !toLocalDate(day).isAfter(toLocalDate(inclusiveTo));
+        day = day.plusDays(1)) {
+      if (Math.abs(socketsOnDay(report, day) - expectedSockets) >= 0.01) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void assertDailyCapacitySocketsInDateRange(
+      CapacityReportByMetricId report,
+      OffsetDateTime inclusiveFrom,
+      OffsetDateTime inclusiveTo,
+      double expectedSockets) {
+    assertNotNull(report.getData(), "Capacity report data must not be null");
+    for (OffsetDateTime day = inclusiveFrom.toLocalDate().atStartOfDay().atOffset(ZoneOffset.UTC);
+        !toLocalDate(day).isAfter(toLocalDate(inclusiveTo));
+        day = day.plusDays(1)) {
+      double actual = socketsOnDay(report, day);
+      if (expectedSockets < 0.01) {
+        assertTrue(
+            actual < 0.01,
+            "Capacity on "
+                + day
+                + " should have zero sockets in "
+                + inclusiveFrom
+                + "–"
+                + inclusiveTo);
+      } else {
+        assertEquals(
+            expectedSockets,
+            actual,
+            0.01,
+            "Capacity on " + day + " should report expected socket capacity");
+      }
+    }
+  }
+
+  private double socketsOnDay(CapacityReportByMetricId report, OffsetDateTime day) {
+    LocalDate targetDay = toLocalDate(day);
+    return report.getData().stream()
+        .filter(snapshot -> isSnapshotDateOnDay(snapshot.getDate(), targetDay))
+        .map(this::snapshotSocketsValue)
+        .findFirst()
+        .orElse(0.0);
+  }
+
+  private LocalDate toLocalDate(OffsetDateTime dateTime) {
+    return dateTime.atZoneSameInstant(ZoneOffset.UTC).toLocalDate();
+  }
+
+  private boolean isSnapshotDateOnDay(OffsetDateTime snapshotDate, LocalDate day) {
+    return snapshotDate.atZoneSameInstant(ZoneOffset.UTC).toLocalDate().equals(day);
+  }
+
+  private double snapshotSocketsValue(CapacitySnapshotByMetricId snapshot) {
+    if (!snapshot.getHasData()) {
+      return 0.0;
+    }
+    return snapshot.getValue().doubleValue();
   }
 }

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -71,9 +71,9 @@ parameters:
   - name: SUBSCRIPTION_SYNC_ENABLED
     value: 'true'
   - name: SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN
-    value: 2M
+    value: '60d'
   - name: SUBSCRIPTION_IGNORE_STARTING_LATER_THAN
-    value: 2M
+    value: '60d'
   - name: ENABLE_PAYG_SUBSCRIPTION_FORCE_SYNC
     value: 'true'
   - name: OFFERING_SYNC_SCHEDULE


### PR DESCRIPTION
Jira issue: SWATCH-3246

## Changes
The problem is that in clowdapp.yaml, we use SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN=2M and SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=2M.
In Spring, these properties standed for 2 months because it uses a custom duration parser, but in Quarkus, 2M stands for 2 minutes. 
The fix is to represent the duration in days: 60d. 

## Testing
Added four scenarios to extend our coverage for the subscription sync scenario: 
- subscriptions-sync-TC003 - Empty upstream org subscription list
- subscriptions-sync-TC004 - Upstream org subscription search failure
- subscriptions-sync-TC005 - Subscription missing from subscription search list
- subscriptions-sync-TC006 - Expired and replacement both returned from subscription search
- subscriptions-sync-TC007 - Subscription filtered because upstream start date is null
- subscriptions-sync-TC008 - Subscription filtered because upstream start date is too far in the future


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added date-range filtering capability for SKU capacity queries.

* **Tests**
  * Expanded subscription synchronization test coverage with six new scenarios covering reconciliation, search failures, subscription replacements, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->