### PR TITLE
SWATCH-5113: Expose customerAwsAccountId on AwsUsageContext

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -357,6 +357,7 @@ Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageCo
 - **Expected Result:**  
   - HTTP 200  
   - `productCode`, `customerId`, and `awsSellerAccountId` match the semicolon-delimited `billing_provider_id` from the contract
+  - `customerAwsAccountId` matches the contract `billing_account_id`
 
 **aws-usage-context-TC002** - **AWS usage context returns 404 when no subscription matches**  
 - **Description:** Verify not-found behavior when lookup criteria do not match any AWS subscription.  

--- a/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
+++ b/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
@@ -61,6 +61,10 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
         contract.getSellerAccountId(),
         usageContext.getAwsSellerAccountId(),
         "awsSellerAccountId should match billing_provider_id");
+    assertEquals(
+        contract.getBillingAccountId(),
+        usageContext.getCustomerAwsAccountId(),
+        "customerAwsAccountId should match billing_account_id");
   }
 
   @TestPlanName("aws-usage-context-TC002")

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -266,7 +266,8 @@ public class ContractsResource implements DefaultApi {
         .subscriptionStartDate(subscription.getStartDate())
         .productCode(productCode)
         .customerId(customerId)
-        .awsSellerAccountId(sellerAccount);
+        .awsSellerAccountId(sellerAccount)
+        .customerAwsAccountId(subscription.getBillingAccountId());
   }
 
   @Override

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1536,6 +1536,9 @@ components:
           type: string
         awsSellerAccountId:
           type: string
+        customerAwsAccountId:
+          description: AWS customer account ID
+          type: string
         subscriptionStartDate:
           type: string
           format: date-time

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -339,6 +339,7 @@ class ContractsResourceTest {
   void incrementsAmbiguousCounterWhenOrgIdPresent() {
     SubscriptionEntity sub1 = new SubscriptionEntity();
     sub1.setBillingProviderId("foo1;foo2;foo3");
+    sub1.setBillingAccountId("123");
     sub1.setEndDate(defaultEndDate);
     SubscriptionEntity sub2 = new SubscriptionEntity();
     sub2.setBillingProviderId("bar1;bar2;bar3");
@@ -370,6 +371,7 @@ class ContractsResourceTest {
     assertEquals("foo1", awsUsageContext.getProductCode());
     assertEquals("foo2", awsUsageContext.getCustomerId());
     assertEquals("foo3", awsUsageContext.getAwsSellerAccountId());
+    assertEquals("123", awsUsageContext.getCustomerAwsAccountId());
   }
 
   @Test
@@ -410,6 +412,7 @@ class ContractsResourceTest {
     sub1.setEndDate(endDate);
     SubscriptionEntity sub2 = new SubscriptionEntity();
     sub2.setBillingProviderId("bar1;bar2;bar3");
+    sub2.setBillingAccountId("123");
     sub2.setEndDate(endDate.plusMinutes(45));
     when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(List.of(sub1, sub2));
     var lookupDate = endDate.plusMinutes(30);
@@ -438,6 +441,7 @@ class ContractsResourceTest {
     assertEquals("bar1", awsUsageContext.getProductCode());
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());
+    assertEquals("123", awsUsageContext.getCustomerAwsAccountId());
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-5113

## Description
Add an optional customerAwsAccountId field to the AwsUsageContext response so downstream services (swatch-producer-aws) can obtain the AWS account identifier needed for BatchMeterUsage without inferring it from other fields.

## Testing
ContractsResourceTest — verify AwsUsageContext includes customerAwsAccountId
Component test: call getAwsUsageContext; assert new field present in JSON. Update Test Plan accordingly.
Not required changes in IQE tests for this task.