### PR TITLE
SWATCH-4835: Remove Splunk-specific wording from documentation

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -757,7 +757,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "description": "Per-second Splunk HEC transmission failure rate over the past 10 minutes.  The y-axis is the total number of log messages that failed transmission.",
+              "description": "Per-second Logging HEC transmission failure rate over the past 10 minutes.  The y-axis is the total number of log messages that failed transmission.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -840,11 +840,11 @@ data:
                   "refId": "A"
                 }
               ],
-              "title": "Splunk HEC Failures",
+              "title": "Logging HEC Failures",
               "type": "timeseries"
             }
           ],
-          "title": "Splunk HEC",
+          "title": "Logging HEC",
           "type": "row"
         },
         {

--- a/README.md
+++ b/README.md
@@ -167,38 +167,37 @@ The OTEL exporter will be listening for gRPC connections on port 4317.
 for the SWATCH contracts service, we need to provide the OTEL_ENDPOINT property to point out to the
 local otel exporter: `java -DOTEL_ENDPOINT=http://localhost:4317 -jar swatch-contracts/build/quarkus-app/quarkus-run.jar`
 
-### Splunk
+### Logging HEC
 
-Some services integrate the log traces into Splunk. For these services, we can start Splunk via:
+In deployed environments, services forward logs via Logging HEC (HTTP Event
+Collector) to the enterprise log stack. By default, Logging HEC is
+**disabled** in the `dev` profile (`LOGGING_HEC_ENABLED=false`), so local
+development logs go to the console only.
 
-```
-podman-compose -f config/splunk/docker-compose.yml up -d
-```
+The following environment variables control Logging HEC forwarding:
 
-Splunk will be accepting events over port 8088.  The web interface is on port
-8000 and you can log in as `admin`/`admin123`.  There are several different
-environment variables you can pass to the container and the
-[documentation](https://splunk.github.io/docker-splunk/) is helpful.
+| Variable | Purpose |
+|----------|---------|
+| `LOGGING_HEC_ENABLED` | Toggle Logging HEC forwarding (`true`/`false`) |
+| `LOGGING_HEC_URL` | Logging HEC endpoint URL |
+| `LOGGING_HEC_TOKEN` | Authentication token for the Logging HEC endpoint |
 
-*NOTE*: We need to configure our services to work with this Splunk instance. For example,
-for the SWATCH Azure producer, we need:
+These map to the `quarkus.log.handler.splunk` Quarkus extension properties.
+If you ever need to test Logging HEC forwarding locally (for example against a
+local collector), set the variables above when starting the service:
 
 ```
 SERVER_PORT=8001 \
 LOGGING_HEC_ENABLED=true \
 LOGGING_HEC_URL=https://localhost:8088 \
-LOGGING_HEC_TOKEN=29fe2838-cab6-4d17-a392-37b7b8f41f75 \
+LOGGING_HEC_TOKEN=<your-token> \
 ./mvnw quarkus:dev
 ```
 
-Some of these environment variables are our own (e.g. `LOGGING_HEC_URL`) and are
-piped into the `quarkus.log.handler.splunk` namespace which is what ultimately
-controls the Splunk HEC configuration.  By default SSL/TLS certificate
-validation is disabled in the `dev` profile for the `swatch-producer-aws`,
-`swatch-producer-azure`, and `swatch-contracts` projects.  If you are seeing
-SSL/TLS error (generally something like `unable to find valid certification path
-to requested target`), then setting `QUARKUS_LOG_HANDLER_SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true`
-is the sure-fire way to disable SSL/TLS certificate validation.
+SSL/TLS certificate validation is disabled by default in the `dev` profile
+for `swatch-producer-aws`, `swatch-producer-azure`, and `swatch-contracts`.
+If you see SSL/TLS errors elsewhere, set
+`QUARKUS_LOG_HANDLER_SPLUNK_DISABLE_CERTIFICATE_VALIDATION=true`.
 
 ### Export Service
 

--- a/docs/playbooks/observability.md
+++ b/docs/playbooks/observability.md
@@ -1,6 +1,6 @@
 # Observability playbook
 
-This guide will help us to set up the environment with Kafka, Database and Splunk into local with all our swatch services. 
+This guide will help us to set up the environment with Kafka, Database and centralized logging into local with all our swatch services.
 
 We'll exercise all the swatch integrations that are part of the diagram in [here](https://miro.com/app/board/uXjVLZZFmEc=/?share_link_id=967248979294).
 
@@ -10,7 +10,7 @@ Read more about the prerequisites in [here](../../CONTRIBUTING.md#build).
 
 ## Set Up
 - Dependant services: instructions [here](../../README.md#dependent-services).
-- splunk: instructions [here](../../README.md#splunk).
+- Logging HEC: instructions [here](../../README.md#logging-hec).
 - Opentelemetry (OTEL) Exporter: instructions [here](../../README.md#opentelemetry-otel-exporter).
 - Wiremock (for prometheus): instructions [here](../../README.md#wiremock-service).
 - perform database migrations: `./mvnw -f swatch-database/pom.xml exec:java`
@@ -128,7 +128,7 @@ traceresponse: 00-314bf601e06b4c76d199a71b0abc119b-bd13c0fb161d55fd-00
 ```
 
 Note that "314bf601e06b4c76d199a71b0abc119b" is the trace ID of the whole operation. 
-Running the splunk query `properties.traceId="314bf601e06b4c76d199a71b0abc119b"` will return all the logs within the spring boot and quarkus services.
+You can search for this trace ID in the centralized logging platform to find all the logs within the spring boot and quarkus services.
 
 ### Sync Accounts (Organizations) by Swatch Conduit
 
@@ -159,7 +159,7 @@ traceresponse: 00-e861d11055c4675e01093c73ed606fa9-344caadf992b1d6c-01
 
 The trace ID is the second token "e861d11055c4675e01093c73ed606fa9".
 
-Searching in Splunk by this trace ID: `properties.traceId="e861d11055c4675e01093c73ed606fa9"`, we should see at least the following messages correlated: 
+Searching in the centralized logging platform by this trace ID (see [swatch-internal-docs/Observability/logging.md](https://gitlab.cee.redhat.com/rhsm/swatch-internal-docs/-/blob/main/docs/Observability/logging.md) for query guidance), we should see at least the following messages correlated:
 
 ```
 2024-11-20 06:58:55,295 [thread=http-nio-8005-exec-3] [INFO ] [org.candlepin.subscriptions.security.LogPrincipalFilter] self- Internal API: /api/rhsm-subscriptions/v1/internal/rpc/syncOrg requested by user: self
@@ -173,4 +173,4 @@ Searching in Splunk by this trace ID: `properties.traceId="e861d11055c4675e01093
 - [Quarkus OTel Tracing docs](https://quarkus.io/guides/opentelemetry-tracing)
 - [Spring Boot Tracing docs](https://docs.spring.io/spring-boot/reference/actuator/tracing.html)
 - [OTel Spring Boot docs](https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/)
-- [Configure the Java agent for Splunk Observability Cloud](https://docs.splunk.com/observability/en/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.html)
+- [OpenTelemetry Java Agent Configuration](https://opentelemetry.io/docs/zero-code/java/agent/configuration/)

--- a/docs/quarkus-profiles.md
+++ b/docs/quarkus-profiles.md
@@ -17,7 +17,7 @@ Quarkus profiles allow different configurations to be applied based on the runti
 - **Local Ports**: Each service runs on a specific development port (e.g., swatch-contracts on 8011, swatch-billable-usage on 8012)
 - **Management Ports**: Management/metrics endpoints run on port + 1000 (e.g., 9011, 9012)
 - **Mock Services**: Points to local WireMock services for external dependencies
-- **Splunk Disabled**: `LOGGING_HEC_ENABLED=false` - logging goes to console instead
+- **Logging HEC Disabled**: `LOGGING_HEC_ENABLED=false` - logging goes to console instead
 - **CORS Relaxed**: `CORS_ORIGINS=/.*/` - allows any origin for local testing
 - **Security Disabled**: Authentication disabled in dev mode for easier testing
 - **Live Reload**: Quarkus live reload enabled with configurable password
@@ -102,7 +102,7 @@ Quarkus profiles allow different configurations to be applied based on the runti
 **Key Features**:
 - **Production APIs**: Points to production Red Hat services
 - **Test APIs Disabled**: `SWATCH_TEST_APIS_ENABLED=false` for security
-- **Full Observability**: OpenTelemetry and Splunk logging enabled
+- **Full Observability**: OpenTelemetry and centralized log forwarding (Logging HEC) enabled
 - **Secure Configuration**: Strict CORS, authentication required, secure defaults
 - **Subscription Editing Disabled**: `DEVTEST_SUBSCRIPTION_EDITING_ENABLED=false`
 
@@ -165,7 +165,7 @@ QUARKUS_PROFILE=dev,kafka-queue
 - **Test**: Disabled or mocked
 
 ### Observability
-- **Production/Stage**: Full OpenTelemetry and Splunk integration
+- **Production/Stage**: Full OpenTelemetry and centralized log forwarding
 - **Dev**: Console logging only
 - **Test**: Minimal logging
 - **Ephemeral**: Simplified configuration for quick validation


### PR DESCRIPTION
Replace Splunk/Splunk HEC references with generic centralized logging terminology (HEC, centralized log forwarding) in docs and Grafana dashboard panel titles.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logging setup documentation with HEC centralized logging configuration details
  * Updated observability playbook with HEC setup instructions and log search guidance
  * Updated Quarkus profiles documentation to reflect HEC centralized logging configuration

* **Chores**
  * Updated Grafana dashboard panel labels for consistent HEC terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->