### PR TITLE
SWATCH-4878 Add EventNormalizer filtering for non-PAYG products

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
@@ -84,8 +84,9 @@ public class EventNormalizer {
    * @return list of flattened events containing only valid tag-measurement pairs
    */
   public List<Event> flattenEventUsage(Event event) {
-    Set<String> tags = event.getProductTag();
-    Set<Measurement> measurements = new HashSet<>(event.getMeasurements());
+    Set<String> tags = Objects.isNull(event.getProductTag()) ? Set.of() : event.getProductTag();
+    Set<Measurement> measurements =
+        Objects.isNull(event.getMeasurements()) ? Set.of() : new HashSet<>(event.getMeasurements());
 
     return tags.stream()
         .flatMap(

--- a/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.subscriptions.event;
 
-import com.google.common.collect.Sets;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.registry.Variant;
@@ -37,19 +36,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
- * Defines the logic for flattening an Event into multiple events based on a (tag,measurement)
- * tuple. This ensures that any event we ingest only contains a single tag and metric, even if the
- * source sends multiple.
+ * Normalizes incoming events by filtering and transforming them based on product configuration.
  *
- * <pre>
- *   Incoming event:
- *      Event(['tag1', 'tag2'], {cores: 2, instance-hours: 4}
- *   Normalized events:
- *      Event(['tag1'], {cores: 2})
- *      Event(['tag1'], {instance-hours: 4})
- *      Event(['tag2'], {cores: 2})
- *      Event(['tag2'], {instance-hours: 4})
- * </pre>
+ * <p>Responsibilities:
+ *
+ * <ul>
+ *   <li>Filters events to only include PAYG-eligible product tags
+ *   <li>Filters measurements to only those supported by the product tags
+ *   <li>Flattens multi-tag, multi-measurement events into individual events with one tag and one
+ *       measurement each
+ *   <li>Ensures only valid tag-measurement combinations (as defined in product configuration) are
+ *       produced
+ * </ul>
+ *
+ * <p>This normalization ensures that downstream processing only handles valid, PAYG-eligible events
+ * with a consistent structure.
  */
 @Component
 public class EventNormalizer {
@@ -63,11 +64,46 @@ public class EventNormalizer {
     this.resolvedEventMapper = resolvedEventMapper;
   }
 
+  /**
+   * Flattens an event into multiple events, each with at most one tag and one measurement. Only
+   * creates events for valid tag-measurement combinations as defined in the product configuration.
+   * Invalid combinations (where the tag does not support the measurement) are filtered out.
+   *
+   * <pre>
+   *   Incoming event:
+   *      Event(['OpenShift-metrics', 'rhel-for-x86-els-payg-addon'], {cores: 2, vCPUs: 4})
+   *   Flattened events (filtered to valid combinations only):
+   *      Event(['OpenShift-metrics'], {cores: 2})       // OpenShift-metrics supports Cores
+   *      Event(['rhel-for-x86-els-payg-addon'], {vCPUs: 4})  // rhel-for-x86-els-payg-addon supports vCPUs
+   *   Invalid combinations filtered out:
+   *      Event(['OpenShift-metrics'], {vCPUs: 4})       // OpenShift-metrics does not support vCPUs
+   *      Event(['rhel-for-x86-els-payg-addon'], {cores: 2})  // rhel-for-x86-els-payg-addon does not support Cores
+   * </pre>
+   *
+   * @param event the event to flatten
+   * @return list of flattened events containing only valid tag-measurement pairs
+   */
   public List<Event> flattenEventUsage(Event event) {
     Set<String> tags = event.getProductTag();
     Set<Measurement> measurements = new HashSet<>(event.getMeasurements());
-    return Sets.cartesianProduct(tags, measurements).stream()
-        .map(tuple -> create(event, (String) tuple.get(0), (Measurement) tuple.get(1)))
+
+    return tags.stream()
+        .flatMap(
+            tag -> {
+              // Get the metrics supported by this tag from the product configuration
+              Set<String> supportedMetrics =
+                  MetricIdUtils.getMetricIdsFromConfigForTag(tag)
+                      .map(MetricId::toUpperCaseFormatted)
+                      .collect(Collectors.toSet());
+
+              // Filter measurements to only those supported by this tag
+              return measurements.stream()
+                  .filter(
+                      m ->
+                          supportedMetrics.contains(
+                              MetricIdUtils.toUpperCaseFormatted(m.getMetricId())))
+                  .map(measurement -> create(event, tag, measurement));
+            })
         .toList();
   }
 
@@ -80,41 +116,43 @@ public class EventNormalizer {
       event.setServiceType("Ansible Managed Node");
     }
 
-    // Filter out non-paygo product tags
-    filterNonPaygoTags(event);
+    // Filter out non-paygo product tags and measurements
+    Set<String> payGoTags = getPayGoTags(event.getProductTag());
+    event.setProductTag(payGoTags);
+    event.setMeasurements(getApplicableMeasurements(event.getMeasurements(), payGoTags));
 
     return event;
   }
 
-  private void filterNonPaygoTags(Event event) {
-    Set<String> productTags = event.getProductTag();
-
+  private Set<String> getPayGoTags(Set<String> productTags) {
     if (productTags == null || productTags.isEmpty()) {
-      return;
+      return productTags;
     }
 
     Set<String> paygoTags =
         productTags.stream().filter(this::isPaygoEligibleTag).collect(Collectors.toSet());
 
     if (paygoTags.isEmpty()) {
-      log.debug("No paygo-eligible tags found in {}. Clearing product_tag.", productTags);
-      event.setProductTag(null);
-    } else {
-      if (paygoTags.size() < productTags.size()) {
-        log.debug("Filtered non-paygo tags from {}. Keeping: {}", productTags, paygoTags);
-        event.setProductTag(paygoTags);
-      }
-      filterUnsupportedMeasurements(event, paygoTags);
+      log.debug("No paygo-eligible tags found in {}.", productTags);
+      return Set.of();
     }
+    return paygoTags;
   }
 
-  private void filterUnsupportedMeasurements(Event event, Set<String> paygoTags) {
-    List<Measurement> measurements = event.getMeasurements();
+  private List<Measurement> getApplicableMeasurements(
+      List<Measurement> measurements, Set<String> paygoTags) {
     if (measurements == null || measurements.isEmpty()) {
-      return;
+      return measurements;
     }
 
-    // Get all supported metrics for the remaining paygo tags
+    // If there are no paygo tags, return all measurements since we can't determine validity
+    // at this point. Event validation will catch this if the event does not provide enough
+    // information to determine the tag.
+    if (paygoTags == null || paygoTags.isEmpty()) {
+      return measurements;
+    }
+
+    // Get all supported metrics for the specified tags
     Set<String> supportedMetrics =
         paygoTags.stream()
             .flatMap(MetricIdUtils::getMetricIdsFromConfigForTag)
@@ -127,7 +165,7 @@ public class EventNormalizer {
                 m -> supportedMetrics.contains(MetricIdUtils.toUpperCaseFormatted(m.getMetricId())))
             .toList();
 
-    if (validMeasurements.size() < measurements.size()) {
+    if (log.isDebugEnabled() && validMeasurements.size() < measurements.size()) {
       List<Measurement> filteredOut =
           measurements.stream().filter(m -> !supportedMetrics.contains(m.getMetricId())).toList();
       log.debug(
@@ -135,8 +173,8 @@ public class EventNormalizer {
           paygoTags,
           filteredOut.stream().map(Measurement::getMetricId).collect(Collectors.toList()),
           validMeasurements.stream().map(Measurement::getMetricId).collect(Collectors.toList()));
-      event.setMeasurements(validMeasurements);
     }
+    return validMeasurements;
   }
 
   private boolean isPaygoEligibleTag(String productTag) {

--- a/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
@@ -21,12 +21,19 @@
 package org.candlepin.subscriptions.event;
 
 import com.google.common.collect.Sets;
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.registry.Variant;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Measurement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -47,6 +54,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EventNormalizer {
 
+  private static final Logger log = LoggerFactory.getLogger(EventNormalizer.class);
   private static final String ANSIBLE_INFRASTRUCTURE_HOUR = "Ansible Infrastructure Hour";
 
   private final ResolvedEventMapper resolvedEventMapper;
@@ -71,7 +79,71 @@ public class EventNormalizer {
         && event.getServiceType().equals(ANSIBLE_INFRASTRUCTURE_HOUR)) {
       event.setServiceType("Ansible Managed Node");
     }
+
+    // Filter out non-paygo product tags
+    filterNonPaygoTags(event);
+
     return event;
+  }
+
+  private void filterNonPaygoTags(Event event) {
+    Set<String> productTags = event.getProductTag();
+
+    if (productTags == null || productTags.isEmpty()) {
+      return;
+    }
+
+    Set<String> paygoTags =
+        productTags.stream().filter(this::isPaygoEligibleTag).collect(Collectors.toSet());
+
+    if (paygoTags.isEmpty()) {
+      log.debug("No paygo-eligible tags found in {}. Clearing product_tag.", productTags);
+      event.setProductTag(null);
+    } else {
+      if (paygoTags.size() < productTags.size()) {
+        log.warn("Filtered non-paygo tags from {}. Keeping: {}", productTags, paygoTags);
+        event.setProductTag(paygoTags);
+      }
+      filterUnsupportedMeasurements(event, paygoTags);
+    }
+  }
+
+  private void filterUnsupportedMeasurements(Event event, Set<String> paygoTags) {
+    List<Measurement> measurements = event.getMeasurements();
+    if (measurements == null || measurements.isEmpty()) {
+      return;
+    }
+
+    // Get all supported metrics for the remaining paygo tags
+    Set<String> supportedMetrics =
+        paygoTags.stream()
+            .flatMap(MetricIdUtils::getMetricIdsFromConfigForTag)
+            .map(MetricId::toUpperCaseFormatted)
+            .collect(Collectors.toSet());
+
+    List<Measurement> validMeasurements =
+        measurements.stream()
+            .filter(
+                m -> supportedMetrics.contains(MetricIdUtils.toUpperCaseFormatted(m.getMetricId())))
+            .toList();
+
+    if (validMeasurements.size() < measurements.size()) {
+      List<Measurement> filteredOut =
+          measurements.stream().filter(m -> !supportedMetrics.contains(m.getMetricId())).toList();
+      log.warn(
+          "Filtered out unsupported measurements for paygo tags {}: {}. Keeping: {}",
+          paygoTags,
+          filteredOut.stream().map(Measurement::getMetricId).collect(Collectors.toList()),
+          validMeasurements.stream().map(Measurement::getMetricId).collect(Collectors.toList()));
+      event.setMeasurements(validMeasurements);
+    }
+  }
+
+  private boolean isPaygoEligibleTag(String productTag) {
+    return Variant.findByTag(productTag)
+        .map(Variant::getSubscription)
+        .map(SubscriptionDefinition::isPaygEligible)
+        .orElse(false);
   }
 
   private Event create(Event from, String tag, Measurement measurement) {

--- a/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
+++ b/src/main/java/org/candlepin/subscriptions/event/EventNormalizer.java
@@ -101,7 +101,7 @@ public class EventNormalizer {
       event.setProductTag(null);
     } else {
       if (paygoTags.size() < productTags.size()) {
-        log.warn("Filtered non-paygo tags from {}. Keeping: {}", productTags, paygoTags);
+        log.debug("Filtered non-paygo tags from {}. Keeping: {}", productTags, paygoTags);
         event.setProductTag(paygoTags);
       }
       filterUnsupportedMeasurements(event, paygoTags);
@@ -130,7 +130,7 @@ public class EventNormalizer {
     if (validMeasurements.size() < measurements.size()) {
       List<Measurement> filteredOut =
           measurements.stream().filter(m -> !supportedMetrics.contains(m.getMetricId())).toList();
-      log.warn(
+      log.debug(
           "Filtered out unsupported measurements for paygo tags {}: {}. Keeping: {}",
           paygoTags,
           filteredOut.stream().map(Measurement::getMetricId).collect(Collectors.toList()),

--- a/src/test/java/org/candlepin/subscriptions/event/EventConflictResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventConflictResolverTest.java
@@ -181,10 +181,14 @@ class EventConflictResolverTest {
         Arguments.of(
             List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0))
+                    .withBillingProvider(BillingProvider.GCP)
+                    .withBillingAccountId("test-ba-1")),
             List.of(
                 deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
-                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP))));
+                event(Set.of(ROSA), Map.of(CORES, 6.0))
+                    .withBillingProvider(BillingProvider.GCP)
+                    .withBillingAccountId("test-ba-1"))));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/candlepin/subscriptions/event/EventConflictResolverTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventConflictResolverTest.java
@@ -66,14 +66,11 @@ class EventConflictResolverTest {
 
   private static final ApplicationClock CLOCK = new TestClockConfiguration().adjustableClock();
   private static final ObjectMapper MAPPER;
-  public static final String TAG1 = "T1";
-  public static final String TAG2 = "T2";
-  public static final String TAG3 = "T3";
+  public static final String ROSA = "rosa";
+  public static final String OSD = "OpenShift-dedicated-metrics";
+  public static final String RHODS = "rhods";
   public static final String CORES = "cores";
   public static final String INSTANCE_HOURS = "instance-hours";
-  public static final String INSTANCE_HOURS1 = "Instance-hours";
-  public static final String CORES1 = "Cores";
-  public static final String CORES_IGNORED = "CoresIgnored";
 
   static {
     MAPPER = new ObjectMapper();
@@ -93,43 +90,43 @@ class EventConflictResolverTest {
   static Stream<Arguments> noResolutionRequiredScenarios() {
     return Stream.of(
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of()),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
             List.of()),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)),
-                event(Set.of(TAG2), Map.of(CORES, 6.0)),
-                event(Set.of(TAG3), Map.of(CORES, 6.0))),
-            List.of()),
-        Arguments.of(
-            List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)),
-                event(Set.of(TAG2), Map.of(CORES, 6.0)),
-                event(Set.of(TAG3), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)),
+                event(Set.of(OSD), Map.of(CORES, 6.0)),
+                event(Set.of(RHODS), Map.of(CORES, 6.0))),
             List.of()),
         Arguments.of(
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 10.0))),
-            List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 10.0))),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)),
+                event(Set.of(OSD), Map.of(CORES, 6.0)),
+                event(Set.of(RHODS), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
             List.of()),
         Arguments.of(
             List.of(
-                event(Set.of(TAG1, TAG2), Map.of(CORES, 6.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 10.0))),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 10.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)),
-                event(Set.of(TAG2), Map.of(CORES, 6.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 10.0))),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 10.0))),
+            List.of()),
+        Arguments.of(
+            List.of(
+                event(Set.of(ROSA, OSD), Map.of(CORES, 6.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 10.0))),
+            List.of(
+                event(Set.of(ROSA), Map.of(CORES, 6.0)),
+                event(Set.of(OSD), Map.of(CORES, 6.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 10.0))),
             List.of()));
   }
 
@@ -146,48 +143,48 @@ class EventConflictResolverTest {
     return Stream.of(
         // Different value triggers amendments
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 8.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 8.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 8.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 8.0)))),
         // Different hardware type triggers amendments.
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0)).withHardwareType(HardwareType.CLOUD)),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0)).withHardwareType(HardwareType.CLOUD)),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withHardwareType(HardwareType.CLOUD))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withHardwareType(HardwareType.CLOUD))),
         // Different SLA triggers amendments.
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0)).withSla(Sla.SELF_SUPPORT)),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0)).withSla(Sla.SELF_SUPPORT)),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withSla(Sla.SELF_SUPPORT))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withSla(Sla.SELF_SUPPORT))),
         // Different Usage triggers amendments.
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0)).withUsage(Usage.PRODUCTION)),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0)).withUsage(Usage.PRODUCTION)),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withUsage(Usage.PRODUCTION))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withUsage(Usage.PRODUCTION))),
         // Different Billing provider triggers amendments.
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP)),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP))),
         // Different billing account ID triggers amendment
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP)),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP))));
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 6.0)).withBillingProvider(BillingProvider.GCP))));
   }
 
   @ParameterizedTest
@@ -369,58 +366,58 @@ class EventConflictResolverTest {
   static Stream<Arguments> tagResolutionScenarios() {
     return Stream.of(
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 10.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 4.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 10.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 4.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                event(Set.of(TAG1), Map.of(CORES, 4.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                event(Set.of(ROSA), Map.of(CORES, 4.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 4.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 4.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG2), Map.of(CORES, -10.0)),
-                event(Set.of(TAG1), Map.of(CORES, 4.0)),
-                event(Set.of(TAG2), Map.of(CORES, 4.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                deduction(Set.of(OSD), Map.of(CORES, -10.0)),
+                event(Set.of(ROSA), Map.of(CORES, 4.0)),
+                event(Set.of(OSD), Map.of(CORES, 4.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG2), Map.of(CORES, 6.0)))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(OSD), Map.of(CORES, 6.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 16.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 16.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 16.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 16.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 6.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                deduction(Set.of(TAG2), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG2), Map.of(CORES, 10.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                deduction(Set.of(OSD), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(OSD), Map.of(CORES, 10.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0)),
-                event(Set.of(TAG2), Map.of(CORES, 8.0))),
+                event(Set.of(ROSA, OSD), Map.of(CORES, 10.0)),
+                event(Set.of(OSD), Map.of(CORES, 8.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG2), Map.of(CORES, 10.0)),
-                deduction(Set.of(TAG2), Map.of(CORES, -10.0)),
-                event(Set.of(TAG2), Map.of(CORES, 8.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(OSD), Map.of(CORES, 10.0)),
+                deduction(Set.of(OSD), Map.of(CORES, -10.0)),
+                event(Set.of(OSD), Map.of(CORES, 8.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 6.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 6.0))),
             List.of(
-                event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0)),
-                event(Set.of(TAG3), Map.of(CORES, 8.0))),
+                event(Set.of(ROSA, OSD), Map.of(CORES, 10.0)),
+                event(Set.of(RHODS), Map.of(CORES, 8.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -6.0)),
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG2), Map.of(CORES, 10.0)),
-                event(Set.of(TAG3), Map.of(CORES, 8.0)))));
+                deduction(Set.of(ROSA), Map.of(CORES, -6.0)),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(OSD), Map.of(CORES, 10.0)),
+                event(Set.of(RHODS), Map.of(CORES, 8.0)))));
   }
 
   @ParameterizedTest
@@ -437,81 +434,80 @@ class EventConflictResolverTest {
         Arguments.of(
             List.of(),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 20.0))),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 20.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 20.0)))),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 20.0)))),
         Arguments.of(
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 10.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 20.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
+                event(Set.of(ROSA), Map.of(CORES, 10.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(CORES, 20.0)),
-                event(Set.of(TAG2), Map.of(CORES, 20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 40.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(CORES, 20.0)),
+                event(Set.of(OSD), Map.of(CORES, 20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 40.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 10.0, INSTANCE_HOURS, 4.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 4.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 10.0, INSTANCE_HOURS, 4.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 4.0))),
             List.of(
-                event(Set.of(TAG2), Map.of(CORES, 10.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 4.0)))),
+                event(Set.of(OSD), Map.of(CORES, 10.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 4.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
-            List.of(event(Set.of(TAG1), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(CORES, 20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(CORES, 20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG2), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                deduction(Set.of(TAG2), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(CORES, 20.0)),
-                event(Set.of(TAG2), Map.of(CORES, 20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 40.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                deduction(Set.of(OSD), Map.of(CORES, -10.0)),
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                deduction(Set.of(OSD), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(CORES, 20.0)),
+                event(Set.of(OSD), Map.of(CORES, 20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 40.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
             List.of(
-                event(Set.of(TAG1), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
+                event(Set.of(ROSA), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(CORES, 20.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                deduction(Set.of(TAG2), Map.of(CORES, -10.0)),
-                deduction(Set.of(TAG2), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(CORES, 20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(CORES, 20.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 40.0)))),
+                deduction(Set.of(ROSA), Map.of(CORES, -10.0)),
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                deduction(Set.of(OSD), Map.of(CORES, -10.0)),
+                deduction(Set.of(OSD), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(CORES, 20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(CORES, 20.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 40.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 40.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                deduction(Set.of(TAG2), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 40.0)))),
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                deduction(Set.of(OSD), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 40.0)))),
         Arguments.of(
-            List.of(event(Set.of(TAG1, TAG2), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
-            List.of(event(Set.of(TAG1, TAG2, TAG3), Map.of(CORES, 10.0, INSTANCE_HOURS, 40.0))),
+            List.of(event(Set.of(ROSA, OSD), Map.of(CORES, 10.0, INSTANCE_HOURS, 20.0))),
+            List.of(event(Set.of(ROSA, OSD, RHODS), Map.of(CORES, 10.0, INSTANCE_HOURS, 40.0))),
             List.of(
-                deduction(Set.of(TAG1), Map.of(INSTANCE_HOURS, -20.0)),
-                deduction(Set.of(TAG2), Map.of(INSTANCE_HOURS, -20.0)),
-                event(Set.of(TAG1), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG2), Map.of(INSTANCE_HOURS, 40.0)),
-                event(Set.of(TAG3), Map.of(CORES, 10.0)),
-                event(Set.of(TAG3), Map.of(INSTANCE_HOURS, 40.0)))));
+                deduction(Set.of(ROSA), Map.of(INSTANCE_HOURS, -20.0)),
+                deduction(Set.of(OSD), Map.of(INSTANCE_HOURS, -20.0)),
+                event(Set.of(ROSA), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(OSD), Map.of(INSTANCE_HOURS, 40.0)),
+                event(Set.of(RHODS), Map.of(CORES, 10.0)))));
   }
 
   @ParameterizedTest
@@ -706,7 +702,7 @@ class EventConflictResolverTest {
     }
 
     private EventArgument(Map<String, Double> measurements) {
-      this(Set.of(TAG1), measurements);
+      this(Set.of(ROSA), measurements);
     }
 
     Event toEvent() {

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -500,22 +500,29 @@ class EventControllerTest {
     when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
 
     verify(eventRecordRepository).saveAll(eventsSaved.capture());
-    List<EventRecord> events = eventsSaved.getAllValues().get(0).stream().toList();
 
-    // After fix: Only paygo-tagged EventRecords should be saved
+    List<EventRecord> events = eventsSaved.getAllValues().getFirst().stream().toList();
+    assertEquals(1, events.size(), "Expected exactly one filtered PAYGO EventRecord to be saved");
+
+    // Only paygo-tagged EventRecords should be saved.
     // Each EventRecord should only have the paygo tag "rhel-for-x86-els-payg-addon"
-    // Non-paygo tag "rhel-for-x86-els-converted" should be filtered out
+    // containing applicable measurements only.
+    EventRecord eventRecord = events.getFirst();
+    assertEquals(
+        1,
+        eventRecord.getEvent().getProductTag().size(),
+        "EventRecord should have exactly 1 product tag");
     assertTrue(
-        events.stream().allMatch(e -> e.getEvent().getProductTag().size() == 1),
-        "All EventRecords should have exactly 1 product tag");
-    assertTrue(
-        events.stream()
-            .allMatch(e -> e.getEvent().getProductTag().contains("rhel-for-x86-els-payg-addon")),
-        "All EventRecords should only contain the paygo tag");
-    assertTrue(
-        events.stream()
-            .noneMatch(e -> e.getEvent().getProductTag().contains("rhel-for-x86-els-converted")),
-        "No EventRecords should contain the non-paygo tag");
+        eventRecord.getEvent().getProductTag().contains("rhel-for-x86-els-payg-addon"),
+        "EventRecord should only contain the paygo tag");
+    assertEquals(
+        1,
+        eventRecord.getEvent().getMeasurements().size(),
+        "EventRecord should have exactly 1 measurement");
+
+    Measurement measurement = eventRecord.getEvent().getMeasurements().getFirst();
+    assertEquals("vCPUs", measurement.getMetricId(), "Measurement should have metric_id 'vCPUs'");
+    assertEquals(4.0, measurement.getValue(), "Measurement should have value 4.0");
   }
 
   @ParameterizedTest

--- a/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventControllerTest.java
@@ -461,6 +461,63 @@ class EventControllerTest {
     assertEquals(1, events.size());
   }
 
+  @Test
+  void testPersistServiceInstancesFiltersNonPaygoTags() {
+    List<String> eventRecords = new ArrayList<>();
+
+    var mixedPaygoNonPaygoEventRecord =
+        """
+                    {
+                     "sla":"Premium",
+                     "org_id":"111111111",
+                     "timestamp":"2024-06-10T10:00:00Z",
+                     "conversion":false,
+                     "event_type":"snapshot_mixed_tags",
+                     "expiration":"2024-06-10T11:00:00Z",
+                     "instance_id":"d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "product_tag":[
+                        "rhel-for-x86-els-payg-addon",
+                        "rhel-for-x86-els-converted"
+                     ],
+                     "display_name":"automation__cluster_d147ddf2-be4a-4a59-acf7-7f222758b47c",
+                     "event_source":"Premium",
+                     "measurements":[
+                        {
+                           "value":4.0,
+                           "metric_id":"vCPUs"
+                        },
+                        {
+                           "value":2.0,
+                           "metric_id":"Sockets"
+                        }
+                     ],
+                     "service_type":"RHEL System"
+                  }
+            """;
+
+    eventRecords.add(mixedPaygoNonPaygoEventRecord);
+    eventController.persistServiceInstances(eventRecords);
+    when(eventRecordRepository.saveAll(any())).thenReturn(new ArrayList<>());
+
+    verify(eventRecordRepository).saveAll(eventsSaved.capture());
+    List<EventRecord> events = eventsSaved.getAllValues().get(0).stream().toList();
+
+    // After fix: Only paygo-tagged EventRecords should be saved
+    // Each EventRecord should only have the paygo tag "rhel-for-x86-els-payg-addon"
+    // Non-paygo tag "rhel-for-x86-els-converted" should be filtered out
+    assertTrue(
+        events.stream().allMatch(e -> e.getEvent().getProductTag().size() == 1),
+        "All EventRecords should have exactly 1 product tag");
+    assertTrue(
+        events.stream()
+            .allMatch(e -> e.getEvent().getProductTag().contains("rhel-for-x86-els-payg-addon")),
+        "All EventRecords should only contain the paygo tag");
+    assertTrue(
+        events.stream()
+            .noneMatch(e -> e.getEvent().getProductTag().contains("rhel-for-x86-els-converted")),
+        "No EventRecords should contain the non-paygo tag");
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {

--- a/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
@@ -86,7 +86,8 @@ class EventNormalizerTest {
     Event result = normalizer.normalizeEvent(event);
 
     // Then: Product tag is cleared (set to null)
-    assertNull(result.getProductTag(), "Product tag should be null when no PAYG tags remain");
+    assertTrue(
+        result.getProductTag().isEmpty(), "Product tags should be empty when no PAYG tags remain");
   }
 
   @Test
@@ -232,24 +233,251 @@ class EventNormalizerTest {
   }
 
   @Test
-  void flattenEventUsageCreatesCartesianProduct() {
-    // Given: Event with 2 tags and 2 measurements
+  void flattenEventUsageWithSinglePaygoProductAndTwoValidMeasurements() {
+    // Given: Event with single PAYG tag supporting both Cores and Instance-hours
+    // OpenShift-dedicated-metrics supports both metrics
     Event event = createEvent();
-    event.setProductTag(Set.of("tag1", "tag2"));
-    event.setMeasurements(List.of(createMeasurement(VCPUS, 1.0), createMeasurement(SOCKETS, 2.0)));
+    event.setProductTag(Set.of("OpenShift-dedicated-metrics"));
+    event.setMeasurements(
+        List.of(
+            createMeasurement(CORES, 8.0),
+            createMeasurement(MetricIdUtils.getInstanceHours(), 24.0)));
 
     // When: Flattening the event
     List<Event> flattened = normalizer.flattenEventUsage(event);
 
-    // Then: Creates 2x2=4 events (cartesian product)
-    assertEquals(4, flattened.size(), "Should create cartesian product of tags x measurements");
+    // Then: Should create 2 events (one per measurement, both valid for this tag)
+    assertEquals(2, flattened.size());
 
-    // Verify each flattened event has exactly 1 tag and 1 measurement
-    for (Event flattenedEvent : flattened) {
-      assertEquals(1, flattenedEvent.getProductTag().size(), "Each event should have 1 tag");
-      assertEquals(
-          1, flattenedEvent.getMeasurements().size(), "Each event should have 1 measurement");
+    // Find the event for each measurement
+    Event coresEvent =
+        flattened.stream()
+            .filter(
+                e ->
+                    e.getMeasurements()
+                        .getFirst()
+                        .getMetricId()
+                        .equals(CORES.toUpperCaseFormatted()))
+            .findFirst()
+            .orElseThrow();
+    Event instanceHoursEvent =
+        flattened.stream()
+            .filter(
+                e ->
+                    e.getMeasurements()
+                        .getFirst()
+                        .getMetricId()
+                        .equals(MetricIdUtils.getInstanceHours().toUpperCaseFormatted()))
+            .findFirst()
+            .orElseThrow();
+
+    // Verify Cores event
+    assertEquals(1, coresEvent.getProductTag().size());
+    assertTrue(coresEvent.getProductTag().contains("OpenShift-dedicated-metrics"));
+    assertEquals(1, coresEvent.getMeasurements().size());
+    assertEquals(8.0, coresEvent.getMeasurements().getFirst().getValue());
+
+    // Verify Instance-hours event
+    assertEquals(1, instanceHoursEvent.getProductTag().size());
+    assertTrue(instanceHoursEvent.getProductTag().contains("OpenShift-dedicated-metrics"));
+    assertEquals(1, instanceHoursEvent.getMeasurements().size());
+    assertEquals(24.0, instanceHoursEvent.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void flattenEventUsageWithTwoPaygoProductsEachWithOneMeasurement() {
+    // Given: Event with 2 PAYG tags and 2 measurements, but each tag only supports one
+    // OpenShift-metrics supports only Cores (not Instance-hours)
+    // OpenShift-dedicated-metrics supports both Cores and Instance-hours
+    Event event = createEvent();
+    event.setProductTag(Set.of("OpenShift-metrics", "OpenShift-dedicated-metrics"));
+    event.setMeasurements(
+        List.of(
+            createMeasurement(CORES, 8.0),
+            createMeasurement(MetricIdUtils.getInstanceHours(), 24.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 3 events total
+    // OpenShift-metrics + Cores (valid)
+    // OpenShift-dedicated-metrics + Cores (valid)
+    // OpenShift-dedicated-metrics + Instance-hours (valid)
+    // OpenShift-metrics + Instance-hours is filtered out (invalid)
+    assertEquals(3, flattened.size());
+
+    // Verify all events have exactly 1 tag and 1 measurement
+    for (Event result : flattened) {
+      assertEquals(1, result.getProductTag().size());
+      assertEquals(1, result.getMeasurements().size());
     }
+
+    // Count events per tag
+    long openshiftMetricsCount =
+        flattened.stream().filter(e -> e.getProductTag().contains("OpenShift-metrics")).count();
+    long openshiftDedicatedCount =
+        flattened.stream()
+            .filter(e -> e.getProductTag().contains("OpenShift-dedicated-metrics"))
+            .count();
+
+    assertEquals(1, openshiftMetricsCount, "OpenShift-metrics should have 1 event (Cores only)");
+    assertEquals(
+        2,
+        openshiftDedicatedCount,
+        "OpenShift-dedicated-metrics should have 2 events (Cores and Instance-hours)");
+
+    // Verify OpenShift-metrics event only has Cores
+    Event openshiftMetricsEvent =
+        flattened.stream()
+            .filter(e -> e.getProductTag().contains("OpenShift-metrics"))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(
+        CORES.toUpperCaseFormatted(),
+        openshiftMetricsEvent.getMeasurements().getFirst().getMetricId());
+  }
+
+  @Test
+  void flattenEventUsageWithSingleTagAndMixedValidInvalidMeasurements() {
+    // Given: Event with PAYG tag supporting only vCPUs, but has Sockets and Cores too
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(
+        List.of(
+            createMeasurement(VCPUS, 4.0),
+            createMeasurement(SOCKETS, 2.0),
+            createMeasurement(CORES, 8.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create only 1 event (only vCPUs is valid for this tag)
+    assertEquals(1, flattened.size());
+
+    Event result = flattened.getFirst();
+    assertEquals(1, result.getProductTag().size());
+    assertTrue(result.getProductTag().contains("rhel-for-x86-els-payg-addon"));
+    assertEquals(1, result.getMeasurements().size());
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void flattenEventUsageWithMultipleTagsEachSupportingDifferentMeasurements() {
+    // Given: Event with 2 PAYG tags, each supporting a different metric
+    // OpenShift-metrics supports only Cores
+    // rhel-for-x86-els-payg-addon supports only vCPUs
+    Event event = createEvent();
+    event.setProductTag(Set.of("OpenShift-metrics", "rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(List.of(createMeasurement(CORES, 8.0), createMeasurement(VCPUS, 4.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 2 events (one per tag with its supported metric)
+    assertEquals(2, flattened.size());
+
+    // Find the event for each tag
+    Event openshiftEvent =
+        flattened.stream()
+            .filter(e -> e.getProductTag().contains("OpenShift-metrics"))
+            .findFirst()
+            .orElseThrow();
+    Event rhelEvent =
+        flattened.stream()
+            .filter(e -> e.getProductTag().contains("rhel-for-x86-els-payg-addon"))
+            .findFirst()
+            .orElseThrow();
+
+    // Verify OpenShift-metrics event has only Cores
+    assertEquals(1, openshiftEvent.getProductTag().size());
+    assertEquals(1, openshiftEvent.getMeasurements().size());
+    assertEquals(
+        CORES.toUpperCaseFormatted(), openshiftEvent.getMeasurements().getFirst().getMetricId());
+    assertEquals(8.0, openshiftEvent.getMeasurements().getFirst().getValue());
+
+    // Verify rhel-for-x86-els-payg-addon event has only vCPUs
+    assertEquals(1, rhelEvent.getProductTag().size());
+    assertEquals(1, rhelEvent.getMeasurements().size());
+    assertEquals(
+        VCPUS.toUpperCaseFormatted(), rhelEvent.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, rhelEvent.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void flattenEventUsageWithMultipleTagsWithOverlappingMeasurementSupport() {
+    // Given: Event with 2 PAYG tags that both support Cores, plus an unsupported measurement
+    // OpenShift-metrics supports only Cores
+    // OpenShift-dedicated-metrics supports Cores and Instance-hours
+    Event event = createEvent();
+    event.setProductTag(Set.of("OpenShift-metrics", "OpenShift-dedicated-metrics"));
+    event.setMeasurements(List.of(createMeasurement(CORES, 8.0), createMeasurement(VCPUS, 4.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 2 events (both tags with Cores, vCPUs filtered out)
+    assertEquals(2, flattened.size());
+
+    for (Event result : flattened) {
+      assertEquals(1, result.getProductTag().size());
+      assertEquals(1, result.getMeasurements().size());
+      assertEquals(CORES.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+      assertEquals(8.0, result.getMeasurements().getFirst().getValue());
+    }
+
+    // Verify both tags are present
+    long openshiftMetricsCount =
+        flattened.stream().filter(e -> e.getProductTag().contains("OpenShift-metrics")).count();
+    long openshiftDedicatedCount =
+        flattened.stream()
+            .filter(e -> e.getProductTag().contains("OpenShift-dedicated-metrics"))
+            .count();
+
+    assertEquals(1, openshiftMetricsCount);
+    assertEquals(1, openshiftDedicatedCount);
+  }
+
+  @Test
+  void flattenEventUsageWithTagHavingNoValidMeasurements() {
+    // Given: Event with PAYG tag that only supports vCPUs, but only has Sockets and Cores
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(List.of(createMeasurement(SOCKETS, 2.0), createMeasurement(CORES, 8.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 0 events (no valid combinations)
+    assertTrue(flattened.isEmpty());
+  }
+
+  @Test
+  void flattenEventUsageWithEmptyTags() {
+    // Given: Event with empty tag set
+    Event event = createEvent();
+    event.setProductTag(Set.of());
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 0 events
+    assertTrue(flattened.isEmpty());
+  }
+
+  @Test
+  void flattenEventUsageWithEmptyMeasurements() {
+    // Given: Event with empty measurements list
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(List.of());
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Should create 0 events
+    assertTrue(flattened.isEmpty());
   }
 
   // Helper methods

--- a/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import java.util.List;
+import java.util.Set;
+import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.json.Measurement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EventNormalizerTest {
+
+  private static final MetricId SOCKETS = MetricIdUtils.getSockets();
+  private static final MetricId VCPUS = MetricIdUtils.getVCpus();
+  private static final MetricId CORES = MetricIdUtils.getCores();
+
+  private EventNormalizer normalizer;
+
+  @BeforeEach
+  void setUp() {
+    // ResolvedEventMapper is a MapStruct interface, so we need to mock it.
+    ResolvedEventMapper mapper = mock(ResolvedEventMapper.class);
+    normalizer = new EventNormalizer(mapper);
+  }
+
+  @Test
+  void normalizeEventWithMixedPaygoAndTraditionalTagsFiltersTraditionalTags() {
+    // Given: Event with both PAYG and TRADITIONAL product tags
+    Event event = createEvent();
+    event.setProductTag(
+        Set.of("rhel-for-x86-els-payg-addon", "rhel-for-x86-els-unconverted")); // mixed
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0), createMeasurement(SOCKETS, 2.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Only PAYG tags remain
+    assertNotNull(result.getProductTag(), "Product tags should not be null");
+    assertEquals(1, result.getProductTag().size(), "Should have only PAYG tag remaining");
+    assertTrue(
+        result.getProductTag().contains("rhel-for-x86-els-payg-addon"), "Should keep PAYG tag");
+
+    // And: Only measurements supported by PAYG tags remain
+    assertNotNull(result.getMeasurements(), "Measurements should not be null");
+    assertEquals(
+        1, result.getMeasurements().size(), "Should have only vCPUs measurement remaining");
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventWithOnlyTraditionalTagsClearsProductTag() {
+    // Given: Event with only TRADITIONAL product tags
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-unconverted")); // TRADITIONAL only
+    event.setMeasurements(List.of(createMeasurement(SOCKETS, 2.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Product tag is cleared (set to null)
+    assertNull(result.getProductTag(), "Product tag should be null when no PAYG tags remain");
+  }
+
+  @Test
+  void normalizeEventWithOnlyPaygoTagsNoFiltering() {
+    // Given: Event with only PAYG product tags
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon")); // PAYG only
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Tags and measurements unchanged
+    assertNotNull(result.getProductTag());
+    assertEquals(1, result.getProductTag().size());
+    assertTrue(result.getProductTag().contains("rhel-for-x86-els-payg-addon"));
+    assertNotNull(result.getMeasurements());
+    assertEquals(1, result.getMeasurements().size());
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventWithNullProductTagNoChange() {
+    // Given: Event with null product tag
+    Event event = createEvent();
+    event.setProductTag(null);
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Event unchanged
+    assertNull(result.getProductTag());
+    assertEquals(1, result.getMeasurements().size());
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventWithEmptyProductTagNoChange() {
+    // Given: Event with empty product tag set
+    Event event = createEvent();
+    event.setProductTag(Set.of());
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Event unchanged
+    assertTrue(result.getProductTag().isEmpty());
+    assertEquals(1, result.getMeasurements().size());
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventWithMultiplePaygoTagsKeepsAllAndValidMeasurements() {
+    // Given: Event with multiple PAYG tags
+    Event event = createEvent();
+    event.setProductTag(
+        Set.of("rhel-for-x86-els-payg-addon", "rhel-for-x86-els-payg")); // both PAYG
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 4.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: All PAYG tags remain
+    assertNotNull(result.getProductTag());
+    assertEquals(2, result.getProductTag().size());
+    assertTrue(result.getProductTag().contains("rhel-for-x86-els-payg-addon"));
+    assertTrue(result.getProductTag().contains("rhel-for-x86-els-payg"));
+    assertEquals(1, result.getMeasurements().size());
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventFiltersUnsupportedMeasurementsOnly() {
+    // Given: Event with PAYG tag and mix of valid/invalid measurements
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon")); // Supports vCPUs only
+    event.setMeasurements(
+        List.of(
+            createMeasurement(VCPUS, 4.0), // valid for PAYG
+            createMeasurement(SOCKETS, 2.0), // invalid for PAYG
+            createMeasurement(CORES, 8.0))); // invalid for PAYG
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Only valid measurements remain
+    assertNotNull(result.getMeasurements());
+    assertEquals(1, result.getMeasurements().size(), "Should filter out invalid measurements");
+    assertEquals(VCPUS.toUpperCaseFormatted(), result.getMeasurements().getFirst().getMetricId());
+    assertEquals(4.0, result.getMeasurements().getFirst().getValue());
+  }
+
+  @Test
+  void normalizeEventWithNullMeasurementsNoError() {
+    // Given: Event with PAYG tag but null measurements
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(null);
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: No error, measurements remain null
+    assertNull(result.getMeasurements());
+  }
+
+  @Test
+  void normalizeEventWithEmptyMeasurementsNoError() {
+    // Given: Event with PAYG tag but empty measurements
+    Event event = createEvent();
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(List.of());
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: No error, measurements remain empty
+    assertTrue(result.getMeasurements().isEmpty());
+  }
+
+  @Test
+  void normalizeEventAnsibleInfrastructureHourConvertsServiceType() {
+    // Given: Event with "Ansible Infrastructure Hour" service type
+    Event event = createEvent();
+    event.setServiceType("Ansible Infrastructure Hour");
+    event.setProductTag(Set.of("rhel-for-x86-els-payg-addon"));
+    event.setMeasurements(List.of(createMeasurement(MetricIdUtils.getVCpus(), 4.0)));
+
+    // When: Normalizing the event
+    Event result = normalizer.normalizeEvent(event);
+
+    // Then: Service type is converted
+    assertEquals(
+        "Ansible Managed Node",
+        result.getServiceType(),
+        "Service type should be converted from 'Ansible Infrastructure Hour' to 'Ansible Managed Node'");
+  }
+
+  @Test
+  void flattenEventUsageCreatesCartesianProduct() {
+    // Given: Event with 2 tags and 2 measurements
+    Event event = createEvent();
+    event.setProductTag(Set.of("tag1", "tag2"));
+    event.setMeasurements(List.of(createMeasurement(VCPUS, 1.0), createMeasurement(SOCKETS, 2.0)));
+
+    // When: Flattening the event
+    List<Event> flattened = normalizer.flattenEventUsage(event);
+
+    // Then: Creates 2x2=4 events (cartesian product)
+    assertEquals(4, flattened.size(), "Should create cartesian product of tags x measurements");
+
+    // Verify each flattened event has exactly 1 tag and 1 measurement
+    for (Event flattenedEvent : flattened) {
+      assertEquals(1, flattenedEvent.getProductTag().size(), "Each event should have 1 tag");
+      assertEquals(
+          1, flattenedEvent.getMeasurements().size(), "Each event should have 1 measurement");
+    }
+  }
+
+  // Helper methods
+
+  private Event createEvent() {
+    Event event = new Event();
+    event.setOrgId("test-org");
+    event.setInstanceId("test-instance");
+    event.setServiceType("RHEL System");
+    return event;
+  }
+
+  private Measurement createMeasurement(MetricId metricId, double value) {
+    Measurement measurement = new Measurement();
+    measurement.setMetricId(metricId.toUpperCaseFormatted());
+    measurement.setValue(value);
+    return measurement;
+  }
+}

--- a/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
+++ b/src/test/java/org/candlepin/subscriptions/event/EventNormalizerTest.java
@@ -480,6 +480,20 @@ class EventNormalizerTest {
     assertTrue(flattened.isEmpty());
   }
 
+  @Test
+  void flattenEventUsageWithNullMeasurements() {
+    Event event = createEvent();
+    event.setMeasurements(null);
+    assertTrue(normalizer.flattenEventUsage(event).isEmpty());
+  }
+
+  @Test
+  void flattenEventUsageWithNullProductTags() {
+    Event event = createEvent();
+    event.setProductTag(null);
+    assertTrue(normalizer.flattenEventUsage(event).isEmpty());
+  }
+
   // Helper methods
 
   private Event createEvent() {
@@ -487,6 +501,8 @@ class EventNormalizerTest {
     event.setOrgId("test-org");
     event.setInstanceId("test-instance");
     event.setServiceType("RHEL System");
+    event.setMeasurements(List.of());
+    event.setProductTag(Set.of());
     return event;
   }
 

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -217,6 +217,24 @@ Test cases should be testable locally and in deployed environments.
     - TRADITIONAL tags remain filtered out during conflict resolution
     - Instance data reflects the resolved measurement value
 
+**tally-payg-filter-TC006 - Mixed tags with single-metric edge case**
+
+- **Description**: Verify mixed PAYG/TRADITIONAL tag events still process correctly when only PAYG metric data is present.
+- **Setup**:
+    - Organization is opted in
+    - Event with PAYG + TRADITIONAL tags
+    - Event includes only vCPUs metric value (no TRADITIONAL metric)
+- **Action**:
+    - Send mixed-tag single-metric event
+    - Perform hourly tally
+- **Verification**:
+    - PAYG product has expected vCPUs tally
+    - PAYG instance is present with expected measurement
+    - TRADITIONAL product has 0 instances in hourly instances report
+- **Expected Result**:
+    - PAYG data is retained and tallied
+    - TRADITIONAL tag remains filtered out, even with incomplete metric payload
+
 ## Hypervisor Handling
 
 **tally-hypervisor-TC001 - RHEL hypervisor without guests appears in instances report**

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -235,6 +235,31 @@ Test cases should be testable locally and in deployed environments.
     - PAYG data is retained and tallied
     - TRADITIONAL tag remains filtered out, even with incomplete metric payload
 
+**tally-payg-filter-TC007 - Role-based product tag lookup filters non-PAYG metrics**
+
+- **Description**: Verify that when product tag is derived from role (not explicitly provided), only metrics supported by the PAYG product are tallied and unsupported metrics are filtered out during normalization.
+- **Setup**:
+    - Organization is opted in
+    - Event with NO product tag (empty product tag set)
+    - Event with role "moa" which maps to PAYG product "rosa"
+    - Event includes BOTH a PAYG-supported metric (Cores) and a TRADITIONAL metric (Sockets)
+    - Cores metric value: 8.0
+    - Sockets metric value: 2.0
+    - Event has AWS billing provider and account ID
+- **Action**:
+    - Send event with empty product tag, role=moa, and mixed metrics to service instance ingress topic
+    - Perform hourly tally
+- **Verification**:
+    - Product tag "rosa" is derived from role "moa" during event normalization
+    - rosa product has tally sum of 8.0 for Cores metric
+    - rosa instance appears in hourly instances report with Cores=8.0 and Instance-hours=0.0
+    - Sockets metric is filtered out (not supported by rosa)
+    - NO RHEL product instances are created (Sockets metric should not trigger RHEL product creation)
+- **Expected Result**:
+    - Role-based product tag derivation works correctly for PAYG products
+    - Only metrics supported by the derived PAYG product are retained after normalization
+    - Unsupported metrics (like Sockets for rosa) are filtered out and do not cause incorrect product tallies
+
 ## Hypervisor Handling
 
 **tally-hypervisor-TC001 - RHEL hypervisor without guests appears in instances report**

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -118,6 +118,105 @@ Test cases should be testable locally and in deployed environments.
     - Service aggregates metrics across multiple hours
     - Instance deduplication works across time ranges
 
+## PAYG Product Tag Filtering
+
+**tally-payg-filter-TC001 - Mixed PAYG and TRADITIONAL tags filtered correctly**
+
+- **Description**: Verify that hourly tally filters out non-PAYG (TRADITIONAL) product tags from events with mixed tags
+- **Setup**:
+    - Organization is opted in
+    - Event with both PAYG tag (rhel-for-x86-els-payg-addon) and TRADITIONAL tag (rhel-for-x86-els-unconverted)
+    - Event has vCPUs metric with value 4.0
+- **Action**:
+    - Send event with mixed product tags to service instance ingress topic
+    - Perform hourly tally
+- **Verification**:
+    - PAYG product (rhel-for-x86-els-payg-addon) has tally sum of 4.0 for vCPUs
+    - TRADITIONAL product (rhel-for-x86-els-unconverted) has NO hourly tally data
+    - PAYG product appears in instances report with 1 instance
+    - TRADITIONAL product has 0 instances in hourly instances report
+- **Expected Result**:
+    - Only PAYG product tags are processed during hourly tally
+    - TRADITIONAL product tags are filtered out and not included in hourly billing
+
+**tally-payg-filter-TC002 - Event with only TRADITIONAL tags not tallied hourly**
+
+- **Description**: Verify that events containing only TRADITIONAL product tags are not processed by hourly tally
+- **Setup**:
+    - Organization is opted in
+    - Event with only TRADITIONAL tag (rhel-for-x86-els-unconverted)
+    - Event has Sockets metric with value 2.0
+- **Action**:
+    - Send event with only TRADITIONAL tag
+    - Perform hourly tally
+- **Verification**:
+    - TRADITIONAL product has NO hourly tally data (product_tag cleared to null)
+    - TRADITIONAL product has 0 instances in hourly instances report
+- **Expected Result**:
+    - Events with only TRADITIONAL tags are excluded from hourly processing
+    - product_tag field is cleared when no PAYG tags remain
+
+**tally-payg-filter-TC003 - Event with only PAYG tags processed normally**
+
+- **Description**: Verify that events containing only PAYG product tags are processed normally without filtering
+- **Setup**:
+    - Organization is opted in
+    - Event with only PAYG tag (rhel-for-x86-els-payg-addon)
+    - Event has vCPUs metric with value 4.0
+- **Action**:
+    - Send event with only PAYG tag
+    - Perform hourly tally
+- **Verification**:
+    - PAYG product has tally sum of 4.0 for vCPUs
+    - PAYG product appears in instances report with 1 instance
+- **Expected Result**:
+    - PAYG-only events are processed normally by hourly tally
+    - No filtering occurs when all tags are PAYG-eligible
+
+**tally-payg-filter-TC004 - Multiple events with mixed tags filtered correctly**
+
+- **Description**: Verify that multiple events with different tag combinations are all filtered correctly
+- **Setup**:
+    - Organization is opted in
+    - Event 1: Mixed tags (PAYG + TRADITIONAL) with vCPUs value 4.0
+    - Event 2: Mixed tags (PAYG + TRADITIONAL) with vCPUs value 2.0, 30 minutes later
+    - Event 3: PAYG only with vCPUs value 6.0, 45 minutes later (all in same hour)
+- **Action**:
+    - Send all three events
+    - Perform hourly tally
+- **Verification**:
+    - PAYG product has tally sum of 6.0 (max value from latest event)
+    - TRADITIONAL product has NO hourly tally data
+- **Expected Result**:
+    - All events have TRADITIONAL tags filtered out
+    - PAYG product correctly aggregates using max value per hour
+    - TRADITIONAL product excluded from all hourly processing
+
+**tally-payg-filter-TC005 - Conflict resolution with mixed PAYG and TRADITIONAL tags**
+
+- **Description**: Verify that conflict resolution correctly handles events with mixed tags, updating PAYG measurements while keeping TRADITIONAL tags filtered out
+- **Setup**:
+    - Organization is opted in
+    - Event 1: Mixed tags (PAYG + TRADITIONAL) with vCPUs value 4.0
+    - Perform hourly tally (creates initial snapshot)
+    - Event 2: Mixed tags (PAYG + TRADITIONAL) with vCPUs value 8.0 for same instance and hour (conflict)
+    - Perform hourly tally again (triggers conflict resolution)
+- **Action**:
+    - Send first event with mixed tags
+    - Perform hourly tally to create initial snapshot
+    - Send second conflicting event with mixed tags and higher value
+    - Perform hourly tally to trigger conflict resolution
+- **Verification**:
+    - After first tally: PAYG product has tally sum of 4.0
+    - After second tally: PAYG product has tally sum of 8.0 (conflict resolved to higher value)
+    - PAYG instance measurements updated to 8.0
+    - TRADITIONAL product has 0 instances in both tally runs
+- **Expected Result**:
+    - Conflict resolution works correctly with filtered PAYG tags
+    - PAYG product measurements are updated to the higher value
+    - TRADITIONAL tags remain filtered out during conflict resolution
+    - Instance data reflects the resolved measurement value
+
 ## Hypervisor Handling
 
 **tally-hypervisor-TC001 - RHEL hypervisor without guests appears in instances report**

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -33,7 +33,19 @@ import com.redhat.swatch.component.tests.api.SwatchDatabase;
 import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.api.Wiremock;
 import com.redhat.swatch.component.tests.api.db.DatabaseService;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.tally.test.model.InstanceData;
+import com.redhat.swatch.tally.test.model.InstanceResponse;
+import com.redhat.swatch.tally.test.model.TallyReportData;
+import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import utils.TallyDbHostSeeder;
 import utils.TallyTestHelpers;
@@ -92,10 +104,139 @@ public class BaseTallyComponentTest {
     }
 
     long startTime = System.currentTimeMillis();
-    com.redhat.swatch.component.tests.utils.AwaitilityUtils.until(
+    AwaitilityUtils.until(
         () -> System.currentTimeMillis() - startTime,
         elapsed -> elapsed >= 5000,
-        com.redhat.swatch.component.tests.utils.AwaitilitySettings.usingTimeout(
-            java.time.Duration.ofSeconds(10)));
+        AwaitilitySettings.usingTimeout(Duration.ofSeconds(10)));
+  }
+
+  // --- Shared tally report query helpers ---
+
+  /**
+   * Retrieves the hourly tally sum for a product and metric within a time range.
+   *
+   * @param orgId the organization ID
+   * @param productTag the product tag
+   * @param metricId the metric ID
+   * @param beginning the start of the time range
+   * @param ending the end of the time range
+   * @return the sum of all tally values, or 0.0 if no data
+   */
+  protected double getHourlyTallySum(
+      String orgId,
+      String productTag,
+      String metricId,
+      OffsetDateTime beginning,
+      OffsetDateTime ending) {
+    Map<String, ?> queryParams =
+        Map.of(
+            "granularity", "Hourly",
+            "beginning", beginning.toString(),
+            "ending", ending.toString());
+
+    TallyReportData resp = service.getTallyReportData(orgId, productTag, metricId, queryParams);
+    if (resp.getData() == null) {
+      return 0.0;
+    }
+
+    return resp.getData().stream()
+        .collect(Collectors.summarizingInt(TallyReportDataPoint::getValue))
+        .getSum();
+  }
+
+  /**
+   * Waits for the hourly tally sum to reach the expected value, retrying with tally runs.
+   *
+   * @param orgId the organization ID
+   * @param productTag the product tag
+   * @param metricId the metric ID
+   * @param beginning the start of the time range
+   * @param ending the end of the time range
+   * @param expected the expected tally sum
+   * @return the final tally sum
+   */
+  protected double awaitHourlyTallySum(
+      String orgId,
+      String productTag,
+      String metricId,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      double expected) {
+    AwaitilitySettings settings =
+        AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(30))
+            .withService(service)
+            .timeoutMessage(
+                "Timed out waiting for hourly tally to reach expected value %.4f (product=%s metric=%s)",
+                expected, productTag, metricId);
+
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          service.performHourlyTallyForOrg(orgId);
+          Assertions.assertEquals(
+              expected,
+              getHourlyTallySum(orgId, productTag, metricId, beginning, ending),
+              0.0001,
+              "Hourly tally sum should match expected value");
+        },
+        settings);
+
+    return getHourlyTallySum(orgId, productTag, metricId, beginning, ending);
+  }
+
+  /**
+   * Retrieves a single instance matching a display name substring for a product within a time
+   * range.
+   *
+   * @param orgId the organization ID
+   * @param productTag the product tag
+   * @param beginning the start of the time range
+   * @param ending the end of the time range
+   * @param displayNameContains the substring to match in display names
+   * @return the matching instance, or null if not found
+   */
+  protected InstanceData getInstanceByDisplayName(
+      String orgId,
+      String productTag,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      String displayNameContains) {
+    InstanceResponse response = service.getInstancesByProduct(orgId, productTag, beginning, ending);
+    if (response.getData() == null) {
+      return null;
+    }
+
+    return response.getData().stream()
+        .filter(instance -> instance.getDisplayName() != null)
+        .filter(instance -> instance.getDisplayName().contains(displayNameContains))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Counts instances matching a display name substring for a product within a time range.
+   *
+   * @param orgId the organization ID
+   * @param productTag the product tag
+   * @param beginning the start of the time range
+   * @param ending the end of the time range
+   * @param displayNameContains the substring to match in display names
+   * @return the count of matching instances
+   */
+  protected long getInstancesCountByDisplayName(
+      String orgId,
+      String productTag,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      String displayNameContains) {
+    InstanceResponse response = service.getInstancesByProduct(orgId, productTag, beginning, ending);
+    if (response.getData() == null) {
+      return 0;
+    }
+
+    return response.getData().stream()
+        .map(InstanceData::getDisplayName)
+        .filter(Objects::nonNull)
+        .filter(d -> d.contains(displayNameContains))
+        .count();
   }
 }

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -21,6 +21,8 @@
 package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import api.TallySwatchService;
 import api.TallyUnleashService;
@@ -42,10 +44,11 @@ import com.redhat.swatch.tally.test.model.TallyReportData;
 import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import utils.TallyDbHostSeeder;
 import utils.TallyTestHelpers;
@@ -162,10 +165,9 @@ public class BaseTallyComponentTest {
     AwaitilityUtils.untilAsserted(
         () -> {
           service.performHourlyTallyForOrg(orgId);
-          Assertions.assertEquals(
+          assertEquals(
               expected,
               getHourlyTallySum(orgId, productTag, metricId, beginning, ending),
-              0.0001,
               "Hourly tally sum should match expected value");
         },
         settings);
@@ -228,5 +230,77 @@ public class BaseTallyComponentTest {
         .filter(Objects::nonNull)
         .filter(d -> d.contains(displayNameContains))
         .count();
+  }
+
+  /**
+   * Asserts that an instance has the expected measurements for a product.
+   *
+   * <p>This method verifies:
+   *
+   * <ul>
+   *   <li>The instance exists in the response
+   *   <li>The actual measurements match the expected measurements (both metric IDs and values)
+   *   <li>No unexpected measurements are present
+   * </ul>
+   *
+   * @param orgId the organization ID
+   * @param instanceId the instance ID to verify
+   * @param productTag the product tag
+   * @param beginning the start of the time range
+   * @param ending the end of the time range
+   * @param expectedMeasurements map of metric ID to expected value
+   */
+  protected void assertInstanceMeasurements(
+      String orgId,
+      String instanceId,
+      String productTag,
+      OffsetDateTime beginning,
+      OffsetDateTime ending,
+      Map<String, Double> expectedMeasurements) {
+    InstanceResponse response = service.getInstancesByProduct(orgId, productTag, beginning, ending);
+    assertNotNull(response.getData(), "Instance response data should not be null");
+    assertNotNull(
+        response.getMeta(), "Instance response meta should not be null for product " + productTag);
+    assertNotNull(
+        response.getMeta().getMeasurements(),
+        "Instance response meta measurements should not be null for product " + productTag);
+
+    List<InstanceData> instances =
+        response.getData().stream()
+            .filter(nextInstance -> instanceId.equals(nextInstance.getInstanceId()))
+            .toList();
+    assertEquals(
+        1,
+        instances.size(),
+        "Expected only 1 instance matching instanceId="
+            + instanceId
+            + " but found "
+            + instances.size());
+
+    // Build actual measurements map from meta.measurements (metric IDs) and instance.measurements
+    // (values)
+    InstanceData instance = instances.get(0);
+    List<String> metricIds = response.getMeta().getMeasurements();
+    List<Double> values = instance.getMeasurements();
+
+    assertNotNull(values, "Instance measurements should not be null");
+    assertEquals(
+        metricIds.size(),
+        values.size(),
+        String.format(
+            "Number of metric IDs (%d) should match number of values (%d). MetricIds=%s, Values=%s",
+            metricIds.size(), values.size(), metricIds, values));
+
+    Map<String, Double> actualMeasurements = new HashMap<>();
+    for (int i = 0; i < metricIds.size(); i++) {
+      actualMeasurements.put(metricIds.get(i), values.get(i));
+    }
+
+    assertEquals(
+        expectedMeasurements,
+        actualMeasurements,
+        String.format(
+            "Instance measurements should match expected. Expected: %s, Actual: %s",
+            expectedMeasurements, actualMeasurements));
   }
 }

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -112,16 +112,6 @@ public class BaseTallyComponentTest {
 
   // --- Shared tally report query helpers ---
 
-  /**
-   * Retrieves the hourly tally sum for a product and metric within a time range.
-   *
-   * @param orgId the organization ID
-   * @param productTag the product tag
-   * @param metricId the metric ID
-   * @param beginning the start of the time range
-   * @param ending the end of the time range
-   * @return the sum of all tally values, or 0.0 if no data
-   */
   protected double getHourlyTallySum(
       String orgId,
       String productTag,

--- a/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
+++ b/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG_ADDON;
+import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_UNCONVERTED;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.tally.test.model.InstanceData;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.json.Measurement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Component tests verifying that hourly tally correctly filters out non-PAYG product tags from
+ * events.
+ *
+ * <p>These tests ensure that when events contain mixed PAYG and TRADITIONAL product tags, only the
+ * PAYG tags are processed during hourly tally operations. This prevents TRADITIONAL products from
+ * being incorrectly included in marketplace billing.
+ */
+public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
+  private TestSetup setup;
+
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+    setup = setupTest();
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC001")
+  public void testHourlyTallyFiltersNonPaygoProductTags() {
+    // Given: An event with mixed PAYG and TRADITIONAL product tags with realistic metrics
+    // rhel-for-x86-els-payg-addon is PAYG (supports vCPUs metric)
+    // rhel-for-x86-els-unconverted is TRADITIONAL (supports Sockets metric)
+    // Event includes BOTH metrics (vCPUs for PAYG, Sockets for TRADITIONAL)
+    String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
+    String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
+    float vcpuValue = 4.0f;
+    float socketsValue = 2.0f;
+
+    createRealisticMixedTagsEvent(setup.start, vcpuValue, socketsValue);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: Only the PAYG product should have tally data
+    // PAYG product should have the vCPUs metric tallied
+    awaitHourlyTallySum(
+        setup.orgId,
+        paygoProductTag,
+        "vCPUs",
+        setup.start,
+        setup.start.plusHours(1),
+        (double) vcpuValue);
+
+    // Note: We cannot query hourly tally reports for TRADITIONAL products as they don't support
+    // hourly granularity. The filtering is verified by checking instances reports instead.
+
+    // And: Verify instance was created for PAYGO product with correct measurements
+    InstanceData paygoInstance =
+        getInstanceByDisplayName(
+            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
+    assertEquals(true, paygoInstance != null, "PAYGO instance should be created from the event");
+    assertEquals(
+        setup.instanceId,
+        paygoInstance.getDisplayName(),
+        "PAYGO instance should have correct display name");
+    assertEquals(
+        true,
+        paygoInstance.getMeasurements() != null && !paygoInstance.getMeasurements().isEmpty(),
+        "PAYGO instance should have measurements applied from the event");
+    assertEquals(
+        1,
+        paygoInstance.getMeasurements().size(),
+        "PAYGO instance should have only vCPUs measurement, not Sockets (filtered out)");
+    assertEquals(
+        (double) vcpuValue,
+        paygoInstance.getMeasurements().get(0),
+        0.0001,
+        "PAYGO instance should have correct vCPUs measurement value from the original event");
+
+    // And: TRADITIONAL product should have NO instances in hourly report
+    long traditionalInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            traditionalProductTag,
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        traditionalInstanceCount,
+        "TRADITIONAL product should have no instances in the hourly instances report");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC002")
+  public void testEventWithOnlyTraditionalTagsNotTalliedHourly() {
+    // Given: An event with ONLY TRADITIONAL product tag (no PAYG tags)
+    // For TRADITIONAL products, we don't set billing provider/account
+    String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
+    String metricId = "Sockets";
+    float value = 2.0f;
+
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            setup.instanceId,
+            setup.start.toString(),
+            UUID.randomUUID().toString(),
+            metricId,
+            value,
+            Event.Sla.PREMIUM,
+            Event.HardwareType.PHYSICAL,
+            RHEL_FOR_X86_ELS_UNCONVERTED.productId(),
+            traditionalProductTag);
+
+    event.setDisplayName(Optional.of(setup.instanceId));
+    // TRADITIONAL products don't have cloud billing - set to null or __EMPTY__
+    event.setBillingProvider(Event.BillingProvider.__EMPTY__);
+    event.setBillingAccountId(Optional.empty());
+
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: Event should NOT be tallied hourly (product_tag should be cleared to null)
+    // TRADITIONAL products don't support hourly tally reports, so we verify by checking
+    // that the instance does not appear in the hourly instances report
+    long traditionalInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            traditionalProductTag,
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        traditionalInstanceCount,
+        "Event with only TRADITIONAL tags should not appear in hourly instances report");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC003")
+  public void testEventWithOnlyPaygoTagsProcessedNormally() {
+    // Given: An event with ONLY PAYG product tags (no TRADITIONAL tags)
+    String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
+    String metricId = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().get(0); // vCPUs
+    float value = 4.0f;
+
+    createMixedTagsEvent(setup.start, Set.of(paygoProductTag), metricId, value);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: Event should be tallied normally (no filtering)
+    awaitHourlyTallySum(
+        setup.orgId,
+        paygoProductTag,
+        metricId,
+        setup.start,
+        setup.start.plusHours(1),
+        (double) value);
+
+    long paygoInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
+    assertEquals(
+        1, paygoInstanceCount, "PAYG-only event should be processed normally in hourly tally");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC004")
+  public void testMultipleEventsWithMixedTagsFilteredCorrectly() {
+    // Given: Multiple events with different tag combinations
+    String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
+    String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
+    String metricId = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().get(0); // vCPUs
+
+    // Event 1: Mixed tags - value 4.0
+    createMixedTagsEvent(
+        setup.start, Set.of(paygoProductTag, traditionalProductTag), metricId, 4.0f);
+
+    // Event 2: Mixed tags at a different time in same hour - value 2.0
+    createMixedTagsEvent(
+        setup.start.plusMinutes(30),
+        Set.of(paygoProductTag, traditionalProductTag),
+        metricId,
+        2.0f);
+
+    // Event 3: PAYG only - value 6.0
+    createMixedTagsEvent(setup.start.plusMinutes(45), Set.of(paygoProductTag), metricId, 6.0f);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: PAYG product should have the max value (6.0) from the latest event
+    // Tally uses max value per instance per hour for conflicting events
+    awaitHourlyTallySum(
+        setup.orgId, paygoProductTag, metricId, setup.start, setup.start.plusHours(1), 6.0);
+
+    // TRADITIONAL product should have NO instances in hourly report (filtered out from all events)
+    long traditionalInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            traditionalProductTag,
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        traditionalInstanceCount,
+        "TRADITIONAL product should not appear in any of the hourly events");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC005")
+  public void testConflictResolutionWithMixedTags() {
+    // Given: First event with mixed PAYG and TRADITIONAL tags with realistic metrics
+    String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
+    String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
+    float firstVcpuValue = 4.0f;
+    float firstSocketsValue = 2.0f;
+    float secondVcpuValue = 8.0f;
+    float secondSocketsValue = 4.0f;
+
+    createRealisticMixedTagsEvent(setup.start, firstVcpuValue, firstSocketsValue);
+
+    // When: Performing first hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: PAYGO product should have first tally with initial vCPU value
+    double firstTally =
+        awaitHourlyTallySum(
+            setup.orgId,
+            paygoProductTag,
+            "vCPUs",
+            setup.start,
+            setup.start.plusHours(1),
+            (double) firstVcpuValue);
+    assertEquals(
+        (double) firstVcpuValue,
+        firstTally,
+        0.0001,
+        "First tally should reflect initial vCPU value");
+
+    // Given: Second conflicting event with mixed tags for SAME instance and SAME timestamp (higher
+    // values)
+    createRealisticMixedTagsEvent(
+        setup.start, // Same exact timestamp to trigger conflict resolution
+        secondVcpuValue,
+        secondSocketsValue);
+
+    // When: Performing second hourly tally (triggers conflict resolution)
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: PAYGO product should be updated to the higher vCPU value (conflict resolved)
+    double secondTally =
+        awaitHourlyTallySum(
+            setup.orgId,
+            paygoProductTag,
+            "vCPUs",
+            setup.start,
+            setup.start.plusHours(1),
+            (double) secondVcpuValue);
+    assertEquals(
+        (double) secondVcpuValue,
+        secondTally,
+        0.0001,
+        "Conflict resolution should update to higher vCPU value from second event");
+
+    // And: Verify instance has updated vCPU measurement after conflict resolution
+    InstanceData paygoInstance =
+        getInstanceByDisplayName(
+            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
+    assertEquals(
+        true, paygoInstance != null, "PAYGO instance should exist after conflict resolution");
+    assertEquals(
+        1,
+        paygoInstance.getMeasurements().size(),
+        "PAYGO instance should have only vCPUs measurement after conflict resolution");
+    assertEquals(
+        (double) secondVcpuValue,
+        paygoInstance.getMeasurements().get(0),
+        0.0001,
+        "Instance vCPU measurement should be updated to second (higher) value after conflict resolution");
+
+    // And: TRADITIONAL product should have NO instances in either tally run
+    long traditionalInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            traditionalProductTag,
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        traditionalInstanceCount,
+        "TRADITIONAL product should not appear in any hourly tally, even with conflict resolution");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC006")
+  public void testMixedTagsWithSingleMetricEdgeCase() {
+    // Given: An unrealistic edge-case event with mixed PAYG and TRADITIONAL tags
+    // but only includes one product's metric (vCPUs for PAYG, not Sockets for TRADITIONAL)
+    // This tests that filtering works even with malformed/incomplete metric data
+    String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
+    String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
+    float vcpuValue = 4.0f;
+
+    createMixedTagsEvent(
+        setup.start, Set.of(paygoProductTag, traditionalProductTag), "vCPUs", vcpuValue);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: PAYG product should be tallied with the vCPUs metric
+    awaitHourlyTallySum(
+        setup.orgId,
+        paygoProductTag,
+        "vCPUs",
+        setup.start,
+        setup.start.plusHours(1),
+        (double) vcpuValue);
+
+    // And: PAYG instance should exist with correct measurement
+    InstanceData paygoInstance =
+        getInstanceByDisplayName(
+            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
+    assertEquals(
+        true,
+        paygoInstance != null,
+        "PAYGO instance should be created even with incomplete metrics");
+    assertEquals(
+        (double) vcpuValue,
+        paygoInstance.getMeasurements().get(0),
+        0.0001,
+        "PAYGO instance should have vCPUs measurement");
+
+    // And: TRADITIONAL product should have NO instances (filtered out)
+    long traditionalInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            traditionalProductTag,
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        traditionalInstanceCount,
+        "TRADITIONAL product should be filtered out even with incomplete metrics");
+  }
+
+  // --- Given helper methods ---
+
+  private TestSetup setupTest() {
+    service.createOptInConfig(orgId);
+
+    // Use a fixed hour bucket so events collide (same instance_id + same hour)
+    OffsetDateTime start =
+        OffsetDateTime.now(ZoneOffset.UTC).minusHours(2).truncatedTo(ChronoUnit.HOURS);
+    String instanceId = UUID.randomUUID().toString();
+
+    return new TestSetup(orgId, start, instanceId);
+  }
+
+  private void createMixedTagsEvent(
+      OffsetDateTime timestamp, Set<String> productTags, String metricId, float value) {
+    // Use the PAYG product configuration as the base
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            setup.instanceId,
+            timestamp.toString(),
+            UUID.randomUUID().toString(),
+            metricId,
+            value,
+            RHEL_FOR_X86_ELS_PAYG_ADDON.productId(),
+            RHEL_FOR_X86_ELS_PAYG_ADDON.productTag());
+
+    // Override product_tag to include both PAYG and TRADITIONAL tags
+    event.setProductTag(productTags);
+    event.setDisplayName(Optional.of(setup.instanceId));
+
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+  }
+
+  /**
+   * Creates a realistic event with mixed PAYG and TRADITIONAL tags, including appropriate metrics
+   * for each product type.
+   *
+   * @param timestamp event timestamp
+   * @param vcpuValue vCPUs value (for PAYG product: rhel-for-x86-els-payg-addon)
+   * @param socketsValue Sockets value (for TRADITIONAL product: rhel-for-x86-els-unconverted)
+   */
+  private void createRealisticMixedTagsEvent(
+      OffsetDateTime timestamp, float vcpuValue, float socketsValue) {
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            setup.instanceId,
+            timestamp.toString(),
+            UUID.randomUUID().toString(),
+            "vCPUs",
+            vcpuValue,
+            RHEL_FOR_X86_ELS_PAYG_ADDON.productId(),
+            RHEL_FOR_X86_ELS_PAYG_ADDON.productTag());
+
+    // Add both PAYG and TRADITIONAL tags
+    event.setProductTag(
+        Set.of(
+            RHEL_FOR_X86_ELS_PAYG_ADDON.productTag(), RHEL_FOR_X86_ELS_UNCONVERTED.productTag()));
+
+    // Add measurements for both products' metrics
+    List<Measurement> measurements = new ArrayList<>();
+
+    Measurement vcpus = new Measurement();
+    vcpus.setMetricId("vCPUs");
+    vcpus.setValue((double) vcpuValue);
+    measurements.add(vcpus);
+
+    Measurement sockets = new Measurement();
+    sockets.setMetricId("Sockets");
+    sockets.setValue((double) socketsValue);
+    measurements.add(sockets);
+
+    event.setMeasurements(measurements);
+    event.setDisplayName(Optional.of(setup.instanceId));
+
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+  }
+
+  private record TestSetup(String orgId, OffsetDateTime start, String instanceId) {}
+}

--- a/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
+++ b/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
@@ -22,6 +22,9 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG_ADDON;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_UNCONVERTED;
 
@@ -69,7 +72,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
     float vcpuValue = 4.0f;
     float socketsValue = 2.0f;
 
-    createRealisticMixedTagsEvent(setup.start, vcpuValue, socketsValue);
+    createMixedTagsEvent(setup.start, vcpuValue, socketsValue);
 
     // When: Performing hourly tally
     service.performHourlyTallyForOrg(setup.orgId);
@@ -82,32 +85,30 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
         "vCPUs",
         setup.start,
         setup.start.plusHours(1),
-        (double) vcpuValue);
+        vcpuValue);
 
     // Note: We cannot query hourly tally reports for TRADITIONAL products as they don't support
-    // hourly granularity. The filtering is verified by checking instances reports instead.
+    // hourly granularity. The filtering is verified by checking instance reports instead.
 
     // And: Verify instance was created for PAYGO product with correct measurements
     InstanceData paygoInstance =
         getInstanceByDisplayName(
             setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertEquals(true, paygoInstance != null, "PAYGO instance should be created from the event");
+    assertNotNull(paygoInstance, "PAYGO instance should be created from the event");
     assertEquals(
         setup.instanceId,
         paygoInstance.getDisplayName(),
         "PAYGO instance should have correct display name");
-    assertEquals(
-        true,
-        paygoInstance.getMeasurements() != null && !paygoInstance.getMeasurements().isEmpty(),
+    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
+    assertFalse(paygoInstance.getMeasurements().isEmpty(),
         "PAYGO instance should have measurements applied from the event");
     assertEquals(
         1,
         paygoInstance.getMeasurements().size(),
         "PAYGO instance should have only vCPUs measurement, not Sockets (filtered out)");
     assertEquals(
-        (double) vcpuValue,
-        paygoInstance.getMeasurements().get(0),
-        0.0001,
+        vcpuValue,
+        paygoInstance.getMeasurements().getFirst(),
         "PAYGO instance should have correct vCPUs measurement value from the original event");
 
     // And: TRADITIONAL product should have NO instances in hourly report
@@ -177,7 +178,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   public void testEventWithOnlyPaygoTagsProcessedNormally() {
     // Given: An event with ONLY PAYG product tags (no TRADITIONAL tags)
     String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
-    String metricId = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().get(0); // vCPUs
+    String metricId = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().getFirst(); // vCPUs
     float value = 4.0f;
 
     createMixedTagsEvent(setup.start, Set.of(paygoProductTag), metricId, value);
@@ -256,7 +257,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
     float secondVcpuValue = 8.0f;
     float secondSocketsValue = 4.0f;
 
-    createRealisticMixedTagsEvent(setup.start, firstVcpuValue, firstSocketsValue);
+    createMixedTagsEvent(setup.start, firstVcpuValue, firstSocketsValue);
 
     // When: Performing first hourly tally
     service.performHourlyTallyForOrg(setup.orgId);
@@ -271,14 +272,13 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
             setup.start.plusHours(1),
             (double) firstVcpuValue);
     assertEquals(
-        (double) firstVcpuValue,
+        firstVcpuValue,
         firstTally,
-        0.0001,
         "First tally should reflect initial vCPU value");
 
     // Given: Second conflicting event with mixed tags for SAME instance and SAME timestamp (higher
     // values)
-    createRealisticMixedTagsEvent(
+    createMixedTagsEvent(
         setup.start, // Same exact timestamp to trigger conflict resolution
         secondVcpuValue,
         secondSocketsValue);
@@ -294,27 +294,26 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
             "vCPUs",
             setup.start,
             setup.start.plusHours(1),
-            (double) secondVcpuValue);
+            secondVcpuValue);
     assertEquals(
-        (double) secondVcpuValue,
+        secondVcpuValue,
         secondTally,
-        0.0001,
         "Conflict resolution should update to higher vCPU value from second event");
 
     // And: Verify instance has updated vCPU measurement after conflict resolution
     InstanceData paygoInstance =
         getInstanceByDisplayName(
             setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertEquals(
-        true, paygoInstance != null, "PAYGO instance should exist after conflict resolution");
+    assertNotNull(paygoInstance, "PAYGO instance should exist after conflict resolution");
+    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
+    assertFalse(paygoInstance.getMeasurements().isEmpty(), "PAYGO instance should have measurements");
     assertEquals(
         1,
         paygoInstance.getMeasurements().size(),
         "PAYGO instance should have only vCPUs measurement after conflict resolution");
     assertEquals(
-        (double) secondVcpuValue,
-        paygoInstance.getMeasurements().get(0),
-        0.0001,
+        secondVcpuValue,
+        paygoInstance.getMeasurements().getFirst(),
         "Instance vCPU measurement should be updated to second (higher) value after conflict resolution");
 
     // And: TRADITIONAL product should have NO instances in either tally run
@@ -354,20 +353,21 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
         "vCPUs",
         setup.start,
         setup.start.plusHours(1),
-        (double) vcpuValue);
+        vcpuValue);
 
     // And: PAYG instance should exist with correct measurement
     InstanceData paygoInstance =
         getInstanceByDisplayName(
             setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
+    assertNotNull(paygoInstance, "PAYGO instance should be created from the event");
+    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
+    assertFalse(paygoInstance.getMeasurements().isEmpty(),
+        "PAYGO instance should have measurements applied from the event");
+    assertEquals(1, paygoInstance.getMeasurements().size(),
+        "PAYGO instance should have 1 measurement");
     assertEquals(
-        true,
-        paygoInstance != null,
-        "PAYGO instance should be created even with incomplete metrics");
-    assertEquals(
-        (double) vcpuValue,
-        paygoInstance.getMeasurements().get(0),
-        0.0001,
+        vcpuValue,
+        paygoInstance.getMeasurements().getFirst(),
         "PAYGO instance should have vCPUs measurement");
 
     // And: TRADITIONAL product should have NO instances (filtered out)
@@ -418,15 +418,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
     kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
   }
 
-  /**
-   * Creates a realistic event with mixed PAYG and TRADITIONAL tags, including appropriate metrics
-   * for each product type.
-   *
-   * @param timestamp event timestamp
-   * @param vcpuValue vCPUs value (for PAYG product: rhel-for-x86-els-payg-addon)
-   * @param socketsValue Sockets value (for TRADITIONAL product: rhel-for-x86-els-unconverted)
-   */
-  private void createRealisticMixedTagsEvent(
+  private void createMixedTagsEvent(
       OffsetDateTime timestamp, float vcpuValue, float socketsValue) {
     Event event =
         helpers.createPaygEventWithTimestamp(

--- a/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
+++ b/swatch-tally/ct/java/tests/TallyFilterNonPaygoProductsTest.java
@@ -22,19 +22,18 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static utils.TallyTestProducts.RHEL_FOR_X86;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG_ADDON;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_UNCONVERTED;
+import static utils.TallyTestProducts.ROSA;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
-import com.redhat.swatch.tally.test.model.InstanceData;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -80,36 +79,20 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
     // Then: Only the PAYG product should have tally data
     // PAYG product should have the vCPUs metric tallied
     awaitHourlyTallySum(
-        setup.orgId,
-        paygoProductTag,
-        "vCPUs",
-        setup.start,
-        setup.start.plusHours(1),
-        vcpuValue);
+        setup.orgId, paygoProductTag, "vCPUs", setup.start, setup.start.plusHours(1), vcpuValue);
 
     // Note: We cannot query hourly tally reports for TRADITIONAL products as they don't support
     // hourly granularity. The filtering is verified by checking instance reports instead.
 
     // And: Verify instance was created for PAYGO product with correct measurements
-    InstanceData paygoInstance =
-        getInstanceByDisplayName(
-            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertNotNull(paygoInstance, "PAYGO instance should be created from the event");
-    assertEquals(
+    // Verifies: product tag, metric ID (vCPUs not Sockets), and value
+    assertInstanceMeasurements(
+        setup.orgId,
         setup.instanceId,
-        paygoInstance.getDisplayName(),
-        "PAYGO instance should have correct display name");
-    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
-    assertFalse(paygoInstance.getMeasurements().isEmpty(),
-        "PAYGO instance should have measurements applied from the event");
-    assertEquals(
-        1,
-        paygoInstance.getMeasurements().size(),
-        "PAYGO instance should have only vCPUs measurement, not Sockets (filtered out)");
-    assertEquals(
-        vcpuValue,
-        paygoInstance.getMeasurements().getFirst(),
-        "PAYGO instance should have correct vCPUs measurement value from the original event");
+        paygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("vCPUs", (double) vcpuValue));
 
     // And: TRADITIONAL product should have NO instances in hourly report
     long traditionalInstanceCount =
@@ -195,44 +178,56 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
         setup.start.plusHours(1),
         (double) value);
 
-    long paygoInstanceCount =
-        getInstancesCountByDisplayName(
-            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertEquals(
-        1, paygoInstanceCount, "PAYG-only event should be processed normally in hourly tally");
+    // And: Instance should exist with correct measurement value
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        paygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("vCPUs", (double) value));
   }
 
   @Test
   @TestPlanName("tally-payg-filter-TC004")
   public void testMultipleEventsWithMixedTagsFilteredCorrectly() {
-    // Given: Multiple events with different tag combinations
+    // Given: Multiple events with different tag combinations at the same hour-truncated timestamp
+    // (matching real-world behavior where events are sent with timestamps truncated to the hour)
     String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
     String traditionalProductTag = RHEL_FOR_X86_ELS_UNCONVERTED.productTag();
     String metricId = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().get(0); // vCPUs
 
+    // All events use same timestamp (hour-truncated) to match real-world usage
     // Event 1: Mixed tags - value 4.0
     createMixedTagsEvent(
         setup.start, Set.of(paygoProductTag, traditionalProductTag), metricId, 4.0f);
 
-    // Event 2: Mixed tags at a different time in same hour - value 2.0
+    // Event 2: Mixed tags - value 2.0 (conflicts with Event 1)
     createMixedTagsEvent(
-        setup.start.plusMinutes(30),
-        Set.of(paygoProductTag, traditionalProductTag),
-        metricId,
-        2.0f);
+        setup.start, Set.of(paygoProductTag, traditionalProductTag), metricId, 2.0f);
 
-    // Event 3: PAYG only - value 6.0
-    createMixedTagsEvent(setup.start.plusMinutes(45), Set.of(paygoProductTag), metricId, 6.0f);
+    // Event 3: PAYG only - value 6.0 (conflicts with Events 1 and 2)
+    createMixedTagsEvent(setup.start, Set.of(paygoProductTag), metricId, 6.0f);
 
     // When: Performing hourly tally
     service.performHourlyTallyForOrg(setup.orgId);
 
-    // Then: PAYG product should have the max value (6.0) from the latest event
-    // Tally uses max value per instance per hour for conflicting events
+    // Then: PAYG product should have the max value (6.0) from the conflicting events
+    // Events with same timestamp are conflicts; conflict resolution takes the max value
     awaitHourlyTallySum(
         setup.orgId, paygoProductTag, metricId, setup.start, setup.start.plusHours(1), 6.0);
 
-    // TRADITIONAL product should have NO instances in hourly report (filtered out from all events)
+    // And: Instance should have the max measurement value (6.0) after conflict resolution
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        paygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("vCPUs", 6.0));
+
+    // And: TRADITIONAL product should have NO instances in hourly report (filtered out from all
+    // events)
     long traditionalInstanceCount =
         getInstancesCountByDisplayName(
             setup.orgId,
@@ -271,10 +266,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
             setup.start,
             setup.start.plusHours(1),
             (double) firstVcpuValue);
-    assertEquals(
-        firstVcpuValue,
-        firstTally,
-        "First tally should reflect initial vCPU value");
+    assertEquals(firstVcpuValue, firstTally, "First tally should reflect initial vCPU value");
 
     // Given: Second conflicting event with mixed tags for SAME instance and SAME timestamp (higher
     // values)
@@ -301,20 +293,13 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
         "Conflict resolution should update to higher vCPU value from second event");
 
     // And: Verify instance has updated vCPU measurement after conflict resolution
-    InstanceData paygoInstance =
-        getInstanceByDisplayName(
-            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertNotNull(paygoInstance, "PAYGO instance should exist after conflict resolution");
-    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
-    assertFalse(paygoInstance.getMeasurements().isEmpty(), "PAYGO instance should have measurements");
-    assertEquals(
-        1,
-        paygoInstance.getMeasurements().size(),
-        "PAYGO instance should have only vCPUs measurement after conflict resolution");
-    assertEquals(
-        secondVcpuValue,
-        paygoInstance.getMeasurements().getFirst(),
-        "Instance vCPU measurement should be updated to second (higher) value after conflict resolution");
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        paygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("vCPUs", (double) secondVcpuValue));
 
     // And: TRADITIONAL product should have NO instances in either tally run
     long traditionalInstanceCount =
@@ -348,27 +333,16 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
 
     // Then: PAYG product should be tallied with the vCPUs metric
     awaitHourlyTallySum(
-        setup.orgId,
-        paygoProductTag,
-        "vCPUs",
-        setup.start,
-        setup.start.plusHours(1),
-        vcpuValue);
+        setup.orgId, paygoProductTag, "vCPUs", setup.start, setup.start.plusHours(1), vcpuValue);
 
     // And: PAYG instance should exist with correct measurement
-    InstanceData paygoInstance =
-        getInstanceByDisplayName(
-            setup.orgId, paygoProductTag, setup.start, setup.start.plusHours(1), setup.instanceId);
-    assertNotNull(paygoInstance, "PAYGO instance should be created from the event");
-    assertNotNull(paygoInstance.getMeasurements(), "PAYGO instance should have measurements");
-    assertFalse(paygoInstance.getMeasurements().isEmpty(),
-        "PAYGO instance should have measurements applied from the event");
-    assertEquals(1, paygoInstance.getMeasurements().size(),
-        "PAYGO instance should have 1 measurement");
-    assertEquals(
-        vcpuValue,
-        paygoInstance.getMeasurements().getFirst(),
-        "PAYGO instance should have vCPUs measurement");
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        paygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("vCPUs", (double) vcpuValue));
 
     // And: TRADITIONAL product should have NO instances (filtered out)
     long traditionalInstanceCount =
@@ -382,6 +356,101 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
         0,
         traditionalInstanceCount,
         "TRADITIONAL product should be filtered out even with incomplete metrics");
+  }
+
+  @Test
+  @TestPlanName("tally-payg-filter-TC007")
+  public void testRoleBasedProductTagLookupFiltersNonPaygoMetrics() {
+    // Given: An event with NO product tag but WITH a role and mixed metrics
+    // - Role "moa" maps to PAYG product "rosa" (supports Cores, Instance-hours)
+    // - Event contains BOTH a PAYG metric (Cores) and a TRADITIONAL metric (Sockets)
+    // - The role-based lookup should derive the PAYG product tag from the role
+    // - The TRADITIONAL metric (Sockets) should be filtered out during normalization
+
+    String expectedPaygoProductTag = ROSA.productTag(); // rosa
+    String paygoMetricId = "Cores"; // Supported by rosa
+    String traditionalMetricId = "Sockets"; // NOT supported by rosa
+    float coresValue = 8.0f;
+    float socketsValue = 2.0f;
+
+    Event event = new Event();
+    event.setEventId(UUID.randomUUID());
+    event.setOrgId(setup.orgId);
+    event.setInstanceId(setup.instanceId);
+    event.setDisplayName(Optional.of(setup.instanceId));
+    event.setTimestamp(setup.start);
+    event.setRecordDate(setup.start);
+    event.setExpiration(Optional.of(setup.start.plusHours(1)));
+    event.setEventSource("test-role-lookup");
+    event.setEventType("snapshot");
+
+    // Critical: NO product tag set - this triggers role-based lookup
+    event.setProductTag(Set.of());
+
+    // Critical: Set role to "moa" which should map to rosa (PAYG product)
+    event.setRole(Event.Role.MOA);
+
+    // Add productIds as empty to force role-based lookup (not engId-based)
+    event.setProductIds(List.of());
+
+    event.setSla(Event.Sla.PREMIUM);
+    event.setUsage(Event.Usage.PRODUCTION);
+    event.setServiceType("rosa Instance");
+    event.setBillingProvider(Event.BillingProvider.AWS);
+    event.setBillingAccountId(Optional.of("aws-account-123"));
+    event.setCloudProvider(Event.CloudProvider.AWS);
+
+    // Add BOTH a PAYG-supported metric (Cores) and an unsupported metric (Sockets)
+    List<Measurement> measurements = new ArrayList<>();
+
+    Measurement cores = new Measurement();
+    cores.setMetricId(paygoMetricId);
+    cores.setValue((double) coresValue);
+    measurements.add(cores);
+
+    Measurement sockets = new Measurement();
+    sockets.setMetricId(traditionalMetricId);
+    sockets.setValue((double) socketsValue);
+    measurements.add(sockets);
+
+    event.setMeasurements(measurements);
+
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: The PAYG product tag (rosa) should be derived from the role (moa)
+    // And: Only the supported metric (Cores) should be tallied, Sockets should be filtered out
+    awaitHourlyTallySum(
+        setup.orgId,
+        expectedPaygoProductTag,
+        paygoMetricId,
+        setup.start,
+        setup.start.plusHours(1),
+        coresValue);
+
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        expectedPaygoProductTag,
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("Cores", (double) coresValue, "Instance-hours", 0.0));
+
+    // And: Verify NO instances exist for any RHEL product tag (which supports Sockets)
+    // This ensures Sockets metric didn't cause a RHEL product to be incorrectly tallied
+    long rhelInstanceCount =
+        getInstancesCountByDisplayName(
+            setup.orgId,
+            RHEL_FOR_X86.productTag(),
+            setup.start,
+            setup.start.plusHours(1),
+            setup.instanceId);
+    assertEquals(
+        0,
+        rhelInstanceCount,
+        "RHEL instance should NOT be created - role=moa should only map to rosa, not RHEL");
   }
 
   // --- Given helper methods ---
@@ -418,8 +487,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
     kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
   }
 
-  private void createMixedTagsEvent(
-      OffsetDateTime timestamp, float vcpuValue, float socketsValue) {
+  private void createMixedTagsEvent(OffsetDateTime timestamp, float vcpuValue, float socketsValue) {
     Event event =
         helpers.createPaygEventWithTimestamp(
             setup.orgId,

--- a/swatch-tally/ct/java/tests/TallyHandlingConflictsTest.java
+++ b/swatch-tally/ct/java/tests/TallyHandlingConflictsTest.java
@@ -29,20 +29,13 @@ import static utils.TallyTestProducts.ROSA;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
-import com.redhat.swatch.tally.test.model.InstanceData;
-import com.redhat.swatch.tally.test.model.InstanceResponse;
-import com.redhat.swatch.tally.test.model.TallyReportData;
-import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,6 +63,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
     service.performHourlyTallyForOrg(setup.orgId);
     double before =
         awaitHourlyTallySum(
+            setup.orgId,
             RHEL_FOR_X86_ELS_PAYG.productTag(),
             metricId,
             setup.start,
@@ -83,6 +77,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
     // Then: Tally should reflect the updated positive measurement
     double after =
         awaitHourlyTallySum(
+            setup.orgId,
             RHEL_FOR_X86_ELS_PAYG.productTag(),
             metricId,
             setup.start,
@@ -104,6 +99,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
     service.performHourlyTallyForOrg(setup.orgId);
     double before =
         awaitHourlyTallySum(
+            setup.orgId,
             RHEL_FOR_X86_ELS_PAYG.productTag(),
             metricId,
             setup.start,
@@ -117,6 +113,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
     // Then: Tally should not reflect the negative measurement
     double after =
         awaitHourlyTallySum(
+            setup.orgId,
             RHEL_FOR_X86_ELS_PAYG.productTag(),
             metricId,
             setup.start,
@@ -147,6 +144,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
 
       for (String metricId : product.metricIds()) {
         awaitHourlyTallySum(
+            setup.orgId,
             product.productTag(),
             metricId,
             setup.start,
@@ -184,6 +182,7 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
           product.productTag(), setup.start, setup.start.plusHours(2), setup.instanceId, 1);
       for (String metricId : product.metricIds()) {
         awaitHourlyTallySum(
+            setup.orgId,
             product.productTag(),
             metricId,
             setup.start,
@@ -230,24 +229,6 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
 
   // --- Then helper methods ---
 
-  private long getInstancesCountByDisplayName(
-      String productTag,
-      OffsetDateTime beginning,
-      OffsetDateTime ending,
-      String displayNameContains) {
-    InstanceResponse response =
-        service.getInstancesByProduct(setup.orgId, productTag, beginning, ending);
-    if (response.getData() == null) {
-      return 0;
-    }
-
-    return response.getData().stream()
-        .map(InstanceData::getDisplayName)
-        .filter(Objects::nonNull)
-        .filter(d -> d.contains(displayNameContains))
-        .count();
-  }
-
   private void awaitInstancesCount(
       String productTag,
       OffsetDateTime beginning,
@@ -265,56 +246,11 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
           service.performHourlyTallyForOrg(setup.orgId);
           assertEquals(
               expectedCount,
-              getInstancesCountByDisplayName(productTag, beginning, ending, displayNameContains),
+              getInstancesCountByDisplayName(
+                  setup.orgId, productTag, beginning, ending, displayNameContains),
               "Instance count should match expected value");
         },
         settings);
-  }
-
-  private double getHourlyTallySum(
-      String productTag, String metricId, OffsetDateTime beginning, OffsetDateTime ending) {
-    Map<String, ?> queryParams =
-        Map.of(
-            "granularity", "Hourly",
-            "beginning", beginning.toString(),
-            "ending", ending.toString());
-
-    TallyReportData resp =
-        service.getTallyReportData(setup.orgId, productTag, metricId, queryParams);
-    if (resp.getData() == null) {
-      return 0.0;
-    }
-
-    return resp.getData().stream()
-        .collect(Collectors.summarizingInt(TallyReportDataPoint::getValue))
-        .getSum();
-  }
-
-  private double awaitHourlyTallySum(
-      String productTag,
-      String metricId,
-      OffsetDateTime beginning,
-      OffsetDateTime ending,
-      double expected) {
-    AwaitilitySettings settings =
-        AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(30))
-            .withService(service)
-            .timeoutMessage(
-                "Timed out waiting for hourly tally to reach expected value %.4f (product=%s metric=%s)",
-                expected, productTag, metricId);
-
-    AwaitilityUtils.untilAsserted(
-        () -> {
-          service.performHourlyTallyForOrg(setup.orgId);
-          assertEquals(
-              expected,
-              getHourlyTallySum(productTag, metricId, beginning, ending),
-              0.0001,
-              "Hourly tally sum should match expected value");
-        },
-        settings);
-
-    return getHourlyTallySum(productTag, metricId, beginning, ending);
   }
 
   private record TestSetup(String orgId, OffsetDateTime start, String instanceId) {}


### PR DESCRIPTION
Jira issue: SWATCH-4878

## Description
Filter any non-paygo products and metrics from incoming events to prevent traditional products from being tallied durring the hourly tally process.

- Add filterNonPaygoTags() to remove TRADITIONAL product tags from events during normalization, ensuring only PAYG products are processed during the hourly tally.

Added swatch-tally component tests for PAYG filtering

- Add TallyFilterNonPaygoProductsTest with 5 comprehensive test cases: TC001: Mixed PAYG/TRADITIONAL tags - verifies filtering and measurements TC002: TRADITIONAL-only events excluded from hourly processing TC003: PAYG-only events processed normally (baseline) TC004: Multiple events with mixed tags filtered correctly TC005: Conflict resolution with mixed tags (same timestamp)
- Add test documentation to TEST_PLAN.md

- Add unit test coverage for EventNormalizer

- Add unit test coverage around the EventNormalizer)


## Testing
### Reproducer

1. Remove the clutter and start with a fresh DB
	```
	dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
	createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions
	```
2. Check out the `main` branch and deploy `make swatch-tally`
3. Send the following event message which contains a mix of paygo and traditional product data.
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress \
 Content-Type:application/vnd.kafka.json.v2+json \
 Accept:application/vnd.kafka.v2+json --raw '{
  "records": [
	{
		"key": "11111111",
		"value": {
			"service_type": "RHEL System",
            "timestamp": "2026-06-03T14:00:00Z",
            "expiration": "2026-06-03T15:00:00Z",
			"display_name": "test-payg-filter-1",
			"instance_id": "999999999",
			"org_id": "11111111",
			"product_ids": ["479"],
			"product_tag": ["rhel-for-x86-els-payg-addon", "rhel-for-x86-els-unconverted"],
			"measurements": [
				{
					"metric_id": "vCPUs",
					"value": 4.0
				},
				{
					"metric_id": "Sockets",
					"value": 2.0
				}
			],
			"billing_provider": "aws",
			"billing_account_id": "123456789012",
			"sla": "Premium",
			"usage": "Production",
			"event_source": "prometheus",
			"event_type": "snapshot"
		}
	}
  ]
}'
```

Notice that 4 events were created! An event was created for each traditional and paygo product mapped to each measurement which is incorrect. There should just be 1 for paygo.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions \
-c "select instance_id, timestamp, data->'product_tag', data->'measurements'->0 from events where org_id='11111111' order by timestamp desc;"

```
```
 instance_id |       timestamp        |             ?column?             |                ?column?                
-------------+------------------------+----------------------------------+----------------------------------------
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-unconverted"] | {"value": 2.0, "metric_id": "Sockets"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-unconverted"] | {"value": 4.0, "metric_id": "vCPUs"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"]  | {"value": 2.0, "metric_id": "Sockets"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"]  | {"value": 4.0, "metric_id": "vCPUs"}
(4 rows)
```

3. Run the hourly tally
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=11111111" x-rh-swatch-psk:placeholder
```
4. Notice that monthly totals were set for SOCKETS and VCPUS.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select * from instance_measurements order by last_modified desc"
```

```
               host_id                | metric_id | value |             instance_id              |         last_modified         
--------------------------------------+-----------+-------+--------------------------------------+-------------------------------
 e09782c6-9633-4f25-8c82-e1125c68d562 | SOCKETS   |     2 | e09782c6-9633-4f25-8c82-e1125c68d562 | 2026-06-22 17:42:27.646886+00
 e09782c6-9633-4f25-8c82-e1125c68d562 | VCPUS     |     4 | e09782c6-9633-4f25-8c82-e1125c68d562 | 2026-06-22 17:42:27.646886+00
(2 rows)
```

Notice that snapshots/measurements were created for both products.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select snapshot_date, granularity, product_id, sla, usage, billing_provider, billing_account_id, m.metric_id, m.value from tally_snapshots s inner join tally_measurements m on m.snapshot_id=s.id where s.org_id='11111111' and s.is_primary=true order by metric_id, granularity"
```

```
     snapshot_date      | granularity |          product_id          |   sla   |   usage    | billing_provider | billing_account_id | metric_id | value 
------------------------+-------------+------------------------------+---------+------------+------------------+--------------------+-----------+-------
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-unconverted | Premium | Production | _ANY             | _ANY               | SOCKETS   |     2
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-unconverted | Premium | Production | _ANY             | _ANY               | SOCKETS   |     2
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-unconverted | Premium | Production | _ANY             | _ANY               | SOCKETS   |     2
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-unconverted | Premium | Production | _ANY             | _ANY               | SOCKETS   |     2
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-payg-addon  | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-payg-addon  | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-payg-addon  | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-payg-addon  | Premium | Production | aws              | 123456789012       | VCPUS     |     4
```


### Verification
1. Clean your database and start fresh so it is easier to verify.
```
dropdb -h localhost -U rhsm-subscriptions rhsm-subscriptions && \
createdb -h localhost -U rhsm-subscriptions rhsm-subscriptions
```
2. Check out the PR's branch and deploy again.
3. Send the following event (mix)
```
http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress \
 Content-Type:application/vnd.kafka.json.v2+json \
 Accept:application/vnd.kafka.v2+json --raw '{
  "records": [
	{
		"key": "11111111",
		"value": {
			"service_type": "RHEL System",
            "timestamp": "2026-06-03T14:00:00Z",
            "expiration": "2026-06-03T15:00:00Z",
			"display_name": "test-payg-filter-1",
			"instance_id": "999999999",
			"org_id": "11111111",
			"product_ids": ["479"],
			"product_tag": ["rhel-for-x86-els-payg-addon", "rhel-for-x86-els-unconverted"],
			"measurements": [
				{
					"metric_id": "vCPUs",
					"value": 4.0
				},
				{
					"metric_id": "Sockets",
					"value": 2.0
				}
			],
			"billing_provider": "aws",
			"billing_account_id": "123456789012",
			"sla": "Premium",
			"usage": "Production",
			"event_source": "prometheus",
			"event_type": "snapshot"
		}
	}
  ]
}'
```

Verify that now there's only 1 event created and that it is for the paygo product with vCPUs measurement.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions \
-c "select instance_id, timestamp, data->'product_tag', data->'measurements'->0 from events where org_id='11111111' order by timestamp desc;"

```
```
 instance_id |       timestamp        |            ?column?             |               ?column?               
-------------+------------------------+---------------------------------+--------------------------------------
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"] | {"value": 4.0, "metric_id": "vCPUs"}
(1 row)

```


4. Run the hourly tally.
```
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=11111111" x-rh-swatch-psk:placeholder
```

Notice that monthly totals were set for VCPUS only.
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select * from instance_measurements order by last_modified desc"
```

```
               host_id                | metric_id | value |             instance_id              |         last_modified         
--------------------------------------+-----------+-------+--------------------------------------+-------------------------------
 5a48a465-8d75-4499-82ef-79113a996db7 | VCPUS     |     4 | 5a48a465-8d75-4499-82ef-79113a996db7 | 2026-06-22 18:04:41.426973+00
(1 row)
```

Also notice that snapshots and measurements are only created for the paygo product and measurement.

```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions -c "select snapshot_date, granularity, product_id, sla, usage, billing_provider, billing_account_id, m.metric_id, m.value from tally_snapshots s inner join tally_measurements m on m.snapshot_id=s.id where s.org_id='11111111' and s.is_primary=true order by metric_id, granularity"
```

```
     snapshot_date      | granularity |         product_id          |   sla   |   usage    | billing_provider | billing_account_id | metric_id | value 
------------------------+-------------+-----------------------------+---------+------------+------------------+--------------------+-----------+-------
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-payg-addon | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 00:00:00+00 | DAILY       | rhel-for-x86-els-payg-addon | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-payg-addon | Premium | Production | aws              | 123456789012       | VCPUS     |     4
 2026-06-03 14:00:00+00 | HOURLY      | rhel-for-x86-els-payg-addon | Premium | Production | aws              | 123456789012       | VCPUS     |     4
(4 rows)
```

#### Further Verification
We will stop verification at the Event level since we have the base case covered. We just need to ensure that the correct event records are produced in the DB. The has been no change to the tally process, just event ingestion.

Use the same event query to verify the events as they are processed:
```
psql -h localhost -U rhsm-subscriptions rhsm-subscriptions \
-c "select instance_id, timestamp, data->'product_tag', data->'measurements'->0 from events where org_id='11111111' order by timestamp desc;"

```

**Conflict Resolution still functions**

  ```
  http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress \
 Content-Type:application/vnd.kafka.json.v2+json \
 Accept:application/vnd.kafka.v2+json --raw '{
  "records": [
	{
		"key": "11111111",
		"value": {
			"service_type": "RHEL System",
            "timestamp": "2026-06-03T14:00:00Z",
            "expiration": "2026-06-03T15:00:00Z",
			"display_name": "test-payg-filter-1",
			"instance_id": "999999999",
			"org_id": "11111111",
			"product_ids": ["479"],
			"product_tag": ["rhel-for-x86-els-payg-addon", "rhel-for-x86-els-unconverted"],
			"measurements": [
				{
					"metric_id": "vCPUs",
					"value": 10.0
				},
				{
					"metric_id": "Sockets",
					"value": 2.0
				}
			],
			"billing_provider": "aws",
			"billing_account_id": "123456789012",
			"sla": "Premium",
			"usage": "Production",
			"event_source": "prometheus",
			"event_type": "snapshot"
		}
	}
  ]
}'
  ```

Hourly tally will produce 2 new events:
* 1 deduction event: -4 vCPUs
* 1 amendment showing a value of 10.0 vCPUs
* No events for Traditional product produced.

**Traditional Product Events are skipped entirely**

```
  http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress \
 Content-Type:application/vnd.kafka.json.v2+json \
 Accept:application/vnd.kafka.v2+json --raw '{
  "records": [
	{
		"key": "11111111",
		"value": {
			"service_type": "RHEL System",
            "timestamp": "2026-06-03T15:00:00Z",
            "expiration": "2026-06-03T16:00:00Z",
			"display_name": "test-payg-filter-1",
			"instance_id": "999999999",
			"org_id": "11111111",
			"product_ids": ["479"],
			"product_tag": ["rhel-for-x86-els-unconverted"],
			"measurements": [
				{
					"metric_id": "Sockets",
					"value": 2.0
				}
			],
			"billing_provider": "aws",
			"billing_account_id": "123456789012",
			"sla": "Premium",
			"usage": "Production",
			"event_source": "prometheus",
			"event_type": "snapshot"
		}
	}
  ]
}'
```

No event produced since there are no applicable products/measurements to apply since it is traditional.

**Normal PayGo Event Processing Continues To Work**

```
  http :9080/topics/platform.rhsm-subscriptions.service-instance-ingress \
 Content-Type:application/vnd.kafka.json.v2+json \
 Accept:application/vnd.kafka.v2+json --raw '{
  "records": [
	{
		"key": "11111111",
		"value": {
			"service_type": "RHEL System",
            "timestamp": "2026-06-03T18:00:00Z",
            "expiration": "2026-06-03T19:00:00Z",
			"display_name": "test-payg-filter-1",
			"instance_id": "999999999",
			"org_id": "11111111",
			"product_ids": ["479"],
			"product_tag": ["rhel-for-x86-els-payg-addon"],
			"measurements": [
				{
					"metric_id": "vCPUs",
					"value": 16.0
				}
			],
			"billing_provider": "aws",
			"billing_account_id": "123456789012",
			"sla": "Premium",
			"usage": "Production",
			"event_source": "prometheus",
			"event_type": "snapshot"
		}
	}
  ]
}'
```

This will produce a new event for the specified timestamp (basic normal functionality).


The final event records should look as follows:
```
 instance_id |       timestamp        |            ?column?             |               ?column?                
-------------+------------------------+---------------------------------+---------------------------------------
 999999999   | 2026-06-03 18:00:00+00 | ["rhel-for-x86-els-payg-addon"] | {"value": 16.0, "metric_id": "vCPUs"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"] | {"value": 10.0, "metric_id": "vCPUs"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"] | {"value": -4.0, "metric_id": "vCPUs"}
 999999999   | 2026-06-03 14:00:00+00 | ["rhel-for-x86-els-payg-addon"] | {"value": 4.0, "metric_id": "vCPUs"}
(4 rows)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Changes

* **Behavior Changes / New Features**
  * Improved event normalization and flattening to enforce PAYGO eligibility, clearing non-PAYGO tags and removing unsupported tag/measurement combinations for downstream processing.
  * Added PAYGO-focused handling for service instance persistence, ensuring only PAYGO-tagged values and supported measurements are kept.
  * Continued service type conversion for “Ansible Infrastructure Hour” to “Ansible Managed Node”.

* **Tests**
  * Added/expanded unit tests for PAYGO tag and measurement filtering, service type conversion, and flattened event expansion, including mixed/edge cases.
  * Added component tests and an hourly tally test-plan section covering PAYGO vs non-PAYGO filtering, conflict resolution, and role-based tag derivation (TC007).

* **Chores / Test Maintenance**
  * Refreshed shared tally test helpers and updated tally/conflict tests to use common await/query utilities.
  * Updated conflict-resolver test constants to domain-specific values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->