### PR TITLE
SWATCH-5145: use github token to deploy components using bonfire

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -100,7 +100,7 @@ spec:
     # Project configuration
     - name: GITHUB_TOKEN_SECRET
       type: string
-      description: Secret name containing the GitHub API token for posting PR comments
+      description: Secret name containing the GitHub API token (bonfire deploy template fetch and PR comments)
       default: "swatch-ci-github-token"
     - name: PROJECT_REPO
       type: string
@@ -397,6 +397,10 @@ spec:
           value: "$(params.DEPLOY_TIMEOUT)"
         - name: OPTIONAL_DEPS_METHOD
           value: "$(params.DEPLOY_OPTIONAL_DEPS_METHOD)"
+        - name: EPHEMERAL_ENV_PROVIDER_SECRET
+          value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
+        - name: GITHUB_TOKEN_SECRET
+          value: "$(params.GITHUB_TOKEN_SECRET)"
       taskSpec:
         params:
           - name: BONFIRE_IMAGE
@@ -426,6 +430,10 @@ spec:
           - name: DEPLOY_TIMEOUT
             type: string
           - name: OPTIONAL_DEPS_METHOD
+            type: string
+          - name: EPHEMERAL_ENV_PROVIDER_SECRET
+            type: string
+          - name: GITHUB_TOKEN_SECRET
             type: string
         workspaces:
           - name: artifacts
@@ -461,6 +469,11 @@ spec:
                   secretKeyRef:
                     name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
                     key: url
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET)
+                    key: github_token
               - name: APP_NAME
                 value: $(params.APP_NAME)
               - name: BONFIRE_COMPONENT_NAME
@@ -486,6 +499,10 @@ spec:
             script: |
               #!/bin/bash
               set +e
+
+              if [ -n "${GITHUB_TOKEN:-}" ]; then
+                export GITHUB_TOKEN="$(echo -n "$GITHUB_TOKEN" | tr -d '[:space:]')"
+              fi
 
               DEPLOY_LOG="$(workspaces.artifacts.path)/deploy.log"
               EXIT_CODE_FILE="$(workspaces.artifacts.path)/deploy-exit-code"

--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -141,7 +141,7 @@ spec:
     # Project configuration
     - name: GITHUB_TOKEN_SECRET
       type: string
-      description: Secret name containing the GitHub API token for posting PR comments
+      description: Secret name containing the GitHub API token (bonfire deploy template fetch and PR comments)
       default: "swatch-ci-github-token"
     - name: PROJECT_REPO
       type: string
@@ -410,6 +410,10 @@ spec:
           value: "$(params.DEPLOY_FRONTENDS)"
         - name: DEPLOY_TIMEOUT
           value: "$(params.DEPLOY_TIMEOUT)"
+        - name: EPHEMERAL_ENV_PROVIDER_SECRET
+          value: "$(params.EPHEMERAL_ENV_PROVIDER_SECRET)"
+        - name: GITHUB_TOKEN_SECRET
+          value: "$(params.GITHUB_TOKEN_SECRET)"
       taskSpec:
         params:
           - name: BONFIRE_IMAGE
@@ -433,6 +437,10 @@ spec:
           - name: DEPLOY_FRONTENDS
             type: string
           - name: DEPLOY_TIMEOUT
+            type: string
+          - name: EPHEMERAL_ENV_PROVIDER_SECRET
+            type: string
+          - name: GITHUB_TOKEN_SECRET
             type: string
         workspaces:
           - name: artifacts
@@ -468,6 +476,11 @@ spec:
                   secretKeyRef:
                     name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
                     key: url
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.GITHUB_TOKEN_SECRET)
+                    key: github_token
               - name: APP_NAME
                 value: $(params.APP_NAME)
               - name: COMPONENTS
@@ -487,6 +500,10 @@ spec:
             script: |
               #!/bin/bash
               set +e
+
+              if [ -n "${GITHUB_TOKEN:-}" ]; then
+                export GITHUB_TOKEN="$(echo -n "$GITHUB_TOKEN" | tr -d '[:space:]')"
+              fi
 
               DEPLOY_LOG="$(workspaces.artifacts.path)/deploy.log"
               EXIT_CODE_FILE="$(workspaces.artifacts.path)/deploy-exit-code"


### PR DESCRIPTION
Jira issue: SWATCH-5145

## Description
Same changes than in https://github.com/RedHatInsights/curiosity-frontend/pull/1891.

We need to use the github token to prevent timeouts when resolving templates at bonfire deployment time. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by passing the GitHub token through the deployment flow and cleaning up any extra whitespace before use.
  * Ensured the required ephemeral environment provider secret continues to be forwarded during deployment.
  * Updated token-related descriptions so the expected deployment inputs are clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->