### PR TITLE
SWATCH-5115: Gate CustomerAWSAccountId on BatchMeterUsage behind Unleash

### DIFF
--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -1,0 +1,97 @@
+# Introduction
+
+The **swatch-producer-aws** module is a service within the Subscription Watch platform that consumes hourly billable-usage aggregates from Kafka, looks up AWS contract context from **swatch-contracts**, and submits usage to AWS Marketplace via `BatchMeterUsage`. It publishes remittance status to `platform.rhsm-subscriptions.billable-usage.status` and increments `swatch_producer_metered_total` for observability.
+
+This document outlines the test plan for swatch-producer-aws.
+
+**Purpose:** To ensure the swatch-producer-aws service is functional, reliable, and meets all defined requirements for AWS usage remittance.
+
+**Scope:**
+
+* Kafka consumption of AWS billable-usage hourly aggregates
+* Contracts API lookup (`awsUsageContext`) and error handling
+* AWS Marketplace `BatchMeterUsage` submission
+* Remittance status emission and metrics
+
+**Assumptions:**
+
+* The swatch-producer-aws service is deployed in a stable and functional environment
+* **swatch-contracts** provides accurate `AwsUsageContext` for subscribed orgs
+* Kafka is available for billable-usage input and status output topics
+* AWS Marketplace and contracts APIs are stubbed via Wiremock in component tests
+
+**Constraints:**
+
+* Testing is limited to the functionality of swatch-producer-aws at a component level
+* End-to-end testing in ephemeral or stage environments is out of scope for this test plan
+
+# Test Strategy
+
+This test plan focuses on covering test scenarios for component-level tests utilizing the Java component test framework.
+
+**Testing Strategy:**
+
+Test cases should be testable locally and in deployed environments.
+
+- Billable-usage aggregates can be published directly to the Kafka `billable-usage-hourly-aggregate` topic
+- Contracts `awsUsageContext` and AWS `BatchMeterUsage` can be stubbed via Wiremock (`AwsWiremockService`)
+- Outcomes can be verified on the `billable-usage.status` topic and, where relevant, on captured AWS request bodies
+- Unleash toggles can be exercised through the component-test harness (`AwsUnleashService`) when feature-flag behavior is under test
+
+# Test Cases
+
+## Customer identification on BatchMeterUsage
+
+When the feature flag is enabled, usage records may use `CustomerAWSAccountId` from `AwsUsageContext.customerAwsAccountId` instead of `CustomerIdentifier`. Covered by component tests in `CustomerAwsAccountIdComponentTest`.
+
+**Feature flag covered:** `swatch.swatch-producer-aws.use-customer-aws-account-id` (default off)
+
+**producer-aws-customer-id-TC001 - Use CustomerIdentifier when feature flag is off**
+
+- **Description**: Verify that with the toggle disabled (default), usage records sent to AWS use `CustomerIdentifier` from `AwsUsageContext.customerId`.
+- **Setup**:
+  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is off
+  - Wiremock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `SUCCEEDED` on `billable-usage.status`
+  - Inspect captured `BatchMeterUsage` request in Wiremock
+- **Expected Result**:
+  - `UsageRecords[0].CustomerIdentifier` equals `customerId`
+  - `CustomerAWSAccountId` is absent from the usage record
+
+**producer-aws-customer-id-TC002 - Use CustomerAWSAccountId when feature flag is on**
+
+- **Description**: Verify that with the toggle enabled and `customerAwsAccountId` present, usage records use `CustomerAWSAccountId`.
+- **Setup**:
+  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is enabled
+  - Wiremock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `SUCCEEDED` on `billable-usage.status`
+  - Inspect captured `BatchMeterUsage` request in Wiremock
+- **Expected Result**:
+  - `UsageRecords[0].CustomerAWSAccountId` matches `customerAwsAccountId` from context
+  - `CustomerIdentifier` is absent from the usage record
+  - `ProductCode` is still sent on the request
+
+**producer-aws-customer-id-TC003 - Fall back to CustomerIdentifier when account id is missing**
+
+- **Description**: Verify that with the toggle enabled but `customerAwsAccountId` absent from context, the producer logs a warning and falls back to `CustomerIdentifier`.
+- **Setup**:
+  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is enabled
+  - Wiremock returns `awsUsageContext` without `customerAwsAccountId`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `SUCCEEDED` on `billable-usage.status`
+  - Inspect captured `BatchMeterUsage` request in Wiremock
+- **Expected Result**:
+  - Remittance status is `SUCCEEDED`
+  - `UsageRecords[0].CustomerIdentifier` equals `customerId`
+  - Warning logged about missing `customerAwsAccountId`

--- a/swatch-producer-aws/ct/README.md
+++ b/swatch-producer-aws/ct/README.md
@@ -7,7 +7,7 @@
 Start the required local services using Docker Compose:
 
 ```bash
-podman compose up -d kafka kafka-bridge kafka-setup wiremock
+podman compose up -d kafka kafka-bridge kafka-setup wiremock unleash
 ```
 
 ### 2. Run Component Tests

--- a/swatch-producer-aws/ct/java/api/AwsUnleashService.java
+++ b/swatch-producer-aws/ct/java/api/AwsUnleashService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import com.redhat.swatch.component.tests.api.UnleashService;
+
+public class AwsUnleashService extends UnleashService {
+
+  public static final String USE_CUSTOMER_AWS_ACCOUNT_ID =
+      "swatch.swatch-producer-aws.use-customer-aws-account-id";
+
+  public void enableUseCustomerAwsAccountId() {
+    enableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
+    waitForUnleashPropagation();
+  }
+
+  public void disableUseCustomerAwsAccountId() {
+    disableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
+    waitForUnleashPropagation();
+  }
+
+  /**
+   * Wait for swatch-producer-aws to pick up the toggle. Unleash admin updates are atomic; the
+   * service polls on {@code quarkus.unleash.fetch-toggles-interval} (1s in dev/ephemeral).
+   */
+  private void waitForUnleashPropagation() {
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for Unleash propagation", e);
+    }
+  }
+}

--- a/swatch-producer-aws/ct/java/api/AwsWiremockService.java
+++ b/swatch-producer-aws/ct/java/api/AwsWiremockService.java
@@ -20,13 +20,22 @@
  */
 package api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.component.tests.api.WiremockService;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageRequest;
+import software.amazon.awssdk.services.marketplacemetering.model.UsageRecord;
 
 public class AwsWiremockService extends WiremockService {
 
   private static final String AWS_USAGE_EVENT_PATH = "/mock/aws";
+  private static final String BATCH_METER_USAGE_TARGET = "AWSMPMeteringService.BatchMeterUsage";
 
   /**
    * Sets up the AWS usage context endpoint (contracts API) and a wiremock stub for the AWS
@@ -38,13 +47,26 @@ public class AwsWiremockService extends WiremockService {
       String rhSubscriptionId,
       String customerId,
       String productCode) {
-    var contextData =
-        Map.of(
-            "rhSubscriptionId", rhSubscriptionId,
-            "customerId", customerId,
-            "productCode", productCode,
-            "awsSellerAccountId", awsSellerAccountId,
-            "subscriptionStartDate", "2020-01-01T00:00:00Z");
+    setupAwsUsageContext(
+        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode, null);
+  }
+
+  public void setupAwsUsageContext(
+      String awsAccountId,
+      String awsSellerAccountId,
+      String rhSubscriptionId,
+      String customerId,
+      String productCode,
+      String customerAwsAccountId) {
+    var contextData = new HashMap<String, Object>();
+    contextData.put("rhSubscriptionId", rhSubscriptionId);
+    contextData.put("customerId", customerId);
+    contextData.put("productCode", productCode);
+    contextData.put("awsSellerAccountId", awsSellerAccountId);
+    contextData.put("subscriptionStartDate", "2020-01-01T00:00:00Z");
+    if (customerAwsAccountId != null) {
+      contextData.put("customerAwsAccountId", customerAwsAccountId);
+    }
 
     given()
         .contentType("application/json")
@@ -107,6 +129,91 @@ public class AwsWiremockService extends WiremockService {
         .statusCode(201);
   }
 
+  public void verifyBatchMeterUsageCustomerIdentifier(String expectedCustomerIdentifier) {
+    UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
+    assertEquals(
+        expectedCustomerIdentifier,
+        usageRecord.customerIdentifier(),
+        "customerIdentifier mismatch");
+    assertFieldAbsent("customerAWSAccountId", usageRecord.customerAWSAccountId());
+  }
+
+  public void verifyBatchMeterUsageCustomerAwsAccountId(String expectedCustomerAwsAccountId) {
+    UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
+    assertEquals(
+        expectedCustomerAwsAccountId,
+        usageRecord.customerAWSAccountId(),
+        "customerAWSAccountId mismatch");
+    assertFieldAbsent("customerIdentifier", usageRecord.customerIdentifier());
+  }
+
+  private static void assertFieldAbsent(String fieldName, String value) {
+    assertTrue(
+        value == null || value.isBlank(),
+        "Unexpected %s in BatchMeterUsage UsageRecord: %s".formatted(fieldName, value));
+  }
+
+  private UsageRecord findLatestBatchMeterUsageUsageRecord() {
+    BatchMeterUsageRequest batchRequest = findLatestBatchMeterUsageRequest();
+    if (batchRequest.usageRecords() == null || batchRequest.usageRecords().isEmpty()) {
+      throw new AssertionError("BatchMeterUsage request missing UsageRecords: " + batchRequest);
+    }
+    return batchRequest.usageRecords().get(0);
+  }
+
+  private BatchMeterUsageRequest findLatestBatchMeterUsageRequest() {
+    var response =
+        given().when().get("/__admin/requests").then().statusCode(200).extract().response();
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode responseJson = objectMapper.readTree(response.getBody().asString());
+      JsonNode requests = responseJson.get("requests");
+
+      if (requests == null || requests.isEmpty()) {
+        throw new AssertionError("No requests found in Wiremock");
+      }
+
+      BatchMeterUsageRequest matchingRequest = null;
+      for (JsonNode requestNode : requests) {
+        JsonNode request = requestNode.get("request");
+        if (request == null) {
+          continue;
+        }
+
+        JsonNode urlNode = request.get("url");
+        JsonNode methodNode = request.get("method");
+        JsonNode bodyNode = request.get("body");
+        if (urlNode == null || methodNode == null || bodyNode == null) {
+          continue;
+        }
+
+        String url = urlNode.asText();
+        String method = methodNode.asText();
+        if (!url.contains(AWS_USAGE_EVENT_PATH) || !"POST".equals(method)) {
+          continue;
+        }
+
+        String requestBody = bodyNode.asText();
+        if (requestBody == null || requestBody.isBlank()) {
+          continue;
+        }
+
+        matchingRequest = BatchMeterUsageRequestParser.parse(requestBody);
+      }
+
+      if (matchingRequest == null) {
+        throw new AssertionError("No BatchMeterUsage requests found at " + AWS_USAGE_EVENT_PATH);
+      }
+
+      return matchingRequest;
+    } catch (AssertionError e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to verify BatchMeterUsage request: " + e.getMessage(), e);
+    }
+  }
+
   private void setupAwsBatchMeterUsage() {
     // The AWS SDK v2 sends JSON (application/x-amz-json-1.1) with the X-Amz-Target header
     // to identify the operation. We return a minimal valid BatchMeterUsage JSON response.
@@ -121,9 +228,7 @@ public class AwsWiremockService extends WiremockService {
                     "urlPathPattern",
                     AWS_USAGE_EVENT_PATH + ".*",
                     "headers",
-                    Map.of(
-                        "X-Amz-Target",
-                        Map.of("equalTo", "AWSMarketplaceMetering.BatchMeterUsage"))),
+                    Map.of("X-Amz-Target", Map.of("equalTo", BATCH_METER_USAGE_TARGET))),
                 "response",
                 Map.of(
                     "status",

--- a/swatch-producer-aws/ct/java/api/BatchMeterUsageRequestParser.java
+++ b/swatch-producer-aws/ct/java/api/BatchMeterUsageRequestParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import software.amazon.awssdk.http.SdkHttpFullResponse;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.JsonProtocolUnmarshaller;
+import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
+import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageRequest;
+
+final class BatchMeterUsageRequestParser {
+
+  private static final JsonNodeParser JSON_NODE_PARSER = JsonNodeParser.create();
+  private static final JsonProtocolUnmarshaller JSON_PROTOCOL_UNMARSHALLER =
+      JsonProtocolUnmarshaller.builder()
+          .protocolUnmarshallDependencies(
+              JsonProtocolUnmarshaller.defaultProtocolUnmarshallDependencies())
+          .build();
+
+  private BatchMeterUsageRequestParser() {}
+
+  static BatchMeterUsageRequest parse(String json) {
+    return JSON_PROTOCOL_UNMARSHALLER.unmarshall(
+        BatchMeterUsageRequest.builder(),
+        SdkHttpFullResponse.builder().build(),
+        JSON_NODE_PARSER.parse(json));
+  }
+}

--- a/swatch-producer-aws/ct/java/tests/BaseAwsComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/BaseAwsComponentTest.java
@@ -22,12 +22,14 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
 
+import api.AwsUnleashService;
 import api.AwsWiremockService;
 import com.redhat.swatch.component.tests.api.ComponentTest;
 import com.redhat.swatch.component.tests.api.KafkaBridge;
 import com.redhat.swatch.component.tests.api.KafkaBridgeService;
 import com.redhat.swatch.component.tests.api.Quarkus;
 import com.redhat.swatch.component.tests.api.SwatchService;
+import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.api.Wiremock;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,11 +37,20 @@ import org.junit.jupiter.api.BeforeEach;
 @ComponentTest(name = "swatch-producer-aws")
 public class BaseAwsComponentTest {
 
+  /**
+   * Must match {@code aws.marketplace.test-credentials.seller-profile} in {@code
+   * application.properties}. AwsCredentialsLookup resolves credentials by seller account id from
+   * the usage context.
+   */
+  protected static final String AWS_SELLER_ACCOUNT_ID = "1234567";
+
   @KafkaBridge
   static KafkaBridgeService kafkaBridge =
       new KafkaBridgeService().subscribeToTopic(BILLABLE_USAGE_STATUS);
 
   @Wiremock static AwsWiremockService wiremock = new AwsWiremockService();
+
+  @Unleash static AwsUnleashService unleash = new AwsUnleashService();
 
   @Quarkus(service = "swatch-producer-aws")
   static SwatchService service = new SwatchService();
@@ -55,7 +66,7 @@ public class BaseAwsComponentTest {
   void setUp() {
     orgId = RandomUtils.generateRandom();
     awsAccountId = RandomUtils.generateRandom();
-    awsSellerAccountId = RandomUtils.generateRandom();
+    awsSellerAccountId = AWS_SELLER_ACCOUNT_ID;
     rhSubscriptionId = RandomUtils.generateRandom();
     customerId = RandomUtils.generateRandom();
     productCode = RandomUtils.generateRandom();

--- a/swatch-producer-aws/ct/java/tests/CustomerAwsAccountIdComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/CustomerAwsAccountIdComponentTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.AwsTestHelper.createUsageAggregate;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
+
+import api.MessageValidators;
+import domain.Product;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CustomerAwsAccountIdComponentTest extends BaseAwsComponentTest {
+
+  private static final double TOTAL_VALUE = 2.0;
+  private static final String CUSTOMER_AWS_ACCOUNT_ID = "123456789012";
+
+  @BeforeEach
+  void setUpFlagDisabled() {
+    unleash.disableUseCustomerAwsAccountId();
+  }
+
+  @AfterEach
+  void tearDown() {
+    unleash.disableUseCustomerAwsAccountId();
+  }
+
+  @Test
+  void testUsesCustomerIdentifierWhenFlagOff() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    wiremock.setupAwsUsageContext(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        CUSTOMER_AWS_ACCOUNT_ID);
+
+    produceAggregateAndWaitForSuccess(metricId);
+
+    wiremock.verifyBatchMeterUsageCustomerIdentifier(customerId);
+  }
+
+  @Test
+  void testUsesCustomerAwsAccountIdWhenFlagOn() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    unleash.enableUseCustomerAwsAccountId();
+    wiremock.setupAwsUsageContext(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        CUSTOMER_AWS_ACCOUNT_ID);
+
+    produceAggregateAndWaitForSuccess(metricId);
+
+    wiremock.verifyBatchMeterUsageCustomerAwsAccountId(CUSTOMER_AWS_ACCOUNT_ID);
+  }
+
+  @Test
+  void testFallsBackToCustomerIdentifierWhenFlagOnAndAccountIdMissing() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    unleash.enableUseCustomerAwsAccountId();
+    wiremock.setupAwsUsageContext(
+        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode);
+
+    produceAggregateAndWaitForSuccess(metricId);
+
+    wiremock.verifyBatchMeterUsageCustomerIdentifier(customerId);
+  }
+
+  private void produceAggregateAndWaitForSuccess(String metricId) {
+    BillableUsageAggregate aggregateData =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
+
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateMatches(awsAccountId, BillableUsage.Status.SUCCEEDED),
+        1);
+  }
+}

--- a/swatch-producer-aws/ct/pom.xml
+++ b/swatch-producer-aws/ct/pom.xml
@@ -22,6 +22,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${awssdk-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -33,6 +40,10 @@
     <dependency>
       <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-product-configuration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>marketplacemetering</artifactId>
     </dependency>
 
     <!-- Required so the Maven reactor compiles this dependency -->

--- a/swatch-producer-aws/ct/resources/test.properties
+++ b/swatch-producer-aws/ct/resources/test.properties
@@ -1,3 +1,4 @@
 swatch.component-tests.services.kafkaBridge.log.enabled=false
 swatch.component-tests.services.wiremock.log.enabled=false
+swatch.component-tests.services.unleash.log.enabled=false
 swatch.component-tests.services.swatch-producer-aws.quarkus.expected-log=is configured to poll records from

--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -95,6 +95,8 @@ objects:
       - swatch-contracts
       - swatch-billable-usage
 
+    featureFlags: true
+
     kafkaTopics:
       - replicas: ${{KAFKA_BILLABLE_USAGE_REPLICAS}}
         partitions: ${{KAFKA_BILLABLE_USAGE_PARTITIONS}}
@@ -261,6 +263,7 @@ objects:
             - name: aws-marketplace-credentials
               secret:
                 secretName: aws-marketplace-credentials
+                optional: true
 
 - apiVersion: apps/v1
   kind: Deployment
@@ -309,11 +312,3 @@ objects:
     name: swatch-psks
   data:
     self: cGxhY2Vob2xkZXI=
-
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: aws-marketplace-credentials
-  data:
-    # Base64 encoded
-    config.ini: W3Byb2ZpbGUgMTIzNDU2N10KYXdzX2FjY2Vzc19rZXlfaWQgPSByYW5kb21zdHVmZgphd3Nfc2VjcmV0X2FjY2Vzc19rZXkgPSByYW5kb21zdHVmZgo=

--- a/swatch-producer-aws/pom.xml
+++ b/swatch-producer-aws/pom.xml
@@ -81,6 +81,10 @@
       <artifactId>clowder-quarkus-config-source</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkiverse.unleash</groupId>
+      <artifactId>quarkus-unleash</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-common-config-workaround</artifactId>
     </dependency>

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
@@ -18,18 +18,23 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.aws.configuration;
+package com.redhat.swatch.aws.config;
 
+import io.getunleash.Unleash;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.Produces;
-import software.amazon.awssdk.profiles.ProfileFile;
 
-@Dependent
-public class ProfileFileConfiguration {
-  @ApplicationScoped
-  @Produces
-  public ProfileFile defaultProfileFile() {
-    return ProfileFile.defaultProfileFile();
+@ApplicationScoped
+public class FeatureFlags {
+  public static final String USE_CUSTOMER_AWS_ACCOUNT_ID =
+      "swatch.swatch-producer-aws.use-customer-aws-account-id";
+
+  private final Unleash unleash;
+
+  public FeatureFlags(Unleash unleash) {
+    this.unleash = unleash;
+  }
+
+  public boolean useCustomerAwsAccountId() {
+    return unleash.isEnabled(USE_CUSTOMER_AWS_ACCOUNT_ID);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfiguration.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.configuration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.profiles.ProfileFile;
+
+@Dependent
+@Slf4j
+public class AwsProfileFileConfiguration {
+
+  private static final Set<String> TEST_CREDENTIAL_PROFILES = Set.of("test", "dev", "ephemeral");
+
+  @ApplicationScoped
+  @Produces
+  public ProfileFile defaultProfileFile(
+      @ConfigProperty(name = "quarkus.profile", defaultValue = "prod") String profile,
+      @ConfigProperty(name = "aws.marketplace.test-credentials.seller-profile")
+          String sellerProfile,
+      @ConfigProperty(name = "aws.marketplace.test-credentials.access-key-id") String accessKeyId,
+      @ConfigProperty(name = "aws.marketplace.test-credentials.secret-access-key")
+          String secretAccessKey) {
+
+    if (TEST_CREDENTIAL_PROFILES.contains(profile)) {
+      log.debug(
+          "Using test AWS marketplace credentials profile '{}' for quarkus profile '{}'",
+          sellerProfile,
+          profile);
+      return syntheticProfileFile(sellerProfile, accessKeyId, secretAccessKey);
+    }
+
+    String awsConfigFile = System.getenv("AWS_CONFIG_FILE");
+    if (awsConfigFile == null || awsConfigFile.isBlank()) {
+      throw new DeploymentException(
+          "AWS_CONFIG_FILE is required for quarkus profile '%s'".formatted(profile));
+    } else if (!Files.isRegularFile(Path.of(awsConfigFile))) {
+      throw new DeploymentException(
+          "AWS marketplace credentials file not found: %s".formatted(awsConfigFile));
+    }
+
+    return ProfileFile.defaultProfileFile();
+  }
+
+  private static ProfileFile syntheticProfileFile(
+      String sellerProfile, String accessKeyId, String secretAccessKey) {
+    String configContent =
+        """
+        [profile %s]
+        aws_access_key_id = %s
+        aws_secret_access_key = %s
+        """
+            .formatted(sellerProfile, accessKeyId, secretAccessKey);
+    return ProfileFile.builder()
+        .content(configContent)
+        .type(ProfileFile.Type.CONFIGURATION)
+        .build();
+  }
+}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/file/AwsCredentialsLookup.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/file/AwsCredentialsLookup.java
@@ -55,6 +55,9 @@ public class AwsCredentialsLookup {
     if (profileFile.profile(awsSellerAccount).isEmpty()) {
       throw new AwsMissingCredentialsException(awsSellerAccount);
     }
-    return ProfileCredentialsProvider.create(awsSellerAccount);
+    return ProfileCredentialsProvider.builder()
+        .profileFile(profileFile)
+        .profileName(awsSellerAccount)
+        .build();
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.aws.service;
 import static com.redhat.swatch.configuration.registry.SubscriptionDefinition.getBillingFactor;
 import static java.util.Optional.ofNullable;
 
+import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
 import com.redhat.swatch.aws.exception.AwsThrottlingException;
 import com.redhat.swatch.aws.exception.AwsUnprocessedRecordsException;
@@ -81,6 +82,7 @@ public class AwsBillableUsageAggregateConsumer {
   private final Duration awsUsageWindow;
   private final BillableUsageStatusProducer billableUsageStatusProducer;
   private final MeterProvider<Counter> meteredTotalCounter;
+  private final FeatureFlags featureFlags;
 
   public AwsBillableUsageAggregateConsumer(
       MeterRegistry meterRegistry,
@@ -88,7 +90,8 @@ public class AwsBillableUsageAggregateConsumer {
       AwsMarketplaceMeteringClientFactory awsMarketplaceMeteringClientFactory,
       @ConfigProperty(name = "ENABLE_AWS_DRY_RUN") Optional<Boolean> isDryRun,
       @ConfigProperty(name = "AWS_MARKETPLACE_USAGE_WINDOW") Duration awsUsageWindow,
-      BillableUsageStatusProducer billableUsageStatusProducer) {
+      BillableUsageStatusProducer billableUsageStatusProducer,
+      FeatureFlags featureFlags) {
     acceptedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_accepted_total");
     rejectedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_rejected_total");
     ignoreCounter = meterRegistry.counter("swatch_aws_marketplace_batch_ignored_total");
@@ -98,6 +101,7 @@ public class AwsBillableUsageAggregateConsumer {
     this.isDryRun = isDryRun;
     this.awsUsageWindow = awsUsageWindow;
     this.billableUsageStatusProducer = billableUsageStatusProducer;
+    this.featureFlags = featureFlags;
   }
 
   @Incoming("billable-usage-hourly-aggregate-in")
@@ -308,12 +312,35 @@ public class AwsBillableUsageAggregateConsumer {
           "Unable to send usage since it is outside of the AWS processing window");
     }
 
-    return UsageRecord.builder()
-        .customerIdentifier(context.getCustomerId())
-        .dimension(metric.getAwsDimension())
-        .quantity(billableUsageAggregate.getTotalValue().intValueExact())
-        .timestamp(effectiveTimestamp.toInstant())
-        .build();
+    UsageRecord.Builder recordBuilder =
+        UsageRecord.builder()
+            .dimension(metric.getAwsDimension())
+            .quantity(billableUsageAggregate.getTotalValue().intValueExact())
+            .timestamp(effectiveTimestamp.toInstant());
+
+    applyCustomerIdentification(recordBuilder, context);
+
+    return recordBuilder.build();
+  }
+
+  private void applyCustomerIdentification(
+      UsageRecord.Builder recordBuilder, AwsUsageContext context) {
+    if (!featureFlags.useCustomerAwsAccountId()) {
+      recordBuilder.customerIdentifier(context.getCustomerId());
+      return;
+    }
+
+    String customerAwsAccountId = context.getCustomerAwsAccountId();
+    if (customerAwsAccountId != null) {
+      recordBuilder.customerAWSAccountId(customerAwsAccountId);
+      return;
+    }
+
+    log.warn(
+        "customerAwsAccountId missing; falling back to customerIdentifier rhSubscriptionId={} awsCustomerId={}",
+        context.getRhSubscriptionId(),
+        context.getCustomerId());
+    recordBuilder.customerIdentifier(context.getCustomerId());
   }
 
   private boolean isForAws(BillableUsageAggregateKey aggregationKey) {

--- a/swatch-producer-aws/src/main/resources/application.properties
+++ b/swatch-producer-aws/src/main/resources/application.properties
@@ -49,6 +49,11 @@ OTEL_DISABLED=true
 %dev.LOGGING_DISABLE_CERTIFICATE_VALIDATION=true
 %dev.CORS_ORIGINS=/.*/
 
+# aws marketplace specific (to be used only for testing, not in stage or production)
+aws.marketplace.test-credentials.seller-profile=1234567
+aws.marketplace.test-credentials.access-key-id=random
+aws.marketplace.test-credentials.secret-access-key=random
+
 # set the test profile properties to the same values as dev; these get activated for @QuarkusTest
 %test.SWATCH_CONTRACTS_ENDPOINT=${%dev.SWATCH_CONTRACTS_ENDPOINT}
 %test.AWS_MARKETPLACE_ENDPOINT_URL=${%dev.AWS_MARKETPLACE_ENDPOINT_URL}
@@ -155,6 +160,15 @@ quarkus.log.handler.splunk.max-retries=${LOGGING_HEC_RETRY_COUNT:0}
 quarkus.log.handler.splunk.metadata-fields.namespace=${LOGGING_NAMESPACE:local}
 quarkus.log.handler.splunk.format=%d %-5p [%c{3.}] (%t) %s%e%n
 quarkus.log.handler.splunk.include-exception=${LOGGING_HEC_INCLUDE_EX:false}
+# unleash config
+quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
+quarkus.unleash.url=${UNLEASH_URL:http://localhost:4242/api}
+quarkus.unleash.token=${UNLEASH_API_TOKEN:default:development.unleash-insecure-api-token}
+quarkus.unleash.name-prefix=swatch
+%test.quarkus.unleash.active=false
+%dev.quarkus.unleash.fetch-toggles-interval=1
+%ephemeral.quarkus.unleash.fetch-toggles-interval=1
+
 # otel config
 quarkus.otel.sdk.disabled=${OTEL_DISABLED}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4317}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
@@ -72,6 +73,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClient;
 import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageRequest;
 import software.amazon.awssdk.services.marketplacemetering.model.BatchMeterUsageResponse;
@@ -125,6 +127,7 @@ class AwsBillableUsageAggregateConsumerTest {
   @InjectMock AwsMarketplaceMeteringClientFactory clientFactory;
   MarketplaceMeteringClient meteringClient;
   @InjectMock BillableUsageStatusProducer billableUsageStatusProducer;
+  @InjectMock FeatureFlags featureFlags;
 
   @Inject MeterRegistry meterRegistry;
   Counter acceptedCounter;
@@ -175,6 +178,7 @@ class AwsBillableUsageAggregateConsumerTest {
             "status", BillableUsage.Status.SUCCEEDED.toString(), "error_code", "");
 
     meteringClient = mock(MarketplaceMeteringClient.class);
+    when(featureFlags.useCustomerAwsAccountId()).thenReturn(false);
   }
 
   @Test
@@ -205,6 +209,53 @@ class AwsBillableUsageAggregateConsumerTest {
         .thenReturn(new AwsUsageContext());
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
     verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldUseCustomerIdentifierWhenFlagOff() throws ApiException {
+    AwsUsageContext context =
+        new AwsUsageContext()
+            .rhSubscriptionId("id")
+            .customerId("marketplace-customer")
+            .customerAwsAccountId("123456789012")
+            .productCode("product")
+            .subscriptionStartDate(OffsetDateTime.MIN);
+
+    UsageRecord record = processUsageAndCaptureRecord(context, false);
+
+    assertEquals("marketplace-customer", record.customerIdentifier());
+    assertTrue(record.customerAWSAccountId() == null || record.customerAWSAccountId().isBlank());
+  }
+
+  @Test
+  void shouldUseCustomerAwsAccountIdWhenFlagOn() throws ApiException {
+    AwsUsageContext context =
+        new AwsUsageContext()
+            .rhSubscriptionId("id")
+            .customerId("marketplace-customer")
+            .customerAwsAccountId("123456789012")
+            .productCode("product")
+            .subscriptionStartDate(OffsetDateTime.MIN);
+
+    UsageRecord record = processUsageAndCaptureRecord(context, true);
+
+    assertEquals("123456789012", record.customerAWSAccountId());
+    assertTrue(record.customerIdentifier() == null || record.customerIdentifier().isBlank());
+  }
+
+  @Test
+  void shouldFallbackToCustomerIdentifierWhenFlagOnAndAccountIdNull() throws ApiException {
+    AwsUsageContext context =
+        new AwsUsageContext()
+            .rhSubscriptionId("id")
+            .customerId("marketplace-customer")
+            .productCode("product")
+            .subscriptionStartDate(OffsetDateTime.MIN);
+
+    UsageRecord record = processUsageAndCaptureRecord(context, true);
+
+    assertEquals("marketplace-customer", record.customerIdentifier());
+    assertTrue(record.customerAWSAccountId() == null || record.customerAWSAccountId().isBlank());
   }
 
   @Test
@@ -328,7 +379,8 @@ class AwsBillableUsageAggregateConsumerTest {
             clientFactory,
             Optional.of(true),
             Duration.of(1, ChronoUnit.HOURS),
-            billableUsageStatusProducer);
+            billableUsageStatusProducer,
+            featureFlags);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     processor.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -412,7 +464,8 @@ class AwsBillableUsageAggregateConsumerTest {
                             usage.getErrorCode())));
 
     // verify success
-    reset(contractsApi, billableUsageStatusProducer);
+    reset(contractsApi, billableUsageStatusProducer, featureFlags);
+    when(featureFlags.useCustomerAwsAccountId()).thenReturn(false);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
@@ -457,6 +510,22 @@ class AwsBillableUsageAggregateConsumerTest {
             "rosa", MetricIdUtils.getInstanceHours().toUpperCaseFormatted(), date, 42.0);
     assertEquals(21600, maxAgeDuration.getSeconds());
     assertEquals(isValid, consumer.isUsageDateValid(clock, aggregate));
+  }
+
+  private UsageRecord processUsageAndCaptureRecord(
+      AwsUsageContext context, boolean useCustomerAwsAccountId) throws ApiException {
+    when(featureFlags.useCustomerAwsAccountId()).thenReturn(useCustomerAwsAccountId);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+        .thenReturn(context);
+    when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
+    when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
+        .thenReturn(BATCH_METER_USAGE_SUCCESS_RESPONSE);
+
+    ArgumentCaptor<BatchMeterUsageRequest> requestCaptor =
+        ArgumentCaptor.forClass(BatchMeterUsageRequest.class);
+    consumer.process(ROSA_INSTANCE_HOURS_RECORD);
+    verify(meteringClient).batchMeterUsage(requestCaptor.capture());
+    return requestCaptor.getValue().usageRecords().get(0);
   }
 
   private static BillableUsageAggregate createAggregate(


### PR DESCRIPTION
Add quarkus-unleash wiring and use-customer-aws-account-id toggle (default off) so UsageRecord sends customerIdentifier unless the flag is on and contracts returns customerAwsAccountId. Includes unit/component tests and TEST_PLAN.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5115


### Verification
<!-- Enter the steps needed to verify the test passed -->
Unit tests:
```bash
mvn test -pl swatch-producer-aws -am
```
Component tests:
```bash
mvn clean test -Pcomponent-tests -pl swatch-producer-aws/ct -am
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature-flagged option to emit either the customer ID or the AWS account ID into AWS batch metering/usage records.
* **Bug Fixes**
  * When the flag is enabled but the AWS account ID is unavailable, the service now falls back to emitting the customer ID.
* **Tests & Documentation**
  * Added component tests covering flag on/off and fallback behavior, plus an updated test plan and local component-test instructions.
* **Deployment**
  * Updated deployment configuration to enable feature flags and to treat the AWS marketplace credentials Secret as optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->