### PR TITLE
SWATCH-4615: Add contract adjustment unit and component tests

### DIFF
--- a/swatch-billable-usage/ct/TEST_PLAN.md
+++ b/swatch-billable-usage/ct/TEST_PLAN.md
@@ -1,0 +1,80 @@
+# Introduction
+
+The **swatch-billable-usage** module is a service within the Subscription Watch platform that consumes tally summaries from Kafka, applies contract coverage from swatch-contracts, and produces billable usage remittance records and downstream Kafka aggregates for marketplace billing.
+
+This document outlines the test plan for swatch-billable-usage component tests, including tally consumption, remittance calculation, contract coverage, status updates, and contract-adjustment behavior.
+
+**Purpose:** To ensure the swatch-billable-usage service is functional, reliable, and meets all defined requirements for remittance processing and billable usage production.
+
+**Scope:**
+
+* Tally summary consumption from Kafka
+* Contract coverage lookup (stubbed via Wiremock)
+* Monthly remittance calculation and persistence
+* Billable usage and hourly aggregate production to Kafka
+* Remittance status updates from billable usage status events
+* Mid-month contract adjustment remittance
+
+**Assumptions:**
+
+* The swatch-billable-usage service is deployed in a stable and functional environment
+* Kafka is available for tally input and billable usage output topics
+* PostgreSQL is available for remittance persistence
+* Contract API responses are stubbed via Wiremock in component tests
+
+**Constraints:**
+
+* Testing is limited to the functionality of swatch-billable-usage at a component level
+* End-to-end testing in ephemeral or stage environments is out of scope for this test plan
+
+# Test Strategy
+
+This test plan focuses on covering test scenarios for component-level tests utilizing the Java component test framework.
+
+**Testing Strategy:**
+
+Test cases should be testable locally and in deployed environments.
+
+- Tally summaries can be published directly to the Kafka TALLY topic
+- Contract coverage can be stubbed via Wiremock (`ContractsWiremockService`)
+- Remittance state can be verified through the internal remittance API
+- Billable usage and aggregate messages can be verified on Kafka output topics
+
+# Test Cases
+
+## Contract Adjustment Remittance
+
+Component tests in `ContractAdjustmentComponentTest`.
+
+**billable-usage-contract-adjustment-TC001 - Remove contract mid-month**
+
+- **Description**: Verify removing a contract mid-month does not change remittance already recorded; additional usage after contract restore applies the adjustment formula.
+- **Setup**:
+  - Wiremock returns ROSA contract with equal Cores and Instance-hours coverage (6 billable units per metric)
+  - Billing account ID generated for the test
+- **Action**:
+  - Phase 1: Publish tally increment 100 → verify initial remittance per metric
+  - Phase 2: Stub no contract; re-tally with zero increment
+  - Phase 3: Restore contract; publish second increment (month total 200)
+- **Verification**:
+  - Phase 2 remittance unchanged from phase 1
+  - Phase 3 remittance matches `BillableUsageRemittanceExpectations.expectedRemittanceAfterUsageIncrease`
+- **Expected Result**:
+  - Cores: initial 76, final 176; Instance-hours: initial 94, final 194
+
+**billable-usage-contract-adjustment-TC002 - Add contract mid-month**
+
+- **Description**: Verify adding a second contract mid-month keeps remittance at the first contract value until usage exceeds combined coverage.
+- **Setup**:
+  - Wiremock returns ROSA contract with coverage 10 billable units per metric
+  - Billing account ID generated for the test
+- **Action**:
+  - Phase 1: Publish tally increment 100 → verify initial remittance
+  - Phase 2: Stub two contracts (10 + 100 coverage); re-tally with zero increment
+  - Phase 3: Publish second increment (month total 200)
+  - Phase 4: Publish large third increment (month total 501)
+- **Verification**:
+  - Phases 2 and 3 remittance unchanged from phase 1
+  - Phase 4 remittance matches combined-contract adjustment formula
+- **Expected Result**:
+  - Cores: initial 60, final 64; Instance-hours: initial 90, final 391

--- a/swatch-billable-usage/ct/java/api/BillableUsageRemittanceExpectations.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageRemittanceExpectations.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+public final class BillableUsageRemittanceExpectations {
+
+  private BillableUsageRemittanceExpectations() {}
+
+  public static double expectedInitialRemittance(
+      double metricUsage, double billingFactor, double contractBillableUnits) {
+    double contractValue = contractBillableUnits / billingFactor;
+    return Math.ceil(metricUsage * billingFactor) / billingFactor - contractValue;
+  }
+
+  /**
+   * Remittance after new usage when contracts may have changed mid-month.
+   *
+   * <p>{@code alreadyRemitted + ceil((totalUsage - alreadyRemitted) × billingFactor) /
+   * billingFactor − contractBillableUnits / billingFactor}
+   */
+  public static double expectedRemittanceAfterUsageIncrease(
+      double totalUsage,
+      double alreadyRemitted,
+      double billingFactor,
+      double contractBillableUnits) {
+    double contractValue = contractBillableUnits / billingFactor;
+    double applicableUsage =
+        Math.ceil((totalUsage - alreadyRemitted) * billingFactor) / billingFactor;
+    return alreadyRemitted + applicableUsage - contractValue;
+  }
+}

--- a/swatch-billable-usage/ct/java/api/BillableUsageTestHelper.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageTestHelper.java
@@ -94,6 +94,43 @@ public final class BillableUsageTestHelper {
         orgId, productId, metricId, value, BillingProvider.AWS, RandomUtils.generateRandom());
   }
 
+  /**
+   * Create a tally summary where {@code currentTotal} reflects cumulative usage for the month while
+   * {@code value} is the increment from this snapshot. Use for re-tally and contract-adjustment
+   * scenarios.
+   */
+  public static TallySummary createTallySummaryWithCurrentTotal(
+      String orgId,
+      String productId,
+      String metricId,
+      double value,
+      double currentTotal,
+      BillingProvider billingProvider,
+      String billingAccountId) {
+    var measurement = new TallyMeasurement();
+    measurement.setHardwareMeasurementType("PHYSICAL");
+    measurement.setMetricId(metricId);
+    measurement.setValue(value);
+    measurement.setCurrentTotal(currentTotal);
+
+    var snapshot = new TallySnapshot();
+    snapshot.setId(UUID.randomUUID());
+    snapshot.setProductId(productId);
+    snapshot.setBillingProvider(billingProvider.toTallyApiModel());
+    snapshot.setBillingAccountId(billingAccountId);
+    snapshot.setSnapshotDate(
+        OffsetDateTime.now().minusHours(1).withOffsetSameInstant(ZoneOffset.UTC));
+    snapshot.setSla(TallySnapshot.Sla.PREMIUM);
+    snapshot.setUsage(TallySnapshot.Usage.PRODUCTION);
+    snapshot.setGranularity(TallySnapshot.Granularity.HOURLY);
+    snapshot.setTallyMeasurements(List.of(measurement));
+
+    var tallySummary = new TallySummary();
+    tallySummary.setOrgId(orgId);
+    tallySummary.setTallySnapshots(List.of(snapshot));
+    return tallySummary;
+  }
+
   public static TallySummary createTallySummaryWithGranularity(
       String orgId,
       String productId,

--- a/swatch-billable-usage/ct/java/api/ContractsWiremockService.java
+++ b/swatch-billable-usage/ct/java/api/ContractsWiremockService.java
@@ -53,11 +53,54 @@ public class ContractsWiremockService extends WiremockService {
     OffsetDateTime startDate = OffsetDateTime.now().minusMonths(1);
     OffsetDateTime endDate = OffsetDateTime.now().plusYears(1);
     registerContractStub(
-        orgId,
-        productId,
-        startDate,
-        endDate,
-        List.of(Map.of("metric_id", metricId, "value", coverageValue)));
+        orgId, productId, startDate, endDate, List.of(contractMetric(metricId, coverageValue)));
+  }
+
+  /**
+   * Setup one contract with coverage for multiple AWS dimensions (same billable-unit value on every
+   * product metric).
+   *
+   * @param orgId Organization ID
+   * @param productId Product ID
+   * @param awsDimensionToBillableUnits AWS dimension to contract value in billable units
+   */
+  public void setupMultiMetricContractCoverage(
+      String orgId, String productId, Map<String, Double> awsDimensionToBillableUnits) {
+    OffsetDateTime startDate = OffsetDateTime.now().minusMonths(1);
+    OffsetDateTime endDate = OffsetDateTime.now().plusYears(1);
+    List<Map<String, Object>> metrics =
+        awsDimensionToBillableUnits.entrySet().stream()
+            .map(entry -> contractMetric(entry.getKey(), entry.getValue()))
+            .toList();
+    registerContractStub(orgId, productId, startDate, endDate, metrics);
+  }
+
+  /**
+   * Setup multiple contracts, each with the same set of AWS dimension coverages. Use to simulate
+   * adding a contract mid-month (c1 + c2) while keeping c1 active.
+   *
+   * @param orgId Organization ID
+   * @param productId Product ID
+   * @param contractsCoverage Per-contract map of AWS dimension to billable-unit coverage
+   */
+  public void setupMultipleMultiMetricContracts(
+      String orgId, String productId, List<Map<String, Double>> contractsCoverage) {
+    OffsetDateTime startDate = OffsetDateTime.now().minusMonths(1);
+    OffsetDateTime endDate = OffsetDateTime.now().plusYears(1);
+    List<Map<String, Object>> contracts =
+        contractsCoverage.stream()
+            .map(
+                coverage ->
+                    contractPayload(
+                        orgId,
+                        productId,
+                        startDate,
+                        endDate,
+                        coverage.entrySet().stream()
+                            .map(entry -> contractMetric(entry.getKey(), entry.getValue()))
+                            .toList()))
+            .toList();
+    registerContractsStub(orgId, productId, contracts);
   }
 
   /**
@@ -100,25 +143,53 @@ public class ContractsWiremockService extends WiremockService {
     registerContractStub(orgId, productId, startDate, endDate, List.of());
   }
 
+  /**
+   * Setup the contracts API to return no contracts. Simulates contract deletion for
+   * contract-enabled products; billable-usage skips processing and leaves existing remittance
+   * unchanged.
+   *
+   * @param orgId Organization ID
+   * @param productId Product ID
+   */
+  public void setupContractNotFound(String orgId, String productId) {
+    registerContractsStub(orgId, productId, List.of());
+  }
+
   private void registerContractStub(
       String orgId,
       String productId,
       OffsetDateTime startDate,
       OffsetDateTime endDate,
       List<?> metrics) {
-    var contractData =
-        Map.of(
-            "org_id",
-            orgId,
-            "product_id",
-            productId,
-            "start_date",
-            startDate.toString(),
-            "end_date",
-            endDate.toString(),
-            "metrics",
-            metrics);
+    registerContractsStub(
+        orgId, productId, List.of(contractPayload(orgId, productId, startDate, endDate, metrics)));
+  }
 
+  private static Map<String, Object> contractPayload(
+      String orgId,
+      String productId,
+      OffsetDateTime startDate,
+      OffsetDateTime endDate,
+      List<?> metrics) {
+    return Map.of(
+        "org_id",
+        orgId,
+        "product_id",
+        productId,
+        "start_date",
+        startDate.toString(),
+        "end_date",
+        endDate.toString(),
+        "metrics",
+        metrics);
+  }
+
+  private static Map<String, Object> contractMetric(String metricId, double coverageValue) {
+    return Map.of("metric_id", metricId, "value", coverageValue);
+  }
+
+  private void registerContractsStub(
+      String orgId, String productId, List<Map<String, Object>> contracts) {
     given()
         .contentType("application/json")
         .body(
@@ -140,7 +211,7 @@ public class ContractsWiremockService extends WiremockService {
                     "headers",
                     Map.of("Content-Type", "application/json"),
                     "jsonBody",
-                    List.of(contractData)),
+                    contracts),
                 "priority",
                 9,
                 "metadata",

--- a/swatch-billable-usage/ct/java/domain/Product.java
+++ b/swatch-billable-usage/ct/java/domain/Product.java
@@ -33,7 +33,7 @@ import lombok.Getter;
 
 @Getter
 public enum Product {
-  ROSA("rosa", MetricIdUtils.getCores()),
+  ROSA("rosa", MetricIdUtils.getCores(), MetricIdUtils.getInstanceHours()),
   RHEL_PAYG_ADDON("rhel-for-x86-els-payg-addon", MetricIdUtils.getVCpus());
 
   private final ProductId id;

--- a/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageRemittanceExpectations.expectedInitialRemittance;
+import static api.BillableUsageRemittanceExpectations.expectedRemittanceAfterUsageIncrease;
+import static api.BillableUsageTestHelper.createTallySummaryWithCurrentTotal;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.swatch.billable.usage.openapi.model.MonthlyRemittance;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import domain.BillingProvider;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Component tests for ROSA contract-adjustment remittance (SWATCH-4615).
+ *
+ * <p>Contract coverage is stubbed via {@link api.ContractsWiremockService}; usage arrives on Kafka
+ * {@code TALLY}; assertions use {@link api.BillableUsageSwatchService#getRemittances}. Expected
+ * values come from {@link api.BillableUsageRemittanceExpectations}.
+ */
+public class ContractAdjustmentComponentTest extends BaseBillableUsageComponentTest {
+
+  private static final MetricId INSTANCE_HOURS = MetricIdUtils.getInstanceHours();
+  private static final String CORES_AWS_DIMENSION = ROSA.getMetric(CORES).getAwsDimension();
+  private static final String INSTANCE_HOURS_AWS_DIMENSION =
+      ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+  private static final double CORES_BILLING_FACTOR = ROSA.getBillingFactor(CORES);
+  // Instance-hours has no billingFactor in rosa.yaml; production default is 1.0
+  private static final double INSTANCE_HOURS_BILLING_FACTOR = 1.0;
+
+  /**
+   * Removing a contract mid-month must not change remittance already recorded; usage billed after
+   * the contract is restored must apply the adjustment formula.
+   */
+  @Test
+  @TestPlanName("billable-usage-contract-adjustment-TC001")
+  public void testVerifyContractAdjustmentForRemoveContract() {
+    String billingAccountId = RandomUtils.generateRandom();
+    double contractMetricValue = 6.0;
+    double applicableMetricUsage = 100.0;
+    double totalBillingUsage = applicableMetricUsage * 2;
+    Map<MetricId, Double> remittedByMetric = new HashMap<>();
+
+    // Phase 1: contract (coverage 6), first tally increment 100 → initial remittance per metric
+    givenRosaContractWithEqualMetricCoverage(contractMetricValue);
+    whenUsageIsTallied(billingAccountId, applicableMetricUsage, applicableMetricUsage);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      double expected =
+          expectedInitialRemittance(
+              applicableMetricUsage, metric.billingFactor(), contractMetricValue);
+      remittedByMetric.put(
+          metric.metricId(), thenAccountRemittanceEquals(metric, billingAccountId, expected));
+    }
+
+    // Phase 2: contract removed, re-tally with zero increment → remittance unchanged
+    givenContractIsRemoved();
+    whenUsageIsTallied(billingAccountId, 0.0, applicableMetricUsage);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      thenAccountRemittanceEquals(
+          metric, billingAccountId, remittedByMetric.get(metric.metricId()));
+    }
+
+    // Phase 3: contract restored, second increment 100 (month total 200) → adjusted remittance
+    givenRosaContractWithEqualMetricCoverage(contractMetricValue);
+    whenUsageIsTallied(billingAccountId, applicableMetricUsage, totalBillingUsage);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      double expected =
+          expectedRemittanceAfterUsageIncrease(
+              totalBillingUsage,
+              remittedByMetric.get(metric.metricId()),
+              metric.billingFactor(),
+              contractMetricValue);
+      thenAccountRemittanceEquals(metric, billingAccountId, expected);
+    }
+  }
+
+  /**
+   * Adding a second contract mid-month keeps remittance at the first contract's value until usage
+   * exceeds combined coverage (contracts 10 + 100; usage 100 → 200 → 501).
+   */
+  @Test
+  @TestPlanName("billable-usage-contract-adjustment-TC002")
+  public void testVerifyContractAdjustmentWhenAddMoreContractInMidMonth() {
+    String billingAccountId = RandomUtils.generateRandom();
+    double initialContractMetricValue = 10.0;
+    double addedContractMetricValue = 100.0;
+    double totalContractMetricValue = initialContractMetricValue + addedContractMetricValue;
+    double applicableMetricUsage = 100.0;
+    Map<MetricId, Double> remittedByMetric = new HashMap<>();
+
+    // Phase 1: first contract (coverage 10), tally increment 100
+    givenRosaContractWithEqualMetricCoverage(initialContractMetricValue);
+    whenUsageIsTallied(billingAccountId, applicableMetricUsage, applicableMetricUsage);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      double expected =
+          expectedInitialRemittance(
+              applicableMetricUsage, metric.billingFactor(), initialContractMetricValue);
+      remittedByMetric.put(
+          metric.metricId(), thenAccountRemittanceEquals(metric, billingAccountId, expected));
+    }
+
+    // Phase 2: second contract added, re-tally only — remittance still reflects first contract
+    givenMultipleRosaContractsWithEqualMetricCoverage(
+        initialContractMetricValue, addedContractMetricValue);
+    whenUsageIsTallied(billingAccountId, 0.0, applicableMetricUsage);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      thenAccountRemittanceEquals(
+          metric, billingAccountId, remittedByMetric.get(metric.metricId()));
+    }
+
+    // Phase 3: second usage increment (month total 200) — still first-contract remittance
+    double totalAfterSecondEvent = applicableMetricUsage * 2;
+    whenUsageIsTallied(billingAccountId, applicableMetricUsage, totalAfterSecondEvent);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      thenAccountRemittanceEquals(
+          metric, billingAccountId, remittedByMetric.get(metric.metricId()));
+    }
+
+    // Phase 4: large third increment (month total 501) — remittance uses combined coverage
+    double totalAfterThirdEvent = totalAfterSecondEvent + 301.0;
+    whenUsageIsTallied(billingAccountId, 301.0, totalAfterThirdEvent);
+
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      double expected =
+          expectedRemittanceAfterUsageIncrease(
+              totalAfterThirdEvent,
+              remittedByMetric.get(metric.metricId()),
+              metric.billingFactor(),
+              totalContractMetricValue);
+      thenAccountRemittanceEquals(metric, billingAccountId, expected);
+    }
+  }
+
+  /** ROSA AWS metrics exercised in each test (Cores and Instance-hours). */
+  private record RosaMetricScenario(MetricId metricId, String awsDimension, double billingFactor) {}
+
+  private List<RosaMetricScenario> rosaMetricScenarios() {
+    return List.of(
+        new RosaMetricScenario(CORES, CORES_AWS_DIMENSION, CORES_BILLING_FACTOR),
+        new RosaMetricScenario(
+            INSTANCE_HOURS, INSTANCE_HOURS_AWS_DIMENSION, INSTANCE_HOURS_BILLING_FACTOR));
+  }
+
+  private Map<String, Double> equalCoverageForAllRosaMetrics(double contractBillableUnits) {
+    return Map.of(
+        CORES_AWS_DIMENSION, contractBillableUnits,
+        INSTANCE_HOURS_AWS_DIMENSION, contractBillableUnits);
+  }
+
+  /** Stub a single contract with equal billable units on every ROSA AWS dimension. */
+  private void givenRosaContractWithEqualMetricCoverage(double contractBillableUnits) {
+    contractsWiremock.setupMultiMetricContractCoverage(
+        orgId, ROSA.getName(), equalCoverageForAllRosaMetrics(contractBillableUnits));
+  }
+
+  /** Stub two active contracts; billable-usage aggregates coverage across both. */
+  private void givenMultipleRosaContractsWithEqualMetricCoverage(
+      double firstContractBillableUnits, double secondContractBillableUnits) {
+    contractsWiremock.setupMultipleMultiMetricContracts(
+        orgId,
+        ROSA.getName(),
+        List.of(
+            equalCoverageForAllRosaMetrics(firstContractBillableUnits),
+            equalCoverageForAllRosaMetrics(secondContractBillableUnits)));
+  }
+
+  /** Stub contracts API so no contract exists for the org/product. */
+  private void givenContractIsRemoved() {
+    contractsWiremock.setupContractNotFound(orgId, ROSA.getName());
+  }
+
+  /**
+   * Publish a TALLY summary per ROSA metric. {@code value} is the increment; {@code currentTotal}
+   * is the month-to-date cumulative usage.
+   */
+  private void whenUsageIsTallied(String billingAccountId, double value, double currentTotal) {
+    for (RosaMetricScenario metric : rosaMetricScenarios()) {
+      var tallySummary =
+          createTallySummaryWithCurrentTotal(
+              orgId,
+              ROSA.getName(),
+              metric.metricId().toString(),
+              value,
+              currentTotal,
+              BillingProvider.AWS,
+              billingAccountId);
+      kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+    }
+  }
+
+  /** Assert monthly remittance via API; billing provider must be {@code aws} (tally API value). */
+  private double thenAccountRemittanceEquals(
+      RosaMetricScenario metric, String billingAccountId, double expectedRemittedValue) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              List<MonthlyRemittance> remittances =
+                  service.getRemittances(
+                      ROSA.getName(),
+                      orgId,
+                      metric.metricId().toString(),
+                      BillingProvider.AWS.toTallyApiModel().value(),
+                      billingAccountId);
+              assertEquals(1, remittances.size(), "Expected one monthly remittance row per metric");
+              assertEquals(
+                  expectedRemittedValue,
+                  remittances.get(0).getRemittedValue(),
+                  0.001,
+                  "Account remittance mismatch for metric " + metric.metricId());
+            });
+    return expectedRemittedValue;
+  }
+}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -221,6 +222,114 @@ class BillableUsageServiceTest {
     thenRemittanceIsUpdated(usage, 28.0);
     thenUsageIsSent(usage, usage.getValue());
     thenBillableMeterMatches(usage, 28.0);
+  }
+
+  /**
+   * Contract removed mid-month: remittance already recorded is preserved; additional usage after
+   * contract restore is adjusted. One metric per {@link #contractAdjustmentForRemoveContract()}
+   * row.
+   */
+  @ParameterizedTest
+  @MethodSource("contractAdjustmentForRemoveContract")
+  void verifyContractAdjustmentForRemoveContract(
+      MetricId metricId, double expectedInitialRemitted, double expectedFinalRemitted)
+      throws ApiException {
+    double applicableMetricUsage = 100.0;
+    double totalBillingUsage = applicableMetricUsage * 2;
+
+    // Phase 1: contract (coverage 6), first usage event (100)
+    BillableUsage firstUsage =
+        givenUsageForRosa(metricId, applicableMetricUsage, applicableMetricUsage);
+    givenExistingContractForUsage(contractWithCoverage(firstUsage, 6), firstUsage);
+
+    service.submitBillableUsage(firstUsage);
+
+    assertEquals(expectedInitialRemitted, getAccountRemitted(firstUsage));
+
+    // Phase 2: no contract, re-process same cumulative usage (increment 0)
+    givenContractApiReturnsNoContracts();
+
+    BillableUsage retally = givenUsageForRosa(metricId, 0.0, applicableMetricUsage);
+    service.submitBillableUsage(retally);
+    assertEquals(expectedInitialRemitted, getAccountRemitted(retally));
+
+    // Phase 3: contract restored, second event (increment 100, total 200)
+    givenExistingContractForUsage(contractWithCoverage(firstUsage, 6), firstUsage);
+    BillableUsage secondUsage =
+        givenUsageForRosa(metricId, applicableMetricUsage, totalBillingUsage);
+    service.submitBillableUsage(secondUsage);
+
+    assertEquals(expectedFinalRemitted, getAccountRemitted(secondUsage));
+  }
+
+  /**
+   * Second contract added mid-month: remittance stays at first-contract value until usage exceeds
+   * combined coverage. Component twin: {@code ContractAdjustmentComponentTest}.
+   */
+  @ParameterizedTest
+  @MethodSource("contractAdjustmentWhenAddMoreContractInMidMonth")
+  void verifyContractAdjustmentWhenAddMoreContractInMidMonth(
+      MetricId metricId, double expectedInitialRemitted, double expectedFinalRemitted)
+      throws ApiException {
+    double applicableMetricUsage = 100.0;
+    double totalAfterSecondEvent = applicableMetricUsage * 2;
+    double totalAfterThirdEvent = totalAfterSecondEvent + 301.0;
+
+    // Phase 1: first contract (coverage 10), usage 100
+    BillableUsage firstUsage =
+        givenUsageForRosa(metricId, applicableMetricUsage, applicableMetricUsage);
+    givenExistingContractForUsage(contractWithCoverage(firstUsage, 10), firstUsage);
+
+    service.submitBillableUsage(firstUsage);
+
+    assertEquals(expectedInitialRemitted, getAccountRemitted(firstUsage));
+
+    // Phase 2: second contract added, re-process without new usage
+    Contract initialContract = contractWithCoverage(firstUsage, 10);
+    Contract addedContract = contractWithCoverage(firstUsage, 100);
+    givenContractApiReturnsContracts(initialContract, addedContract);
+
+    BillableUsage retally = givenUsageForRosa(metricId, 0.0, applicableMetricUsage);
+    service.submitBillableUsage(retally);
+    assertEquals(expectedInitialRemitted, getAccountRemitted(retally));
+
+    // Phase 3: second usage event (cumulative 200) — still first-contract remittance
+    BillableUsage secondUsage =
+        givenUsageForRosa(metricId, applicableMetricUsage, totalAfterSecondEvent);
+    service.submitBillableUsage(secondUsage);
+    assertEquals(expectedInitialRemitted, getAccountRemitted(secondUsage));
+
+    // Phase 4: large third event (cumulative 501) — combined contract coverage
+    BillableUsage thirdUsage = givenUsageForRosa(metricId, 301.0, totalAfterThirdEvent);
+    service.submitBillableUsage(thirdUsage);
+
+    assertEquals(expectedFinalRemitted, getAccountRemitted(thirdUsage));
+  }
+
+  static Stream<Arguments> contractAdjustmentForRemoveContract() {
+    // Remittance = ceil(usage × billingFactor) / billingFactor − contractCoverage / billingFactor
+    // Phase 3 (total usage 200): alreadyRemitted + ceil((200 − alreadyRemitted) × bf) / bf − 6/bf
+    //   Cores (bf=0.25): initial 100 − 24 = 76; final 76 + (124 − 24) = 176
+    //   Instance-hours (bf=1): initial 100 − 6 = 94; final 94 + (106 − 6) = 194
+    return Stream.of(
+        arguments(MetricIdUtils.getCores(), 76.0, 176.0),
+        arguments(MetricIdUtils.getInstanceHours(), 94.0, 194.0));
+  }
+
+  static Stream<Arguments> contractAdjustmentWhenAddMoreContractInMidMonth() {
+    // Phase 1: contract coverage 10 billable units, usage 100
+    // Phase 4: combined contract coverage 110, cumulative usage 501 (100 + 100 + 301)
+    //   Cores (bf=0.25): initial 100 − 40 = 60; final 60 + (444 − 440) = 64
+    //   Instance-hours (bf=1): initial 100 − 10 = 90; final 90 + (411 − 110) = 391
+    return Stream.of(
+        arguments(MetricIdUtils.getCores(), 60.0, 64.0),
+        arguments(MetricIdUtils.getInstanceHours(), 90.0, 391.0));
+  }
+
+  /** BillableUsage snapshotDate is overwritten during processing; reset for remittance lookup. */
+  private double getAccountRemitted(BillableUsage usage) {
+    usage.setSnapshotDate(CLOCK.startOfCurrentMonth());
+    return service.getTotalRemitted(usage);
   }
 
   // Simulates progression through contract billing.
@@ -508,8 +617,11 @@ class BillableUsageServiceTest {
   }
 
   private BillableUsage givenCoresUsageForRosa(Double value, Double currentTotal) {
-    return billable(
-        ROSA, MetricIdUtils.getCores(), CLOCK.startOfCurrentMonth(), value, currentTotal);
+    return givenUsageForRosa(MetricIdUtils.getCores(), value, currentTotal);
+  }
+
+  private BillableUsage givenUsageForRosa(MetricId metricId, Double value, Double currentTotal) {
+    return billable(ROSA, metricId, CLOCK.startOfCurrentMonth(), value, currentTotal);
   }
 
   private BillableUsage billable(
@@ -536,19 +648,41 @@ class BillableUsageServiceTest {
     givenExistingContractForUsage(contract, usage);
   }
 
+  private Contract contractWithCoverage(BillableUsage usage, int billableUnits) {
+    Contract contract = new Contract();
+    contract.setStartDate(usage.getSnapshotDate().minusDays(10));
+    contract.addMetricsItem(
+        new Metric()
+            .metricId(
+                SubscriptionDefinition.getAwsDimension(
+                    usage.getProductId(), MetricId.fromString(usage.getMetricId()).getValue()))
+            .value(billableUnits));
+    return contract;
+  }
+
   private void givenExistingContractForUsage(Contract contract, BillableUsage usage) {
     try {
       when(contractsApi.getContract(
-              usage.getOrgId(),
-              usage.getProductId(),
-              usage.getVendorProductCode(),
-              usage.getBillingProvider().value(),
-              usage.getBillingAccountId(),
-              usage.getSnapshotDate()))
+              eq(usage.getOrgId()),
+              eq(usage.getProductId()),
+              any(),
+              eq(usage.getBillingProvider().value()),
+              eq(usage.getBillingAccountId()),
+              any(OffsetDateTime.class)))
           .thenReturn(List.of(contract));
     } catch (ApiException e) {
       fail(e);
     }
+  }
+
+  private void givenContractApiReturnsContracts(Contract... contracts) throws ApiException {
+    when(contractsApi.getContract(any(), any(), any(), any(), any(), any(OffsetDateTime.class)))
+        .thenReturn(List.of(contracts));
+  }
+
+  private void givenContractApiReturnsNoContracts() throws ApiException {
+    when(contractsApi.getContract(any(), any(), any(), any(), any(), any(OffsetDateTime.class)))
+        .thenReturn(List.of());
   }
 
   private List<Contract> givenExistingContract(


### PR DESCRIPTION
Add automated coverage for ROSA **contract-adjustment remittance** when contracts change mid-month.
These tests will substitute the IQE ones (`test_verify_contract_adjustment_for_remove_contract`, `test_verify_contract_adjustment_when_add_more_contract_in_mid_month`) in a shift-left approach.

Jira issue: SWATCH-4615

## Description
- Add unit tests for mid-month contract removal and contract addition remittance on ROSA (Cores + Instance-hours).
- Add `ContractAdjustmentComponentTest` (wiremock contracts + Kafka TALLY + remittance API) with `@TestPlanName` tags.
- Add baseline `swatch-billable-usage/ct/TEST_PLAN.md` (module-level structure; initial cases cover contract adjustment).
- Extend `ContractsWiremockService` for multi-metric and multi-contract stubs.
- Add `BillableUsageRemittanceExpectations` in `ct/java/api/` for component assertions.

## Testing
Unit tests:
```bash
./mvnw test -pl swatch-billable-usage
```
Component tests:
```bash
./mvnw test -Pcomponent-tests -pl swatch-billable-usage/ct -am
```