### PR TITLE
swatch-5071 Align IT Subscription Service Kafka consumer logic with UMB consumer

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.product.umb.CanonicalMessage;
@@ -37,12 +38,13 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 public class SubscriptionKafkaMessageConsumer {
 
   @Inject FeatureFlags featureFlags;
+  @Inject SubscriptionSyncService service;
 
   private final XmlMapper xmlMapper = CanonicalMessage.createMapper();
 
   @Blocking
   @Incoming(IT_SUBSCRIPTION_SYNC)
-  public void consumeFromKafka(String subscriptionMessageXml) {
+  public void consumeFromKafka(String subscriptionMessageXml) throws JsonProcessingException {
     log.debug("IT Subscription Kafka consumer was called");
     if (subscriptionMessageXml == null) {
       return;
@@ -54,24 +56,31 @@ public class SubscriptionKafkaMessageConsumer {
     consumeSubscription(subscriptionMessageXml);
   }
 
-  public void consumeSubscription(String subscriptionMessageXml) {
+  public void consumeSubscription(String subscriptionMessageXml) throws JsonProcessingException {
+    CanonicalMessage subscriptionMessage;
     try {
-      CanonicalMessage subscriptionMessage =
-          xmlMapper.readValue(subscriptionMessageXml, CanonicalMessage.class);
-      UmbSubscription subscription = subscriptionMessage.getPayload().getSync().getSubscription();
-      log.info(
-          "IT Subscription message consumed: source=kafka, "
-              + "subscriptionNumber={}, webCustomerId={}, sku={}, quantity={}, "
-              + "effectiveStartDate={}, effectiveEndDate={}, terminated={}",
-          subscription.getSubscriptionNumber(),
-          subscription.getWebCustomerId(),
-          subscription.findSku().orElse(null),
-          subscription.getQuantity(),
-          subscription.getEffectiveStartDate(),
-          subscription.getEffectiveEndDate(),
-          subscription.findTerminatedStatus().isPresent());
-    } catch (Exception e) {
-      log.warn("Unable to process IT Subscription Kafka message.", e);
+      subscriptionMessage = xmlMapper.readValue(subscriptionMessageXml, CanonicalMessage.class);
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "Unable to process IT Subscription Kafka message: messagePreview={}",
+          subscriptionMessageXml != null && subscriptionMessageXml.length() > 100
+              ? subscriptionMessageXml.substring(0, 100) + "..."
+              : subscriptionMessageXml,
+          e);
+      throw e;
     }
+    UmbSubscription subscription = subscriptionMessage.getPayload().getSync().getSubscription();
+    log.info(
+        "IT Subscription message consumed: source=kafka, "
+            + "subscriptionNumber={}, webCustomerId={}, sku={}, quantity={}, "
+            + "effectiveStartDate={}, effectiveEndDate={}, terminated={}",
+        subscription.getSubscriptionNumber(),
+        subscription.getWebCustomerId(),
+        subscription.findSku().orElse(null),
+        subscription.getQuantity(),
+        subscription.getEffectiveStartDate(),
+        subscription.getEffectiveEndDate(),
+        subscription.findTerminatedStatus().isPresent());
+    service.saveUmbSubscription(subscription);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
@@ -22,11 +22,14 @@ package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.config.FeatureFlags;
+import com.redhat.swatch.contract.product.umb.UmbSubscription;
 import com.redhat.swatch.contract.test.LoggerCaptor;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -72,6 +75,7 @@ class SubscriptionKafkaMessageConsumerTest {
       """;
 
   @InjectMock FeatureFlags featureFlags;
+  @InjectMock SubscriptionSyncService service;
   @InjectSpy SubscriptionKafkaMessageConsumer consumer;
   @Inject @Any InMemoryConnector connector;
 
@@ -97,6 +101,7 @@ class SubscriptionKafkaMessageConsumerTest {
         .atMost(Duration.ofMillis(500))
         .untilAsserted(() -> verify(consumer).consumeSubscription(SUBSCRIPTION_XML));
     thenKafkaSubscriptionDeserializedSuccessfully();
+    verify(service).saveUmbSubscription(any(UmbSubscription.class));
   }
 
   @Test
@@ -107,27 +112,30 @@ class SubscriptionKafkaMessageConsumerTest {
         .atMost(Duration.ofMillis(500))
         .untilAsserted(() -> verify(consumer).consumeSubscription("this is not xml"));
     LoggerCaptor.thenWarnLogWithMessage("Unable to process IT Subscription Kafka message");
+    verify(service, never()).saveUmbSubscription(any(UmbSubscription.class));
   }
 
   @Test
-  void shouldIgnoreNullMessage() {
+  void shouldIgnoreNullMessage() throws Exception {
     consumer.consumeFromKafka(null);
 
     LoggerCaptor.thenLogNothing();
+    verify(service, never()).saveUmbSubscription(any(UmbSubscription.class));
   }
 
   @Test
-  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() throws Exception {
     when(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()).thenReturn(false);
     whenSendMessage(SUBSCRIPTION_XML);
     assertMessageIsNotProcessed();
+    verify(service, after(500).never()).saveUmbSubscription(any(UmbSubscription.class));
   }
 
   private void whenSendMessage(String message) {
     subscriptionKafkaChannel.send(message);
   }
 
-  private void assertMessageIsNotProcessed() {
+  private void assertMessageIsNotProcessed() throws Exception {
     verify(consumer, after(500).never()).consumeSubscription(SUBSCRIPTION_XML);
   }
 


### PR DESCRIPTION
Jira issue: SWATCH-5071

## Description
The IT Subscription Service Kafka consumer (SubscriptionKafkaMessageConsumer) now follows the same processing logic as the existing UMB consumer (SubscriptionSyncTaskConsumer).

To be consistent with the UMB Consumer, the catch exception was updated to be JsonProcessingException.

The consumer was already gated by the swatch.swatch-contracts.enable-it-subscription-service unleash feature flag.

## Testing
Unit tests are updated.

## Verification
Component tests in: SWATCH-5072: Component tests
Stage testing in: SWATCH-5073: Stage verification of parallel consumption


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kafka subscription messages now persist successfully after valid XML is processed.
  * Message handling is now more precise by focusing error handling on parsing issues instead of all exceptions.
  * Null messages and feature-disabled scenarios no longer trigger any persistence action.
* **Tests**
  * Expanded assertions to verify persistence occurs after successful processing.
  * Added/updated negative-path checks to ensure persistence is never called when inputs are null or the consumer is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->