### PR TITLE
SWATCH-5086: Add logging traces when reconcile creates and deletes subscriptions

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -394,6 +394,7 @@ Test cases should be testable locally and in an ephemeral environment.
   - Other fields unchanged on new contract (org_id, sku, metrics)
   - Response status: "SUCCESS" (new contract created)
   - Log message: "Deleting contract that does not align to IT partner gateway"
+  - Application logs contain `Subscription deleted` with `delete_reason=PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY` for the prior subscription segment
 
 **contracts-update-TC004 - Update contract end date (renewal)**  
 - **Description**: Verify updating the contract end date ( with a date in the future ) when the customer renews the subscription.  
@@ -546,6 +547,7 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Expected Result:**  
   - HTTP 204 No Content response
   - Contract no longer returned by organization contract lookup
+  - Application logs contain `Subscription deleted` with `delete_reason=CONTRACT_DELETED` for the contract's subscription row
 
 **contracts-deletion-TC002** - **Delete non-existent contract**  
 - **Description:** Verify graceful handling for deleting a non-existent UUID.  
@@ -932,6 +934,7 @@ This section verifies the automatic contract termination behavior when contracts
   - Run subscription sync for the org
 - **Verification**:
   - List subscriptions for the org via internal API
+  - Application logs contain `Subscription deleted` with `delete_reason=NOT_IN_UPSTREAM_RESPONSE` for the removed row
 - **Expected Results**:
   - No subscription rows remain for the org
 
@@ -959,6 +962,7 @@ This section verifies the automatic contract termination behavior when contracts
 - **Verification**:
   - List subscriptions for the org via internal API
   - `GET /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}` for the report window (RHEL, Sockets)
+  - Application logs contain `Subscription deleted` with `delete_reason=NOT_IN_UPSTREAM_RESPONSE` for subscription A and `Subscription created/updated` for subscription B
 - **Expected Results**:
   - Subscription A is absent
   - Subscription B is present
@@ -983,7 +987,7 @@ This section verifies the automatic contract termination behavior when contracts
   - Capacity API: A’s socket capacity on each day from window start through A’s end date; B’s socket capacity on each day from B’s start through window end
 
 **subscriptions-sync-TC007 - Subscription filtered because upstream start date is null**
-- **Description**: When IT subscription search returns a subscription with a null effective start date, `shouldSyncSub` rejects the DTO. The subscription id is not added to `seenIds`, and an existing row for that id is deleted on reconcile.
+- **Description**: When IT subscription search returns a subscription with a null effective start date, the upstream DTO is filtered. An existing row for that id is deleted on reconcile with a specific filter reason.
 - **Setup**:
   - One active subscription stored for the org
   - IT subscription search returns the same subscription id with no `effectiveStartDate`
@@ -993,6 +997,7 @@ This section verifies the automatic contract termination behavior when contracts
   - List subscriptions for the org via internal API
 - **Expected Results**:
   - The stored subscription row is removed
+  - Application logs contain `Subscription deleted` with `delete_reason=FILTERED_NULL_START_DATE`
 
 **subscriptions-sync-TC008 - Subscription filtered because upstream start date is too far in the future**
 - **Description**: When IT subscription search returns a subscription whose start date is beyond `SUBSCRIPTION_IGNORE_STARTING_LATER_THAN`, `shouldSyncSub` rejects the DTO. The subscription is not synced from upstream; an existing row for that id is deleted on reconcile.
@@ -1005,6 +1010,20 @@ This section verifies the automatic contract termination behavior when contracts
   - List subscriptions for the org via internal API
 - **Expected Results**:
   - The stored subscription row is removed
+  - Application logs contain `Subscription deleted` with `delete_reason=FILTERED_START_TOO_FAR_IN_FUTURE`
+
+**subscriptions-sync-TC009 - Subscription filtered because upstream end date is too far in the past**
+- **Description**: When IT subscription search returns a subscription whose end date is before `SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN`, `shouldSyncSub` rejects the DTO. An existing row for that subscription id is deleted on reconcile.
+- **Setup**:
+  - One active subscription stored for the org
+  - IT subscription search returns the same subscription id with an end date more than `SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN` in the past
+- **Action**:
+  - Run subscription sync for the org
+- **Verification**:
+  - List subscriptions for the org via internal API
+- **Expected Results**:
+  - The stored subscription row is removed
+  - Application logs contain `Subscription deleted` with `delete_reason=FILTERED_END_TOO_FAR_IN_PAST`
 
 **subscriptions-termination-TC001** - **Terminate subscription with timestamp**  
 - **Description:** Verify manual subscription termination.  

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -42,6 +42,7 @@ import com.redhat.swatch.contract.test.model.CapacityReportByMetricId;
 import com.redhat.swatch.contract.test.model.CapacitySnapshotByMetricId;
 import com.redhat.swatch.contract.test.model.GranularityType;
 import com.redhat.swatch.contract.test.model.ReportCategory;
+import com.redhat.swatch.contract.test.model.SubscriptionDeleteReason;
 import domain.BillingProvider;
 import domain.Contract;
 import domain.Product;
@@ -292,5 +293,12 @@ public class BaseContractComponentTest {
         service.getCapacityReportByMetricId(
             product, orgId, metric.toString(), beginning, ending, GranularityType.DAILY, category);
     return getCapacityValueFromReport(report);
+  }
+
+  protected void thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason deleteReason) {
+    service
+        .logs()
+        .assertContains(
+            "Subscription deleted org_id=" + orgId, "delete_reason=" + deleteReason.name());
   }
 }

--- a/swatch-contracts/ct/java/tests/ContractsDeletionComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsDeletionComponentTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.SubscriptionDeleteReason;
 import domain.BillingProvider;
 import domain.Contract;
 import io.restassured.response.Response;
@@ -49,6 +50,7 @@ public class ContractsDeletionComponentTest extends BaseContractComponentTest {
 
     // Then: Contract should no longer exist
     thenContractShouldNotExist(orgId);
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.CONTRACT_DELETED);
   }
 
   @TestPlanName("contracts-deletion-TC002")

--- a/swatch-contracts/ct/java/tests/ContractsUpdateComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsUpdateComponentTest.java
@@ -30,6 +30,7 @@ import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.contract.test.model.ContractResponse;
+import com.redhat.swatch.contract.test.model.SubscriptionDeleteReason;
 import domain.BillingProvider;
 import domain.Contract;
 import domain.Product;
@@ -119,6 +120,8 @@ public class ContractsUpdateComponentTest extends BaseContractComponentTest {
         initialUuid, newContract.getUuid(), "UUID should be different (new contract created)");
     thenContractDatesShouldBeUpdated(newContract, updatedStartDate, updatedEndDate);
     thenContractFieldsShouldRemainUnchanged(newContract, initialContract);
+    thenSubscriptionAuditDeleteLog(
+        SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY);
   }
 
   @TestPlanName("contracts-update-TC004")

--- a/swatch-contracts/ct/java/tests/SubscriptionsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsSyncComponentTest.java
@@ -36,6 +36,7 @@ import com.redhat.swatch.contract.test.model.CapacitySnapshotByMetricId;
 import com.redhat.swatch.contract.test.model.EnabledOrgsRequest;
 import com.redhat.swatch.contract.test.model.EnabledOrgsResponse;
 import com.redhat.swatch.contract.test.model.GranularityType;
+import com.redhat.swatch.contract.test.model.SubscriptionDeleteReason;
 import domain.Offering;
 import domain.Product;
 import domain.Subscription;
@@ -95,6 +96,7 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
     whenSubscriptionSyncRunsForOrg();
 
     thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.NOT_IN_UPSTREAM_RESPONSE);
   }
 
   @TestPlanName("subscriptions-sync-TC004")
@@ -121,6 +123,8 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
 
     thenSubscriptionIsAbsent(expiredSubscription.getSubscriptionId());
     thenSubscriptionIsPresent(replacementSubscription.getSubscriptionId());
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.NOT_IN_UPSTREAM_RESPONSE);
+    thenSubscriptionAuditSaveLog(replacementSubscription.getSubscriptionId());
     thenDailyCapacityShowsSocketsOnDaysInRange(REPORT_START, REPLACEMENT_START.minusDays(1), 0.0);
     thenDailyCapacityShowsSocketsOnDaysInRange(REPLACEMENT_START, REPORT_END, SOCKETS_CAPACITY);
   }
@@ -150,6 +154,7 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
     whenSubscriptionSyncRunsWithUpstream(upstreamWithNullStart);
 
     thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.FILTERED_NULL_START_DATE);
   }
 
   @TestPlanName("subscriptions-sync-TC008")
@@ -167,6 +172,24 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
     whenSubscriptionSyncRunsWithUpstream(upstreamFarFutureStart);
 
     thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.FILTERED_START_TOO_FAR_IN_FUTURE);
+  }
+
+  @TestPlanName("subscriptions-sync-TC009")
+  @Test
+  void shouldDeleteSubscriptionWhenUpstreamEndTooFarInPast() {
+    Subscription subscription = givenExistingSubscription(ACTIVE_SUBSCRIPTION_START, REPORT_END);
+    OffsetDateTime expiredEnd = clock.now().minusDays(61);
+    Subscription upstreamExpiredEnd =
+        subscription.toBuilder()
+            .startDate(clock.startOfToday().minusDays(90))
+            .endDate(expiredEnd)
+            .build();
+
+    whenSubscriptionSyncRunsWithUpstream(upstreamExpiredEnd);
+
+    thenSubscriptionIsAbsent(subscription.getSubscriptionId());
+    thenSubscriptionAuditDeleteLog(SubscriptionDeleteReason.FILTERED_END_TOO_FAR_IN_PAST);
   }
 
   private Subscription givenSubscription() {
@@ -179,6 +202,21 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
   private Subscription givenExistingSubscription(OffsetDateTime startDate, OffsetDateTime endDate) {
     String seed = RandomUtils.generateRandom();
     String sku = RandomUtils.generateRandom();
+    return givenExistingSubscriptionWithSku(sku, seed, seed, startDate, endDate);
+  }
+
+  private Subscription givenExistingSubscriptionWithSku(
+      String sku, OffsetDateTime startDate, OffsetDateTime endDate) {
+    String seed = RandomUtils.generateRandom();
+    return givenExistingSubscriptionWithSku(sku, seed, seed, startDate, endDate);
+  }
+
+  private Subscription givenExistingSubscriptionWithSku(
+      String sku,
+      String subscriptionId,
+      String subscriptionNumber,
+      OffsetDateTime startDate,
+      OffsetDateTime endDate) {
     wiremock
         .forProductAPI()
         .stubOfferingData(Offering.buildRhelOffering(sku, 4.0, SOCKETS_CAPACITY));
@@ -188,8 +226,8 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
     Subscription subscription =
         Subscription.buildRhelSubscriptionUsingSku(orgId, Map.of(SOCKETS, SOCKETS_CAPACITY), sku)
             .toBuilder()
-            .subscriptionId(seed)
-            .subscriptionNumber(seed)
+            .subscriptionId(subscriptionId)
+            .subscriptionNumber(subscriptionNumber)
             .startDate(startDate)
             .endDate(endDate)
             .build();
@@ -351,5 +389,12 @@ public class SubscriptionsSyncComponentTest extends BaseContractComponentTest {
       return 0.0;
     }
     return snapshot.getValue().doubleValue();
+  }
+
+  private void thenSubscriptionAuditSaveLog(String subscriptionId) {
+    service
+        .logs()
+        .assertContains(
+            "Subscription created/updated org_id=" + orgId + " subscription_id=" + subscriptionId);
   }
 }

--- a/swatch-contracts/ct/pom.xml
+++ b/swatch-contracts/ct/pom.xml
@@ -103,6 +103,7 @@
               <sourceDirectory>${maven.multiModuleProjectDirectory}/swatch-contracts/schemas</sourceDirectory>
               <sourcePaths>
                 <sourcePath>enable_partner_gateway_contracts_variant_payload.yaml</sourcePath>
+                <sourcePath>subscription_delete_reason.yaml</sourcePath>
               </sourcePaths>
             </configuration>
           </execution>

--- a/swatch-contracts/schemas/subscription_delete_reason.yaml
+++ b/swatch-contracts/schemas/subscription_delete_reason.yaml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: SubscriptionDeleteReason
+description: Why a subscription row was removed during sync reconcile or partner entitlement upsert.
+type: string
+enum:
+  - NOT_IN_UPSTREAM_RESPONSE
+  - PRODUCT_DENYLIST
+  - FILTERED_NULL_START_DATE
+  - FILTERED_START_TOO_FAR_IN_FUTURE
+  - FILTERED_END_TOO_FAR_IN_PAST
+  - PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY
+  - CONTRACT_DELETED

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -299,42 +299,42 @@ public class ContractService {
                       return contract1;
                     }));
 
-    existingContracts.forEach(
-        existingContract -> {
-          var matchingUpdatedContract =
-              contractStartDateMap.remove(existingContract.getStartDate().toInstant());
+    boolean hasDeletedContracts = false;
+    for (ContractEntity existingContract : existingContracts) {
+      var matchingUpdatedContract =
+          contractStartDateMap.remove(existingContract.getStartDate().toInstant());
 
-          if (matchingUpdatedContract == null) {
-            log.info(
-                "Deleting contract that does not align to IT partner gateway: {}",
-                existingContract);
-            contractRepository.delete(existingContract);
-          } else {
-            if (!matchingUpdatedContract.equals(existingContract)) {
-              log.info(
-                  "Contract updated. Old values: {} New values: {}",
-                  existingContract,
-                  matchingUpdatedContract);
-              if (existingContract.getMetrics() != matchingUpdatedContract.getMetrics()) {
-                var metrics =
-                    existingContract.getMetrics().stream()
-                        .filter(metric -> !matchingUpdatedContract.getMetrics().contains(metric))
-                        .toList();
-                metrics.forEach(metric -> deleteContractMetric(existingContract, metric));
-              }
-              contractEntityMapper.updateContract(existingContract, matchingUpdatedContract);
-              contractsToPersist.add(existingContract);
-            } else {
-              log.debug("No change in contract: {}", existingContract);
-            }
+      if (matchingUpdatedContract == null) {
+        log.info(
+            "Deleting contract that does not align to IT partner gateway: {}", existingContract);
+        contractRepository.delete(existingContract);
+        hasDeletedContracts = true;
+      } else {
+        if (!matchingUpdatedContract.equals(existingContract)) {
+          log.info(
+              "Contract updated. Old values: {} New values: {}",
+              existingContract,
+              matchingUpdatedContract);
+          if (existingContract.getMetrics() != matchingUpdatedContract.getMetrics()) {
+            var metrics =
+                existingContract.getMetrics().stream()
+                    .filter(metric -> !matchingUpdatedContract.getMetrics().contains(metric))
+                    .toList();
+            metrics.forEach(metric -> deleteContractMetric(existingContract, metric));
           }
-        });
+          contractEntityMapper.updateContract(existingContract, matchingUpdatedContract);
+          contractsToPersist.add(existingContract);
+        } else {
+          log.debug("No change in contract: {}", existingContract);
+        }
+      }
+    }
 
     // If not found in existing Contracts then create new ones.
     contractsToPersist.addAll(contractStartDateMap.values());
 
-    boolean areRecordsUpdated = !contractsToPersist.isEmpty();
-    if (areRecordsUpdated) {
+    boolean areRecordsUpdated = !contractsToPersist.isEmpty() || hasDeletedContracts;
+    if (!contractsToPersist.isEmpty()) {
       contractsToPersist.forEach(
           contractEntity -> {
             log.info("Updating or creating contract: {}", contractEntity);
@@ -377,47 +377,48 @@ public class ContractService {
         subscriptionService.findBySubscriptionNumber(
             contractEntities.get(0).getSubscriptionNumber());
 
-    existingSubscriptionRecords.forEach(
-        existingSubscription -> {
-          var matchingUpdatedSubscription =
-              subscriptionStartDateMap.remove(existingSubscription.getStartDate().toInstant());
+    boolean hasDeletedSubscriptions = false;
+    for (SubscriptionEntity existingSubscription : existingSubscriptionRecords) {
+      var matchingUpdatedSubscription =
+          subscriptionStartDateMap.remove(existingSubscription.getStartDate().toInstant());
 
-          if (matchingUpdatedSubscription == null) {
-            subscriptionService.delete(
-                existingSubscription,
-                SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY);
-          } else {
-            var measurementsEqual =
-                Objects.equals(
-                    existingSubscription.getSubscriptionMeasurements(),
-                    matchingUpdatedSubscription.getSubscriptionMeasurements());
-            if (!matchingUpdatedSubscription.equals(existingSubscription) || !measurementsEqual) {
-              log.info(
-                  "Subscription updated. Old values: {} New values: {}",
-                  existingSubscription,
-                  matchingUpdatedSubscription);
-              if (!measurementsEqual) {
-                log.info(
-                    "Subscription measurements updated. Old values: {} New values: {}",
-                    existingSubscription.getSubscriptionMeasurements(),
-                    matchingUpdatedSubscription.getSubscriptionMeasurements());
-                deleteMisalignedSubscriptionMeasurements(
-                    existingSubscription, matchingUpdatedSubscription);
-              }
-              subscriptionEntityMapper.updateSubscription(
-                  existingSubscription, matchingUpdatedSubscription);
-              subscriptionsToPersist.add(existingSubscription);
-            } else {
-              log.debug("No change in subscription: {}", existingSubscription);
-            }
+      if (matchingUpdatedSubscription == null) {
+        subscriptionService.delete(
+            existingSubscription,
+            SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY);
+        hasDeletedSubscriptions = true;
+      } else {
+        var measurementsEqual =
+            Objects.equals(
+                existingSubscription.getSubscriptionMeasurements(),
+                matchingUpdatedSubscription.getSubscriptionMeasurements());
+        if (!matchingUpdatedSubscription.equals(existingSubscription) || !measurementsEqual) {
+          log.info(
+              "Subscription updated. Old values: {} New values: {}",
+              existingSubscription,
+              matchingUpdatedSubscription);
+          if (!measurementsEqual) {
+            log.info(
+                "Subscription measurements updated. Old values: {} New values: {}",
+                existingSubscription.getSubscriptionMeasurements(),
+                matchingUpdatedSubscription.getSubscriptionMeasurements());
+            deleteMisalignedSubscriptionMeasurements(
+                existingSubscription, matchingUpdatedSubscription);
           }
-        });
+          subscriptionEntityMapper.updateSubscription(
+              existingSubscription, matchingUpdatedSubscription);
+          subscriptionsToPersist.add(existingSubscription);
+        } else {
+          log.debug("No change in subscription: {}", existingSubscription);
+        }
+      }
+    }
 
     // If not found in existing subscriptions then create new ones.
     subscriptionsToPersist.addAll(subscriptionStartDateMap.values());
 
-    boolean areRecordsUpdated = !subscriptionsToPersist.isEmpty();
-    if (areRecordsUpdated) {
+    boolean areRecordsUpdated = !subscriptionsToPersist.isEmpty() || hasDeletedSubscriptions;
+    if (!subscriptionsToPersist.isEmpty()) {
       log.info("Persisting subscriptions: {}", subscriptionsToPersist);
       subscriptionsToPersist.forEach(subscriptionService::save);
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -45,13 +45,11 @@ import com.redhat.swatch.contract.openapi.model.Contract;
 import com.redhat.swatch.contract.openapi.model.ContractRequest;
 import com.redhat.swatch.contract.openapi.model.ContractResponse;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
-import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.ContractEntity;
 import com.redhat.swatch.contract.repository.ContractMetricEntity;
 import com.redhat.swatch.contract.repository.ContractMetricRepository;
 import com.redhat.swatch.contract.repository.ContractRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
-import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.utils.ContractMessageProcessingResult;
 import com.redhat.swatch.panache.Specification;
 import io.micrometer.core.annotation.Timed;
@@ -91,7 +89,7 @@ public class ContractService {
 
   private final ContractRepository contractRepository;
   private final ContractMetricRepository contractMetricRepository;
-  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionService subscriptionService;
   private final MeasurementMetricIdTransformer measurementMetricIdTransformer;
   @Inject protected ContractEntityMapper contractEntityMapper;
   @Inject protected ContractDtoMapper contractDtoMapper;
@@ -104,13 +102,13 @@ public class ContractService {
   ContractService(
       ContractRepository contractRepository,
       ContractMetricRepository contractMetricRepository,
-      SubscriptionRepository subscriptionRepository,
+      SubscriptionService subscriptionService,
       MeasurementMetricIdTransformer measurementMetricIdTransformer,
       AwsPartnerEntitlementsProvider awsPartnerEntitlementsProvider,
       AzurePartnerEntitlementsProvider azurePartnerEntitlementsProvider) {
     this.contractRepository = contractRepository;
     this.contractMetricRepository = contractMetricRepository;
-    this.subscriptionRepository = subscriptionRepository;
+    this.subscriptionService = subscriptionService;
     this.measurementMetricIdTransformer = measurementMetricIdTransformer;
     this.partnerEntitlementsProviders =
         List.of(awsPartnerEntitlementsProvider, azurePartnerEntitlementsProvider);
@@ -376,7 +374,7 @@ public class ContractService {
                     }));
 
     var existingSubscriptionRecords =
-        subscriptionRepository.findBySubscriptionNumber(
+        subscriptionService.findBySubscriptionNumber(
             contractEntities.get(0).getSubscriptionNumber());
 
     existingSubscriptionRecords.forEach(
@@ -385,10 +383,9 @@ public class ContractService {
               subscriptionStartDateMap.remove(existingSubscription.getStartDate().toInstant());
 
           if (matchingUpdatedSubscription == null) {
-            log.info(
-                "Deleting subscription that does not align to IT partner gateway: {}",
-                existingSubscription);
-            subscriptionRepository.delete(existingSubscription);
+            subscriptionService.delete(
+                existingSubscription,
+                SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY);
           } else {
             var measurementsEqual =
                 Objects.equals(
@@ -422,7 +419,7 @@ public class ContractService {
     boolean areRecordsUpdated = !subscriptionsToPersist.isEmpty();
     if (areRecordsUpdated) {
       log.info("Persisting subscriptions: {}", subscriptionsToPersist);
-      subscriptionsToPersist.forEach(subscriptionRepository::persist);
+      subscriptionsToPersist.forEach(subscriptionService::save);
     }
     return areRecordsUpdated;
   }
@@ -518,9 +515,7 @@ public class ContractService {
 
   private void terminateActiveSubscriptionsForContract(
       ContractEntity contract, OffsetDateTime terminationDate) {
-    subscriptionRepository
-        .find(SubscriptionEntity.class, SubscriptionEntity.forContract(contract))
-        .stream()
+    subscriptionService.findByContract(contract).stream()
         .filter(sub -> sub.getEndDate() == null || sub.getEndDate().isAfter(terminationDate))
         .forEach(
             sub -> {
@@ -532,7 +527,7 @@ public class ContractService {
               sub.setBillingProviderId(null);
               sub.setBillingAccountId(null);
               sub.getSubscriptionMeasurements().clear();
-              subscriptionRepository.persist(sub);
+              subscriptionService.terminate(sub);
             });
   }
 
@@ -623,16 +618,12 @@ public class ContractService {
 
       log.debug("Synchronizing the subscription for contract {}", existingContract);
       SubscriptionEntity subscription = createOrUpdateSubscription(existingContract);
-      subscriptionRepository.persist(subscription);
+      subscriptionService.save(subscription);
     }
   }
 
   private SubscriptionEntity createOrUpdateSubscription(ContractEntity contract) {
-    Optional<SubscriptionEntity> existingSubscription =
-        subscriptionRepository
-            .find(SubscriptionEntity.class, SubscriptionEntity.forContract(contract))
-            .stream()
-            .findFirst();
+    Optional<SubscriptionEntity> existingSubscription = findFirstSubscriptionByContract(contract);
     if (existingSubscription.isEmpty()) {
       return createSubscriptionForContract(contract, null);
     } else {
@@ -659,15 +650,10 @@ public class ContractService {
 
   private void deleteContract(ContractEntity contract) {
     if (contract != null) {
-      var subscription =
-          subscriptionRepository
-              .find(SubscriptionEntity.class, SubscriptionEntity.forContract(contract))
-              .stream()
-              .findFirst()
-              .orElse(null);
+      var subscription = findFirstSubscriptionByContract(contract).orElse(null);
       contractRepository.delete(contract);
       if (subscription != null) {
-        subscriptionRepository.delete(subscription);
+        subscriptionService.delete(subscription, SubscriptionDeleteReason.CONTRACT_DELETED);
       }
     }
   }
@@ -782,6 +768,10 @@ public class ContractService {
     return null;
   }
 
+  private Optional<SubscriptionEntity> findFirstSubscriptionByContract(ContractEntity contract) {
+    return subscriptionService.findByContract(contract).stream().findFirst();
+  }
+
   private static StatusResponse buildContractDetailsMissingStatus(
       ContractValidationFailedException e) {
     var violations = e.getViolations();
@@ -790,20 +780,5 @@ public class ContractService {
       log.warn("Property {} {}", violation.getPropertyPath(), violation.getMessage());
     }
     return ContractMessageProcessingResult.CONTRACT_DETAILS_MISSING.toStatus();
-  }
-
-  @Transactional
-  public void deletePaygSubscriptionsByOrgId(String orgId) {
-    var paygSubs =
-        subscriptionRepository
-            .streamByOrgId(orgId)
-            .filter(
-                s ->
-                    s.getBillingProvider() != null
-                        && List.of(BillingProvider.AWS, BillingProvider.AZURE)
-                            .contains(s.getBillingProvider()))
-            .toList();
-    paygSubs.forEach(subscriptionRepository::delete);
-    log.info("Deleted {} PAYG subs for org id {}", paygSubs.size(), orgId);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionDeleteReason.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionDeleteReason.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+/** Why a subscription row was removed during sync reconcile or partner entitlement upsert. */
+public enum SubscriptionDeleteReason {
+  /** Subscription id exists in SWATCH but was absent from the latest upstream search response. */
+  NOT_IN_UPSTREAM_RESPONSE,
+
+  /** Offering SKU matches the configured product denylist. */
+  PRODUCT_DENYLIST,
+
+  /** Upstream DTO rejected because effective start date is null. */
+  FILTERED_NULL_START_DATE,
+
+  /** Upstream DTO rejected because start date is beyond SUBSCRIPTION_IGNORE_STARTING_LATER_THAN. */
+  FILTERED_START_TOO_FAR_IN_FUTURE,
+
+  /** Upstream DTO rejected because end date is before SUBSCRIPTION_IGNORE_EXPIRED_OLDER_THAN. */
+  FILTERED_END_TOO_FAR_IN_PAST,
+
+  /**
+   * PAYG subscription segment removed during partner entitlement upsert because its start date is
+   * not present in the IT Partner Gateway contract segments for the subscription number.
+   */
+  PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY,
+
+  /** Subscription removed because its parent contract was deleted. */
+  CONTRACT_DELETED
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import com.redhat.swatch.contract.repository.ContractEntity;
+import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import com.redhat.swatch.contract.repository.SubscriptionRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@ApplicationScoped
+@AllArgsConstructor
+@Slf4j
+public class SubscriptionService {
+
+  private final SubscriptionRepository subscriptionRepository;
+
+  public Stream<SubscriptionEntity> streamByOrgId(String orgId) {
+    return subscriptionRepository.streamByOrgId(orgId);
+  }
+
+  public List<SubscriptionEntity> findBySubscriptionNumber(String subscriptionNumber) {
+    return subscriptionRepository.findBySubscriptionNumber(subscriptionNumber);
+  }
+
+  public List<SubscriptionEntity> findActiveSubscription(String subscriptionId) {
+    return subscriptionRepository.findActiveSubscription(subscriptionId);
+  }
+
+  public List<SubscriptionEntity> findByContract(ContractEntity contract) {
+    return subscriptionRepository.find(
+        SubscriptionEntity.class, SubscriptionEntity.forContract(contract));
+  }
+
+  @Transactional(TxType.MANDATORY)
+  public void flushAndClearPersistenceContext() {
+    subscriptionRepository.flush();
+    subscriptionRepository.getEntityManager().clear();
+  }
+
+  @Transactional(TxType.MANDATORY)
+  public void save(SubscriptionEntity subscription) {
+    subscription = persistAndMerge(subscription);
+    log.info(
+        "Subscription created/updated org_id={} subscription_id={} subscription_number={} start_date={} end_date={} billing_account_id={}",
+        subscription.getOrgId(),
+        subscription.getSubscriptionId(),
+        subscription.getSubscriptionNumber(),
+        subscription.getStartDate(),
+        subscription.getEndDate(),
+        subscription.getBillingAccountId());
+  }
+
+  @Transactional(TxType.MANDATORY)
+  public void terminate(SubscriptionEntity subscription) {
+    subscription = persistAndMerge(subscription);
+    log.info(
+        "Subscription terminated org_id={} subscription_id={} subscription_number={} start_date={} end_date={} billing_account_id={}",
+        subscription.getOrgId(),
+        subscription.getSubscriptionId(),
+        subscription.getSubscriptionNumber(),
+        subscription.getStartDate(),
+        subscription.getEndDate(),
+        subscription.getBillingAccountId());
+  }
+
+  @Transactional(TxType.MANDATORY)
+  public void delete(SubscriptionEntity subscription, SubscriptionDeleteReason deleteReason) {
+    Objects.requireNonNull(deleteReason, "deleteReason must not be null");
+    subscriptionRepository.delete(subscription);
+    log.info(
+        "Subscription deleted org_id={} subscription_id={} subscription_number={} start_date={} end_date={} billing_account_id={} delete_reason={}",
+        subscription.getOrgId(),
+        subscription.getSubscriptionId(),
+        subscription.getSubscriptionNumber(),
+        subscription.getStartDate(),
+        subscription.getEndDate(),
+        subscription.getBillingAccountId(),
+        deleteReason);
+  }
+
+  private SubscriptionEntity persistAndMerge(SubscriptionEntity subscription) {
+    var em = subscriptionRepository.getEntityManager();
+    if (em.contains(subscription)) {
+      subscriptionRepository.persist(subscription);
+      return subscription;
+    }
+
+    // merge is needed here because the existing subscription might not be found if we only use
+    // the subscription number (since primary keys are subscription ID and start date).
+    // To be fixed in SWATCH-2801.
+    return em.merge(subscription);
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
@@ -36,13 +36,11 @@ import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
-import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.utils.CustomBatchIterator;
 import com.redhat.swatch.contract.utils.SubscriptionDtoUtil;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.annotation.Timed;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
@@ -51,15 +49,15 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +69,7 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
 @AllArgsConstructor
 public class SubscriptionSyncService {
 
-  private final SubscriptionRepository subscriptionRepository;
+  private final SubscriptionService subscriptionService;
   private final OfferingRepository offeringRepository;
   private final SubscriptionSearchService subscriptionSearchService;
   private final ApplicationClock clock;
@@ -81,7 +79,6 @@ public class SubscriptionSyncService {
   private final ApplicationConfiguration properties;
   private final ObjectMapper objectMapper;
   private final ProductDenylist productDenylist;
-  private final EntityManager entityManager;
 
   public void syncSubscription(
       Subscription subscription, Optional<SubscriptionEntity> subscriptionOptional) {
@@ -193,7 +190,7 @@ public class SubscriptionSyncService {
        */
       if (existingSubscription.quantityHasChanged(newOrUpdated.getQuantity())) {
         existingSubscription.endSubscription();
-        subscriptionRepository.persist(existingSubscription);
+        subscriptionService.terminate(existingSubscription);
         final SubscriptionEntity newSub =
             SubscriptionEntity.builder()
                 .subscriptionId(existingSubscription.getSubscriptionId())
@@ -208,19 +205,13 @@ public class SubscriptionSyncService {
                 .billingProvider(newOrUpdated.getBillingProvider())
                 .build();
         capacityReconciliationService.reconcileCapacityForSubscription(newSub);
-        // merge is needed here because the existing subscription might not be found if we only use
-        // the subscription number (since primary keys are subscription ID and start date).
-        // To be fixed in SWATCH-2801.
-        subscriptionRepository.merge(newSub);
+        subscriptionService.save(newSub);
       } else {
         updateExistingSubscription(newOrUpdated, existingSubscription);
-        subscriptionRepository.persist(existingSubscription);
+        subscriptionService.save(existingSubscription);
       }
     } else {
-      // Same as above, the newOrUpdated entity might not be in the persistence context, so we need
-      // to use the merge operation here as well.
-      // To be fixed in SWATCH-2801.
-      subscriptionRepository.merge(newOrUpdated);
+      subscriptionService.save(newOrUpdated);
     }
   }
 
@@ -298,39 +289,59 @@ public class SubscriptionSyncService {
 
     // Filter out non PAYG subscriptions for faster processing when they are not needed.
     // Slow processing was causing: https://issues.redhat.com/browse/ENT-5083
-
     if (paygOnly) {
       dtos =
           dtos.filter(
               subscription -> SubscriptionDtoUtil.extractBillingProviderId(subscription) != null);
     }
 
-    var subIdToDtoMap =
-        dtos.filter(this::shouldSyncSub)
-            .collect(
-                Collectors.toMap(
-                    dto -> dto.getId().toString(),
-                    Function.identity(),
-                    (firstMatch, secondMatch) -> firstMatch));
+    // Partition upstream IT Search DTOs by subscription id: sync vs delete (filtered out).
+    Map<String, Subscription> subIdsToSync = new HashMap<>();
+    Map<String, SubscriptionDeleteReason> subIdsToDelete = new HashMap<>();
+    dtos.forEach(
+        dto -> {
+          String subId = dto.getId().toString();
+          var filteredByReason = shouldSyncSub(dto);
+          if (filteredByReason.isPresent()) {
+            subIdsToDelete.putIfAbsent(subId, filteredByReason.get());
+          } else {
+            subIdsToSync.putIfAbsent(subId, dto);
+          }
+        });
 
-    List<SubscriptionEntity> subEntitiesForDeletion = new ArrayList<>();
+    if (subIdsToSync.isEmpty() && subIdsToDelete.isEmpty()) {
+      log.warn("No subscriptions found in upstream for orgId={}", orgId);
+    }
 
-    Set<String> seenIds = new HashSet<>(subIdToDtoMap.keySet());
+    List<Map.Entry<SubscriptionEntity, SubscriptionDeleteReason>> subEntitiesForDeletion =
+        new ArrayList<>();
+
+    Set<String> subscriptionIdsToSync = new HashSet<>(subIdsToSync.keySet());
 
     var batchSize = 1024;
-    CustomBatchIterator.batchStreamOf(subscriptionRepository.streamByOrgId(orgId), batchSize)
+    CustomBatchIterator.batchStreamOf(subscriptionService.streamByOrgId(orgId), batchSize)
         .forEach(
             batch -> {
               batch.forEach(
                   subEntity -> {
                     var subId = subEntity.getSubscriptionId();
-                    var dto = subIdToDtoMap.remove(subId);
+                    var dto = subIdsToSync.remove(subId);
+
+                    if (subIdsToDelete.containsKey(subId)) {
+                      subEntitiesForDeletion.add(Map.entry(subEntity, subIdsToDelete.get(subId)));
+                      return;
+                    }
 
                     // delete from swatch because it didn't appear in the latest list from the
                     // subscription service, or it's in the denylist
-                    if (!seenIds.contains(subId)
-                        || (productDenylist.productIdMatches(subEntity.getOffering().getSku()))) {
-                      subEntitiesForDeletion.add(subEntity);
+                    if (!subscriptionIdsToSync.contains(subId)) {
+                      subEntitiesForDeletion.add(
+                          Map.entry(subEntity, SubscriptionDeleteReason.NOT_IN_UPSTREAM_RESPONSE));
+                      return;
+                    }
+                    if (productDenylist.productIdMatches(subEntity.getOffering().getSku())) {
+                      subEntitiesForDeletion.add(
+                          Map.entry(subEntity, SubscriptionDeleteReason.PRODUCT_DENYLIST));
                       return;
                     }
 
@@ -341,12 +352,11 @@ public class SubscriptionSyncService {
 
                     syncSubscription(dto, Optional.of(subEntity));
                   });
-              subscriptionRepository.flush();
-              entityManager.clear();
+              subscriptionService.flushAndClearPersistenceContext();
             });
 
-    // These are additional subs that should be sync'd but weren't previously in the database
-    Stream<Subscription> stream = subIdToDtoMap.values().stream();
+    // These are additional subs that should be synced but weren't previously in the database
+    Stream<Subscription> stream = subIdsToSync.values().stream();
 
     CustomBatchIterator.batchStreamOf(stream, batchSize)
         .forEach(
@@ -356,15 +366,14 @@ public class SubscriptionSyncService {
                     // Contract provided subscriptions will have a different start_date than what is
                     // stored in Subscription SearchAPI
                     var existingSubscription =
-                        subscriptionRepository
+                        subscriptionService
                             .findBySubscriptionNumber(dto.getSubscriptionNumber())
                             .stream()
                             .findFirst();
                     syncSubscription(dto, existingSubscription);
                   });
 
-              subscriptionRepository.flush();
-              entityManager.clear();
+              subscriptionService.flushAndClearPersistenceContext();
             });
 
     if (paygOnly) {
@@ -377,12 +386,13 @@ public class SubscriptionSyncService {
       log.info("Removing {} stale/incorrect subscription records", subEntitiesForDeletion.size());
     }
 
-    subEntitiesForDeletion.forEach(subscriptionRepository::delete);
+    subEntitiesForDeletion.forEach(
+        deletion -> subscriptionService.delete(deletion.getKey(), deletion.getValue()));
 
     log.info("Finished syncing subscriptions for orgId {}", orgId);
   }
 
-  private boolean shouldSyncSub(Subscription sub) {
+  private Optional<SubscriptionDeleteReason> shouldSyncSub(Subscription sub) {
     // Reject subs expired long ago, or subs that won't be active quite yet.
     OffsetDateTime now = clock.now();
 
@@ -397,7 +407,7 @@ public class SubscriptionSyncService {
           sub.getId(),
           sub.getSubscriptionNumber(),
           sub.getWebCustomerId());
-      return false;
+      return Optional.of(SubscriptionDeleteReason.FILTERED_NULL_START_DATE);
     }
 
     long earliestAllowedFutureStartDate =
@@ -405,8 +415,15 @@ public class SubscriptionSyncService {
     long latestAllowedExpiredEndDate =
         now.minus(properties.getSubscriptionIgnoreExpiredOlderThan()).toInstant().toEpochMilli();
 
-    return startDate < earliestAllowedFutureStartDate
-        && (endDate == null || endDate > latestAllowedExpiredEndDate);
+    if (startDate >= earliestAllowedFutureStartDate) {
+      return Optional.of(SubscriptionDeleteReason.FILTERED_START_TOO_FAR_IN_FUTURE);
+    }
+
+    if (endDate != null && endDate <= latestAllowedExpiredEndDate) {
+      return Optional.of(SubscriptionDeleteReason.FILTERED_END_TOO_FAR_IN_PAST);
+    }
+
+    return Optional.empty();
   }
 
   private SubscriptionEntity convertDto(UmbSubscription subscription) {
@@ -485,7 +502,7 @@ public class SubscriptionSyncService {
                   determineSubscriptionOffering(subscription);
                   capacityReconciliationService.reconcileCapacityForSubscription(subscription);
                 }
-                subscriptionRepository.persist(subscription);
+                subscriptionService.save(subscription);
               });
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Error parsing subscriptionsJson", e);
@@ -509,7 +526,7 @@ public class SubscriptionSyncService {
   public void saveUmbSubscription(UmbSubscription umbSubscription) {
     SubscriptionEntity subscription = convertDto(umbSubscription);
     var subscriptions =
-        subscriptionRepository.findBySubscriptionNumber(subscription.getSubscriptionNumber());
+        subscriptionService.findBySubscriptionNumber(subscription.getSubscriptionNumber());
     if (subscriptions.size() > 1) {
       log.warn(
           "Skipping UMB message because multiple subscriptions were found for subscriptionNumber={}",
@@ -538,7 +555,7 @@ public class SubscriptionSyncService {
 
   @Transactional
   public String terminateSubscription(String subscriptionId, OffsetDateTime terminationDate) {
-    var subscriptions = subscriptionRepository.findActiveSubscription(subscriptionId);
+    var subscriptions = subscriptionService.findActiveSubscription(subscriptionId);
     if (subscriptions.isEmpty()) {
       throw new EntityNotFoundException(
           String.format(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,6 +84,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -110,6 +113,7 @@ class ContractServiceTest extends BaseUnitTest {
   @InjectSpy ContractRepository contractRepository;
   @Inject OfferingRepository offeringRepository;
   @InjectSpy SubscriptionRepository subscriptionRepository;
+  @InjectSpy SubscriptionService subscriptionService;
   @InjectWireMock WireMockServer wireMockServer;
   @InjectSpy MeasurementMetricIdTransformer measurementMetricIdTransformer;
 
@@ -136,7 +140,7 @@ class ContractServiceTest extends BaseUnitTest {
         request.getPartnerEntitlement().getRhEntitlements().get(0).getSku(),
         entity.getOffering().getSku());
     assertEquals(response.getUuid(), entity.getUuid().toString());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer).mapContractMetricsToSubscriptionMeasurements(any());
   }
 
@@ -154,7 +158,7 @@ class ContractServiceTest extends BaseUnitTest {
     var contract = givenPartnerEntitlementContractRequest();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer, times(2))
         .mapContractMetricsToSubscriptionMeasurements(any());
   }
@@ -193,7 +197,7 @@ class ContractServiceTest extends BaseUnitTest {
     var request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
     assertEquals("New contract created", statusResponse.getMessage());
   }
 
@@ -205,7 +209,7 @@ class ContractServiceTest extends BaseUnitTest {
     var request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
     verify(contractRepository, times(2)).persist(any(ContractEntity.class));
     verify(contractRepository).delete(existingContract);
     assertEquals("New contract created", statusResponse.getMessage());
@@ -216,7 +220,7 @@ class ContractServiceTest extends BaseUnitTest {
     givenExistingContract();
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
-    verify(subscriptionRepository, times(4)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(3)).save(any(SubscriptionEntity.class));
     verify(measurementMetricIdTransformer, times(4))
         .mapContractMetricsToSubscriptionMeasurements(any());
   }
@@ -238,7 +242,7 @@ class ContractServiceTest extends BaseUnitTest {
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
 
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
-    verify(subscriptionRepository, times(2)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -249,7 +253,7 @@ class ContractServiceTest extends BaseUnitTest {
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
 
     assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -468,7 +472,7 @@ class ContractServiceTest extends BaseUnitTest {
     ArgumentCaptor<SubscriptionEntity> subscriptionSaveCapture =
         ArgumentCaptor.forClass(SubscriptionEntity.class);
     contractService.createPartnerContract(PartnerEntitlementsRequest.from(contract));
-    verify(subscriptionRepository).persist(subscriptionSaveCapture.capture());
+    verify(subscriptionService).save(subscriptionSaveCapture.capture());
     subscriptionSaveCapture.getValue();
     assertEquals(
         "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31;",
@@ -478,16 +482,18 @@ class ContractServiceTest extends BaseUnitTest {
   @Test
   void testDeleteContractDeletesSubscription() {
     ContractEntity contract = givenExistingContract();
-    SubscriptionEntity subscription = givenExistingSubscription();
+    SubscriptionEntity subscription = subscriptionService.findByContract(contract).getFirst();
     contractService.deleteContract(contract.getUuid().toString());
-    verify(subscriptionRepository).delete(argThat(sameSubscription(subscription)));
+    verify(subscriptionService)
+        .delete(
+            argThat(sameSubscription(subscription)), eq(SubscriptionDeleteReason.CONTRACT_DELETED));
     verify(contractRepository).delete(argThat(c -> c.getUuid().equals(contract.getUuid())));
   }
 
   @Test
   void testDeleteContractNoopWhenMissing() {
     contractService.deleteContract(UUID.randomUUID().toString());
-    verify(subscriptionRepository, times(0)).delete(any());
+    verify(subscriptionService, times(0)).delete(any(), any());
     verify(contractRepository, times(0)).delete(any());
   }
 
@@ -497,15 +503,16 @@ class ContractServiceTest extends BaseUnitTest {
     givenExistingSubscription();
     contractService.deleteContractsByOrgId(ORG_ID);
     verify(contractRepository).delete(any());
-    verify(subscriptionRepository).delete(any());
+    verify(subscriptionService)
+        .delete(any(SubscriptionEntity.class), eq(SubscriptionDeleteReason.CONTRACT_DELETED));
   }
 
   @Test
   void testSyncSubscriptionsForContractsByOrg() {
-    givenExistingContract();
-    var expectedSubscription = givenExistingSubscription();
+    ContractEntity contract = givenExistingContract();
+    var expectedSubscription = subscriptionService.findByContract(contract).getFirst();
     contractService.syncSubscriptionsForContractsByOrg(ORG_ID);
-    verify(subscriptionRepository).persist(argThat(sameSubscription(expectedSubscription)));
+    verify(subscriptionService).save(argThat(sameSubscription(expectedSubscription)));
   }
 
   @Test
@@ -517,10 +524,10 @@ class ContractServiceTest extends BaseUnitTest {
     ArgumentCaptor<SubscriptionEntity> subscriptionsSaveCapture =
         ArgumentCaptor.forClass(SubscriptionEntity.class);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(subscriptionsSaveCapture.capture());
+    verify(subscriptionService).save(subscriptionsSaveCapture.capture());
     var persistedSubscriptions = subscriptionsSaveCapture.getValue();
     assertEquals(DEFAULT_END_DATE, persistedSubscriptions.getEndDate());
-    verify(subscriptionRepository, times(0)).delete(any());
+    verify(subscriptionService, times(0)).delete(any(), any());
   }
 
   @Test
@@ -531,8 +538,11 @@ class ContractServiceTest extends BaseUnitTest {
     mockPartnerApi();
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
-    verify(subscriptionRepository, times(1)).delete(argThat(sameSubscription(subscription)));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(1))
+        .delete(
+            argThat(sameSubscription(subscription)),
+            eq(SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY));
   }
 
   @Test
@@ -541,7 +551,7 @@ class ContractServiceTest extends BaseUnitTest {
     var stub = mockPartnerApi(createPartnerApiResponseNoContractDimensions());
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     assertEquals("New contract created", statusResponse.getMessage());
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     wireMockServer.removeStub(stub);
   }
 
@@ -676,6 +686,7 @@ class ContractServiceTest extends BaseUnitTest {
     subscriptionRepository.persist(subscription);
     // to not interfere with the verifications
     reset(subscriptionRepository);
+    clearInvocations(subscriptionService);
     return subscription;
   }
 
@@ -710,6 +721,7 @@ class ContractServiceTest extends BaseUnitTest {
     var entity = contractRepository.findById(UUID.fromString(created.getContract().getUuid()));
     // reset the invocations of this repository, so it does not mix up with the assertions.
     reset(contractRepository);
+    clearInvocations(subscriptionService);
     return entity;
   }
 
@@ -874,7 +886,10 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   private static ArgumentMatcher<SubscriptionEntity> sameSubscription(SubscriptionEntity expected) {
-    return actual -> actual.getSubscriptionNumber().equals(expected.getSubscriptionNumber());
+    return actual ->
+        actual.getSubscriptionNumber().equals(expected.getSubscriptionNumber())
+            && Objects.equals(actual.getSubscriptionId(), expected.getSubscriptionId())
+            && Objects.equals(actual.getStartDate(), expected.getStartDate());
   }
 
   private PartnerEntitlementV1 givenAwsEntitlement(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -26,6 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.redhat.swatch.contract.model.MeasurementMetricIdTransformer.MEASUREMENT_TYPE_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,6 +109,9 @@ class ContractServiceTest extends BaseUnitTest {
       OffsetDateTime.parse("2023-06-09T13:59:43.035365Z");
   private static final OffsetDateTime DEFAULT_END_DATE =
       OffsetDateTime.now(ZoneOffset.UTC).plusYears(4).truncatedTo(ChronoUnit.MICROS);
+  private static final String AZURE_PARTNER_ORG_ID = "7186626";
+  private static final OffsetDateTime ORPHAN_SEGMENT_START_DATE =
+      OffsetDateTime.parse("2023-06-09T04:00:00.035365Z");
 
   @Inject ContractService contractService;
   @Inject ObjectMapper objectMapper;
@@ -172,6 +177,43 @@ class ContractServiceTest extends BaseUnitTest {
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
     // we should get redundant message ignored
     assertEquals("Redundant message ignored", statusResponse.getMessage());
+  }
+
+  @Test
+  void createPartnerContractWhenOrphanSubscriptionDeletedIsNotRedundant() throws Exception {
+    var contract = givenAzurePartnerEntitlementContract();
+    mockPartnerApi();
+    contractService.createPartnerContract(contract);
+
+    var orphanSubscription = givenExistingSubscriptionWithStartDate(ORPHAN_SEGMENT_START_DATE);
+    clearInvocations(subscriptionService);
+
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+
+    assertNotEquals("Redundant message ignored", statusResponse.getMessage());
+    verify(subscriptionService)
+        .delete(
+            argThat(sameSubscription(orphanSubscription)),
+            eq(SubscriptionDeleteReason.PARTNER_ENTITLEMENT_START_DATE_NOT_IN_GATEWAY));
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
+  }
+
+  @Test
+  void createPartnerContractWhenOrphanContractDeletedIsNotRedundant() throws Exception {
+    var contract = givenAzurePartnerEntitlementContract();
+    mockPartnerApi();
+    contractService.createPartnerContract(contract);
+
+    var existingContract = contractRepository.getContractsByOrgId(AZURE_PARTNER_ORG_ID).getFirst();
+    var orphanContract = givenOrphanContractSegment(existingContract, ORPHAN_SEGMENT_START_DATE);
+    clearInvocations(subscriptionService);
+    reset(contractRepository);
+
+    StatusResponse statusResponse = contractService.createPartnerContract(contract);
+
+    assertNotEquals("Redundant message ignored", statusResponse.getMessage());
+    verify(contractRepository).delete(argThat(c -> c.getUuid().equals(orphanContract.getUuid())));
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -723,6 +765,28 @@ class ContractServiceTest extends BaseUnitTest {
     reset(contractRepository);
     clearInvocations(subscriptionService);
     return entity;
+  }
+
+  @Transactional
+  ContractEntity givenOrphanContractSegment(ContractEntity template, OffsetDateTime startDate) {
+    ContractEntity orphan =
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .subscriptionNumber(template.getSubscriptionNumber())
+            .startDate(startDate)
+            .endDate(template.getEndDate())
+            .orgId(template.getOrgId())
+            .offering(template.getOffering())
+            .billingProvider(template.getBillingProvider())
+            .billingProviderId(template.getBillingProviderId())
+            .billingAccountId(template.getBillingAccountId())
+            .vendorProductCode(template.getVendorProductCode())
+            .lastUpdated(OffsetDateTime.now(ZoneOffset.UTC))
+            .build();
+    contractRepository.persist(orphan);
+    reset(contractRepository);
+    clearInvocations(subscriptionService);
+    return orphan;
   }
 
   private ContractRequest givenContractRequest() {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionServiceTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.contract.repository.BillingProvider;
+import com.redhat.swatch.contract.repository.ContractEntity;
+import com.redhat.swatch.contract.repository.OfferingEntity;
+import com.redhat.swatch.contract.repository.OfferingRepository;
+import com.redhat.swatch.contract.repository.SubscriptionEntity;
+import com.redhat.swatch.contract.repository.SubscriptionRepository;
+import com.redhat.swatch.contract.test.LoggerCaptor;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import org.candlepin.clock.ApplicationClock;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class SubscriptionServiceTest {
+
+  private static final String ORG_ID = "org123";
+  private static final String SUBSCRIPTION_ID = "456";
+  private static final String SUBSCRIPTION_NUMBER = "890";
+  private static final String SKU = "RH000001";
+
+  @Inject SubscriptionService subscriptionService;
+  @Inject SubscriptionRepository subscriptionRepository;
+  @Inject OfferingRepository offeringRepository;
+  @Inject ApplicationClock clock;
+
+  private OffsetDateTime startDate;
+  private OffsetDateTime endDate;
+
+  @BeforeAll
+  static void configureLogging() {
+    LoggerCaptor.registerHandler(SubscriptionService.class);
+  }
+
+  @BeforeEach
+  @Transactional
+  void setUp() {
+    LoggerCaptor.clearRecords();
+    subscriptionRepository.deleteAll();
+    offeringRepository.deleteAll();
+    offeringRepository.persistAndFlush(createOffering());
+
+    startDate = clock.now().truncatedTo(ChronoUnit.SECONDS);
+    endDate = startDate.plusYears(1);
+  }
+
+  @Test
+  @TestTransaction
+  void saveCreatesNewSubscriptionFromDetachedEntity() {
+    var subscription = newSubscription("initial-acct", 4L);
+
+    subscriptionService.save(subscription);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    var persisted = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER);
+    assertEquals(1, persisted.size());
+    assertEquals(ORG_ID, persisted.getFirst().getOrgId());
+    assertEquals("initial-acct", persisted.getFirst().getBillingAccountId());
+    assertLogContains("Subscription created/updated org_id=org123 subscription_id=456");
+  }
+
+  @Test
+  @TestTransaction
+  void saveUpdatesManagedSubscription() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+    LoggerCaptor.clearRecords();
+
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    managed.setQuantity(16L);
+    managed.setBillingAccountId("managed-update");
+
+    subscriptionService.save(managed);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    var reloaded = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    assertEquals(16L, reloaded.getQuantity());
+    assertEquals("managed-update", reloaded.getBillingAccountId());
+    assertLogContains("Subscription created/updated org_id=org123 subscription_id=456");
+  }
+
+  @Test
+  @TestTransaction
+  void saveMergesDetachedEntityUpdates() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+    subscriptionService.flushAndClearPersistenceContext();
+
+    EntityManager entityManager = subscriptionRepository.getEntityManager();
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    entityManager.detach(managed);
+    managed.setBillingAccountId("detached-update");
+    managed.setQuantity(32L);
+    LoggerCaptor.clearRecords();
+
+    subscriptionService.save(managed);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    var reloaded = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    assertEquals("detached-update", reloaded.getBillingAccountId());
+    assertEquals(32L, reloaded.getQuantity());
+    assertLogContains("Subscription created/updated org_id=org123 subscription_id=456");
+  }
+
+  @Test
+  @TestTransaction
+  void terminatePersistsEndDateForManagedSubscription() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+    LoggerCaptor.clearRecords();
+
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    var terminationDate = startDate.plusMonths(6);
+    managed.setEndDate(terminationDate);
+    managed.setBillingAccountId(null);
+    managed.setBillingProvider(null);
+
+    subscriptionService.terminate(managed);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    var reloaded = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    assertEquals(terminationDate, reloaded.getEndDate());
+    assertEquals(null, reloaded.getBillingAccountId());
+    assertLogContains("Subscription terminated org_id=org123 subscription_id=456");
+  }
+
+  @Test
+  @TestTransaction
+  void terminateMergesDetachedEntityWithUpdatedEndDate() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+    subscriptionService.flushAndClearPersistenceContext();
+
+    EntityManager entityManager = subscriptionRepository.getEntityManager();
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    entityManager.detach(managed);
+    var terminationDate = startDate.plusMonths(3);
+    managed.setEndDate(terminationDate);
+    LoggerCaptor.clearRecords();
+
+    subscriptionService.terminate(managed);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    var reloaded = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    assertEquals(terminationDate, reloaded.getEndDate());
+    assertLogContains("Subscription terminated org_id=org123 subscription_id=456");
+  }
+
+  @Test
+  @TestTransaction
+  void deleteRemovesSubscriptionAndLogsReason() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    LoggerCaptor.clearRecords();
+
+    subscriptionService.delete(managed, SubscriptionDeleteReason.PRODUCT_DENYLIST);
+    subscriptionService.flushAndClearPersistenceContext();
+
+    assertTrue(subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).isEmpty());
+    assertLogContains(
+        "Subscription deleted org_id=org123 subscription_id=456", "delete_reason=PRODUCT_DENYLIST");
+  }
+
+  @Test
+  @TestTransaction
+  void flushAndClearPersistenceContextEvictsManagedEntities() {
+    subscriptionRepository.persistAndFlush(newSubscription("initial-acct", 4L));
+
+    EntityManager entityManager = subscriptionRepository.getEntityManager();
+    var managed = subscriptionRepository.findBySubscriptionNumber(SUBSCRIPTION_NUMBER).getFirst();
+    assertTrue(entityManager.contains(managed));
+
+    subscriptionService.flushAndClearPersistenceContext();
+
+    assertFalse(entityManager.contains(managed));
+    assertEquals(
+        4L,
+        subscriptionRepository
+            .findBySubscriptionNumber(SUBSCRIPTION_NUMBER)
+            .getFirst()
+            .getQuantity());
+  }
+
+  @Test
+  @TestTransaction
+  void findByContractReturnsPersistedSubscription() {
+    var subscription = newSubscription("contract-acct", 8L);
+    subscriptionRepository.persistAndFlush(subscription);
+
+    var contract = new ContractEntity();
+    contract.setSubscriptionNumber(SUBSCRIPTION_NUMBER);
+    contract.setStartDate(startDate);
+
+    var result = subscriptionService.findByContract(contract);
+
+    assertEquals(1, result.size());
+    assertEquals(SUBSCRIPTION_ID, result.getFirst().getSubscriptionId());
+    assertEquals("contract-acct", result.getFirst().getBillingAccountId());
+  }
+
+  @Test
+  @TestTransaction
+  void streamByOrgIdReturnsSubscriptionsForOrg() {
+    subscriptionRepository.persistAndFlush(newSubscription("acct-1", 4L));
+    subscriptionRepository.persistAndFlush(
+        newSubscriptionForOrg("other-org", "sub-2", "num-2", 2L));
+
+    var result = subscriptionService.streamByOrgId(ORG_ID).toList();
+
+    assertEquals(1, result.size());
+    assertEquals(SUBSCRIPTION_ID, result.getFirst().getSubscriptionId());
+  }
+
+  private OfferingEntity createOffering() {
+    return OfferingEntity.builder()
+        .sku(SKU)
+        .productIds(Set.of(69))
+        .productTags(Set.of("rhel"))
+        .build();
+  }
+
+  private SubscriptionEntity newSubscription(String billingAccountId, long quantity) {
+    return SubscriptionEntity.builder()
+        .subscriptionId(SUBSCRIPTION_ID)
+        .subscriptionNumber(SUBSCRIPTION_NUMBER)
+        .orgId(ORG_ID)
+        .offering(offeringRepository.findById(SKU))
+        .quantity(quantity)
+        .startDate(startDate)
+        .endDate(endDate)
+        .billingProvider(BillingProvider.RED_HAT)
+        .billingAccountId(billingAccountId)
+        .build();
+  }
+
+  private SubscriptionEntity newSubscriptionForOrg(
+      String orgId, String subscriptionId, String subscriptionNumber, long quantity) {
+    return SubscriptionEntity.builder()
+        .subscriptionId(subscriptionId)
+        .subscriptionNumber(subscriptionNumber)
+        .orgId(orgId)
+        .offering(offeringRepository.findById(SKU))
+        .quantity(quantity)
+        .startDate(startDate)
+        .endDate(endDate)
+        .billingProvider(BillingProvider.RED_HAT)
+        .billingAccountId("acct")
+        .build();
+  }
+
+  private static void assertLogContains(String... fragments) {
+    for (String fragment : fragments) {
+      LoggerCaptor.thenInfoLogWithMessage(fragment);
+    }
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -28,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -47,7 +49,6 @@ import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
-import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.utils.SubscriptionDtoUtil;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -64,6 +65,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.candlepin.clock.ApplicationClock;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -75,7 +77,7 @@ class SubscriptionSyncServiceTest {
   private static final String SKU = "testsku";
 
   @InjectMock OfferingRepository offeringRepository;
-  @InjectMock SubscriptionRepository subscriptionRepository;
+  @InjectMock SubscriptionService subscriptionService;
   @InjectMock ContractService contractService;
   @InjectMock ProductDenylist denylist;
   @InjectMock SubscriptionSearchService subscriptionSearchService;
@@ -83,6 +85,12 @@ class SubscriptionSyncServiceTest {
   @InjectMock OfferingSyncService offeringSyncService;
   @Inject ApplicationClock clock;
   @Inject SubscriptionSyncService subscriptionSyncService;
+
+  @BeforeEach
+  void defaultSubscriptionServiceStubs() {
+    doNothing().when(subscriptionService).flushAndClearPersistenceContext();
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.empty());
+  }
 
   @Test
   void shouldCreateNewRecordOnQuantityChange() {
@@ -95,9 +103,8 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     subscriptionSyncService.syncSubscription(dto, Optional.of(subscription));
     // for existing subscription:
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
-    // for the new one:
-    verify(subscriptionRepository).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService).terminate(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(Mockito.any(SubscriptionEntity.class));
   }
@@ -140,7 +147,7 @@ class SubscriptionSyncServiceTest {
     // from the value in the quantityChangedSub.
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(subscriptionSearchService.getSubscriptionsByOrgId("123")).thenReturn(List.of(dto));
-    when(subscriptionRepository.streamByOrgId("123")).thenReturn(subscriptions.stream());
+    when(subscriptionService.streamByOrgId("123")).thenReturn(subscriptions.stream());
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("123", false);
 
     verify(initialSubSpy, never()).endSubscription();
@@ -186,7 +193,7 @@ class SubscriptionSyncServiceTest {
     // the quantity has changed for a second time
     when(denylist.productIdMatches(any())).thenReturn(false);
     when(subscriptionSearchService.getSubscriptionsByOrgId("123")).thenReturn(List.of(dto));
-    when(subscriptionRepository.streamByOrgId("123")).thenReturn(subscriptions.stream());
+    when(subscriptionService.streamByOrgId("123")).thenReturn(subscriptions.stream());
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("123", false);
 
     // We don't want to modify the original subscription that has already been ended.  We want to
@@ -203,7 +210,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 4);
     subscriptionSyncService.syncSubscription(dto, Optional.of(createSubscription()));
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService, Mockito.times(2))
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -216,7 +223,7 @@ class SubscriptionSyncServiceTest {
     when(denylist.productIdMatches(any())).thenReturn(false);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository, Mockito.times(1)).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService, Mockito.times(1)).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService)
         .reconcileCapacityForSubscription(any(SubscriptionEntity.class));
   }
@@ -226,7 +233,7 @@ class SubscriptionSyncServiceTest {
     String sku = "MW0001";
     when(denylist.productIdMatches(sku)).thenReturn(true);
     subscriptionSyncService.syncSubscription(sku, new SubscriptionEntity(), Optional.empty());
-    verify(subscriptionRepository, never()).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -236,7 +243,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(sku)).thenReturn(Optional.empty());
     when(offeringSyncService.syncOffering(sku)).thenReturn(SyncResult.SKIPPED_NOT_FOUND);
     subscriptionSyncService.syncSubscription(sku, new SubscriptionEntity(), Optional.empty());
-    verify(subscriptionRepository, never()).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -291,14 +298,15 @@ class SubscriptionSyncServiceTest {
     var dto = createDto(123, "456", "890", 4);
     givenOfferingWithProductIds(290);
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
 
     // let's update only the product IDs
     givenOfferingWithProductIds(290, 69);
-    reset(subscriptionRepository, capacityReconciliationService);
+    reset(capacityReconciliationService, subscriptionService);
+    defaultSubscriptionServiceStubs();
     subscriptionSyncService.syncSubscription(dto, Optional.empty());
-    verify(subscriptionRepository).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
   }
 
@@ -318,7 +326,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
 
     verify(subscriptionSearchService).getSubscriptionsByOrgId("100");
-    verify(subscriptionRepository).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -333,7 +341,7 @@ class SubscriptionSyncServiceTest {
 
     verify(subscriptionSearchService).getSubscriptionsByOrgId("100");
     verifyNoInteractions(denylist, offeringRepository);
-    verify(subscriptionRepository, times(0)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(0)).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -348,7 +356,7 @@ class SubscriptionSyncServiceTest {
 
     verify(subscriptionSearchService).getSubscriptionsByOrgId("100");
     verifyNoInteractions(denylist, offeringRepository);
-    verify(subscriptionRepository, times(0)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(0)).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -364,7 +372,7 @@ class SubscriptionSyncServiceTest {
 
     verify(subscriptionSearchService).getSubscriptionsByOrgId("100");
     verifyNoInteractions(denylist, offeringRepository);
-    verify(subscriptionRepository, times(0)).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(0)).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -384,12 +392,12 @@ class SubscriptionSyncServiceTest {
         Map.of(
             SubscriptionDtoUtil.AWS_MARKETPLACE,
             new ExternalReference().customerAccountID("new1BillingAccountId")));
-    Mockito.when(subscriptionRepository.findBySubscriptionNumber(dto.getSubscriptionNumber()))
+    Mockito.when(subscriptionService.findBySubscriptionNumber(dto.getSubscriptionNumber()))
         .thenReturn(List.of(existingSub));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("100", false);
     verify(subscriptionSearchService).getSubscriptionsByOrgId("100");
-    verify(subscriptionRepository)
-        .persist(
+    verify(subscriptionService)
+        .save(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->
@@ -406,7 +414,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     String subscriptionsJson = mapper.writeValueAsString(new Subscription[] {subscription});
     subscriptionSyncService.saveSubscriptions(subscriptionsJson, true);
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
   }
 
@@ -430,7 +438,7 @@ class SubscriptionSyncServiceTest {
     var subscription = createDto("123", 1);
     String subscriptionsJson = mapper.writeValueAsString(new Subscription[] {subscription});
     subscriptionSyncService.saveSubscriptions(subscriptionsJson, false);
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     verifyNoInteractions(capacityReconciliationService);
   }
 
@@ -446,7 +454,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", false);
-    verify(subscriptionRepository, times(2)).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -465,7 +473,7 @@ class SubscriptionSyncServiceTest {
     when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
     when(offeringRepository.findById(SKU)).thenReturn(offering);
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", true);
-    verify(subscriptionRepository, atLeastOnce()).merge(any(SubscriptionEntity.class));
+    verify(subscriptionService, atLeastOnce()).save(any(SubscriptionEntity.class));
   }
 
   @Test
@@ -482,9 +490,9 @@ class SubscriptionSyncServiceTest {
     dao2.setOffering(offering2);
 
     when(subscriptionSearchService.getSubscriptionsByOrgId("123")).thenReturn(subList);
-    when(subscriptionRepository.stream("123")).thenReturn(Stream.of(dao1, dao2));
+    when(subscriptionService.streamByOrgId("123")).thenReturn(Stream.of(dao1, dao2));
     subscriptionSyncService.forceSyncSubscriptionsForOrg("123", false);
-    verify(subscriptionRepository).streamByOrgId("123");
+    verify(subscriptionService).streamByOrgId("123");
   }
 
   @Test
@@ -559,7 +567,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionSearchService);
-    verify(subscriptionRepository).persist(any(SubscriptionEntity.class));
+    verify(subscriptionService).save(any(SubscriptionEntity.class));
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -582,7 +590,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.of(existing));
 
     verifyNoInteractions(subscriptionSearchService);
-    verify(subscriptionRepository).persist(existing);
+    verify(subscriptionService).save(existing);
     assertEquals(BillingProvider.RED_HAT, existing.getBillingProvider());
     assertEquals("newBillingProviderId", existing.getBillingProviderId());
     assertEquals("newBillingAccountId", existing.getBillingAccountId());
@@ -601,7 +609,7 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.empty());
 
     verify(offeringSyncService).syncOffering(SKU);
-    verify(subscriptionRepository).merge(incoming);
+    verify(subscriptionService).save(incoming);
     assertNull(incoming.getBillingAccountId());
   }
 
@@ -618,27 +626,75 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.syncSubscription(SKU, incoming, Optional.empty());
 
     verify(offeringSyncService).syncOffering(SKU);
-    verify(subscriptionRepository, times(0)).persist(incoming);
+    verify(subscriptionService, times(0)).save(incoming);
+  }
+
+  @Test
+  void shouldDeleteStoredSubscriptionWhenUpstreamFilteredByNullStartDate() {
+    var subscription = createSubscription();
+    var dto = createDto("456", 1);
+    dto.setEffectiveStartDate(null);
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    when(subscriptionSearchService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
+
+    subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
+
+    verify(subscriptionService)
+        .delete(subscription, SubscriptionDeleteReason.FILTERED_NULL_START_DATE);
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
+  }
+
+  @Test
+  void shouldDeleteStoredSubscriptionWhenUpstreamFilteredByFutureStart() {
+    var subscription = createSubscription();
+    var dto = createDto("456", 1);
+    dto.setEffectiveStartDate(toEpochMillis(NOW.plusMonths(2).plusDays(1)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.plusMonths(14)));
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    when(subscriptionSearchService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
+
+    subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
+
+    verify(subscriptionService)
+        .delete(subscription, SubscriptionDeleteReason.FILTERED_START_TOO_FAR_IN_FUTURE);
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
+  }
+
+  @Test
+  void shouldDeleteStoredSubscriptionWhenUpstreamFilteredByExpiredEnd() {
+    var subscription = createSubscription();
+    var dto = createDto("456", 1);
+    dto.setEffectiveStartDate(toEpochMillis(NOW.minusMonths(14)));
+    dto.setEffectiveEndDate(toEpochMillis(NOW.minusDays(61)));
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    when(subscriptionSearchService.getSubscriptionsByOrgId(any())).thenReturn(List.of(dto));
+
+    subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
+
+    verify(subscriptionService)
+        .delete(subscription, SubscriptionDeleteReason.FILTERED_END_TOO_FAR_IN_PAST);
+    verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
   }
 
   @Test
   void testShouldRemoveStaleSubscriptionsNotPresentInSubscriptionService() {
     var subscription = createSubscription();
-    when(subscriptionRepository.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
-    verify(subscriptionRepository).delete(subscription);
+    verify(subscriptionService)
+        .delete(subscription, SubscriptionDeleteReason.NOT_IN_UPSTREAM_RESPONSE);
   }
 
   @Test
   void testShouldRemoveStaleSubscriptionsPresentInSubscriptionServiceButDenylisted() {
     var subscription = createSubscription();
     var subServiceSub = createDto("456", 1);
-    when(subscriptionRepository.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
     when(subscriptionSearchService.getSubscriptionsByOrgId(any()))
         .thenReturn(List.of(subServiceSub));
     when(denylist.productIdMatches(any())).thenReturn(true);
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
-    verify(subscriptionRepository).delete(subscription);
+    verify(subscriptionService).delete(subscription, SubscriptionDeleteReason.PRODUCT_DENYLIST);
   }
 
   @Test
@@ -646,12 +702,18 @@ class SubscriptionSyncServiceTest {
     var subscription = createSubscription();
     var subServiceSub = createDto("456", 1);
     subscription.setStartDate(clock.dateFromMilliseconds(subServiceSub.getEffectiveStartDate()));
-    when(subscriptionRepository.streamByOrgId(any())).thenReturn(Stream.of(subscription));
+    OfferingEntity offering = OfferingEntity.builder().sku(SKU).build();
+    when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
+    when(offeringRepository.findById(SKU)).thenReturn(offering);
+    when(subscriptionService.streamByOrgId(any())).thenReturn(Stream.of(subscription));
     when(subscriptionSearchService.getSubscriptionsByOrgId(any()))
         .thenReturn(List.of(subServiceSub));
     when(denylist.productIdMatches(any())).thenReturn(false);
+    doAnswer(invocation -> invocation.getArgument(0))
+        .when(subscriptionService)
+        .save(any(SubscriptionEntity.class));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org124", false);
-    verify(subscriptionRepository, times(0)).delete(subscription);
+    verify(subscriptionService, times(0)).delete(any(), any());
   }
 
   @Test
@@ -661,13 +723,19 @@ class SubscriptionSyncServiceTest {
     subscription2.setEndDate(subscription1.getEndDate().plusDays(2));
     var subServiceSub = createDto("456", 1);
     subscription2.setStartDate(clock.dateFromMilliseconds(subServiceSub.getEffectiveStartDate()));
-    when(subscriptionRepository.streamByOrgId(any()))
+    OfferingEntity offering = OfferingEntity.builder().sku(SKU).build();
+    when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
+    when(offeringRepository.findById(SKU)).thenReturn(offering);
+    when(subscriptionService.streamByOrgId(any()))
         .thenReturn(Stream.of(subscription1, subscription2));
     when(subscriptionSearchService.getSubscriptionsByOrgId(any()))
         .thenReturn(List.of(subServiceSub));
     when(denylist.productIdMatches(any())).thenReturn(false);
+    doAnswer(invocation -> invocation.getArgument(0))
+        .when(subscriptionService)
+        .save(any(SubscriptionEntity.class));
     subscriptionSyncService.reconcileSubscriptionsWithSubscriptionService("org123", false);
-    verify(subscriptionRepository, times(0)).delete(any());
+    verify(subscriptionService, times(0)).delete(any(), any());
   }
 
   @Test
@@ -683,8 +751,8 @@ class SubscriptionSyncServiceTest {
     existingSubscription.setQuantity(10);
     var dto = createDto("456", 10);
     subscriptionSyncService.syncSubscription(dto, Optional.of(existingSubscription));
-    verify(subscriptionRepository)
-        .persist(
+    verify(subscriptionService)
+        .save(
             argThat(
                 (ArgumentMatcher<SubscriptionEntity>)
                     s ->
@@ -699,7 +767,7 @@ class SubscriptionSyncServiceTest {
     OfferingEntity o = new OfferingEntity();
     o.setMetered(true);
     when(offeringRepository.findById(SKU)).thenReturn(o);
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
+    when(subscriptionService.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now();
     var result = subscriptionSyncService.terminateSubscription("456", termination);
@@ -713,7 +781,7 @@ class SubscriptionSyncServiceTest {
     OfferingEntity offering = OfferingEntity.builder().metered(true).build();
     s.setOffering(offering);
     when(offeringRepository.findById(SKU)).thenReturn(offering);
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
+    when(subscriptionService.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now().minusDays(1);
     var result = subscriptionSyncService.terminateSubscription("456", termination);
@@ -727,7 +795,7 @@ class SubscriptionSyncServiceTest {
   void terminateInTheFutureActivePAYGSubscriptionTest() {
     SubscriptionEntity s = createSubscription();
     s.getOffering().setMetered(true);
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
+    when(subscriptionService.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now().plusDays(1);
     var result = subscriptionSyncService.terminateSubscription("456", termination);
@@ -740,7 +808,7 @@ class SubscriptionSyncServiceTest {
   @Test
   void terminateActiveNonPAYGSubscriptionTest() {
     SubscriptionEntity s = createSubscription();
-    when(subscriptionRepository.findActiveSubscription("456")).thenReturn(List.of(s));
+    when(subscriptionService.findActiveSubscription("456")).thenReturn(List.of(s));
 
     var termination = OffsetDateTime.now();
     var result = subscriptionSyncService.terminateSubscription("456", termination);

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/LogsVerifier.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/LogsVerifier.java
@@ -21,7 +21,9 @@
 package com.redhat.swatch.component.tests.utils;
 
 import com.redhat.swatch.component.tests.api.Service;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 
 public class LogsVerifier {
@@ -32,17 +34,26 @@ public class LogsVerifier {
     this.service = service;
   }
 
-  public void assertContains(String expectedLog) {
-    assertContains(expectedLog, AwaitilitySettings.defaults());
+  /**
+   * Asserts that the service logs contain at least one of the expected texts.
+   *
+   * @param expectedTextsInLogLine the expected texts in a single log line
+   */
+  public void assertContains(String... expectedTextsInLogLine) {
+    assertContains(expectedTextsInLogLine, AwaitilitySettings.defaults());
   }
 
-  public void assertContains(String expectedLog, AwaitilitySettings settings) {
+  private void assertContains(String[] expectedTextsInLogLine, AwaitilitySettings settings) {
     AwaitilityUtils.untilAsserted(
         () -> {
           List<String> actualLogs = service.getLogs();
           Assertions.assertTrue(
-              actualLogs.stream().anyMatch(line -> line.contains(expectedLog)),
-              "Log does not contain " + expectedLog + ". Full logs: " + actualLogs);
+              actualLogs.stream()
+                  .anyMatch(line -> Stream.of(expectedTextsInLogLine).allMatch(line::contains)),
+              "Log does not contain "
+                  + Arrays.toString(expectedTextsInLogLine)
+                  + ". Full logs: "
+                  + actualLogs);
         },
         settings);
   }


### PR DESCRIPTION
Jira issue: SWATCH-5086

## Description
Changes:
- New SubscriptionService (persistence layer) — Centralizes DB ops (save, terminate, delete, flush/clear). Why: one place for subscription lifecycle + audit logs. 
- Structured audit logs — INFO logs on create/update, terminate, and delete with key fields. 
- SubscriptionDeleteReason enum — Typed reasons (NOT_IN_UPSTREAM_RESPONSE, FILTERED_*, CONTRACT_DELETED, etc.).  subscription_delete_reason.yaml schema — Shared enum for component tests. Why: type-safe CT assertions. Strong: keeps CT aligned with production reasons.
- Reconcile logic update — Partitions upstream DTOs into sync vs delete-with-reason; deletes go through subscriptionService.delete(...). 
- ContractService refactor — Uses SubscriptionService instead of direct repository calls. 

## Testing
Added:
- Tests + CT + TEST_PLAN — Unit tests for SubscriptionService, sync delete-reason tests, CT assertions on delete_reason, new TC009 (expired end filter). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced subscription deletion/audit logging to include a structured, consistent deletion reason across contract deletion, contract updates/replacements, and sync reconciliation (including upstream reconciliation and effective-date filtering cases).
  * Introduced a formal set of supported deletion reasons to keep reporting uniform across flows.

* **Tests**
  * Strengthened verification to assert the correct audit log entries and deletion reason values during contract update/deletion and subscription sync scenarios.

* **Documentation**
  * Updated the test plan with expanded expected log-based checks for subscription/contract-related cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->