### PR TITLE
SWATCH-5076: Update the IT Product Service UMB Consumer with logging

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/ProductStatusUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/ProductStatusUMBMessageConsumer.java
@@ -66,6 +66,13 @@ public class ProductStatusUMBMessageConsumer {
       OperationalProductEvent productEvent =
           mapper.readValue(message, OperationalProductEvent.class);
 
+      log.info(
+          "IT Product message consumed: source=umb, productCode={}, eventType={}, "
+              + "productCategory={}",
+          productEvent.getProductCode(),
+          productEvent.getEventType(),
+          productEvent.getProductCategory());
+
       service.syncUmbProductFromEvent(productEvent);
     } catch (Exception e) {
       log.error("Unable to read UMB product message for JSON: {}", message, e);


### PR DESCRIPTION
Jira issue: SWATCH-5076

## Description
Added the following log statement:
```
      log.info(
          "IT Product message consumed: source=umb, productCode={}, eventType={}, "
              + "productCategory={}",
          productEvent.getProductCode(),
          productEvent.getEventType(),
          productEvent.getProductCategory());
```

that will allow us to compare the messages received from umb and kafka (future task). 

Moreover, we don't need to add any specific metric because Quarkus already uses `quarkus_messaging_message_count_total` by channel that is the metric we need for grafana. 

## Testing
As in https://github.com/RedHatInsights/rhsm-subscriptions/pull/5964, we don't need to update any tests. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging for product status messages: added an informational log that captures structured fields for productCode, eventType, and productCategory to improve visibility into incoming events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->