### PR TITLE
Fix timezone-unsafe next_event_date assertion 

### DIFF
--- a/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsTerminationComponentTest.java
@@ -28,11 +28,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -195,7 +192,7 @@ public class ContractsTerminationComponentTest extends BaseContractComponentTest
         is(HttpStatus.SC_OK));
 
     // Then: The subscription table is updated with next_event_date and next_event_type
-    thenSubscriptionIsUpdatedWithNextEventData(subscription);
+    thenSubscriptionIsUpdatedWithNextEventData(subscription, terminationDate);
   }
 
   private Contract givenContractTerminatedViaMessageBroker() {
@@ -295,7 +292,8 @@ public class ContractsTerminationComponentTest extends BaseContractComponentTest
     return contracts.get(0);
   }
 
-  private void thenSubscriptionIsUpdatedWithNextEventData(Subscription subscription) {
+  private void thenSubscriptionIsUpdatedWithNextEventData(
+      Subscription subscription, OffsetDateTime expectedNextEventDate) {
     var skuItem =
         await("Subscription table should be updated with next event info")
             .atMost(1, MINUTES)
@@ -316,31 +314,6 @@ public class ContractsTerminationComponentTest extends BaseContractComponentTest
         "next_event_type should be 'Subscription End'",
         skuItem.get().getNextEventType(),
         equalTo(SubscriptionEventType.SUBSCRIPTION_END));
-    assertThat("next_event_date should be set", skuItem.get().getNextEventDate(), notNullValue());
-    verifyNextEventDateIsTomorrowAtEndOfDay(skuItem.get().getNextEventDate());
-  }
-
-  /** Helper method to verify next_event_date is tomorrow at end of day (23:59:59). */
-  private void verifyNextEventDateIsTomorrowAtEndOfDay(OffsetDateTime nextEventDate) {
-    OffsetDateTime tomorrow = OffsetDateTime.now().plusDays(1);
-
-    assertThat(
-        "next_event_date should be tomorrow",
-        nextEventDate.toLocalDate(),
-        equalTo(tomorrow.toLocalDate()));
-
-    // Verify it's at the end of the day (allowing for timezone and daylight saving time
-    // differences).
-    // Depending on offset conversions, this can be 21, 22, or 23.
-    assertThat(
-        "next_event_date hour should be near end of day (21, 22, or 23)",
-        nextEventDate.getHour(),
-        is(greaterThanOrEqualTo(21)));
-    assertThat(
-        "next_event_date hour should not be after end of day",
-        nextEventDate.getHour(),
-        is(lessThanOrEqualTo(23)));
-    assertThat("next_event_date minute should be 59", nextEventDate.getMinute(), equalTo(59));
-    assertThat("next_event_date second should be 59", nextEventDate.getSecond(), equalTo(59));
+    assertDatesAreEqual(expectedNextEventDate, skuItem.get().getNextEventDate());
   }
 }


### PR DESCRIPTION
## Summary

Fixes a flaky assertion in `ContractsTerminationComponentTest.shouldUpdateSubscriptionTableWhenContractIsTerminated` (contracts-termination-TC007).

The test was failing because it compared **local calendar dates** instead of the actual timestamp.

## What was wrong

TC007 terminates a subscription with tomorrow at 23:59:59 local time, e.g. `2026-06-26T23:59:59-04:00`. That is the same instant as `2026-06-27T03:59:59Z`. The old assertion used `toLocalDate()`, so in US timezones it expected `2026-06-26` while the API returned `2026-06-27`.

## Fix

Assert `next_event_date` against the `terminationDate` sent in the test, using `DateUtils.assertDatesAreEqual` — same approach as `SubscriptionsTerminationComponentTest`.

## Verify
```bash
TZ=America/New_York ./mvnw test -Pcomponent-tests -pl swatch-contracts/ct -Dtest=ContractsTerminationComponentTest#shouldUpdateSubscriptionTableWhenContractIsTerminated
```
```bash
TZ=America/New_York ./mvnw test -Pcomponent-tests -pl swatch-contracts/ct -Dtest=ContractsTerminationComponentTest
```