### PR TITLE
SWATCH-5052: Add not-null constraint to host tally buckets

### DIFF
--- a/src/main/resources/liquibase/202606181400-add-not-null-constraint-to-host-tally-buckets-sla.xml
+++ b/src/main/resources/liquibase/202606181400-add-not-null-constraint-to-host-tally-buckets-sla.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="202606181400-1" author="wpoteat">
+        <preConditions onFail="HALT">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM host_tally_buckets WHERE sla IS NULL
+            </sqlCheck>
+        </preConditions>
+        <comment>Make Host Tally Buckets SLA non-null and default existing to _ANY</comment>
+        <addNotNullConstraint
+            tableName="host_tally_buckets"
+            columnName="sla"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/src/main/resources/liquibase/changelog.xml
+++ b/src/main/resources/liquibase/changelog.xml
@@ -211,5 +211,6 @@
     <include file="liquibase/202605111456-remove-last-modified-triggers.xml"/>
     <include file="liquibase/202605151359-host-tally-buckets-partial-index.xml"/>
     <include file="liquibase/202605191440-update-views-with-is-primary.xml"/>
+    <include file="liquibase/202606181400-add-not-null-constraint-to-host-tally-buckets-sla.xml"/>
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5052

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The tables tally_snapshots and host_tally_buckets all have the four fields of sla/usage/billing_provider and billing_account_id. These are treated as not-null by the code, so the task is to make the database constrain them as such.

Of the eight columns, 7 have had that constraint added over several changesets. This will take care of the final one: host_tally_buckets.sla. 


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run the following to confirm that no null values exist in the prod and stage databases
```select * from tally_snapshots where sla is null limit 10```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data integrity through the application of stricter validation constraints on core system data to improve reliability and prevent incomplete records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->