### PR TITLE
SWATCH-4844: Add custom-threshold receipt to Stage notification test plan

### DIFF
--- a/docs/integration-test-plans/Notification Service Integration Test Plan.md
+++ b/docs/integration-test-plans/Notification Service Integration Test Plan.md
@@ -101,3 +101,15 @@ Limitation:
 4. **Expected Result:**
    - No notification is emitted when the PAYG usage type does not match the offering.
    - A notification is emitted when the PAYG usage type matches the offering and usage exceeds the threshold.
+
+## stage-custom-threshold-notification-receipt-TC001
+
+1. **Description:** An opted-in organization with a custom threshold configured receives a proactive notification when utilization crosses that threshold. For this calendar month, no prior custom-threshold notification for the same product-metric has been sent.
+2. **Setup:**
+   - The organization is opted-in for notifications.
+   - The organization has a custom threshold configured.
+   - The organization has a contract for a product.
+   - Usage is added for that product, crossing the custom threshold but not the over-usage threshold.
+3. **Action:** Trigger the hourly tally sync job.
+4. **Verification:** Check the organization's email inbox for the expected organization ID, product, metric, and exact usage percentage.
+5. **Expected Result:** A custom-threshold notification with the correct data is received.


### PR DESCRIPTION
## Summary

- Appends `stage-custom-threshold-notification-receipt-TC001` to `docs/integration-test-plans/Notification Service Integration Test Plan.md`.
- No other test-plan edits (existing over-usage cases and wording unchanged).

IQE implementation: [SWATCH-4846](https://redhat.atlassian.net/browse/SWATCH-4846)

Parent: [SWATCH-4843](https://redhat.atlassian.net/browse/SWATCH-4843)

## Test plan

- [ ] Team review of the new test case
- [ ] IQE receipt test in SWATCH-4846

[SWATCH-4846]: https://redhat.atlassian.net/browse/SWATCH-4846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SWATCH-4843]: https://redhat.atlassian.net/browse/SWATCH-4843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new stage test plan scenario covering custom-threshold notification receipt.
  * Documented an opted-in organization case where usage crosses a custom threshold and triggers a single notification email with the expected organization, product, metric, and monthly usage percentage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->