### PR TITLE
SWATCH-5126: /v1/version should return the git commit SHA

### DIFF
--- a/api/rhsm-subscriptions-api-v1-spec.yaml
+++ b/api/rhsm-subscriptions-api-v1-spec.yaml
@@ -516,6 +516,7 @@ components:
           properties:
             version:
               type: string
+              description: Git commit SHA (abbreviated) of the deployed application build
             artifact:
               type: string
             name:

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
     <swagger-codegen-maven-plugin.version>3.0.81</swagger-codegen-maven-plugin.version>
+    <git-commit-id-maven-plugin.version>10.0.0</git-commit-id-maven-plugin.version>
 
     <!-- Sonar configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -354,6 +355,12 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring.boot.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>${git-commit-id-maven-plugin.version}</version>
         </plugin>
 
         <!-- Required to start Quarkus services in dev mode from the Maven command -->

--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/VersionResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/VersionResource.java
@@ -30,6 +30,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class VersionResource implements VersionApi {
 
+  static final String GIT_COMMIT_PROPERTY = "git.commit.id.abbrev";
+
   private final BuildProperties buildProperties;
 
   public VersionResource(BuildProperties buildProperties) {
@@ -39,7 +41,7 @@ public class VersionResource implements VersionApi {
   @Override
   public VersionInfo getVersion() {
     VersionInfoBuild versionInfoBuild = new VersionInfoBuild();
-    versionInfoBuild.setVersion(buildProperties.getVersion());
+    versionInfoBuild.setVersion(resolveBuildVersion());
     versionInfoBuild.setArtifact(buildProperties.getArtifact());
     versionInfoBuild.setName(buildProperties.getName());
     versionInfoBuild.setGroup(buildProperties.getGroup());
@@ -47,5 +49,13 @@ public class VersionResource implements VersionApi {
     VersionInfo versionInfo = new VersionInfo();
     versionInfo.setBuild(versionInfoBuild);
     return versionInfo;
+  }
+
+  private String resolveBuildVersion() {
+    String gitCommit = buildProperties.get(GIT_COMMIT_PROPERTY);
+    if (gitCommit != null && !gitCommit.isBlank()) {
+      return gitCommit;
+    }
+    return buildProperties.getVersion();
   }
 }

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/VersionResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/VersionResourceTest.java
@@ -41,14 +41,14 @@ class VersionResourceTest {
 
   @Test
   void getVersion() {
-    when(buildProperties.getVersion()).thenReturn("VERSION");
+    when(buildProperties.get(VersionResource.GIT_COMMIT_PROPERTY)).thenReturn("abc1234");
     when(buildProperties.getArtifact()).thenReturn("ARTIFACT");
     when(buildProperties.getName()).thenReturn("NAME");
     when(buildProperties.getGroup()).thenReturn("GROUP");
 
     VersionInfo versionInfo = versionResource.getVersion();
     VersionInfoBuild expected = versionInfo.getBuild();
-    assertEquals("VERSION", expected.getVersion());
+    assertEquals("abc1234", expected.getVersion());
     assertEquals("ARTIFACT", expected.getArtifact());
     assertEquals("NAME", expected.getName());
     assertEquals("GROUP", expected.getGroup());

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -1210,3 +1210,18 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Only matching category rows return
 - **Expected Result**:
     - Category sorting works and shows expected results
+
+## Version API
+
+**version-TC001 - Build metadata from version endpoint**
+
+- **Description**: Verify `GET /v1/version` returns service metadata for the deployed swatch-tally application
+- **Setup**: Component test environment with swatch-tally running
+- **Action**: Call the public version endpoint
+- **Verification**:
+    - HTTP 200
+    - Response includes non-empty `build.version`, `build.artifact`, `build.name`, and
+      `build.group`
+    - `build.version` is the git commit SHA (7–40 hex chars)
+    - `build.artifact` is `swatch-tally`
+- **Expected Result**: Version endpoint is available and exposes build info suitable for test-run traceability

--- a/swatch-tally/ct/java/api/TallySwatchService.java
+++ b/swatch-tally/ct/java/api/TallySwatchService.java
@@ -29,6 +29,7 @@ import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.utils.SwatchUtils;
 import com.redhat.swatch.tally.test.model.InstanceResponse;
 import com.redhat.swatch.tally.test.model.TallyReportData;
+import com.redhat.swatch.tally.test.model.VersionInfo;
 import io.restassured.response.Response;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -51,6 +52,30 @@ public class TallySwatchService extends SwatchService {
 
   private static final String API_PATH = "/api/rhsm-subscriptions/v1";
   private static final String INTERNAL_API_PATH = API_PATH + "/internal";
+
+  // --- Version methods ---
+
+  /**
+   * Retrieves build and version metadata from the public version endpoint.
+   *
+   * @return version information for the deployed application
+   */
+  public VersionInfo getVersion() {
+    Response response =
+        given().headers(SECURITY_HEADERS).get(API_PATH + "/version").then().extract().response();
+
+    assertEquals(
+        HttpStatus.SC_OK,
+        response.getStatusCode(),
+        "Get version failed with status code: "
+            + response.getStatusCode()
+            + ", response body: "
+            + response.getBody().asString());
+
+    Log.debug(this, "Version endpoint response: %s", response.getBody().asString());
+
+    return response.as(VersionInfo.class);
+  }
 
   // --- Configuration methods ---
 

--- a/swatch-tally/ct/java/tests/VersionComponentTest.java
+++ b/swatch-tally/ct/java/tests/VersionComponentTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.tally.test.model.VersionInfo;
+import com.redhat.swatch.tally.test.model.VersionInfoBuild;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class VersionComponentTest extends BaseTallyComponentTest {
+
+  private static final Pattern GIT_COMMIT_SHA =
+      Pattern.compile("^[0-9a-f]{7,40}$", Pattern.CASE_INSENSITIVE);
+
+  @Test
+  @TestPlanName("version-TC001")
+  void shouldReturnBuildInfoFromVersionEndpoint() {
+    // When
+    VersionInfo versionInfo = service.getVersion();
+
+    // Then
+    assertNotNull(versionInfo.getBuild());
+    VersionInfoBuild build = versionInfo.getBuild();
+    assertNotNull(build.getVersion());
+    assertFalse(build.getVersion().isBlank());
+    assertTrue(
+        GIT_COMMIT_SHA.matcher(build.getVersion()).matches(),
+        "build.version should be a git SHA, got: " + build.getVersion());
+    assertFalse(
+        build.getVersion().contains("SNAPSHOT"),
+        "build.version must be the git commit SHA, not the Maven pom version");
+    assertNotNull(build.getArtifact());
+    assertEquals("swatch-tally", build.getArtifact());
+    assertNotNull(build.getName());
+    assertFalse(build.getName().isBlank());
+    assertNotNull(build.getGroup());
+    assertFalse(build.getGroup().isBlank());
+
+    log.info(
+        "Version endpoint: version={}, artifact={}, name={}, group={}",
+        build.getVersion(),
+        build.getArtifact(),
+        build.getName(),
+        build.getGroup());
+  }
+}

--- a/swatch-tally/pom.xml
+++ b/swatch-tally/pom.xml
@@ -307,13 +307,43 @@
       </plugin>
 
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <additionalProperties>
+                <git.commit.id.abbrev>${git.commit.id.abbrev}</git.commit.id.abbrev>
+              </additionalProperties>
+            </configuration>
+          </execution>
+          <execution>
             <goals>
               <goal>repackage</goal>
-              <goal>build-info</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Jira issue: SWATCH-5126

## Description
Before these changes, the `/v1/version` returned the pom version which is always `1.1.0-SNAPSHOT` since we don't update this manifest. 

After these changes, it returns the git commit SHA.

This is important because the git commit SHA is the value used in the image tag generation of the containers and also the IQE framework uses to attach the version to the metadata of the pipelines into ibutsu/report portal.

## Testing
Added component tests in swatch-tally (swatch-api)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `GET /v1/version` response now reports `build.version` as the deployed Git commit SHA (when available) for more precise deployment tracking.
  * Added a `getVersion()` capability in the Swatch Tally client to retrieve version build metadata from the service.
* **Documentation**
  * Updated the Version API test plan to include `version-TC001` and expected build metadata rules.
* **Tests**
  * Added/updated automated tests to verify `build` metadata completeness and that `build.version` matches a git-SHA-like format (non-SNAPSHOT), including artifact/name/group checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->