### PR TITLE
SWATCH-4146: Fix billing_provider_id type in SubscriptionCapacityView

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionCapacityView.java
@@ -83,7 +83,7 @@ public class SubscriptionCapacityView implements Serializable {
   private BillingProvider billingProvider;
 
   @Column(name = "billing_provider_id")
-  private BillingProvider billingProviderId;
+  private String billingProviderId;
 
   @Column(name = "billing_account_id")
   private String billingAccountId;


### PR DESCRIPTION
The view column stores a composite billing provider identifier string, not the BillingProvider enum. Align the JPA mapping with SubscriptionEntity.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4146


### Verification
<!-- Enter the steps needed to verify the test passed -->
Unit tests:
`mvn test -pl swatch-contracts -am
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data structure handling for billing provider identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->