### PR TITLE
Upgrade Quarkus platform from 3.36.1 to 3.36.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <codegen.skipIfSpecIsUnchanged>true</codegen.skipIfSpecIsUnchanged>
 
     <!-- Dependencies -->
-    <quarkus.platform.version>3.36.1</quarkus.platform.version>
+    <quarkus.platform.version>3.36.2</quarkus.platform.version>
     <spring.boot.version>4.0.6</spring.boot.version>
     <resteasy.version>7.0.0.Final</resteasy.version>
     <!-- Only use as provided in the common dependencies.


### PR DESCRIPTION
SWATCH-5107, SWATCH-5106, SWATCH-5105, SWATCH-5104, SWATCH-5103, SWATCH-5102, SWATCH-5101, SWATCH-5100, SWATCH-5099, SWATCH-5098, SWATCH-5097, SWATCH-5096, SWATCH-5095, SWATCH-5094, SWATCH-5093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Quarkus platform dependency to version 3.36.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->