### PR TITLE
SWATCH-4990: set default threshold for all orgs.

### DIFF
--- a/swatch-utilization/TEST_PLAN.md
+++ b/swatch-utilization/TEST_PLAN.md
@@ -561,18 +561,22 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Notification action `severity` is `MODERATE`
     - Notification is sent (threshold comparison uses greater-than-or-equal)
 
-**custom-threshold-TC003 - No notification when no org preference exists**
+**custom-threshold-TC003 - Notification sent using default 80% threshold when no org preference exists**
 
-- **Description**: Verify no custom threshold notification is sent when the organization has not configured a custom threshold.
+- **Description**: Verify that a custom threshold notification is sent using the default 80% threshold when the organization has not configured a custom threshold.
 - **Setup**:
     - The organization has not configured a custom threshold
-    - A utilization summary is produced with positive usage
+    - A utilization summary is produced with usage above 80%
 - **Action**:
     - Send the utilization summary to the utilization topic
 - **Verification**:
-    - Check absence of notification message on notifications topic
+    - Wait for notification message on notifications topic
+    - Verify notification payload
 - **Expected Result**:
-    - No notification event created
+    - Notification event is created using the default 80% threshold
+    - Notification event contains correct information (org_id, product_id, metric_id, utilization_percentage)
+    - Notification action `severity` is `MODERATE`
+    - `preferences_hash` is absent from notification context (no persisted preference)
 
 **custom-threshold-TC004 - No notification when utilization is below custom threshold**
 
@@ -602,3 +606,16 @@ Additional cases can be added under the same `utilization-notifications-featuref
     - Both notifications are sent. The two notification types are independent (neither suppresses the other)
     - One custom threshold notification with `severity` `MODERATE`
     - One over-usage notification with `severity` `IMPORTANT`
+
+**custom-threshold-TC006 - No notification when utilization is below default threshold and no org preference exists**
+
+- **Description**: Verify that no custom threshold notification is sent when the organization has not configured a custom threshold and usage is below the default 80% threshold.
+- **Setup**:
+    - The organization has not configured a custom threshold
+    - A utilization summary is produced with usage below 80%
+- **Action**:
+    - Send the utilization summary to the utilization topic
+- **Verification**:
+    - Check absence of notification message on notifications topic
+- **Expected Result**:
+    - No notification event created

--- a/swatch-utilization/ct/java/api/MessageValidators.java
+++ b/swatch-utilization/ct/java/api/MessageValidators.java
@@ -22,11 +22,10 @@ package api;
 
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.swatch.component.tests.api.DefaultMessageValidator;
+import domain.EventTypes;
 
 /** Message validators for notification messages in utilization component tests. */
 public class MessageValidators {
-
-  private static final String OVERUSAGE_EVENT_TYPE = "exceeded-utilization-threshold";
 
   /** Matches notifications by organization ID. */
   public static DefaultMessageValidator<Action> matchesOrgId(String orgId) {
@@ -49,7 +48,7 @@ public class MessageValidators {
           if (!orgId.equals(action.getOrgId())) {
             return false;
           }
-          if (!OVERUSAGE_EVENT_TYPE.equals(action.getEventType())) {
+          if (!EventTypes.EXCEEDED_UTILIZATION_THRESHOLD.equals(action.getEventType())) {
             return false;
           }
           var context = action.getContext();

--- a/swatch-utilization/ct/java/api/MessageValidators.java
+++ b/swatch-utilization/ct/java/api/MessageValidators.java
@@ -26,6 +26,8 @@ import com.redhat.swatch.component.tests.api.DefaultMessageValidator;
 /** Message validators for notification messages in utilization component tests. */
 public class MessageValidators {
 
+  private static final String OVERUSAGE_EVENT_TYPE = "exceeded-utilization-threshold";
+
   /** Matches notifications by organization ID. */
   public static DefaultMessageValidator<Action> matchesOrgId(String orgId) {
     return new DefaultMessageValidator<>(a -> orgId.equals(a.getOrgId()), Action.class);
@@ -39,12 +41,15 @@ public class MessageValidators {
         Action.class);
   }
 
-  /** Matches overage notifications by org_id, product_id, and metric_id. */
-  public static DefaultMessageValidator<Action> matchesOverageNotification(
+  /** Matches over-usage threshold notifications by org_id, product_id, and metric_id. */
+  public static DefaultMessageValidator<Action> matchesOverUsageNotification(
       String orgId, String productId, String metricId) {
     return new DefaultMessageValidator<>(
         action -> {
           if (!orgId.equals(action.getOrgId())) {
+            return false;
+          }
+          if (!OVERUSAGE_EVENT_TYPE.equals(action.getEventType())) {
             return false;
           }
           var context = action.getContext();

--- a/swatch-utilization/ct/java/domain/EventTypes.java
+++ b/swatch-utilization/ct/java/domain/EventTypes.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package domain;
+
+public final class EventTypes {
+
+  public static final String EXCEEDED_UTILIZATION_THRESHOLD = "exceeded-utilization-threshold";
+  public static final String EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD =
+      "exceeded-custom-utilization-threshold";
+
+  private EventTypes() {}
+}

--- a/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
+++ b/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
@@ -21,7 +21,7 @@
 package tests;
 
 import static api.MessageValidators.matchesNotificationByEventType;
-import static api.MessageValidators.matchesOverageNotification;
+import static api.MessageValidators.matchesOverUsageNotification;
 import static com.redhat.swatch.component.tests.utils.Topics.NOTIFICATIONS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -182,7 +182,7 @@ public class BaseUtilizationComponentTest {
       Severity expectedSeverity) {
     Action notification =
         kafkaBridge.waitForKafkaMessage(
-            NOTIFICATIONS, matchesOverageNotification(orgId, productId, metricId.getValue()));
+            NOTIFICATIONS, matchesOverUsageNotification(orgId, productId, metricId.getValue()));
 
     assertThat("Notification should be sent", notification, notNullValue());
     assertThat("Notification should have timestamp", notification.getTimestamp(), notNullValue());

--- a/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
+++ b/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
@@ -23,6 +23,7 @@ package tests;
 import static com.redhat.swatch.component.tests.utils.Topics.UTILIZATION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.swatch.component.tests.api.TestPlanName;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Component tests for custom usage threshold notification (TC001-TC005). */
+/** Component tests for custom usage threshold notification (TC001-TC006). */
 public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
   private static final String CUSTOM_THRESHOLD_EVENT_TYPE = "exceeded-custom-utilization-threshold";
@@ -113,10 +114,32 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
   @TestPlanName("custom-threshold-TC003")
   @Test
-  void shouldNotSendNotification_whenNoOrgPreferenceExists() {
+  void shouldSendNotification_whenNoOrgPreferenceExists_usesDefaultThreshold() {
     MetricId metricId = MetricIdUtils.getCores();
     givenMeasurement(
         utilizationSummary, metricId, USAGE_ABOVE_CUSTOM_THRESHOLD, FULL_CAPACITY, false);
+
+    whenUtilizationEventIsReceived();
+
+    var notification =
+        thenThresholdNotificationShouldBeSent(
+            CUSTOM_THRESHOLD_EVENT_TYPE,
+            Severity.MODERATE,
+            utilizationSummary.getProductId(),
+            metricId,
+            USAGE_ABOVE_CUSTOM_THRESHOLD,
+            FULL_CAPACITY,
+            null,
+            null);
+    thenPreferencesHashShouldBeAbsent(notification);
+  }
+
+  @TestPlanName("custom-threshold-TC006")
+  @Test
+  void shouldNotSendNotification_whenNoOrgPreferenceExists_andUsageIsBelowDefaultThreshold() {
+    MetricId metricId = MetricIdUtils.getCores();
+    givenMeasurement(
+        utilizationSummary, metricId, USAGE_BELOW_CUSTOM_THRESHOLD, FULL_CAPACITY, false);
 
     whenUtilizationEventIsReceived();
 
@@ -181,5 +204,10 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
     assertThat(
         notification.getContext().getAdditionalProperties().get("preferences_hash"),
         notNullValue());
+  }
+
+  private void thenPreferencesHashShouldBeAbsent(Action notification) {
+    assertThat(
+        notification.getContext().getAdditionalProperties().get("preferences_hash"), nullValue());
   }
 }

--- a/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
+++ b/swatch-utilization/ct/java/tests/CustomThresholdComponentTest.java
@@ -31,6 +31,7 @@ import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
+import domain.EventTypes;
 import domain.Severity;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,9 +40,6 @@ import org.junit.jupiter.api.Test;
 
 /** Component tests for custom usage threshold notification (TC001-TC006). */
 public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
-
-  private static final String CUSTOM_THRESHOLD_EVENT_TYPE = "exceeded-custom-utilization-threshold";
-  private static final String DEFAULT_THRESHOLD_EVENT_TYPE = "exceeded-utilization-threshold";
 
   private static final int CUSTOM_THRESHOLD = 80;
   private static final double FULL_CAPACITY = 100.0;
@@ -79,7 +77,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     var notification =
         thenThresholdNotificationShouldBeSent(
-            CUSTOM_THRESHOLD_EVENT_TYPE,
+            EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD,
             Severity.MODERATE,
             utilizationSummary.getProductId(),
             metricId,
@@ -101,7 +99,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     var notification =
         thenThresholdNotificationShouldBeSent(
-            CUSTOM_THRESHOLD_EVENT_TYPE,
+            EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD,
             Severity.MODERATE,
             utilizationSummary.getProductId(),
             metricId,
@@ -123,7 +121,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     var notification =
         thenThresholdNotificationShouldBeSent(
-            CUSTOM_THRESHOLD_EVENT_TYPE,
+            EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD,
             Severity.MODERATE,
             utilizationSummary.getProductId(),
             metricId,
@@ -143,7 +141,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     whenUtilizationEventIsReceived();
 
-    thenNoThresholdNotificationShouldBeSent(CUSTOM_THRESHOLD_EVENT_TYPE);
+    thenNoThresholdNotificationShouldBeSent(EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD);
   }
 
   @TestPlanName("custom-threshold-TC004")
@@ -156,7 +154,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     whenUtilizationEventIsReceived();
 
-    thenNoThresholdNotificationShouldBeSent(CUSTOM_THRESHOLD_EVENT_TYPE);
+    thenNoThresholdNotificationShouldBeSent(EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD);
   }
 
   @TestPlanName("custom-threshold-TC005")
@@ -170,7 +168,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
 
     var customNotification =
         thenThresholdNotificationShouldBeSent(
-            CUSTOM_THRESHOLD_EVENT_TYPE,
+            EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD,
             Severity.MODERATE,
             utilizationSummary.getProductId(),
             metricId,
@@ -180,7 +178,7 @@ public class CustomThresholdComponentTest extends BaseUtilizationComponentTest {
             null);
     thenPreferencesHashShouldBePresent(customNotification);
     thenThresholdNotificationShouldBeSent(
-        DEFAULT_THRESHOLD_EVENT_TYPE,
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
         Severity.IMPORTANT,
         utilizationSummary.getProductId(),
         metricId,

--- a/swatch-utilization/ct/java/tests/OverUsageThresholdComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OverUsageThresholdComponentTest.java
@@ -32,6 +32,7 @@ import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.utilization.test.model.Measurement;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary.Granularity;
+import domain.EventTypes;
 import domain.Product;
 import domain.Severity;
 import java.time.Duration;
@@ -43,8 +44,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class OverUsageThresholdComponentTest extends BaseUtilizationComponentTest {
-
-  private static final String DEFAULT_THRESHOLD_EVENT_TYPE = "exceeded-utilization-threshold";
 
   // Test data constants - aligned with CUSTOMER_OVER_USAGE_DEFAULT_THRESHOLD_PERCENT=5.0
   private static final double BASELINE_CAPACITY = 100.0;
@@ -82,7 +81,7 @@ public class OverUsageThresholdComponentTest extends BaseUtilizationComponentTes
 
     thenOverUsageCounterShouldBeIncremented();
     thenThresholdNotificationShouldBeSent(
-        DEFAULT_THRESHOLD_EVENT_TYPE,
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
         Severity.IMPORTANT,
         Product.ROSA.getName(),
         MetricIdUtils.getCores(),
@@ -132,7 +131,7 @@ public class OverUsageThresholdComponentTest extends BaseUtilizationComponentTes
         });
 
     thenThresholdNotificationShouldBeSent(
-        DEFAULT_THRESHOLD_EVENT_TYPE,
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
         Severity.IMPORTANT,
         Product.ROSA.getName(),
         MetricIdUtils.getCores(),
@@ -174,7 +173,7 @@ public class OverUsageThresholdComponentTest extends BaseUtilizationComponentTes
 
     thenOverUsageCounterShouldBeIncremented();
     thenThresholdNotificationShouldBeSent(
-        DEFAULT_THRESHOLD_EVENT_TYPE,
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
         Severity.IMPORTANT,
         Product.RHEL.getName(),
         MetricIdUtils.getSockets(),

--- a/swatch-utilization/ct/java/tests/UtilizationMultiComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationMultiComponentTest.java
@@ -20,7 +20,7 @@
  */
 package tests;
 
-import static api.MessageValidators.matchesOverageNotification;
+import static api.MessageValidators.matchesOverUsageNotification;
 import static com.redhat.swatch.component.tests.utils.AwaitilityUtils.untilAsserted;
 import static com.redhat.swatch.component.tests.utils.Topics.NOTIFICATIONS;
 import static com.redhat.swatch.component.tests.utils.Topics.UTILIZATION;
@@ -210,12 +210,11 @@ public class UtilizationMultiComponentTest extends BaseUtilizationComponentTest 
 
   /** Verifies no notification is sent for the given product and metric. */
   private void thenNoNotificationShouldBeSent(String productId, MetricId metricId) {
-    // Use a short timeout to verify no notification messages arrive for this product/metric
     var notifications =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS,
-            matchesOverageNotification(orgId, productId, metricId.getValue()),
-            0, // Expected count is 0
+            matchesOverUsageNotification(orgId, productId, metricId.getValue()),
+            0,
             AwaitilitySettings.usingTimeout(Duration.ofSeconds(5)));
 
     assertThat(

--- a/swatch-utilization/ct/java/tests/UtilizationNotificationsFeatureFlagsComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationNotificationsFeatureFlagsComponentTest.java
@@ -33,6 +33,7 @@ import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.utilization.test.model.Measurement;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary.Granularity;
+import domain.EventTypes;
 import domain.Product;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,8 +43,6 @@ import org.junit.jupiter.api.Test;
 public class UtilizationNotificationsFeatureFlagsComponentTest
     extends BaseUtilizationComponentTest {
 
-  private static final String OVERUSAGE_EVENT_TYPE = "exceeded-utilization-threshold";
-  private static final String CUSTOM_THRESHOLD_EVENT_TYPE = "exceeded-custom-utilization-threshold";
   private static final double BASELINE_CAPACITY = 100.0;
   private static final double USAGE_EXCEEDING_THRESHOLD = 110.0;
 
@@ -91,7 +90,8 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
   @TestPlanName("utilization-notifications-featureflags-TC004")
   void shouldSuppressNotification_whenOverusageEventTypeIsDenylisted() {
     givenSendNotificationsEnabledWithDenylistedEventTypes(
-        OVERUSAGE_EVENT_TYPE, CUSTOM_THRESHOLD_EVENT_TYPE);
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
+        EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD);
 
     whenOverUsageRhelExceedsThreshold();
 
@@ -114,7 +114,8 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
     var orgIdNotOnAllowlist = RandomUtils.generateRandom();
 
     givenSendNotificationsEnabledWithDenylistedEventTypes(
-        OVERUSAGE_EVENT_TYPE, CUSTOM_THRESHOLD_EVENT_TYPE);
+        EventTypes.EXCEEDED_UTILIZATION_THRESHOLD,
+        EventTypes.EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD);
     givenOrgOnNotificationsAllowlist(orgId);
 
     whenOverUsageRhelExceedsThresholdForOrg(orgId);

--- a/swatch-utilization/ct/java/tests/UtilizationNotificationsFeatureFlagsComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationNotificationsFeatureFlagsComponentTest.java
@@ -21,7 +21,7 @@
 package tests;
 
 import static api.MessageValidators.matchesOrgId;
-import static api.MessageValidators.matchesOverageNotification;
+import static api.MessageValidators.matchesOverUsageNotification;
 import static com.redhat.swatch.component.tests.utils.Topics.NOTIFICATIONS;
 import static com.redhat.swatch.component.tests.utils.Topics.UTILIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,6 +43,7 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
     extends BaseUtilizationComponentTest {
 
   private static final String OVERUSAGE_EVENT_TYPE = "exceeded-utilization-threshold";
+  private static final String CUSTOM_THRESHOLD_EVENT_TYPE = "exceeded-custom-utilization-threshold";
   private static final double BASELINE_CAPACITY = 100.0;
   private static final double USAGE_EXCEEDING_THRESHOLD = 110.0;
 
@@ -89,7 +90,8 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
   @Test
   @TestPlanName("utilization-notifications-featureflags-TC004")
   void shouldSuppressNotification_whenOverusageEventTypeIsDenylisted() {
-    givenSendNotificationsEnabledWithDenylistedEventTypes(OVERUSAGE_EVENT_TYPE);
+    givenSendNotificationsEnabledWithDenylistedEventTypes(
+        OVERUSAGE_EVENT_TYPE, CUSTOM_THRESHOLD_EVENT_TYPE);
 
     whenOverUsageRhelExceedsThreshold();
 
@@ -111,7 +113,8 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
   void shouldDifferByAllowlist_whenDenylistedEventAndTwoOrgs() {
     var orgIdNotOnAllowlist = RandomUtils.generateRandom();
 
-    givenSendNotificationsEnabledWithDenylistedEventTypes(OVERUSAGE_EVENT_TYPE);
+    givenSendNotificationsEnabledWithDenylistedEventTypes(
+        OVERUSAGE_EVENT_TYPE, CUSTOM_THRESHOLD_EVENT_TYPE);
     givenOrgOnNotificationsAllowlist(orgId);
 
     whenOverUsageRhelExceedsThresholdForOrg(orgId);
@@ -180,7 +183,7 @@ public class UtilizationNotificationsFeatureFlagsComponentTest
     Action notification =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS,
-            matchesOverageNotification(
+            matchesOverUsageNotification(
                 expectedOrgId, Product.RHEL.getName(), Product.RHEL.getFirstMetric().getId()));
     assertNotNull(notification, "Notification should be sent");
     assertEquals(

--- a/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
@@ -33,6 +33,7 @@ import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.utilization.test.model.UtilizationSummary;
+import domain.EventTypes;
 import domain.Severity;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterAll;
@@ -225,7 +226,7 @@ public class UtilizationOverUsageComponentTest extends BaseUtilizationComponentT
     var notifications =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS,
-            matchesNotificationByEventType(orgId, "exceeded-utilization-threshold"),
+            matchesNotificationByEventType(orgId, EventTypes.EXCEEDED_UTILIZATION_THRESHOLD),
             0,
             AwaitilitySettings.usingTimeout(Duration.ofSeconds(5)));
 

--- a/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
+++ b/swatch-utilization/ct/java/tests/UtilizationOverUsageComponentTest.java
@@ -20,8 +20,8 @@
  */
 package tests;
 
-import static api.MessageValidators.matchesOrgId;
-import static api.MessageValidators.matchesOverageNotification;
+import static api.MessageValidators.matchesNotificationByEventType;
+import static api.MessageValidators.matchesOverUsageNotification;
 import static com.redhat.swatch.component.tests.utils.Topics.NOTIFICATIONS;
 import static com.redhat.swatch.component.tests.utils.Topics.UTILIZATION;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -212,7 +212,7 @@ public class UtilizationOverUsageComponentTest extends BaseUtilizationComponentT
     var notification =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS,
-            matchesOverageNotification(
+            matchesOverUsageNotification(
                 orgId, utilizationSummary.getProductId(), metricId.getValue()));
     assertEquals(
         Severity.IMPORTANT.name(),
@@ -222,12 +222,11 @@ public class UtilizationOverUsageComponentTest extends BaseUtilizationComponentT
 
   // Helper methods - Then
   private void thenNoNotificationShouldBeSent() {
-    // Use a short timeout to verify no notification messages arrive
     var notifications =
         kafkaBridge.waitForKafkaMessage(
             NOTIFICATIONS,
-            matchesOrgId(orgId),
-            0, // Expected count is 0
+            matchesNotificationByEventType(orgId, "exceeded-utilization-threshold"),
+            0,
             AwaitilitySettings.usingTimeout(Duration.ofSeconds(5)));
 
     assertThat("No notification should be sent to Kafka topic", notifications, empty());

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -49,6 +49,7 @@ public class CustomThresholdUtilizationHandlerService
     var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
 
     int threshold = preference.getCustomThreshold();
+    boolean thresholdOverridden = false;
     if (!customThresholdValidator.isValid(threshold)) {
       int defaultThreshold = orgPreferencesService.getDefaultThreshold();
       log.warn(
@@ -57,6 +58,7 @@ public class CustomThresholdUtilizationHandlerService
           payload.getOrgId(),
           defaultThreshold);
       threshold = defaultThreshold;
+      thresholdOverridden = true;
     } else if (preference.getLastModified() == null) {
       log.debug(
           "No persisted preference for orgId={}, threshold value {}% returned by preferences service matches default",
@@ -74,7 +76,7 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      if (preference.getLastModified() != null) {
+      if (!thresholdOverridden && preference.getLastModified() != null) {
         event.addContextProperty(
             PREFERENCES_HASH, hashLastModified(preference.getLastModified().toInstant()));
       }

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -47,15 +47,9 @@ public class CustomThresholdUtilizationHandlerService
   protected Optional<HandlerEvent> evaluateThreshold(
       double utilizationPercent, UtilizationSummary payload, Measurement measurement) {
     var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
-    // In SWATCH-4990, we need to remove this condition, so all orgs are opted in.
-    if (preference.getLastModified() == null) {
-      log.debug(
-          "No org preference found for orgId={}, skipping custom threshold check",
-          payload.getOrgId());
-      return Optional.empty();
-    }
 
     int threshold = preference.getCustomThreshold();
+    boolean thresholdOverridden = false;
     if (!customThresholdValidator.isValid(threshold)) {
       int defaultThreshold = orgPreferencesService.getDefaultThreshold();
       log.warn(
@@ -64,6 +58,11 @@ public class CustomThresholdUtilizationHandlerService
           payload.getOrgId(),
           defaultThreshold);
       threshold = defaultThreshold;
+      thresholdOverridden = true;
+    } else if (preference.getLastModified() == null) {
+      log.debug(
+          "No persisted preference for orgId={}, threshold value {}% returned by preferences service matches default",
+          payload.getOrgId(), threshold);
     }
 
     if (utilizationPercent >= threshold) {
@@ -77,8 +76,10 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      event.addContextProperty(
-          PREFERENCES_HASH, hashLastModified(preference.getLastModified().toInstant()));
+      if (!thresholdOverridden && preference.getLastModified() != null) {
+        event.addContextProperty(
+            PREFERENCES_HASH, hashLastModified(preference.getLastModified().toInstant()));
+      }
       return Optional.of(event);
     }
 

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerService.java
@@ -49,7 +49,6 @@ public class CustomThresholdUtilizationHandlerService
     var preference = orgPreferencesService.getOrgPreferences(payload.getOrgId());
 
     int threshold = preference.getCustomThreshold();
-    boolean thresholdOverridden = false;
     if (!customThresholdValidator.isValid(threshold)) {
       int defaultThreshold = orgPreferencesService.getDefaultThreshold();
       log.warn(
@@ -58,7 +57,6 @@ public class CustomThresholdUtilizationHandlerService
           payload.getOrgId(),
           defaultThreshold);
       threshold = defaultThreshold;
-      thresholdOverridden = true;
     } else if (preference.getLastModified() == null) {
       log.debug(
           "No persisted preference for orgId={}, threshold value {}% returned by preferences service matches default",
@@ -76,7 +74,7 @@ public class CustomThresholdUtilizationHandlerService
           String.format(PERCENT_FORMAT, utilizationPercent),
           threshold);
       var event = buildEvent(utilizationPercent);
-      if (!thresholdOverridden && preference.getLastModified() != null) {
+      if (preference.getLastModified() != null) {
         event.addContextProperty(
             PREFERENCES_HASH, hashLastModified(preference.getLastModified().toInstant()));
       }

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/service/CustomThresholdUtilizationHandlerServiceTest.java
@@ -26,6 +26,7 @@ import static com.redhat.swatch.utilization.service.CustomThresholdUtilizationHa
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -193,20 +194,52 @@ class CustomThresholdUtilizationHandlerServiceTest {
 
     whenCheckSummary(summary);
 
+    verify(orgPreferencesService, atLeastOnce()).getDefaultThreshold();
+    assertEquals(EXPECTED_SINGLE_INCREMENT, getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID));
+    var captor = ArgumentCaptor.forClass(Action.class);
+    verify(notificationsProducer, times(1)).produce(captor.capture());
+    assertNull(
+        captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH),
+        "preferences_hash must be absent when the stored threshold was invalid and the default was used");
+  }
+
+  @Test
+  void shouldSendNotification_whenOrgHasNoPersistedPreferences_usesDefaultThreshold() {
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, null);
+    UtilizationSummary summary =
+        givenUtilizationSummary(
+            PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
+
+    whenCheckSummary(summary);
+
     verify(notificationsProducer, times(1))
         .produce(argThat(action -> EVENT_TYPE.equals(action.getEventType())));
-    verify(orgPreferencesService, atLeastOnce()).getDefaultThreshold();
+    verify(orgPreferencesService, never()).getDefaultThreshold();
     assertEquals(EXPECTED_SINGLE_INCREMENT, getCounterValue(PAYG_PRODUCT_ID, CORES_METRIC_ID));
   }
 
   @Test
-  void shouldNotSendNotification_whenOrgHasNoPersistedPreferences() {
-    var response = new OrgPreferencesResponse();
-    response.setCustomThreshold(CUSTOM_THRESHOLD);
-    when(orgPreferencesService.getOrgPreferences(ORG_ID)).thenReturn(response);
+  void shouldNotIncludePreferencesHash_whenOrgHasNoPersistedPreferences() {
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, null);
     UtilizationSummary summary =
         givenUtilizationSummary(
             PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_EXCEEDING_THRESHOLD);
+
+    whenCheckSummary(summary);
+
+    var captor = ArgumentCaptor.forClass(Action.class);
+    verify(notificationsProducer, times(1)).produce(captor.capture());
+    assertNull(
+        captor.getValue().getContext().getAdditionalProperties().get(PREFERENCES_HASH),
+        "preferences_hash must be absent when no preference is persisted");
+  }
+
+  @Test
+  void
+      shouldNotSendNotification_whenOrgHasNoPersistedPreferences_andUsageIsBelowDefaultThreshold() {
+    givenOrgPreference(ORG_ID, CUSTOM_THRESHOLD, null);
+    UtilizationSummary summary =
+        givenUtilizationSummary(PAYG_PRODUCT_ID, CORES_METRIC_ID, CAPACITY, USAGE_BELOW_THRESHOLD);
 
     whenCheckSummary(summary);
 


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4990

## Description
This PR aligns with the latest [product requirement](https://docs.google.com/document/d/1Z08hQrk-amQoCWOafXhhtlv2eKOJVIDzH9TL17vWv6Y/edit?tab=t.0) that all orgs should have a default threshold for utilization. Component and unit tests have been updated.

## Testing
podman compose up -d
make build component-test swatch-utilization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom usage threshold notifications now reliably fall back to the system default 80% when no organization preference exists.
  * For default-threshold alerts, `preferences_hash` is omitted from the notification context.
  * No custom-threshold notification is emitted when utilization is below the 80% default.
* **Tests**
  * Expanded coverage for default vs. custom threshold behavior, `preferences_hash` presence/absence, and correct exceeded-utilization event typing.
* **Documentation**
  * Updated the custom-threshold test plan with new TC003 and TC006 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->