### PR TITLE
SWATCH-4504: Reduce ephemeral deployment time for Konflux IQE tests

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -356,10 +356,33 @@ spec:
             value: "$(params.BONFIRE_REVISION)"
           - name: pathInRepo
             value: tasks/reserve-namespace.yaml
+    - name: update-namespace
+      runAfter:
+        - reserve-namespace
+      when:
+        - input: "$(tasks.check-component-label.results.TESTS_SKIPPED)"
+          operator: in
+          values: ["false"]
+      params:
+        - name: NS
+          value: "$(tasks.reserve-namespace.results.NS)"
+        - name: EPHEMERAL_ENV_PROVIDER_SECRET
+          value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
+        - name: BONFIRE_IMAGE
+          value: "$(params.BONFIRE_IMAGE)"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: "https://github.com/$(params.PROJECT_REPO).git"
+          - name: revision
+            value: "$(params.PROJECT_TASKS_REVISION)"
+          - name: pathInRepo
+            value: .tekton/tasks/update-namespace.yaml
     - name: deploy-application
       onError: continue
       runAfter:
-        - reserve-namespace
+        - update-namespace
         - update-extra-deploy-args
       when:
         - input: "$(tasks.check-component-label.results.TESTS_SKIPPED)"

--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -73,10 +73,11 @@ spec:
     - name: EXTRA_DEPLOY_ARGS
       type: string
       description: Extra arguments for the deployment
-      # Skip not required components:
-      # - puptoo: insights-puptoo is the service that processes Ingress flow uploads
-      default: >-
-        --timeout 1800 --remove-dependencies ingress/puptoo
+      default: ""
+    - name: DEPLOY_OPTIONAL_DEPS_METHOD
+      type: string
+      description: Method to deploy optional dependencies - see bonfire docs https://github.com/redhatinsights/bonfire?tab=readme-ov-file#dependency-processing
+      default: ""
     - name: DEPLOY_FRONTENDS
       type: string
       description: Deploy frontend in the env or not
@@ -414,6 +415,8 @@ spec:
           value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
         - name: GITHUB_TOKEN_SECRET
           value: "$(params.GITHUB_TOKEN_SECRET)"
+        - name: OPTIONAL_DEPS_METHOD
+          value: "$(params.DEPLOY_OPTIONAL_DEPS_METHOD)"
       taskSpec:
         params:
           - name: BONFIRE_IMAGE
@@ -441,6 +444,7 @@ spec:
           - name: EPHEMERAL_ENV_PROVIDER_SECRET
             type: string
           - name: GITHUB_TOKEN_SECRET
+          - name: OPTIONAL_DEPS_METHOD
             type: string
         workspaces:
           - name: artifacts
@@ -497,6 +501,8 @@ spec:
                 value: "$(params.DEPLOY_FRONTENDS)"
               - name: DEPLOY_TIMEOUT
                 value: "$(params.DEPLOY_TIMEOUT)"
+              - name: OPTIONAL_DEPS_METHOD
+                value: "$(params.OPTIONAL_DEPS_METHOD)"
             script: |
               #!/bin/bash
               set +e

--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -376,10 +376,34 @@ spec:
           - name: pathInRepo
             value: tasks/reserve-namespace.yaml
 
+    - name: update-namespace
+      runAfter:
+        - reserve-namespace
+      when:
+        - input: "$(tasks.verify-snapshot-completeness.results.SKIP_TESTS)"
+          operator: in
+          values: ["false"]
+      params:
+        - name: NS
+          value: "$(tasks.reserve-namespace.results.NS)"
+        - name: EPHEMERAL_ENV_PROVIDER_SECRET
+          value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
+        - name: BONFIRE_IMAGE
+          value: "$(params.BONFIRE_IMAGE)"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: "https://github.com/$(params.PROJECT_REPO).git"
+          - name: revision
+            value: "$(params.PROJECT_TASKS_REVISION)"
+          - name: pathInRepo
+            value: .tekton/tasks/update-namespace.yaml
+
     - name: deploy-application
       onError: continue
       runAfter:
-        - reserve-namespace
+        - update-namespace
         - build-extra-deploy-args
       when:
         - input: "$(tasks.verify-snapshot-completeness.results.SKIP_TESTS)"

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -40,10 +40,11 @@ spec:
     # Deployment configuration
     ## Workaround to reduce the footprint of the ephemeral environment for rbac. To be fixed in SWATCH-4504.
     ## Workaround to reduce the footprint of the ephemeral environment for host-inventory. To be fixed in SWATCH-5159.
+    ## Workaround to not deploy swatch-tally-ct-hbi in an ephemeral environment. To be fixed in SWATCH-5160.
     - name: EXTRA_DEPLOY_ARGS
       value: >-
         --timeout 1800
-        --exclude-components puptoo,ingress,storage-broker
+        --exclude-components puptoo,ingress,storage-broker,swatch-tally-ct-hbi
         --remove-dependencies host-inventory/ingress
         -p rbac/CELERY_INITIAL_DELAY_SEC=10
         -p rbac/MAX_SEED_THREADS=8

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -39,7 +39,12 @@ spec:
     
     # Deployment configuration
     - name: EXTRA_DEPLOY_ARGS
-      value: "--timeout 1800"
+      value: >-
+        --timeout 1800
+        --exclude-components puptoo,ingress,storage-broker
+        --remove-dependencies host-inventory/ingress
+    - name: DEPLOY_OPTIONAL_DEPS_METHOD
+      value: "none"
     - name: DEPLOY_FRONTENDS
       value: "false"
     - name: DEPLOY_TIMEOUT

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -38,11 +38,19 @@ spec:
       value: "app:rhsm app:export-service"
     
     # Deployment configuration
+    ## Workaround to reduce the footprint of the ephemeral environment for rbac. To be fixed in SWATCH-4504.
     - name: EXTRA_DEPLOY_ARGS
       value: >-
         --timeout 1800
         --exclude-components puptoo,ingress,storage-broker
         --remove-dependencies host-inventory/ingress
+        -p rbac/CELERY_INITIAL_DELAY_SEC=10
+        -p rbac/MAX_SEED_THREADS=8
+        -p rbac/MIN_POSTGRES_EXPORTER_REPLICAS=0
+        -p rbac/NOTIFICATIONS_ENABLED=False
+        -p rbac/NOTIFICATIONS_RH_ENABLED=False
+        -p rbac/KAFKA_ENABLED=False
+        -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0
     - name: DEPLOY_OPTIONAL_DEPS_METHOD
       value: "none"
     - name: DEPLOY_FRONTENDS

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -39,6 +39,7 @@ spec:
     
     # Deployment configuration
     ## Workaround to reduce the footprint of the ephemeral environment for rbac. To be fixed in SWATCH-4504.
+    ## Workaround to reduce the footprint of the ephemeral environment for host-inventory. To be fixed in SWATCH-5159.
     - name: EXTRA_DEPLOY_ARGS
       value: >-
         --timeout 1800
@@ -51,6 +52,12 @@ spec:
         -p rbac/NOTIFICATIONS_RH_ENABLED=False
         -p rbac/KAFKA_ENABLED=False
         -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0
+        -p host-inventory/GUNICORN_WORKERS=1
+        -p host-inventory/GUNICORN_THREADS=1
+        -p host-inventory/REPLICAS_EXPORT_SVC=0
+        -p host-inventory/REPLICAS_WORKSPACES=0
+        -p host-inventory/REPLICAS_WORKSPACES_BULK=0
+        -p host-inventory/REPLICAS_HOST_APP_DATA=0
     - name: DEPLOY_OPTIONAL_DEPS_METHOD
       value: "none"
     - name: DEPLOY_FRONTENDS

--- a/.tekton/tasks/update-namespace.yaml
+++ b/.tekton/tasks/update-namespace.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: update-namespace
+spec:
+  description: Applies ephemeral namespace adjustments after reserve-namespace and before deploy.
+  params:
+    - name: NS
+      type: string
+      description: Reserved ephemeral namespace name
+    - name: EPHEMERAL_ENV_PROVIDER_SECRET
+      type: string
+      description: Secret for connecting to the ephemeral env provider cluster
+    - name: BONFIRE_IMAGE
+      type: string
+      description: Bonfire container image (provides oc and login.sh)
+  steps:
+    - name: update-namespace
+      image: "$(params.BONFIRE_IMAGE)"
+      env:
+        - name: OC_LOGIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
+              key: token
+        - name: OC_LOGIN_SERVER
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
+              key: url
+        - name: BONFIRE_BOT
+          value: "true"
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        CLOWD_ENV="env-$(params.NS)"
+
+        echo "Connecting to the ephemeral namespace cluster"
+        login.sh
+
+        wait_for_clowd_environment() {
+          local name=$1
+          for _ in $(seq 1 60); do
+            if oc get clowdenvironment "${name}" &>/dev/null; then
+              return 0
+            fi
+            echo "Waiting for ClowdEnvironment ${name}..."
+            sleep 5
+          done
+          echo "ERROR: ClowdEnvironment ${name} not found after 5 minutes"
+          return 1
+        }
+
+        disable_otel_collector() {
+          echo "Disabling otelCollector sidecar on ${CLOWD_ENV}"
+          oc patch clowdenvironment "${CLOWD_ENV}" \
+            -p '{"spec":{"providers":{"sidecars":{"otelCollector":{"enabled":false}}}}}' \
+            --type=merge
+        }
+
+        wait_for_clowd_environment "${CLOWD_ENV}"
+        oc get clowdenvironment "${CLOWD_ENV}"
+
+        disable_otel_collector

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -245,7 +245,7 @@ objects:
                 path: /health/liveness
                 port: 9000
                 scheme: HTTP
-              initialDelaySeconds: 160
+              initialDelaySeconds: 60
               periodSeconds: 20
               successThreshold: 1
               timeoutSeconds: 5
@@ -255,7 +255,7 @@ objects:
                 path: /health
                 port: 9000
                 scheme: HTTP
-              initialDelaySeconds: 160
+              initialDelaySeconds: 60
               periodSeconds: 20
               successThreshold: 1
               timeoutSeconds: 5

--- a/swatch-billable-usage/deploy/clowdapp.yaml
+++ b/swatch-billable-usage/deploy/clowdapp.yaml
@@ -118,6 +118,9 @@ parameters:
     value: '1'
   - name: DB_CHANGELOG_CLEANUP_SQL
     value: 'select 1'
+  - name: DB_CHANGELOG_CLEANUP_DISABLED
+    description: When true, skip db-changelog cleanup jobs
+    value: 'false'
   - name: EGRESS_IMAGE
     value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
   - name: EGRESS_IMAGE_TAG
@@ -416,6 +419,7 @@ objects:
     deployments: [ ]
     jobs:
     - name: changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+      disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
       restartPolicy: Never
       podSpec:
         image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -459,6 +463,7 @@ objects:
   metadata:
     name: billable-db-changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
   spec:
+    disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
     appName: swatch-billable-db-cleanup
     jobs:
       - changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -60,6 +60,9 @@ parameters:
     value: '1'
   - name: DB_CHANGELOG_CLEANUP_SQL
     value: 'select 1'
+  - name: DB_CHANGELOG_CLEANUP_DISABLED
+    description: When true, skip db-changelog cleanup jobs
+    value: 'false'
   - name: EGRESS_IMAGE
     value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
   - name: EGRESS_IMAGE_TAG
@@ -630,6 +633,7 @@ objects:
       deployments: []
       jobs:
         - name: changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+          disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
           restartPolicy: Never
           podSpec:
             image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -673,6 +677,7 @@ objects:
     metadata:
       name: contracts-db-changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
     spec:
+      disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
       appName: swatch-contracts-db-cleanup
       jobs:
         - changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}

--- a/swatch-metrics-hbi/deploy/clowdapp.yaml
+++ b/swatch-metrics-hbi/deploy/clowdapp.yaml
@@ -88,6 +88,9 @@ parameters:
     value: '1'
   - name: DB_CHANGELOG_CLEANUP_SQL
     value: 'select 1'
+  - name: DB_CHANGELOG_CLEANUP_DISABLED
+    description: When true, skip db-changelog cleanup jobs
+    value: 'false'
   - name: EGRESS_IMAGE
     value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
   - name: EGRESS_IMAGE_TAG
@@ -382,6 +385,7 @@ objects:
     deployments: []
     jobs:
       - name: changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+        disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
         restartPolicy: Never
         podSpec:
           image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -425,6 +429,7 @@ objects:
   metadata:
     name: metrics-hbi-db-changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
   spec:
+    disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
     appName: swatch-metrics-hbi-db-cleanup
     jobs:
       - changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -140,6 +140,9 @@ parameters:
     value: '1'
   - name: DB_CHANGELOG_CLEANUP_SQL
     value: 'select 1'
+  - name: DB_CHANGELOG_CLEANUP_DISABLED
+    description: When true, skip db-changelog cleanup jobs
+    value: 'false'
 # Increment in AppInterface before each migration
   - name: DB_MIGRATION_RUN_NUMBER
     value: '1'
@@ -898,6 +901,7 @@ objects:
     deployments: []
     jobs:
       - name: db-changelog-cleanup-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+        disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
         restartPolicy: Never
         podSpec:
           image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -937,6 +941,7 @@ objects:
             value: ${DB_CHANGELOG_CLEANUP_SQL}
 
       - name: tally-manual-migration-${DB_MIGRATION_RUN_NUMBER}
+        disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
         restartPolicy: Never
         podSpec:
           image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -985,6 +990,7 @@ objects:
   metadata:
     name: db-changelog-cleanup-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
   spec:
+    disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
     appName: swatch-db-changelog-cleanup
     jobs:
       - db-changelog-cleanup-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
@@ -994,6 +1000,7 @@ objects:
   metadata:
     name: tally-manual-migration-${DB_MIGRATION_RUN_NUMBER}
   spec:
+    disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
     appName: swatch-db-changelog-cleanup
     jobs:
     - tally-manual-migration-${DB_MIGRATION_RUN_NUMBER}

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -86,6 +86,9 @@ parameters:
     value: '1'
   - name: DB_CHANGELOG_CLEANUP_SQL
     value: 'select 1'
+  - name: DB_CHANGELOG_CLEANUP_DISABLED
+    description: When true, skip db-changelog cleanup jobs
+    value: 'false'
   - name: EGRESS_IMAGE
     value: quay.io/redhat-services-prod/rh-subs-watch-tenant/rhsm-subscriptions-egress
   - name: EGRESS_IMAGE_TAG
@@ -346,6 +349,7 @@ objects:
     deployments: [ ]
     jobs:
     - name: changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
+      disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
       restartPolicy: Never
       podSpec:
         image: ${EGRESS_IMAGE}:${EGRESS_IMAGE_TAG}
@@ -389,6 +393,7 @@ objects:
   metadata:
     name: utilization-db-changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}
   spec:
+    disabled: ${{DB_CHANGELOG_CLEANUP_DISABLED}}
     appName: swatch-utilization-db-cleanup
     jobs:
       - changelog-${DB_CHANGELOG_CLEANUP_RUN_NUMBER}


### PR DESCRIPTION
Jira issue: [SWATCH-4504](https://redhat.atlassian.net/browse/SWATCH-4504)

## Summary

Reduce Konflux ephemeral IQE deploy time and resource footprint for bonfire deploy rhsm. 

Full IQE suite passed. vs baseline: deploy ~6m 44s → ~5m 15s (~22%), CPU requested 17.19 → 10.45 cores (~39%), memory 42.52 → 30.49 Gi (~28%), ClowdApps 28 → 24.

app-interface MR required for LOGGING_HEC_ENABLED and DB_CHANGELOG_CLEANUP_DISABLED: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/194986

### Changes
- new update-namespace task disables otel collector on the ephemeral ClowdEnvironment before deploy (~1m faster, ~2.6 CPU / ~5.8 Gi saved)
- Integration pipelinerun passes slim-deploy flags via EXTRA_DEPLOY_ARGS: exclude puptoo, ingress, storage-broker, swatch-tally-ct-hbi; remove host-inventory/ingress dependency; rbac and host-inventory replica/worker overrides (~1m faster, HBI 11→8 pods, rbac 4→3, ~3 Gi less)
- DEPLOY_OPTIONAL_DEPS_METHOD=none wired through the pipeline.
- swatch-api probe initial delay 160s → 60s (~1m faster deploy)
- DB_CHANGELOG_CLEANUP_DISABLED on billable-usage, contracts, metrics-hbi, tally, utilization — skips changelog cleanup jobs when enabled. 

## Verification

Run:

```
export NAMESPACE=$(bonfire namespace reserve)

oc patch clowdenvironment "env-${NAMESPACE}" \
  -p '{"spec":{"providers":{"sidecars":{"otelCollector":{"enabled":false}}}}}' \
  --type=merge

bonfire deploy rhsm \
  --source appsre \
  --ref-env insights-production \
  --timeout 1800 \
  --optional-deps-method none \
  --frontends false \
  --no-remove-resources app:rhsm \
  --set-template-ref rhsm=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-api=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-billable-usage=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-contracts=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-metrics-hbi=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-tally=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --set-template-ref swatch-utilization=jcarvaja/SWATCH-4504-slim-ephemeral-deploy \
  --remove-dependencies host-inventory/ingress \
  --exclude-components ingress,puptoo,storage-broker,swatch-tally-ct-hbi \
  -p host-inventory/GUNICORN_WORKERS=1 \
  -p host-inventory/GUNICORN_THREADS=1 \
  -p host-inventory/REPLICAS_EXPORT_SVC=0 \
  -p host-inventory/REPLICAS_WORKSPACES=0 \
  -p host-inventory/REPLICAS_WORKSPACES_BULK=0 \
  -p host-inventory/REPLICAS_HOST_APP_DATA=0 \
  -p rbac/CELERY_INITIAL_DELAY_SEC=10 \
  -p rbac/MAX_SEED_THREADS=8 \
  -p rbac/MIN_POSTGRES_EXPORTER_REPLICAS=0 \
  -p rbac/NOTIFICATIONS_ENABLED=False \
  -p rbac/NOTIFICATIONS_RH_ENABLED=False \
  -p rbac/KAFKA_ENABLED=False \
  -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0 \
  -p swatch-api/LOGGING_HEC_ENABLED=false \
  -p swatch-tally/LOGGING_HEC_ENABLED=false \
  -p swatch-system-conduit/LOGGING_HEC_ENABLED=false \
  -p swatch-billable-usage/LOGGING_HEC_ENABLED=false \
  -p swatch-contracts/LOGGING_HEC_ENABLED=false \
  -p swatch-metrics/LOGGING_HEC_ENABLED=false \
  -p swatch-metrics-hbi/LOGGING_HEC_ENABLED=false \
  -p swatch-producer-aws/LOGGING_HEC_ENABLED=false \
  -p swatch-producer-azure/LOGGING_HEC_ENABLED=false \
  -p swatch-utilization/LOGGING_HEC_ENABLED=false \
  -p swatch-billable-usage/DB_CHANGELOG_CLEANUP_DISABLED=true \
  -p swatch-contracts/DB_CHANGELOG_CLEANUP_DISABLED=true \
  -p swatch-metrics-hbi/DB_CHANGELOG_CLEANUP_DISABLED=true \
  -p swatch-tally/DB_CHANGELOG_CLEANUP_DISABLED=true \
  -p swatch-utilization/DB_CHANGELOG_CLEANUP_DISABLED=true
  ```
  
And then run the IQE tests:
  
- `bonfire deploy-iqe-cji rhsm --debug-pod -n $(oc project -q)`
- `oc rsh $(oc get pods | grep iqe | cut -d' ' -f1)`
- `ENV_FOR_DYNACONF=clowder_smoke iqe tests plugin rhsm_subscriptions -m ephemeral`

[SWATCH-4504]: https://redhat.atlassian.net/browse/SWATCH-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable control for optional dependency deployment in integration test pipelines.
  * Inserted an environment preparation step in test workflows that updates the reserved namespace before deployment (including disabling the telemetry sidecar).
  * Added a `DB_CHANGELOG_CLEANUP_DISABLED` switch across multiple deployment templates to skip database changelog cleanup when desired.
* **Bug Fixes**
  * Reduced initial delay for readiness and liveness HTTP probes so services are marked healthy/unhealthy sooner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->