### PR TITLE
Add unit tests for BillableUsageStatusConsumer edge cases

### DIFF
--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
@@ -181,9 +181,42 @@ class BillableUsageStatusConsumerTest {
     Awaitility.await().untilAsserted(() -> verifyRemittanceHasUpdatedAtHigherThan(createdAt));
   }
 
+  @Test
+  void testWhenStatusIsNullThenRemittanceIsNotUpdated() {
+    var existingRemittance = givenExistingPendingRemittance();
+    var nullStatusMessage = createBillableUsageAggregate(null, null, BILLED_ON, existingRemittance);
+
+    whenSendResponse(nullStatusMessage);
+    Awaitility.await().untilAsserted(this::verifyRemittanceStillPending);
+  }
+
+  @Test
+  void testWhenStatusUpdateReferencesMultipleRemittancesThenAllAreUpdated() {
+    var remittance1 = givenExistingRemittance();
+    var remittance2 = givenExistingRemittance();
+    var remittance3 = givenExistingRemittance();
+
+    var successMessage =
+        createBillableUsageAggregate(
+            Status.SUCCEEDED, null, BILLED_ON, remittance1, remittance2, remittance3);
+
+    whenSendResponse(successMessage);
+    Awaitility.await().untilAsserted(this::verifyUpdateForSuccess);
+  }
+
   @Transactional
   BillableUsageRemittanceEntity givenExistingRemittance() {
     var remittance = buildBillableUsageRemittanceEntity();
+    remittanceRepository.persist(remittance);
+    return remittance;
+  }
+
+  @Transactional
+  BillableUsageRemittanceEntity givenExistingPendingRemittance() {
+    var remittance = buildBillableUsageRemittanceEntity();
+    // Status must be explicitly PENDING so verifyRemittanceStillPending can assert it was not
+    // changed.
+    remittance.setStatus(RemittanceStatus.PENDING);
     remittanceRepository.persist(remittance);
     return remittance;
   }
@@ -240,6 +273,17 @@ class BillableUsageStatusConsumerTest {
             result -> {
               assertEquals(RemittanceStatus.FAILED, result.getStatus());
               assertEquals(expected, result.getErrorCode());
+              assertNull(result.getBilledOn());
+            });
+  }
+
+  @Transactional
+  void verifyRemittanceStillPending() {
+    remittanceRepository.findAll().stream()
+        .forEach(
+            result -> {
+              assertEquals(RemittanceStatus.PENDING, result.getStatus());
+              assertNull(result.getErrorCode());
               assertNull(result.getBilledOn());
             });
   }


### PR DESCRIPTION
Jira issue: SWATCH-5162

## Description
Added two new test cases to `BillableUsageStatusConsumerTest`:

  1. **`testWhenStatusIsNullThenRemittanceIsNotUpdated`** - Validates that status messages with null status values do not modify existing remittances
  2. **`testWhenStatusUpdateReferencesMultipleRemittancesThenAllAreUpdated`** - Validates that a single status message can update multiple remittance UUIDs in one batch operation

* No production code changes required - the existing implementation already correctly handles both scenarios

## Testing
  `mvn test -Dtest=BillableUsageStatusConsumerTest -pl swatch-billable-usage`

  Closes SWATCH-5162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for remittance processing behavior in additional scenarios.
  * Added checks to ensure pending remittances stay unchanged when no status is provided.
  * Added validation that multiple related remittances are all updated correctly on success, including billed date and error status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->