### PR TITLE
SWATCH-4504: Reduce ephemeral deployment time for Konflux IQE tests

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -73,10 +73,11 @@ spec:
     - name: EXTRA_DEPLOY_ARGS
       type: string
       description: Extra arguments for the deployment
-      # Skip not required components:
-      # - puptoo: insights-puptoo is the service that processes Ingress flow uploads
+      # Skip platform upload pipeline (not used by IQE clowder_smoke).
       default: >-
-        --timeout 1800 --remove-dependencies ingress/puptoo
+        --timeout 1800
+        --exclude-components puptoo,ingress,storage-broker
+        --remove-dependencies host-inventory/ingress
     - name: DEPLOY_FRONTENDS
       type: string
       description: Deploy frontend in the env or not

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -37,9 +37,12 @@ spec:
     - name: COMPONENTS_W_RESOURCES
       value: "app:rhsm app:export-service"
     
-    # Deployment configuration
+    # Deployment configuration (keep in sync with bonfire-integration-tests-pipeline.yaml)
     - name: EXTRA_DEPLOY_ARGS
-      value: "--timeout 1800"
+      value: >-
+        --timeout 1800
+        --exclude-components puptoo,ingress,storage-broker
+        --remove-dependencies host-inventory/ingress
     - name: DEPLOY_FRONTENDS
       value: "false"
     - name: DEPLOY_TIMEOUT

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -112,3 +112,25 @@ objects:
       password: ZHVtbXktcGFzc3dvcmQ=
       # dummy-web-name:dummy-web-client:13345
       servers: ZHVtbXktd2ViLW5hbWU6ZHVtbXktd2ViLWNsaWVudDoxMzM0NQ==
+
+  # Placeholder cdappconfig for Clowder/IQE: ingress is excluded from ephemeral deploy
+  # but Clowder still expects this secret when reconciling the rhsm ClowdJobInvocation.
+  # IQE does not use the upload pipeline in clowder_smoke.
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ingress
+    type: Opaque
+    stringData:
+      cdappconfig.json: >-
+        {"logging":{"type":"null","cloudwatch":{"accessKeyId":"","logGroup":"","region":"","secretAccessKey":""}},"metricsPath":"/metrics","metricsPort":9000,"privatePort":10000,"publicPort":8000,"webPort":8000,"dependencyEndpoints":{"v2":{}},"endpoints":[],"metadata":{"envName":"${ENV_NAME}","name":"ingress"}}
+
+  # Same as ingress above: required dependency secret only; storage-broker is not deployed.
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: storage-broker
+    type: Opaque
+    stringData:
+      cdappconfig.json: >-
+        {"logging":{"type":"null","cloudwatch":{"accessKeyId":"","logGroup":"","region":"","secretAccessKey":""}},"metricsPath":"/metrics","metricsPort":9000,"privatePort":10000,"publicPort":8000,"webPort":8000,"dependencyEndpoints":{"v2":{}},"endpoints":[],"metadata":{"envName":"${ENV_NAME}","name":"storage-broker"}}


### PR DESCRIPTION
Jira issue: [SWATCH-4504](https://redhat.atlassian.net/browse/SWATCH-4504)

## Summary

Changes to reduce `deploy-application` time in the bonfire integration pipeline by excluding platform components not needed for IQE `clowder_smoke` / `ephemeral` marker tests.

- **`EXTRA_DEPLOY_ARGS`**: `--exclude-components puptoo,ingress,storage-broker` + `--remove-dependencies host-inventory/ingress`

Ephemeral experiments showed ~5 min to `swatch-api` ready vs ~11.5 min Konflux baseline (**~57%** on critical path).

[SWATCH-4504]: https://redhat.atlassian.net/browse/SWATCH-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ