### PR TITLE
swatch-5068: Add feature flag to the IT Subscription Service Kafka/UMB Consumers

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -869,6 +869,7 @@ This section verifies the automatic contract termination behavior when contracts
 - **Description**: Verify subscription creation via UMB XML message.  
 - **Setup**:  
   - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish message to `VirtualTopic.canonical.subscription` channel
 - **Verification**:  
@@ -884,6 +885,9 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-creation-TC002 - Process UMB subscription with AWS external references**  
 - **Description**: Verify AWS marketplace subscription data extraction from UMB.  
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish message to `VirtualTopic.canonical.subscription` channel  
 - **Verification**: Query subscription and check AWS fields  
@@ -895,6 +899,9 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-creation-TC003 - Process UMB subscription with Azure external references**  
 - **Description**: Verify Azure marketplace subscription data from UMB.  
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish message to `SUBSCRIPTION_SYNC_TASK_UMB` Kafka topic  
 - **Verification**: Check Azure-specific fields  
@@ -903,6 +910,9 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-creation-TC004 - Process malformed UMB XML message**  
 - **Description**: Verify error handling for invalid XML.  
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish malformed UMB XML message to `VirtualTopic.canonical.subscription` channel  
 - **Verification**: Subscription not created  
@@ -913,6 +923,9 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-creation-TC005 - Process UMB message with missing required fields**  
 - **Description**: Verify validation for incomplete subscription data.  
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish the UMB message with missing required fields to `VirtualTopic.canonical.subscription` channel  
 - **Verification**: Check for validation errors  
@@ -924,6 +937,8 @@ This section verifies the automatic contract termination behavior when contracts
 **subscriptions-creation-TC006 - Process subscription update via UMB**  
 - **Description**: Verify subscription updates through messaging.  
 - **Setup**:  
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
   - Send initial subscription message  
   - Send an update with a different quantity or dates  
 - **Action**: Publish initial message, then update the message  
@@ -936,6 +951,9 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-creation-TC007 - Process terminated subscription via UMB**  
 - **Description**: Verify subscription termination messages.  
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Ensure Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled (UMB subscription consumer from IT Subscription Service)
 - **Action**:  
   - Publish message to `VirtualTopic.canonical.subscription` channel  
   - Update the end date to the current timestamp  

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -28,6 +28,8 @@ public class ContractsUnleashService extends UnleashService {
 
   public static final String PARTNER_GATEWAY_CONTRACTS =
       "swatch.swatch-contracts.enable-partner-gateway-contracts";
+  public static final String IT_SUBSCRIPTION_SERVICE =
+      "swatch.swatch-contracts.enable-it-subscription-service";
 
   public void enablePartnerGatewayContracts() {
     enableFlag(PARTNER_GATEWAY_CONTRACTS);
@@ -37,6 +39,17 @@ public class ContractsUnleashService extends UnleashService {
         AwaitilitySettings.defaults()
             .timeoutMessage(
                 "Unleash toggle '%s' should be enabled".formatted(PARTNER_GATEWAY_CONTRACTS)));
+    waitForUnleashPropagation();
+  }
+
+  public void enableItSubscriptionService() {
+    enableFlag(IT_SUBSCRIPTION_SERVICE);
+    AwaitilityUtils.until(
+        () -> isFlagEnabled(IT_SUBSCRIPTION_SERVICE),
+        enabled -> enabled,
+        AwaitilitySettings.defaults()
+            .timeoutMessage(
+                "Unleash toggle '%s' should be enabled".formatted(IT_SUBSCRIPTION_SERVICE)));
     waitForUnleashPropagation();
   }
 
@@ -55,5 +68,9 @@ public class ContractsUnleashService extends UnleashService {
 
   public void disablePartnerGatewayContracts() {
     disableFlag(PARTNER_GATEWAY_CONTRACTS);
+  }
+
+  public void disableItSubscriptionService() {
+    disableFlag(IT_SUBSCRIPTION_SERVICE);
   }
 }

--- a/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
@@ -50,6 +50,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +61,11 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
   @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
 
   private String sku;
+
+  @BeforeAll
+  static void enableItSubscriptionServiceFeatureFlag() {
+    unleash.enableItSubscriptionService();
+  }
 
   @BeforeEach
   void setUp() {

--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -348,6 +348,7 @@
                 <sourcePath>subscriptions_export_json_item.yaml</sourcePath>
                 <sourcePath>subscriptions_export_json_measurement.yaml</sourcePath>
                 <sourcePath>enable_partner_gateway_contracts_variant_payload.yaml</sourcePath>
+                <sourcePath>it_subscription_service_feature_flag_variant_payload.yaml</sourcePath>
               </sourcePaths>
             </configuration>
           </execution>

--- a/swatch-contracts/schemas/it_subscription_service_feature_flag_variant_payload.yaml
+++ b/swatch-contracts/schemas/it_subscription_service_feature_flag_variant_payload.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: ItSubscriptionServiceFeatureFlagVariantPayload
+description: JSON payload for the enable-it-subscription-service feature toggle variant.
+type: object
+properties:
+  kafka_consumer_enabled:
+    description: If the kafka consumer is enabled.
+    type: boolean
+    default: false
+  umb_consumer_enabled:
+    description: If the UMB consumer is enabled.
+    type: boolean
+    default: true

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.model.ItSubscriptionServiceFeatureFlagVariantPayload;
 import com.redhat.swatch.contract.model.PartnerGatewayContractsFeatureFlagVariantPayload;
 import io.getunleash.Unleash;
 import io.getunleash.variant.Variant;
@@ -37,6 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 public class FeatureFlags {
   public static final String PARTNER_GATEWAY_CONTRACTS =
       "swatch.swatch-contracts.enable-partner-gateway-contracts";
+  public static final String IT_SUBSCRIPTION_SERVICE =
+      "swatch.swatch-contracts.enable-it-subscription-service";
   public static final String CONFIG_VARIANT = "config";
 
   protected static final boolean DEFAULT_IS_ENABLED = true;
@@ -46,18 +49,40 @@ public class FeatureFlags {
 
   /** Whether the Kafka consumer for partner-gateway contracts is allowed. */
   public boolean isPartnerGatewayContractsKafkaConsumerEnabled() {
-    return isPartnerGatewayContractsEnabled(
+    return isFeatureFlagEnabled(
+        PARTNER_GATEWAY_CONTRACTS,
+        this::mapToPartnerGatewayContractsPayload,
         PartnerGatewayContractsFeatureFlagVariantPayload::getKafkaConsumerEnabled);
   }
 
   /** Whether the UMB consumer for partner-gateway contracts is allowed. */
   public boolean isPartnerGatewayContractsUmbConsumerEnabled() {
-    return isPartnerGatewayContractsEnabled(
+    return isFeatureFlagEnabled(
+        PARTNER_GATEWAY_CONTRACTS,
+        this::mapToPartnerGatewayContractsPayload,
         PartnerGatewayContractsFeatureFlagVariantPayload::getUmbConsumerEnabled);
   }
 
+  /** Whether the Kafka consumer for IT Subscription Service is allowed. */
+  public boolean isItSubscriptionServiceKafkaConsumerEnabled() {
+    return isFeatureFlagEnabled(
+        IT_SUBSCRIPTION_SERVICE,
+        this::mapToItSubscriptionServicePayload,
+        ItSubscriptionServiceFeatureFlagVariantPayload::getKafkaConsumerEnabled);
+  }
+
+  /** Whether the UMB consumer for IT Subscription Service is allowed. */
+  public boolean isItSubscriptionServiceUmbConsumerEnabled() {
+    return isFeatureFlagEnabled(
+        IT_SUBSCRIPTION_SERVICE,
+        this::mapToItSubscriptionServicePayload,
+        ItSubscriptionServiceFeatureFlagVariantPayload::getUmbConsumerEnabled);
+  }
+
   /**
-   * If {@value #PARTNER_GATEWAY_CONTRACTS} is disabled, returns {@code false}.
+   * Generic feature flag evaluation logic.
+   *
+   * <p>If the feature flag is disabled, returns {@code false}.
    *
    * <p>If the toggle is enabled and Unleash returns a variant whose name is not {@value
    * #CONFIG_VARIANT}, returns {@code true} (no structured payload to interpret).
@@ -69,15 +94,17 @@ public class FeatureFlags {
    * JSON; this method returns the consumer_enabled flag from that object. Missing payload, invalid
    * JSON, or a null/false flag yields {@code true}.
    */
-  private boolean isPartnerGatewayContractsEnabled(
-      Function<PartnerGatewayContractsFeatureFlagVariantPayload, Boolean> condition) {
-    if (!unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)) {
+  private <T> boolean isFeatureFlagEnabled(
+      String featureFlagName,
+      Function<Variant, Optional<T>> payloadMapper,
+      Function<T, Boolean> condition) {
+    if (!unleash.isEnabled(featureFlagName, DEFAULT_IS_ENABLED)) {
       return false;
     }
 
-    Variant variant = unleash.getVariant(PARTNER_GATEWAY_CONTRACTS);
+    Variant variant = unleash.getVariant(featureFlagName);
     if (!CONFIG_VARIANT.equals(variant.getName())) {
-      log.debug("Feature flag '{}' with no valid variant '{}'", PARTNER_GATEWAY_CONTRACTS, variant);
+      log.debug("Feature flag '{}' with no valid variant '{}'", featureFlagName, variant);
       return true;
     }
 
@@ -85,11 +112,23 @@ public class FeatureFlags {
       return true;
     }
 
-    return mapToPartnerGatewayContractsPayload(variant).map(condition).orElse(true);
+    return payloadMapper.apply(variant).map(condition).orElse(true);
   }
 
   private Optional<PartnerGatewayContractsFeatureFlagVariantPayload>
       mapToPartnerGatewayContractsPayload(Variant variant) {
+    return mapToPayload(
+        variant, PartnerGatewayContractsFeatureFlagVariantPayload.class, PARTNER_GATEWAY_CONTRACTS);
+  }
+
+  private Optional<ItSubscriptionServiceFeatureFlagVariantPayload>
+      mapToItSubscriptionServicePayload(Variant variant) {
+    return mapToPayload(
+        variant, ItSubscriptionServiceFeatureFlagVariantPayload.class, IT_SUBSCRIPTION_SERVICE);
+  }
+
+  private <T> Optional<T> mapToPayload(
+      Variant variant, Class<T> payloadClass, String featureFlagName) {
     var payload = variant.getPayload();
     if (payload.isEmpty()) {
       return Optional.empty();
@@ -97,13 +136,12 @@ public class FeatureFlags {
 
     String payloadValue = payload.get().getValue();
     try {
-      return Optional.ofNullable(
-          mapper.readValue(payloadValue, PartnerGatewayContractsFeatureFlagVariantPayload.class));
+      return Optional.ofNullable(mapper.readValue(payloadValue, payloadClass));
     } catch (JsonProcessingException e) {
       log.warn(
           "Failed to parse the payload '{}' for feature flag '{}'",
           payloadValue,
-          PARTNER_GATEWAY_CONTRACTS,
+          featureFlagName,
           e);
       return Optional.empty();
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
@@ -23,16 +23,20 @@ package com.redhat.swatch.contract.service;
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.product.umb.CanonicalMessage;
 import com.redhat.swatch.contract.product.umb.UmbSubscription;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
 @ApplicationScoped
 @Slf4j
 public class SubscriptionKafkaMessageConsumer {
+
+  @Inject FeatureFlags featureFlags;
 
   private final XmlMapper xmlMapper = CanonicalMessage.createMapper();
 
@@ -41,6 +45,10 @@ public class SubscriptionKafkaMessageConsumer {
   public void consumeFromKafka(String subscriptionMessageXml) {
     log.debug("IT Subscription Kafka consumer was called");
     if (subscriptionMessageXml == null) {
+      return;
+    }
+    if (!featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()) {
+      log.debug("IT Subscription Kafka consumer is disabled by feature flag.");
       return;
     }
     consumeSubscription(subscriptionMessageXml);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumer.java
@@ -25,6 +25,7 @@ import static com.redhat.swatch.contract.config.Channels.SUBSCRIPTION_SYNC_TASK_
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.model.EnabledOrgsResponse;
 import com.redhat.swatch.contract.product.umb.CanonicalMessage;
 import com.redhat.swatch.contract.product.umb.UmbSubscription;
@@ -41,11 +42,15 @@ public class SubscriptionSyncTaskConsumer {
   private final SubscriptionSyncService service;
   private final boolean umbEnabled;
   private final XmlMapper xmlMapper;
+  private final FeatureFlags featureFlags;
 
   public SubscriptionSyncTaskConsumer(
-      SubscriptionSyncService service, @ConfigProperty(name = "UMB_ENABLED") boolean umbEnabled) {
+      SubscriptionSyncService service,
+      @ConfigProperty(name = "UMB_ENABLED") boolean umbEnabled,
+      FeatureFlags featureFlags) {
     this.service = service;
     this.umbEnabled = umbEnabled;
+    this.featureFlags = featureFlags;
     this.xmlMapper = CanonicalMessage.createMapper();
   }
 
@@ -61,6 +66,10 @@ public class SubscriptionSyncTaskConsumer {
   public void consumeFromUmb(String subscriptionMessageXml) throws JsonProcessingException {
     if (!umbEnabled) {
       log.debug("UMB processing is not enabled");
+      return;
+    }
+    if (!featureFlags.isItSubscriptionServiceUmbConsumerEnabled()) {
+      log.debug("IT Subscription UMB consumer is disabled by feature flag.");
       return;
     }
     CanonicalMessage subscriptionMessage =

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.config;
 
 import static com.redhat.swatch.contract.config.FeatureFlags.CONFIG_VARIANT;
 import static com.redhat.swatch.contract.config.FeatureFlags.DEFAULT_IS_ENABLED;
+import static com.redhat.swatch.contract.config.FeatureFlags.IT_SUBSCRIPTION_SERVICE;
 import static com.redhat.swatch.contract.config.FeatureFlags.PARTNER_GATEWAY_CONTRACTS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -186,5 +187,46 @@ class FeatureFlagsTest {
   private void givenPartnerGatewayContractsEnabledWithVariant(Variant variant) {
     when(unleash.isEnabled(PARTNER_GATEWAY_CONTRACTS, DEFAULT_IS_ENABLED)).thenReturn(true);
     when(unleash.getVariant(PARTNER_GATEWAY_CONTRACTS)).thenReturn(variant);
+  }
+
+  @Test
+  void shouldReturnFalse_whenItSubscriptionServiceDisabled() {
+    when(unleash.isEnabled(IT_SUBSCRIPTION_SERVICE, DEFAULT_IS_ENABLED)).thenReturn(false);
+
+    assertFalse(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled());
+    assertFalse(featureFlags.isItSubscriptionServiceUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldRespectItSubscriptionServiceKafkaConsumerFlag() {
+    givenItSubscriptionServiceEnabledWithConfigPayload("{\"kafka_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldRespectItSubscriptionServiceUmbConsumerFlag() {
+    givenItSubscriptionServiceEnabledWithConfigPayload("{\"umb_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isItSubscriptionServiceUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldDecoupleKafkaAndUmbForItSubscriptionService() {
+    givenItSubscriptionServiceEnabledWithConfigPayload(
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
+
+    assertFalse(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled());
+    assertTrue(featureFlags.isItSubscriptionServiceUmbConsumerEnabled());
+  }
+
+  private void givenItSubscriptionServiceEnabledWithConfigPayload(String json) {
+    givenItSubscriptionServiceEnabledWithVariant(
+        new Variant(CONFIG_VARIANT, new Payload("json", json), true, "any", true));
+  }
+
+  private void givenItSubscriptionServiceEnabledWithVariant(Variant variant) {
+    when(unleash.isEnabled(IT_SUBSCRIPTION_SERVICE, DEFAULT_IS_ENABLED)).thenReturn(true);
+    when(unleash.getVariant(IT_SUBSCRIPTION_SERVICE)).thenReturn(variant);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
@@ -22,9 +22,13 @@ package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.test.LoggerCaptor;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
@@ -67,6 +71,7 @@ class SubscriptionKafkaMessageConsumerTest {
       </CanonicalMessage>
       """;
 
+  @InjectMock FeatureFlags featureFlags;
   @InjectSpy SubscriptionKafkaMessageConsumer consumer;
   @Inject @Any InMemoryConnector connector;
 
@@ -81,6 +86,7 @@ class SubscriptionKafkaMessageConsumerTest {
   void setUp() {
     subscriptionKafkaChannel = connector.source(IT_SUBSCRIPTION_SYNC);
     LoggerCaptor.clearRecords();
+    when(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()).thenReturn(true);
   }
 
   @Test
@@ -110,8 +116,19 @@ class SubscriptionKafkaMessageConsumerTest {
     LoggerCaptor.thenLogNothing();
   }
 
+  @Test
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
+    when(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()).thenReturn(false);
+    whenSendMessage(SUBSCRIPTION_XML);
+    assertMessageIsNotProcessed();
+  }
+
   private void whenSendMessage(String message) {
     subscriptionKafkaChannel.send(message);
+  }
+
+  private void assertMessageIsNotProcessed() {
+    verify(consumer, after(500).never()).consumeSubscription(SUBSCRIPTION_XML);
   }
 
   private void thenKafkaSubscriptionDeserializedSuccessfully() {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncTaskConsumerTest.java
@@ -21,9 +21,12 @@
 package com.redhat.swatch.contract.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.model.EnabledOrgsResponse;
 import com.redhat.swatch.contract.product.umb.UmbSubscription;
 import com.redhat.swatch.contract.test.resources.EnableUmbResource;
@@ -31,6 +34,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -40,7 +44,13 @@ class SubscriptionSyncTaskConsumerTest {
   private static final String ORG_ID = "org123";
 
   @InjectMock SubscriptionSyncService service;
+  @InjectMock FeatureFlags featureFlags;
   @Inject SubscriptionSyncTaskConsumer consumer;
+
+  @BeforeEach
+  void setUp() {
+    when(featureFlags.isItSubscriptionServiceUmbConsumerEnabled()).thenReturn(true);
+  }
 
   @Test
   void testConsumeFromTopic() {
@@ -70,5 +80,28 @@ class SubscriptionSyncTaskConsumerTest {
                 """;
     consumer.consumeFromUmb(productMessageXml);
     verify(service).saveUmbSubscription(any(UmbSubscription.class));
+  }
+
+  @Test
+  void testConsumeFromUmb_whenFeatureFlagIsDisabled() throws JsonProcessingException {
+    when(featureFlags.isItSubscriptionServiceUmbConsumerEnabled()).thenReturn(false);
+    String productMessageXml =
+        """
+               <CanonicalMessage>
+                <Payload>
+                    <Sync>
+                        <Subscription>
+                            <Identifiers>
+                                <Reference system="EBS" entity-name="Account" qualifier="number">account123</Reference>
+                                <Reference system="WEB" entity-name="Customer" qualifier="id">org123_ICUST</Reference>
+                                <Identifier system="SUBSCRIPTION" entity-name="Subscription" qualifier="number">1234</Identifier>
+                            </Identifiers>
+                        </Subscription>
+                    </Sync>
+                </Payload>
+               </CanonicalMessage>
+                """;
+    consumer.consumeFromUmb(productMessageXml);
+    verify(service, never()).saveUmbSubscription(any(UmbSubscription.class));
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-5068

## Description
Gate the IT Subscription Service Kafka and UMB contract consumers behind Unleash (feature flags), with optional structured config variant payload to turn each consumer on or off independently.

Changes:
- **FeatureFlags**: New `isItSubscriptionServiceKafkaConsumerEnabled() `and `isItSubscriptionServiceUmbConsumerEnabled()` helpers that read `swatch.swatch-contracts.enable-it-subscription-service` and, when the variant is `config` with a JSON payload, apply `kafka_consumer_enabled `/ `umb_consumer_enabled`. When the toggle is enabled but no variant is configured, both consumers default to enabled. When the toggle is disabled entirely, both consumers are disabled (fallback: `DEFAULT_IS_ENABLED = true` when Unleash is unreachable).
- **Consumers**: `SubscriptionKafkaMessageConsumer (it-subscription-sync` channel)  and `SubscriptionSyncTaskConsumer (subscription-sync-task` UMB channel) each return early with a debug log when the corresponding flag path is disabled.
- **Schema / build:** `it_subscription_service_feature_flag_variant_payload.yaml` added to `swatch-contracts/schemas/` and referenced in `pom.xml` `sourcePaths` so the `ItSubscriptionServiceFeatureFlagVariantPayload` model class is generated.

Follow-up (separate MR in app-interface)
After this PR is approved, a separate MR in app-interface will register swatch.swatch-contracts.enable-it-subscription-service in the insights-default and insights-stage-default Unleash projects. To control consumers independently, add a config variant whose string payload is JSON, for example:

{"kafka_consumer_enabled": true, "umb_consumer_enabled": false}


Testing

- Unit tests: new cases in FeatureFlagsTest covering toggle disabled, toggle enabled with no variant, variant enabled with kafka_consumer_enabled / umb_consumer_enabled true/false combinations, and invalid JSON payload. 
- SubscriptionKafkaMessageConsumerTest and SubscriptionSyncTaskConsumerTest : test verifying the consumer ignores messages when the respective flag is disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an IT Subscription Service feature toggle, including separate enable/disable behavior for Kafka and UMB consumers driven by payload settings.
  * Added enable/disable support for the new toggle to the Unleash controls.
* **Bug Fixes**
  * Kafka and UMB message processing now stops immediately when the corresponding IT Subscription Service feature flags are disabled.
* **Tests**
  * Expanded unit and component test coverage for the new toggle, including disabled scenarios and independent Kafka/UMB outcomes.
  * Updated the subscription UMB test plan to require the new toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->