### PR TITLE
ci: automatically add the skip-integration-tests label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     outputs:
-      modified-services: ${{ steps.add-labels.outputs.modified-services }}
+      modified-services: ${{ steps.add-service-labels.outputs.modified-services }}
+      skip-integration-tests: ${{ steps.add-skip-integration-tests-label.outputs.skip-integration-tests }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -37,7 +38,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y gh
       - name: Detect and label modified services
-        id: add-labels
+        id: add-service-labels
         continue-on-error: true
         run: |
           # Source utilities
@@ -78,6 +79,25 @@ jobs:
           echo "modified-services=$MODIFIED_SERVICES_STR" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Manage skip-integration-tests label
+        id: add-skip-integration-tests-label
+        continue-on-error: true
+        run: |
+          source bin/pr_label_utils.sh
+
+          CURRENT_LABELS=$(get_current_labels "$PR_NUMBER")
+
+          git fetch origin "$BASE_BRANCH"
+          if manage_skip_integration_test_label "$PR_NUMBER" "$CURRENT_LABELS" "$BASE_BRANCH"; then
+            echo "skip-integration-tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip-integration-tests=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
 
   validate-format:
     name: Validate Format
@@ -244,7 +264,7 @@ jobs:
     name: Verify SWATCH services for local testing
     runs-on: ubuntu-latest
     needs: [test, labeler]
-    if: always() && (needs.test.result == 'success') && (needs.labeler.result == 'success' || needs.labeler.result == 'skipped')
+    if: always() && (needs.test.result == 'success') && (needs.labeler.result == 'success' || needs.labeler.result == 'skipped') && needs.labeler.outputs.skip-integration-tests != 'true'
     steps:
       - uses: actions/checkout@v7
 

--- a/bin/pr_label_utils.sh
+++ b/bin/pr_label_utils.sh
@@ -12,6 +12,7 @@ SWATCH_LIGHTNING_SERVICES=("swatch-billable-usage" "swatch-contracts" "swatch-pr
 # All services (combination of both teams)
 ALL_SERVICES=("${SWATCH_THUNDER_SERVICES[@]}" "${SWATCH_LIGHTNING_SERVICES[@]}")
 SWATCH_ALL_LABEL="swatch-all"
+SKIP_INTEGRATION_TESTS_LABEL="skip-integration-tests"
 
 # Get current PR labels
 get_current_labels() {
@@ -186,6 +187,96 @@ manage_team_labels() {
     fi
     
     echo "Team label management completed"
+}
+
+# --- skip-integration-tests label rules ---
+# Rules use the CHANGED_FILES array (set by manage_skip_integration_test_label).
+# Each entry in SKIP_INTEGRATION_TEST_SCOPES is a predicate for an allowed change scope.
+# The label is added when every changed file matches at least one scope (scopes may combine).
+
+get_pr_changed_files() {
+    local base_branch="$1"
+    git diff --name-only "origin/$base_branch...HEAD"
+}
+
+is_markdown_file() {
+    [[ "$1" == *.md ]]
+}
+
+is_under_docs() {
+    [[ "$1" == docs/* ]]
+}
+
+is_under_github() {
+    [[ "$1" == .github/* ]]
+}
+
+is_under_grafana() {
+    [[ "$1" == .rhcicd/grafana/* ]]
+}
+
+is_under_bin() {
+    [[ "$1" == bin/* ]]
+}
+
+file_matches_any_skip_scope() {
+    local file="$1"
+    local scope
+
+    for scope in "${SKIP_INTEGRATION_TEST_SCOPES[@]}"; do
+        if "$scope" "$file"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+should_skip_integration_tests() {
+    if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+        echo "skip-integration-tests: no changed files"
+        return 1
+    fi
+
+    local file
+    for file in "${CHANGED_FILES[@]}"; do
+        if ! file_matches_any_skip_scope "$file"; then
+            echo "skip-integration-tests: file outside allowed scopes: $file"
+            return 1
+        fi
+    done
+
+    echo "skip-integration-tests: all changed files are within allowed scopes"
+    return 0
+}
+
+manage_skip_integration_test_label() {
+    local pr_number=$1
+    local current_labels=$2
+    local base_branch="$3"
+
+    SKIP_INTEGRATION_TEST_SCOPES=(
+        is_markdown_file
+        is_under_docs
+        is_under_github
+        is_under_grafana
+        is_under_bin
+    )
+
+    CHANGED_FILES=()
+    while IFS= read -r file; do
+        [ -n "$file" ] && CHANGED_FILES+=("$file")
+    done < <(get_pr_changed_files "$base_branch")
+
+    echo "Managing skip-integration-tests label..."
+    echo "Changed files (${#CHANGED_FILES[@]}): ${CHANGED_FILES[*]}"
+
+    if should_skip_integration_tests; then
+        add_label_if_needed "$pr_number" "$SKIP_INTEGRATION_TESTS_LABEL" "$current_labels"
+        return 0
+    fi
+
+    remove_label_if_needed "$pr_number" "$SKIP_INTEGRATION_TESTS_LABEL" "$current_labels"
+    return 1
 }
 
 # Remove all service and team labels


### PR DESCRIPTION
## Description
Automates management of the **skip-integration-tests** label in pull requests. This label tells Konflux Integration Tests pipelines to skip IQE and component test runs when a PR only touches:
- Markdown/Docs files
- GitHub workflows
- Grafana
- Scripts under `bin` (not used by Konflux)

More changes:
- Renames the existing labeler step id from add-labels to add-service-labels (behavior unchanged).
- Implements scope-based rules in bin/pr_label_utils.sh: the label is applied when every changed file falls within at least one allowed scope; scopes can be combined in the same PR.
- Skip "Verify SWATCH services for local testing" when this label is present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic PR labeling to indicate when integration tests can be skipped.
  * The label now updates based on the files changed in a PR.
* **Bug Fixes**
  * Updated CI execution so service-related jobs no longer run when the skip-integration-tests label is set.
  * Improved label handling to keep PR status consistent with the current change set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->