### PR TITLE
SWATCH-5049: Link public API docs to console Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,8 +771,8 @@ going to `Dashboards -> +Import` from the left nav.
 
 Links to Swagger UI and API specs:
 
-* Customer-facing **v1** API — [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) · [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) · [petstore][customer-v1-api] · [source](api/rhsm-subscriptions-api-v1-spec.yaml)
-* Customer-facing **v2** API — [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) · [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) · [petstore][customer-v2-api] · [source](api/rhsm-subscriptions-api-v2-spec.yaml)
+* Customer-facing **v1** API — [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) · [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) · [source](api/rhsm-subscriptions-api-v1-spec.yaml)
+* Customer-facing **v2** API — [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) · [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) · [source](api/rhsm-subscriptions-api-v2-spec.yaml)
 * [Internal Billing Producer API][billing-api]
   ([source](swatch-billable-usage/src/main/resources/META-INF/openapi.yaml))
 * [Internal Metering API][metering-api]
@@ -788,8 +788,6 @@ Links to Swagger UI and API specs:
 * [Internal System Conduit API][conduit-api]
   ([source](swatch-system-conduit/src/main/spec/internal-organizations-sync-api-spec.yaml))
 
-[customer-v1-api]:    https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/api/rhsm-subscriptions-api-v1-spec.yaml
-[customer-v2-api]:    https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/api/rhsm-subscriptions-api-v2-spec.yaml
 [billing-api]:        https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
 [metering-api]:       https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/swatch-metrics/src/main/resources/META-INF/openapi.yaml
 [tally-api]:          https://petstore.swagger.io/?url=https://raw.githubusercontent.com/RedHatInsights/rhsm-subscriptions/main/src/main/spec/internal-tally-api-spec.yaml

--- a/README.md
+++ b/README.md
@@ -771,10 +771,8 @@ going to `Dashboards -> +Import` from the left nav.
 
 Links to Swagger UI and API specs:
 
-* [Customer-facing v1 API][customer-v1-api]
-  ([source](api/rhsm-subscriptions-api-v1-spec.yaml))
-* [Customer-facing v2 API][customer-v2-api]
-  ([source](api/rhsm-subscriptions-api-v2-spec.yaml))
+* Customer-facing **v1** API — [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) · [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) · [petstore][customer-v1-api] · [source](api/rhsm-subscriptions-api-v1-spec.yaml)
+* Customer-facing **v2** API — [console (stage)](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) · [console (prod)](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) · [petstore][customer-v2-api] · [source](api/rhsm-subscriptions-api-v2-spec.yaml)
 * [Internal Billing Producer API][billing-api]
   ([source](swatch-billable-usage/src/main/resources/META-INF/openapi.yaml))
 * [Internal Metering API][metering-api]

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,14 +1,19 @@
 # API Documentation
 
-Our API is documented in the [Red Hat API
-catalog](https://developers.redhat.com/api-catalog/).  The information there
-comes from our OpenAPI specification.
+Customer-facing API documentation on the Hybrid Cloud Console:
 
-The API catalog has
-[code](https://github.com/RedHatInsights/api-documentation-frontend) to
-transform a [YAML
-document](https://github.com/RedHatInsights/api-documentation-frontend/blob/main/packages/discovery/Discovery.yml)
-into the displayed HTML.
+| Version | Stage | Production |
+|---------|-------|------------|
+| **v2** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) (when v2 is deployed) |
+| **v1** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) |
+
+OpenAPI JSON (no console login): `https://{console-host}/api/rhsm-subscriptions/v{1,2}/openapi.json`
+
+Our API is also listed in the [Red Hat API
+catalog](https://developers.redhat.com/api-catalog/). The catalog uses our
+OpenAPI specification via
+[api-documentation-frontend](https://github.com/RedHatInsights/api-documentation-frontend)
+and [Discovery.yml](https://github.com/RedHatInsights/api-documentation-frontend/blob/main/packages/discovery/Discovery.yml).
 
 Locally, the API is served from `/api-docs/` for Spring and
 `/q/dev-ui/io.quarkus.quarkus-smallrye-openapi/swagger-ui` for Quarkus.

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -4,8 +4,8 @@ Customer-facing API documentation on the Hybrid Cloud Console:
 
 | Version | Stage | Production |
 |---------|-------|------------|
-| **v2** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) |
 | **v1** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) |
+| **v2** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) |
 
 OpenAPI JSON (no console login): `https://{console-host}/api/rhsm-subscriptions/v{1,2}/openapi.json`
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -4,16 +4,19 @@ Customer-facing API documentation on the Hybrid Cloud Console:
 
 | Version | Stage | Production |
 |---------|-------|------------|
-| **v2** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) (when v2 is deployed) |
+| **v2** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v2) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v2) |
 | **v1** | [Swagger UI](https://console.stage.redhat.com/docs/api/rhsm-subscriptions/v1) | [Swagger UI](https://console.redhat.com/docs/api/rhsm-subscriptions/v1) |
 
 OpenAPI JSON (no console login): `https://{console-host}/api/rhsm-subscriptions/v{1,2}/openapi.json`
 
-Our API is also listed in the [Red Hat API
-catalog](https://developers.redhat.com/api-catalog/). The catalog uses our
-OpenAPI specification via
-[api-documentation-frontend](https://github.com/RedHatInsights/api-documentation-frontend)
-and [Discovery.yml](https://github.com/RedHatInsights/api-documentation-frontend/blob/main/packages/discovery/Discovery.yml).
+Our API is also listed on the [Red Hat API
+catalog](https://developers.redhat.com/api-catalog/). That site is built by
+[api-documentation-frontend](https://github.com/RedHatInsights/api-documentation-frontend),
+which registers RHSM in
+[Discovery.yml](https://github.com/RedHatInsights/api-documentation-frontend/blob/main/packages/discovery/Discovery.yml)
+and pulls the live spec from
+`https://console.redhat.com/api/rhsm-subscriptions/v{1,2}/openapi.json` at
+build time.
 
 Locally, the API is served from `/api-docs/` for Spring and
 `/q/dev-ui/io.quarkus.quarkus-smallrye-openapi/swagger-ui` for Quarkus.


### PR DESCRIPTION
## Summary

- Update `docs/api-documentation.md` with Hybrid Cloud Console Swagger links for v1/v2 (stage and prod).
- Update README APIs section to list console docs alongside petstore and source YAML.

## Test plan

- [ ] Links resolve on stage (`console.stage.redhat.com/docs/api/rhsm-subscriptions/v2`)
- [ ] Prod v1 link works; prod v2 note reflects deploy status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation with clearer customer-facing links for both v1 and v2, including prod and stage access.
  * Added direct references to the API specification locations and improved guidance on where to find the live API catalog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->