### PR TITLE
SWATCH-5066: Update the IT Subscription Service UMB Consumer with logging

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/UmbSubscription.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/umb/UmbSubscription.java
@@ -29,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -90,23 +91,29 @@ public class UmbSubscription {
         .orElseThrow();
   }
 
-  public String getSku() {
-    if (products.length != 1) {
-      throw new IllegalStateException("Could not find top level SKU for subscription " + this);
-    }
-    return products[0].getSku();
+  public Optional<String> findSku() {
+    return findProduct().map(SubscriptionProduct::getSku);
   }
 
-  public SubscriptionProductStatus[] getProductStatusState() {
-    if (products.length != 1) {
-      throw new IllegalStateException(
-          "Could not find top level product with a status for subscription " + this);
+  public Optional<SubscriptionProduct> findProduct() {
+    if (products == null || products.length != 1) {
+      return Optional.empty();
     }
-    return products[0].getProduct().getStatus();
+    return Optional.ofNullable(products[0]);
   }
 
-  public String getEbsAccountNumber() {
-    return getReference("EBS", "Account", "number").orElse(null);
+  public Optional<SubscriptionProductStatus> findTerminatedStatus() {
+    return findProduct()
+        .map(SubscriptionProduct::getProduct)
+        .filter(Objects::nonNull)
+        .map(SubscriptionProduct::getStatus)
+        .filter(Objects::nonNull)
+        .flatMap(
+            statuses ->
+                Arrays.stream(statuses)
+                    .filter(Objects::nonNull)
+                    .filter(status -> "Terminated".equalsIgnoreCase(status.getState()))
+                    .findFirst());
   }
 
   public static OffsetDateTime convertToUtc(LocalDateTime timestamp) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
@@ -417,21 +417,13 @@ public class SubscriptionSyncService {
      * date.
      */
 
-    if (Objects.nonNull(subscription.getProductStatusState())) {
-      Optional<SubscriptionProductStatus> status =
-          Arrays.stream(subscription.getProductStatusState())
-              .filter(x -> "Terminated".equalsIgnoreCase(x.getState()))
-              .findFirst();
-
-      boolean isSubscriptionTerminated = status.isPresent();
-
-      /*
-       * Note that a status only has a "StartDate", which indicates the start of the corresponding
-       * status - this doesn't directly correlate to the StartDate of a subscription.
-       */
-      if (isSubscriptionTerminated) {
-        endDate = UmbSubscription.convertToUtc(status.get().getStartDate());
-      }
+    /*
+     * Note that a status only has a "StartDate", which indicates the start of the corresponding
+     * status - this doesn't directly correlate to the StartDate of a subscription.
+     */
+    Optional<SubscriptionProductStatus> terminatedStatus = subscription.findTerminatedStatus();
+    if (terminatedStatus.isPresent()) {
+      endDate = UmbSubscription.convertToUtc(terminatedStatus.get().getStartDate());
     }
     // NOTE: we are not setting the offering yet
     return SubscriptionEntity.builder()
@@ -522,7 +514,7 @@ public class SubscriptionSyncService {
           "Skipping UMB message because multiple subscriptions were found for subscriptionNumber={}",
           subscription.getSubscriptionNumber());
     } else {
-      syncSubscription(umbSubscription.getSku(), subscription, subscriptions.stream().findFirst());
+      syncSubscription(getSku(umbSubscription), subscription, subscriptions.stream().findFirst());
     }
   }
 
@@ -581,5 +573,14 @@ public class SubscriptionSyncService {
       return msg;
     }
     return String.format("Subscription %s terminated at %s.", subscriptionId, terminationDate);
+  }
+
+  private static String getSku(UmbSubscription subscription) {
+    return subscription
+        .findSku()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Could not find top level SKU for subscription " + subscription));
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumer.java
@@ -59,19 +59,24 @@ public class SubscriptionSyncTaskConsumer {
   @Blocking
   @Incoming(SUBSCRIPTION_SYNC_TASK_UMB)
   public void consumeFromUmb(String subscriptionMessageXml) throws JsonProcessingException {
-    log.info("Received message from UMB for subscription sync service. {}", subscriptionMessageXml);
     if (!umbEnabled) {
+      log.debug("UMB processing is not enabled");
       return;
     }
     CanonicalMessage subscriptionMessage =
         xmlMapper.readValue(subscriptionMessageXml, CanonicalMessage.class);
     UmbSubscription subscription = subscriptionMessage.getPayload().getSync().getSubscription();
     log.info(
-        "Received UMB message for subscriptionNumber={} webCustomerId={} startDate={} endDate={}",
+        "IT Subscription message consumed: source=umb, "
+            + "subscriptionNumber={}, webCustomerId={}, sku={}, quantity={}, "
+            + "effectiveStartDate={}, effectiveEndDate={}, terminated={}",
         subscription.getSubscriptionNumber(),
         subscription.getWebCustomerId(),
+        subscription.findSku().orElse(null),
+        subscription.getQuantity(),
         subscription.getEffectiveStartDate(),
-        subscription.getEffectiveEndDate());
+        subscription.getEffectiveEndDate(),
+        subscription.findTerminatedStatus().isPresent());
     service.saveUmbSubscription(subscription);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/product/umb/SubscriptionMessageTests.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/product/umb/SubscriptionMessageTests.java
@@ -21,6 +21,7 @@
 package com.redhat.swatch.contract.product.umb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import java.io.IOException;
@@ -127,5 +128,49 @@ class SubscriptionMessageTests {
             .build();
     assertEquals(expected, actual);
     actual.getPayload().getSync().getSubscription().getEffectiveStartDateInUtc();
+  }
+
+  @Test
+  void testTerminatedSubscriptionHelpers() throws IOException {
+    XmlMapper mapper = CanonicalMessage.createMapper();
+    CanonicalMessage message =
+        mapper.readValue(
+            getClass().getClassLoader().getResource("mocked-subscription-message.xml"),
+            CanonicalMessage.class);
+    UmbSubscription subscription = message.getPayload().getSync().getSubscription();
+
+    assertEquals("MW01882", subscription.findSku().orElseThrow());
+    assertTrue(subscription.findTerminatedStatus().isPresent());
+  }
+
+  @Test
+  void testSubscriptionWithoutProductIsNotTerminated() {
+    UmbSubscription subscription =
+        UmbSubscription.builder()
+            .identifiers(
+                Identifiers.builder()
+                    .references(
+                        new Reference[] {
+                          Reference.builder()
+                              .system("WEB")
+                              .entityName("Customer")
+                              .qualifier("id")
+                              .value("org123_ICUST")
+                              .build()
+                        })
+                    .ids(
+                        new Reference[] {
+                          Reference.builder()
+                              .system("SUBSCRIPTION")
+                              .entityName("Subscription")
+                              .qualifier("number")
+                              .value("1234")
+                              .build()
+                        })
+                    .build())
+            .build();
+
+    assertTrue(subscription.findSku().isEmpty());
+    assertTrue(subscription.findTerminatedStatus().isEmpty());
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-5066

## Description
Adding the following log statement:
```
log.info(
        "IT Subscription message consumed: source=umb, "
            + "subscriptionNumber={}, webCustomerId={}, sku={}, quantity={}, "
            + "effectiveStartDate={}, effectiveEndDate={}, terminated={}",
```            
that will allow us to compare the messages received from umb and kafka (future task).

Note that we don't need to add any specific metric because Quarkus already uses quarkus_messaging_message_count_total by channel that is the metric we need for grafana.

Refactored the UmbSubscription model to reuse the same logic in the service and the log. 

## Testing
As in https://github.com/RedHatInsights/rhsm-subscriptions/pull/5964, we don't need to update any tests. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More detailed UMB subscription logging showing subscription number, customer, resolved SKU, quantity, effective dates, and terminated-status presence.
  * UMB processing now respects the enabled flag and avoids emitting raw XML when disabled.
  * Safer subscription data handling: robust SKU and status lookups and more reliable determination of effective end dates.

* **Tests**
  * Added unit tests for subscription helper methods and edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->