### PR TITLE
SWATCH-5133: Add component tests for awsUsageContext and azureUsageContext APIs

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -343,6 +343,72 @@ Test cases should be testable locally and in an ephemeral environment.
   - HTTP 200 with empty array  
   - No errors
 
+## AWS Usage Context
+
+Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext`. Test class: `AwsUsageContextComponentTest`.
+
+**aws-usage-context-TC001** - **Get AWS usage context for an existing PAYG subscription**  
+- **Description:** Verify that `getAwsUsageContext` returns marketplace billing fields for an active AWS contract.  
+- **Setup:**  
+  - Sync offering and create an AWS ROSA contract via internal API for a known org  
+  - Note `billing_provider_id` on the created contract (`{productCode};{customerId};{sellerAccountId}`)  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext` with `orgId`, `productId=rosa`, `date` (current), `sla=Premium`, `usage=Production`, `awsAccountId` matching the contract `billing_account_id`.  
+- **Verification:** Parse response body as `AwsUsageContext`.  
+- **Expected Result:**  
+  - HTTP 200  
+  - `productCode`, `customerId`, and `awsSellerAccountId` match the semicolon-delimited `billing_provider_id` from the contract
+
+**aws-usage-context-TC002** - **AWS usage context returns 404 when no subscription matches**  
+- **Description:** Verify not-found behavior when lookup criteria do not match any AWS subscription.  
+- **Setup:** Ensure no AWS contract exists for the org/product/billing account used in the request (fresh org, no contract created).  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext` with `orgId`, `productId=rosa`, `date` (current), `sla=Premium`, `usage=Production`, and a non-existent `awsAccountId`.  
+- **Verification:** Check HTTP status and response body.  
+- **Expected Result:**  
+  - HTTP 404  
+  - Empty response body (no `code` field)
+
+**aws-usage-context-TC003** - **AWS usage context returns 404 when matched subscriptions are inactive**  
+- **Description:** Verify not-found when subscriptions match lookup criteria but none are active at the lookup date.  
+- **Setup:** Create an AWS ROSA contract, then terminate it with an end date within the lookup window (before the lookup `date`).  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext` with matching `orgId`, `productId`, `awsAccountId`, and `date` after termination.  
+- **Verification:** Check HTTP status and error body.  
+- **Expected Result:**  
+  - HTTP 404  
+  - Error code `CONTRACTS1005` (`SUBSCRIPTION_RECENTLY_TERMINATED`)
+
+## Azure Usage Context
+
+Component tests for GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext`. Test class: `AzureUsageContextComponentTest`.
+
+**azure-usage-context-TC001** - **Get Azure usage context for an existing PAYG subscription**  
+- **Description:** Verify that `getAzureMarketplaceContext` returns marketplace billing fields for an active Azure contract.  
+- **Setup:**  
+  - Sync offering and create an Azure ROSA contract via internal API for a known org  
+  - Note `billing_provider_id` on the created contract (`{azureResourceId};{planId};{offerId};…`)  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext` with `orgId`, `productId=rosa`, `date` (current), `sla=Premium`, `usage=Production`, `azureAccountId` matching the contract `billing_account_id`.  
+- **Verification:** Parse response body as `AzureUsageContext`.  
+- **Expected Result:**  
+  - HTTP 200  
+  - `azureResourceId`, `planId`, and `offerId` match the corresponding fields from `billing_provider_id`
+
+**azure-usage-context-TC002** - **Azure usage context returns 404 when no subscription matches**  
+- **Description:** Verify not-found behavior when lookup criteria do not match any Azure subscription.  
+- **Setup:** Ensure no Azure contract exists for the org/product/billing account used in the request (fresh org, no contract created).  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext` with `orgId`, `productId=rosa`, `date` (current), `sla=Premium`, `usage=Production`, and a non-existent `azureAccountId`.  
+- **Verification:** Check HTTP status and response body.  
+- **Expected Result:**  
+  - HTTP 404  
+  - Empty response body (no `code` field)
+
+**azure-usage-context-TC003** - **Azure usage context returns 404 when matched subscriptions are inactive**  
+- **Description:** Verify not-found when subscriptions match lookup criteria but none are active at the lookup date.  
+- **Setup:** Create an Azure ROSA contract, then terminate it with an end date within the lookup window (before the lookup `date`).  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext` with matching `orgId`, `productId`, `azureAccountId`, and `date` after termination.  
+- **Verification:** Check HTTP status and error body.  
+- **Expected Result:**  
+  - HTTP 404  
+  - Error code `CONTRACTS1005` (`SUBSCRIPTION_RECENTLY_TERMINATED`)
+
 ## Contract Update via Kafka
 
 **contracts-update-TC001 - Process contract update message (existing contract)**  

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -77,6 +77,10 @@ public class ContractsSwatchService extends SwatchService {
   private static final String SYNC_ALL_SUBSCRIPTIONS_ENDPOINT =
       ENDPOINT_PREFIX + "/rpc/subscriptions/sync";
   private static final String SUBSCRIPTIONS_UMB_ENDPOINT = ENDPOINT_PREFIX + "/subscriptions/umb";
+  private static final String AWS_USAGE_CONTEXT_ENDPOINT =
+      SUBSCRIPTIONS_ENDPOINT + "/awsUsageContext";
+  private static final String AZURE_USAGE_CONTEXT_ENDPOINT =
+      SUBSCRIPTIONS_ENDPOINT + "/azureUsageContext";
   private static final String SYNC_SUBSCRIPTIONS_FOR_CONTRACTS_BY_ORG_ENDPOINT =
       ENDPOINT_PREFIX + "/rpc/sync/contracts/%s/subscriptions";
   private static final String SKU_PRODUCT_TAGS_ENDPOINT =
@@ -471,6 +475,66 @@ public class ContractsSwatchService extends SwatchService {
 
     String endpoint = String.format(FORCE_RECONCILE_OFFERING_ENDPOINT, sku);
     return given().headers(SECURITY_HEADERS).when().post(endpoint);
+  }
+
+  public Response getAwsUsageContext(
+      String orgId,
+      Product product,
+      OffsetDateTime date,
+      ServiceLevelType sla,
+      UsageType usage,
+      String awsAccountId) {
+    Objects.requireNonNull(product, "product must not be null");
+    Objects.requireNonNull(date, "date must not be null");
+
+    var request =
+        given()
+            .headers(SECURITY_HEADERS)
+            .queryParam("productId", product.getName())
+            .queryParam("date", date.toString());
+    if (orgId != null) {
+      request.queryParam("orgId", orgId);
+    }
+    if (sla != null) {
+      request.queryParam("sla", sla);
+    }
+    if (usage != null) {
+      request.queryParam("usage", usage);
+    }
+    if (awsAccountId != null) {
+      request.queryParam("awsAccountId", awsAccountId);
+    }
+    return request.when().get(AWS_USAGE_CONTEXT_ENDPOINT);
+  }
+
+  public Response getAzureMarketplaceContext(
+      String orgId,
+      Product product,
+      OffsetDateTime date,
+      ServiceLevelType sla,
+      UsageType usage,
+      String azureAccountId) {
+    Objects.requireNonNull(product, "product must not be null");
+    Objects.requireNonNull(date, "date must not be null");
+
+    var request =
+        given()
+            .headers(SECURITY_HEADERS)
+            .queryParam("productId", product.getName())
+            .queryParam("date", date.toString());
+    if (orgId != null) {
+      request.queryParam("orgId", orgId);
+    }
+    if (sla != null) {
+      request.queryParam("sla", sla);
+    }
+    if (usage != null) {
+      request.queryParam("usage", usage);
+    }
+    if (azureAccountId != null) {
+      request.queryParam("azureAccountId", azureAccountId);
+    }
+    return request.when().get(AZURE_USAGE_CONTEXT_ENDPOINT);
   }
 
   private List<com.redhat.swatch.contract.test.model.Contract> getContracts(

--- a/swatch-contracts/ct/java/domain/ErrorCodes.java
+++ b/swatch-contracts/ct/java/domain/ErrorCodes.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package domain;
+
+public final class ErrorCodes {
+
+  public static final String SUBSCRIPTION_RECENTLY_TERMINATED_CODE = "CONTRACTS1005";
+
+  private ErrorCodes() {}
+}

--- a/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
+++ b/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static domain.ErrorCodes.SUBSCRIPTION_RECENTLY_TERMINATED_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.contract.test.model.AwsUsageContext;
+import com.redhat.swatch.contract.test.model.ServiceLevelType;
+import com.redhat.swatch.contract.test.model.UsageType;
+import domain.Contract;
+import domain.Product;
+import io.restassured.response.Response;
+import java.time.OffsetDateTime;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+public class AwsUsageContextComponentTest extends BaseContractComponentTest {
+
+  @TestPlanName("aws-usage-context-TC001")
+  @Test
+  void shouldReturnAwsUsageContextForExistingContract() {
+    Contract contract = givenRosaContractIsCreated(10.0);
+
+    AwsUsageContext usageContext =
+        whenGetAwsMarketplaceContext(contract.getBillingAccountId())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(AwsUsageContext.class);
+
+    assertEquals(
+        contract.getProductCode(),
+        usageContext.getProductCode(),
+        "productCode should match billing_provider_id");
+    assertEquals(
+        contract.getCustomerId(),
+        usageContext.getCustomerId(),
+        "customerId should match billing_provider_id");
+    assertEquals(
+        contract.getSellerAccountId(),
+        usageContext.getAwsSellerAccountId(),
+        "awsSellerAccountId should match billing_provider_id");
+  }
+
+  @TestPlanName("aws-usage-context-TC002")
+  @Test
+  void shouldReturn404WhenAwsUsageContextNotFound() {
+    Response response = whenGetAwsMarketplaceContext("nonexistent-billing-account");
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND,
+        response.statusCode(),
+        "AWS usage context lookup should return 404 when no subscription matches");
+    assertTrue(
+        response.body().asString().isBlank(),
+        "Missing subscription should return 404 without an error body");
+  }
+
+  @TestPlanName("aws-usage-context-TC003")
+  @Test
+  void shouldReturn404WhenAwsUsageContextHasInactiveSubs() {
+    Contract contract = givenRosaContractIsTerminated();
+
+    Response response = whenGetAwsMarketplaceContext(contract.getBillingAccountId());
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND,
+        response.statusCode(),
+        "AWS usage context lookup should return 404 when no active subscription matches");
+    assertEquals(
+        SUBSCRIPTION_RECENTLY_TERMINATED_CODE,
+        response.jsonPath().getString("code"),
+        "Inactive subscription should return " + SUBSCRIPTION_RECENTLY_TERMINATED_CODE);
+  }
+
+  private Contract givenRosaContractIsTerminated() {
+    Contract contract = givenRosaContractIsCreated(10.0);
+    OffsetDateTime terminationDate = OffsetDateTime.now().minusMinutes(30);
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.terminateSubscription(contract, terminationDate).statusCode(),
+        "Contract termination should succeed");
+    return contract;
+  }
+
+  private Response whenGetAwsMarketplaceContext(String billingAccountId) {
+    return service.getAwsUsageContext(
+        orgId,
+        Product.ROSA,
+        OffsetDateTime.now(),
+        ServiceLevelType.PREMIUM,
+        UsageType.PRODUCTION,
+        billingAccountId);
+  }
+}

--- a/swatch-contracts/ct/java/tests/AzureUsageContextComponentTest.java
+++ b/swatch-contracts/ct/java/tests/AzureUsageContextComponentTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static domain.ErrorCodes.SUBSCRIPTION_RECENTLY_TERMINATED_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.AzureUsageContext;
+import com.redhat.swatch.contract.test.model.ServiceLevelType;
+import com.redhat.swatch.contract.test.model.UsageType;
+import domain.BillingProvider;
+import domain.Contract;
+import domain.Product;
+import io.restassured.response.Response;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+public class AzureUsageContextComponentTest extends BaseContractComponentTest {
+
+  @TestPlanName("azure-usage-context-TC001")
+  @Test
+  void shouldReturnAzureUsageContextForExistingContract() {
+    Contract contract = givenExistingRosaContract();
+
+    var usageContext =
+        whenGetAzureMarketplaceContext(contract.getBillingAccountId())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(AzureUsageContext.class);
+
+    assertEquals(
+        contract.getResourceId(),
+        usageContext.getAzureResourceId(),
+        "azureResourceId should match billing_provider_id");
+    assertEquals(
+        contract.getPlanId(), usageContext.getPlanId(), "planId should match billing_provider_id");
+    assertEquals(
+        contract.getProductCode(),
+        usageContext.getOfferId(),
+        "offerId should match billing_provider_id");
+  }
+
+  @TestPlanName("azure-usage-context-TC002")
+  @Test
+  void shouldReturn404WhenAzureUsageContextNotFound() {
+    Response response = whenGetAzureMarketplaceContext("nonexistent-billing-account");
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND,
+        response.statusCode(),
+        "Azure usage context lookup should return 404 when no subscription matches");
+    assertTrue(
+        response.body().asString().isBlank(),
+        "Missing subscription should return 404 without an error body");
+  }
+
+  @TestPlanName("azure-usage-context-TC003")
+  @Test
+  void shouldReturn404WhenAzureUsageContextHasInactiveSubs() {
+    Contract contract = givenExistingRosaContractTerminated();
+
+    Response response = whenGetAzureMarketplaceContext(contract.getBillingAccountId());
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND,
+        response.statusCode(),
+        "Azure usage context lookup should return 404 when no active subscription matches");
+    assertEquals(
+        SUBSCRIPTION_RECENTLY_TERMINATED_CODE,
+        response.jsonPath().getString("code"),
+        "Inactive subscription should return " + SUBSCRIPTION_RECENTLY_TERMINATED_CODE);
+  }
+
+  private Contract givenExistingRosaContract() {
+    String sku = RandomUtils.generateRandom();
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AZURE, Map.of(CORES, 10.0), sku);
+    givenContractIsCreated(contract);
+    return contract;
+  }
+
+  private Contract givenExistingRosaContractTerminated() {
+    Contract contract = givenExistingRosaContract();
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.terminateSubscription(contract, OffsetDateTime.now().minusMinutes(30)).statusCode(),
+        "Contract termination should succeed");
+    return contract;
+  }
+
+  private Response whenGetAzureMarketplaceContext(String azureAccountId) {
+    return service.getAzureMarketplaceContext(
+        orgId,
+        Product.ROSA,
+        OffsetDateTime.now(),
+        ServiceLevelType.PREMIUM,
+        UsageType.PRODUCTION,
+        azureAccountId);
+  }
+}

--- a/swatch-contracts/ct/java/utils/AzureContractRequestMapper.java
+++ b/swatch-contracts/ct/java/utils/AzureContractRequestMapper.java
@@ -40,7 +40,8 @@ public class AzureContractRequestMapper extends ContractRequestMapper {
   protected PartnerIdentityV1 buildPartnerIdentities(Contract contract) {
     return new PartnerIdentityV1()
         .azureCustomerId(contract.getCustomerId())
-        .clientId(contract.getClientId());
+        .clientId(contract.getClientId())
+        .azureSubscriptionId(contract.getBillingAccountId());
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/DefaultExceptionMapper.java
@@ -42,10 +42,14 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception> {
 
   @Override
   public Response toResponse(Exception exception) {
-    if (!(exception instanceof UsageContextSubscriptionNotFoundException)) {
-      log.error(
-          "Request '{}' failed with error '{}'", info.getPath(), exception.getMessage(), exception);
+    // Usage-context subscription misses are expected; do not log them at ERROR here.
+    if (exception instanceof UsageContextSubscriptionNotFoundException e) {
+      return e.getResponse();
     }
+
+    // Proceed with the rest of unexpected exceptions
+    log.error(
+        "Request '{}' failed with error '{}'", info.getPath(), exception.getMessage(), exception);
     if (exception instanceof ServiceException e) {
       return Response.status(e.getStatus()).entity(e.error()).build();
     } else if (exception instanceof ClientErrorException clientErrorException) {


### PR DESCRIPTION
Jira issue: SWATCH-5133

## Description
Add component test coverage for the AWS and Azure marketplace usage context endpoints in swatch-contracts. New AwsUsageContextComponentTest and AzureUsageContextComponentTest exercise happy-path lookup, 404 when no subscription matches (empty body), and 404 with CONTRACTS1005 when the matched subscription is inactive after termination. ContractsSwatchService gains getAwsUsageContext and getAzureMarketplaceContext helpers, TEST_PLAN.md documents the six new cases, and AzureContractRequestMapper now sets azureSubscriptionId so Azure contracts persist billing_account_id correctly.

DefaultExceptionMapper returns early for UsageContextSubscriptionNotFoundException without ERROR logging, with a short comment clarifying that missing usage-context subscriptions are expected.

## Testing
IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1542
- aws-usage-context-TC001 was migrated from `test_get_aws_usage_context`
- azure-usage-context-TC001 was migrated from `test_get_azure_usage_context`
- aws-usage-context-TC002 and azure-usage-context-TC002 to cover when there are no subscriptions
- aws-usage-context-TC003 and azure-usage-context-TC003 to cover when there are no active subscriptions




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AWS usage context endpoints: New REST services enable retrieval of PAYG contract information with automatic active subscription status validation
  * Azure usage context endpoints: New REST services enable retrieval of marketplace contract information with automatic active subscription status validation
  * Enhanced error handling: Improved error responses with specific error codes and messaging when subscriptions have been recently terminated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->