### PR TITLE
SWATCH-3506: Reduce usage-context 404 log noise with trace ID

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/UsageContextSubscriptionNotFoundException.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/UsageContextSubscriptionNotFoundException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.exception;
+
+import jakarta.ws.rs.NotFoundException;
+
+/** Raised when usage-context lookup finds no matching subscription; logged at WARN at source. */
+public class UsageContextSubscriptionNotFoundException extends NotFoundException {
+
+  public UsageContextSubscriptionNotFoundException() {
+    super();
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.resource;
 
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
+import com.redhat.swatch.contract.exception.UsageContextSubscriptionNotFoundException;
 import com.redhat.swatch.contract.openapi.model.Error;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.WebApplicationException;
@@ -41,8 +42,10 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
 
   @Override
   public Response toResponse(Exception exception) {
-    log.error(
-        "Request '{}' failed with error '{}'", info.getPath(), exception.getMessage(), exception);
+    if (!(exception instanceof UsageContextSubscriptionNotFoundException)) {
+      log.error(
+          "Request '{}' failed with error '{}'", info.getPath(), exception.getMessage(), exception);
+    }
     if (exception instanceof ServiceException e) {
       return Response.status(e.getStatus()).entity(e.error()).build();
     } else if (exception instanceof ClientErrorException clientErrorException) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/UsageContextSubscriptionProvider.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.service;
 
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
+import com.redhat.swatch.contract.exception.UsageContextSubscriptionNotFoundException;
 import com.redhat.swatch.contract.repository.DbReportCriteria;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionEntity_;
@@ -29,7 +30,6 @@ import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +55,7 @@ public class UsageContextSubscriptionProvider {
     if (subscriptions.isEmpty()) {
       log.warn("No subscription found for criteria {}", criteria);
       incrementCounter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, criteria);
-      throw new NotFoundException();
+      throw new UsageContextSubscriptionNotFoundException();
     }
 
     var existsRecentlyTerminatedSubscription =
@@ -85,7 +85,7 @@ public class UsageContextSubscriptionProvider {
       } else {
         log.warn("No active subscription found for criteria {}", criteria);
         incrementCounter(MISSING_SUBSCRIPTIONS_COUNTER_NAME, criteria);
-        throw new NotFoundException();
+        throw new UsageContextSubscriptionNotFoundException();
       }
     }
 


### PR DESCRIPTION
Log missing subscription lookups at WARN and skip duplicate ERROR logging in DefaultExceptionMapper for that path only.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-3506


### Verification
<!-- Enter the steps needed to verify the test passed -->
Unit tests:
`mvn test -pl swatch-contracts -am`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription lookup error handling with enhanced diagnostic capabilities including trace ID logging for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->