### PR TITLE
SWATCH-4871: Mitigate memory leaks in swatch-metrics

### DIFF
--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/PrometheusMeteringController.java
@@ -154,9 +154,9 @@ public class PrometheusMeteringController {
       OffsetDateTime start,
       OffsetDateTime end,
       AtomicInteger counter) {
+    Sample sample = Timer.start(registry);
     try {
       log.info("Collecting metrics for orgId={}: {} {}", orgId, tag, metric);
-      Sample sample = Timer.start(registry);
       AtomicInteger eventsSent = new AtomicInteger(0);
       QuerySummaryResult metricData =
           prometheusService.runRangeQuery(
@@ -180,6 +180,8 @@ public class PrometheusMeteringController {
 
       log.info("Sent {} events for {} {} metrics.", eventsSent.get(), tag, metric);
     } catch (Exception e) {
+      // Stop the timer even on failure to prevent Timer.Sample leak
+      sample.stop(registry.timer("metrics.collection.timer", PRODUCT_TAG, tag, "status", "error"));
       log.warn(
           "Exception thrown while updating {} {} {} metrics. [Attempt: {}]: {}",
           tag,

--- a/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
+++ b/swatch-metrics/src/main/java/com/redhat/swatch/metrics/service/prometheus/PrometheusService.java
@@ -85,7 +85,17 @@ public class PrometheusService {
       File data =
           queryRangeApi.queryRange(
               query, start.toEpochSecond(), end.toEpochSecond(), Integer.toString(step), timeout);
-      return parseQueryResult(data, resultDataItemConsumer);
+      try {
+        return parseQueryResult(data, resultDataItemConsumer);
+      } finally {
+        // Clean up temporary response file to prevent memory leak
+        if (data != null && data.exists()) {
+          if (!data.delete()) {
+            log.warn(
+                "Failed to delete temporary Prometheus response file: {}", data.getAbsolutePath());
+          }
+        }
+      }
     } catch (ProcessingException | ApiException ex) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(ex), ex);
@@ -102,7 +112,17 @@ public class PrometheusService {
     try {
       log.debug("Running prometheus query: Time: {}, Query: {}", time.toEpochSecond(), query);
       File data = queryApi.query(query, time, timeout);
-      return parseQueryResult(data, itemConsumer);
+      try {
+        return parseQueryResult(data, itemConsumer);
+      } finally {
+        // Clean up temporary response file to prevent memory leak
+        if (data != null && data.exists()) {
+          if (!data.delete()) {
+            log.warn(
+                "Failed to delete temporary Prometheus response file: {}", data.getAbsolutePath());
+          }
+        }
+      }
     } catch (ProcessingException | ApiException ex) {
       throw new ExternalServiceException(
           ErrorCode.REQUEST_PROCESSING_ERROR, formatErrorMessage(ex), ex);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4871

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

We have seen an OOMKill on swatch-metrics-service about every 59-67 hours. An investigation yielded a few places where we could be seeing memory leaks.

 We may also want to increase the memory limit:
swatch-metrics-service and swatch-metrics-rhel-service have a memory limit set to 1400Mi in this repo at swatch-metrics/deploy/clowdapp.yaml.
Swatch-metrics-service is overridden for production to 800Mi in app-interface: data/services/insights/rhsm/cicd/deploy-clowder.yml. 

It will be helpful to merge https://github.com/RedHatInsights/rhsm-subscriptions/pull/6302 first so that the memory usage can be evaluated before and after this change.

## Testing

### Full verification will need to happen after the deployment to stage
<!-- Enter the steps needed to verify the test passed -->
1. The tests pass in the CI
2.  The swatch-tally-service should not OOMKill in stage




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the metrics collection timer is always completed, even when metric collection fails.
  * Temporary Prometheus response files are now cleaned up after query parsing, with warnings if cleanup fails, reducing leftover files and disk usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->