### PR TITLE
Update dependencies: AWS SDK, Jackson, OkHttp, OpenTelemetry, RESTEasy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,16 +21,16 @@
     <!-- Dependencies -->
     <quarkus.platform.version>3.36.2</quarkus.platform.version>
     <spring.boot.version>4.0.6</spring.boot.version>
-    <resteasy.version>7.0.0.Final</resteasy.version>
+    <resteasy.version>7.0.2.Final</resteasy.version>
     <!-- Only use as provided in the common dependencies.
     Spring and Quarkus already provides the compatible Jackson versions -->
-    <jackson.version>2.21.4</jackson.version>
+    <jackson.version>2.22.0</jackson.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <slf4j.version>2.0.18</slf4j.version>
     <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
     <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-    <opentelemetry-api.version>1.62.0</opentelemetry-api.version>
-    <awssdk-bom.version>2.46.3</awssdk-bom.version>
+    <opentelemetry-api.version>1.63.0</opentelemetry-api.version>
+    <awssdk-bom.version>2.46.4</awssdk-bom.version>
     <guava.version>33.6.0-jre</guava.version>
     <liquibase.version>5.0.3</liquibase.version>
     <postgresql.version>42.7.11</postgresql.version>
@@ -269,7 +269,7 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
-        <version>4.12.0</version>
+        <version>5.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Update dependencies: AWS SDK, Jackson, OkHttp, OpenTelemetry, RESTEasy

Consolidate dependency bumps from PRs #6232, #6233, #6234, #6236, #6237:
- software.amazon.awssdk:bom 2.46.3 -> 2.46.4
- jackson monorepo -> 2.22.0
- com.squareup.okhttp3:okhttp -> v5
- io.opentelemetry:opentelemetry-api -> 1.63.0
- resteasy.version -> 7.0.2.Final

Reverted jsonschema2pojo 1.3.3 bump (from #6239) — 1.3.3 generates
invalid `@Valid` type-use annotations on `String` type arguments in
collections (e.g. `List<@Valid java.lang.String>`), causing compilation
failures.

<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
Consolidate Dependabot dependency bumps into a single PR. Dropped the
jsonschema2pojo 1.3.2 → 1.3.3 upgrade because 1.3.3 introduced a code
generation bug that produces uncompilable Java.

## Testing

```
./mvnw clean package -DskipTests
./mvnw spotless:check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several managed libraries and a pinned HTTP client version to newer releases, which may improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->