### PR TITLE
fix(SWATCH-4482): return 400 for invalid enum query params

### DIFF
--- a/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/EnumParamConverterProvider.java
+++ b/swatch-common-resteasy/src/main/java/com/redhat/swatch/common/resteasy/EnumParamConverterProvider.java
@@ -20,6 +20,7 @@
  */
 package com.redhat.swatch.common.resteasy;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import jakarta.ws.rs.ext.Provider;
@@ -79,8 +80,7 @@ public class EnumParamConverterProvider implements ParamConverterProvider {
         // Combined with our logging configuration, this tells the OnMdcEvaluator class to suppress
         // the stacktrace
         MDC.put("INVALID_" + className.getSimpleName().toUpperCase(), Boolean.TRUE.toString());
-        throw new IllegalArgumentException(
-            String.format(INVALID_VALUE_EXCEPTION_MSG, value, className));
+        throw new BadRequestException(String.format(INVALID_VALUE_EXCEPTION_MSG, value, className));
       }
     }
 

--- a/swatch-contracts/ct/java/tests/CapacityReportGranularityComponentTest.java
+++ b/swatch-contracts/ct/java/tests/CapacityReportGranularityComponentTest.java
@@ -37,7 +37,6 @@ import io.restassured.response.Response;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class CapacityReportGranularityComponentTest extends BaseContractComponentTest {
@@ -240,7 +239,6 @@ public class CapacityReportGranularityComponentTest extends BaseContractComponen
     thenLastSnapshotShouldEndAt(snapshots, beginning.plusYears(yearRange - 1));
   }
 
-  @Disabled(value = "Test disabled due to a known issue to be fixed in SWATCH-4482.")
   @TestPlanName("capacity-report-granularity-TC007")
   @Test
   void shouldNotGetCapacityReportInvalidGranularity() {

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -241,10 +241,11 @@ Test cases should be testable locally and in deployed environments.
 
 The tally report filtering test cases are organized into two component test files:
 
-- **TallyReportFiltersPaygTest.java** - Contains 20 test cases (TC001-TC023, excluding TC009, TC010, TC024) covering PAYG (Pay-As-You-Go) scenarios:
+- **TallyReportFiltersPaygTest.java** - Contains 21 test cases (TC001-TC023, TC025, excluding TC009, TC010, TC024) covering PAYG (Pay-As-You-Go) scenarios:
   - TC001-TC008: Basic filtering by granularity, SLA, usage, billing provider, and billing account ID
   - TC011-TC014: Validation errors and metadata verification
   - TC016-TC023: Daily granularity filtering, monthly/quarterly/yearly granularity support
+  - TC025: Invalid granularity enum value
   - Product: RHEL for x86 ELS PAYG (supports hourly granularity)
 
 - **TallyReportFiltersEdgeCaseTest.java** - Contains 3 test cases for edge cases requiring special event patterns:
@@ -652,6 +653,18 @@ All test files use `@BeforeAll` to create test data once and share it across all
 - **Expected Result**:
     - API accepts and processes yearly granularity queries
     - All filter parameters are properly reflected in response metadata
+
+**tally-report-filters-TC025 - Invalid granularity enum value**
+
+- **Description**: Verify that tally report API returns validation error when granularity is not a valid enum value
+- **Setup**:
+    - Organization is opted in
+- **Action**:
+    - Request tally report with granularity=HOURLLY (typo)
+- **Verification**:
+    - HTTP 400 Bad Request
+- **Expected Result**:
+    - Invalid enum query parameters return client error instead of server error
 
 **tally-report-filters-TC024 - Daily report tracks billing account change for same instance**
 

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -740,5 +741,28 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
     TallyReportDataMeta meta = response.getMeta();
     assertNotNull(meta, "Metadata should not be null");
     assertEquals(GranularityType.YEARLY, meta.getGranularity(), "Granularity should be YEARLY");
+  }
+
+  @TestPlanName("tally-report-filters-TC025")
+  @Test
+  void shouldReturnBadRequestForInvalidGranularity() {
+    // When: Querying report with an invalid granularity enum value
+    Map<String, Object> queryParams =
+        Map.of(
+            "granularity",
+            "HOURLLY",
+            "beginning",
+            timeRanges.dailyBeginning().toString(),
+            "ending",
+            timeRanges.dailyEnding().toString());
+
+    Response response =
+        service.getTallyReportDataRaw(testOrgId, PRODUCT_TAG, METRIC_ID, queryParams);
+
+    // Then: API returns 400 Bad Request
+    assertEquals(
+        HttpStatus.SC_BAD_REQUEST,
+        response.getStatusCode(),
+        "Invalid granularity should return 400 Bad Request");
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-4482

## Summary

Invalid enum query parameters (for example granularity=HOURLLY) returned HTTP 500 because EnumParamConverterProvider threw IllegalArgumentException. That provider lives in swatch-common-resteasy and is used by both Quarkus services such as swatch-contracts and Spring Boot services such as swatch-tally through swatch-core. The fix throws BadRequestException so clients get HTTP 400.

Re-enables capacity-report-granularity-TC007 and adds tally-report-filters-TC025 plus a CapacityResourceV1Test regression case.

## Test plan
IQE MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1528
/use-iqe-image-tag=rhsm-subscriptions-d32201cd13fed85ddc1c13990125767c1167438a

Run CapacityResourceV1Test#testValidateGranularityNonExisting. Run capacity-report-granularity-TC007 and tally-report-filters-TC025 component tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API validation error handling for invalid enum query parameters to return proper HTTP 400 Bad Request responses.

* **Tests**
  * Added new test coverage for invalid parameter validation.
  * Re-enabled previously skipped test case.

* **Documentation**
  * Updated test plan to reflect new validation test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->