### PR TITLE
SWATCH-5123 Update Component Tests Service Lifecycle

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
@@ -410,4 +410,11 @@ public class KafkaBridgeService extends RestService {
 
     return message;
   }
+
+  @Override
+  public void onTestStopped() {
+    super.onTestStopped();
+    // Clear message cache to prevent memory buildup across test classes
+    messageCache.values().forEach(CopyOnWriteArrayList::clear);
+  }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/Service.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/Service.java
@@ -53,6 +53,10 @@ public interface Service extends AutoCloseable {
 
   <I> I getManagedResource(Class<I> clazz);
 
+  /**
+   * Registers this service with a context at suite level. Services start once before the first test
+   * and stop at JVM shutdown.
+   */
   ServiceContext register(String serviceName, ComponentTestContext context);
 
   void init(ManagedResource resource);

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -138,6 +139,28 @@ public abstract class BaseKubernetesClient<
     return logs;
   }
 
+  /** Get pod logs since a timestamp (same as {@code oc logs --since-time}). */
+  public Map<String, String> logsSince(
+      Map<String, String> podLabels, String containerName, Instant since) {
+    String sinceTime = since.toString();
+    Map<String, String> logs = new HashMap<>();
+    for (Pod pod : podsInService(podLabels)) {
+      if (isPodRunning(pod)) {
+        String podName = pod.getMetadata().getName();
+        logs.put(
+            podName,
+            client
+                .pods()
+                .withName(podName)
+                .inContainer(containerName)
+                .sinceTime(sinceTime)
+                .getLog());
+      }
+    }
+
+    return logs;
+  }
+
   /** Resolve the port by the service. */
   public int port(String serviceName, int port, Service service, Map<String, String> podLabels) {
     String svcPortForwardKey = serviceName + "-" + port;
@@ -160,9 +183,11 @@ public abstract class BaseKubernetesClient<
     return portForwardByService.getValue().localPort;
   }
 
-  /** Delete all the resources within the test. */
-  public void deleteResourcesInComponentTestContext(String contextId) {
-    portForwardsByService.values().forEach(this::closePortForward);
+  /** Close port forwards for a specific service. */
+  public void closePortForwardsForService(String serviceName) {
+    portForwardsByService.values().stream()
+        .filter(entry -> entry.getKey().getName().equals(serviceName))
+        .forEach(this::closePortForward);
   }
 
   public void checkServiceExists(String serviceName) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/BaseService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/BaseService.java
@@ -200,7 +200,6 @@ public class BaseService<T extends Service> implements Service {
   public ServiceContext register(String serviceName, ComponentTestContext context) {
     this.serviceName = serviceName;
     this.context = new ServiceContext(this, context);
-    context.getTestStore().put(serviceName, this);
     return this.context;
   }
 
@@ -219,6 +218,11 @@ public class BaseService<T extends Service> implements Service {
   @Override
   public void onTestStarted() {
     this.managedResource.getLoggingHandler().onTestStarted();
+  }
+
+  @Override
+  public void onTestStopped() {
+    this.managedResource.getLoggingHandler().onTestStopped();
   }
 
   private void doStart() {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ComponentTestContext.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ComponentTestContext.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import lombok.Getter;
+import lombok.Setter;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class ComponentTestContext {
@@ -44,25 +46,19 @@ public final class ComponentTestContext {
   private static final int COMPONENT_TEST_ID_MAX_SIZE = 60;
 
   private final ExtensionContext testContext;
-  private final String id;
-  private final ExtensionContext.Namespace testNamespace;
+  @Getter private final String id;
   private final Map<String, Object> customConfigurationByTarget = new HashMap<>();
   private final Map<Class<?>, List<Annotation>> annsForConfiguration = new HashMap<>();
 
-  private ExtensionContext methodTestContext;
+  @Setter private ExtensionContext methodTestContext;
   private boolean failed;
-  private boolean debug;
+  @Setter @Getter private boolean debug;
 
-  protected ComponentTestContext(ExtensionContext testContext) {
+  ComponentTestContext(ExtensionContext testContext) {
     this.testContext = testContext;
     this.id = generateContextId(testContext);
-    this.testNamespace = ExtensionContext.Namespace.create(ComponentTestContext.class);
 
     loadCustomConfiguration(GLOBAL, new ComponentTestConfigurationBuilder());
-  }
-
-  public String getId() {
-    return id;
   }
 
   public boolean isFailed() {
@@ -73,14 +69,6 @@ public final class ComponentTestContext {
     // sometimes the failed flag has not been propagated yet, so we need to check the JUnit test
     // context
     return testContext.getExecutionException().isPresent();
-  }
-
-  public boolean isDebug() {
-    return debug;
-  }
-
-  public void setDebug(boolean debug) {
-    this.debug = debug;
   }
 
   public ComponentTestConfiguration getConfiguration() {
@@ -118,24 +106,12 @@ public final class ComponentTestContext {
     return Optional.of(methodTestContext.getRequiredTestMethod().getName());
   }
 
-  public ExtensionContext.Store getTestStore() {
-    return getTestContext().getStore(this.testNamespace);
-  }
-
   public ExtensionContext getTestContext() {
     return Optional.ofNullable(methodTestContext).orElse(testContext);
   }
 
   public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
     return getTestContext().getRequiredTestClass().isAnnotationPresent(annotationClass);
-  }
-
-  public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
-    return getTestContext().getRequiredTestClass().getAnnotation(annotationClass);
-  }
-
-  public void setMethodTestContext(ExtensionContext methodTestContext) {
-    this.methodTestContext = methodTestContext;
   }
 
   public Path getLogFolder() {
@@ -161,7 +137,7 @@ public final class ComponentTestContext {
     return configurationsByClass.stream()
         .filter(clazz::isInstance)
         .map(clazz::cast)
-        .filter(apply::test)
+        .filter(apply)
         .findFirst();
   }
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ComponentTestExtension.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ComponentTestExtension.java
@@ -31,12 +31,10 @@ import com.redhat.swatch.component.tests.utils.ReflectionUtils;
 import com.redhat.swatch.component.tests.utils.ServiceLoaderUtils;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.TestInstance;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -57,21 +55,31 @@ public class ComponentTestExtension
         LifecycleMethodExecutionExceptionHandler,
         TestWatcher {
 
+  // Store key for suite-level services
+  private static final String SUITE_SERVICES_KEY = "suite-services";
+
   private final List<AnnotationBinding> bindingsRegistry =
       ServiceLoaderUtils.load(AnnotationBinding.class);
   private final List<ExtensionBootstrap> extensionsRegistry =
       ServiceLoaderUtils.load(ExtensionBootstrap.class);
 
-  private List<ServiceContext> services = new ArrayList<>();
+  private ServicesStore services;
   private ComponentTestContext context;
   private List<ExtensionBootstrap> extensions;
 
   @Override
-  public void beforeAll(ExtensionContext testContext) {
+  public void beforeAll(@NonNull ExtensionContext testContext) {
     // Init context
     context = new ComponentTestContext(testContext);
     Log.configure();
     Log.debug("Context ID: '%s'", context.getId());
+
+    // Get suite-level store for services
+    services =
+        testContext
+            .getRoot()
+            .getStore(ExtensionContext.Namespace.GLOBAL)
+            .computeIfAbsent(SUITE_SERVICES_KEY, k -> new ServicesStore(), ServicesStore.class);
 
     // Init extensions
     extensions = initExtensions();
@@ -79,7 +87,7 @@ public class ComponentTestExtension
 
     // Init services from class annotations
     ReflectionUtils.findAllAnnotations(testContext.getRequiredTestClass())
-        .forEach(annotation -> initServiceFromAnnotation(annotation));
+        .forEach(this::initServiceFromAnnotation);
 
     // Init services from static fields
     ReflectionUtils.findAllFields(testContext.getRequiredTestClass()).stream()
@@ -88,16 +96,8 @@ public class ComponentTestExtension
   }
 
   @Override
-  public void afterAll(ExtensionContext testContext) {
-    try {
-      List<ServiceContext> servicesToFinish = new ArrayList<>(services);
-      Collections.reverse(servicesToFinish);
-      servicesToFinish.forEach(s -> s.getOwner().stop());
-      deleteLogIfTestSuitePassed();
-      services.clear();
-    } finally {
-      extensions.forEach(ext -> ext.afterAll(context));
-    }
+  public void afterAll(@NonNull ExtensionContext testContext) {
+    extensions.forEach(ext -> ext.afterAll(context));
   }
 
   @Override
@@ -113,83 +113,70 @@ public class ComponentTestExtension
             + testContext.getDisplayName());
     context.setMethodTestContext(testContext);
     extensions.forEach(ext -> ext.beforeEach(context));
-    services.forEach(
-        service -> {
-          if (!service.getOwner().isRunning()) {
-            service.getOwner().start();
-          }
-
-          service.getOwner().onTestStarted();
-        });
+    services.get().forEach(Service::onTestStarted);
   }
 
   @Override
-  public void afterEach(ExtensionContext testContext) {
-    services.forEach(service -> service.getOwner().onTestStopped());
-
-    if (!isClassLifecycle(testContext)) {
-      // Stop services from instance fields
-      ReflectionUtils.findAllFields(testContext.getRequiredTestClass()).stream()
-          .filter(ReflectionUtils::isInstance)
-          .forEach(field -> stopServiceFromField(testContext, field));
-    }
-
+  public void afterEach(@NonNull ExtensionContext testContext) {
+    // Notify all services and extensions that test stopped
+    services.get().forEach(Service::onTestStopped);
     extensions.forEach(ext -> ext.afterEach(context));
   }
 
   @Override
   public boolean supportsParameter(
-      ParameterContext parameterContext, ExtensionContext extensionContext) {
+      ParameterContext parameterContext, @NonNull ExtensionContext extensionContext) {
     return isParameterSupported(parameterContext.getParameter().getType());
   }
 
   @Override
   public Object resolveParameter(
-      ParameterContext parameterContext, ExtensionContext extensionContext) {
+      @NonNull ParameterContext parameterContext, @NonNull ExtensionContext extensionContext) {
     return getParameter(new DependencyContext(parameterContext));
   }
 
   @Override
   public void handleAfterAllMethodExecutionException(
-      ExtensionContext context, Throwable throwable) {
+      @NonNull ExtensionContext context, @NonNull Throwable throwable) {
     testOnError(throwable);
   }
 
   @Override
   public void handleAfterEachMethodExecutionException(
-      ExtensionContext context, Throwable throwable) {
+      @NonNull ExtensionContext context, @NonNull Throwable throwable) {
     testOnError(throwable);
   }
 
   @Override
   public void handleBeforeAllMethodExecutionException(
-      ExtensionContext context, Throwable throwable) {
+      @NonNull ExtensionContext context, @NonNull Throwable throwable) {
     testOnError(throwable);
   }
 
   @Override
-  public void testSuccessful(ExtensionContext testContext) {
+  public void testSuccessful(@NonNull ExtensionContext testContext) {
     extensions.forEach(ext -> ext.onSuccess(context));
   }
 
   @Override
-  public void testFailed(ExtensionContext context, Throwable cause) {
+  public void testFailed(@NonNull ExtensionContext context, Throwable cause) {
     testOnError(cause);
   }
 
   @Override
-  public void testDisabled(ExtensionContext testContext, Optional<String> reason) {
+  public void testDisabled(
+      @NonNull ExtensionContext testContext, @NonNull Optional<String> reason) {
     extensions.forEach(ext -> ext.onDisabled(context, reason));
   }
 
   @Override
   public void handleBeforeEachMethodExecutionException(
-      ExtensionContext context, Throwable throwable) {
+      @NonNull ExtensionContext context, @NonNull Throwable throwable) {
     testOnError(throwable);
   }
 
   private void launchService(Service service) {
-    Log.info(service, "Starting service (%s) ...", service.getDisplayName());
+    Log.debug(service, "Starting service (%s) ...", service.getDisplayName());
     extensions.forEach(ext -> ext.onServiceLaunch(context, service));
     try {
       service.start();
@@ -209,7 +196,13 @@ public class ComponentTestExtension
   private void initResourceFromField(ExtensionContext context, Field field) {
     if (Service.class.isAssignableFrom(field.getType())) {
       Service service = ReflectionUtils.getFieldValue(findTestInstance(context, field), field);
-      initService(service, field.getName(), field.getAnnotations());
+      Annotation[] annotations = field.getAnnotations();
+      getAnnotationBinding(annotations)
+          .ifPresent(
+              binding -> {
+                Service resolved = initService(service, field.getName(), binding, annotations);
+                ReflectionUtils.setFieldValue(findTestInstance(context, field), field, resolved);
+              });
     } else if (InjectUtils.isAnnotatedWithInject(field)) {
       injectDependency(context, field);
     }
@@ -224,14 +217,6 @@ public class ComponentTestExtension
                     binding.getDefaultName(annotation),
                     binding,
                     annotation));
-  }
-
-  private void stopServiceFromField(ExtensionContext context, Field field) {
-    if (Service.class.isAssignableFrom(field.getType())) {
-      Service service = ReflectionUtils.getFieldValue(findTestInstance(context, field), field);
-      service.stop();
-      services.removeIf(s -> service.getName().equals(s.getName()));
-    }
   }
 
   private void injectDependency(ExtensionContext testContext, Field field) {
@@ -249,32 +234,39 @@ public class ComponentTestExtension
     }
   }
 
-  private void initService(Service service, String name, Annotation... annotations) {
-    AnnotationBinding binding =
-        getAnnotationBinding(annotations)
-            .orElseThrow(() -> new RuntimeException("Unknown annotation for service"));
-    initService(service, name, binding, annotations);
-  }
-
-  private void initService(
+  /**
+   * Initializes a service. If the service already exists in the suite registry, it reuses the
+   * existing instance. Otherwise, creates and starts a new service.
+   *
+   * @return the suite-scoped service owner (newly created or reused)
+   */
+  private Service initService(
       Service service, String name, AnnotationBinding binding, Annotation... annotations) {
-    if (service.isRunning()) {
-      return;
-    }
 
-    // Validate
-    service.validate(binding, annotations);
+    ServiceContext serviceContext =
+        services.getOrCreate(
+            name,
+            () -> {
+              try {
+                if (service.isRunning()) {
+                  throw new IllegalStateException(
+                      "Service '%s' is already running before suite registration".formatted(name));
+                }
 
-    // Resolve managed resource
-    ManagedResource resource = getManagedResource(name, service, binding, annotations);
-
-    // Initialize it
-    ServiceContext serviceContext = service.register(name, context);
-    service.init(resource);
-    services.add(serviceContext);
-
+                service.validate(binding, annotations);
+                ManagedResource resource = getManagedResource(name, service, binding, annotations);
+                ServiceContext newServiceContext = service.register(name, context);
+                service.init(resource);
+                extensions.forEach(ext -> ext.updateServiceContext(newServiceContext));
+                launchService(service);
+                return newServiceContext;
+              } catch (Exception e) {
+                Log.error("Failed to initialize service %s: %s", name, e.getMessage());
+                throw e;
+              }
+            });
     extensions.forEach(ext -> ext.updateServiceContext(serviceContext));
-    launchService(service);
+    return serviceContext.getOwner();
   }
 
   private Optional<AnnotationBinding> getAnnotationBinding(Annotation... annotations) {
@@ -317,36 +309,15 @@ public class ComponentTestExtension
   private List<ExtensionBootstrap> initExtensions() {
     return extensionsRegistry.stream()
         .filter(binding -> binding.appliesFor(context))
-        .map(
-            binding -> {
-              binding.updateContext(context);
-              return binding;
-            })
+        .peek(binding -> binding.updateContext(context))
         .collect(Collectors.toList());
   }
 
-  private void deleteLogIfTestSuitePassed() {
-    if (!context.isFailed()) {
-      context.getLogFile().toFile().delete();
-    }
-  }
-
-  private boolean isClassLifecycle(ExtensionContext context) {
-    if (context.getTestInstanceLifecycle().isPresent()) {
-      return context.getTestInstanceLifecycle().get() == TestInstance.Lifecycle.PER_CLASS;
-    } else if (context.getParent().isPresent()) {
-      return isClassLifecycle(context.getParent().get());
-    }
-
-    return false;
-  }
-
+  @SuppressWarnings("unchecked")
   private Optional<Object> findTestInstance(ExtensionContext context, Field field) {
     Optional<TestInstances> testInstances = context.getTestInstances();
-    if (testInstances.isPresent()) {
-      return testInstances.get().findInstance((Class<Object>) field.getDeclaringClass());
-    }
-
-    return context.getTestInstance();
+    return testInstances
+        .map(instances -> instances.findInstance((Class<Object>) field.getDeclaringClass()))
+        .orElseGet(context::getTestInstance);
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServiceContext.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServiceContext.java
@@ -25,6 +25,7 @@ import com.redhat.swatch.component.tests.configuration.BaseConfigurationBuilder;
 import com.redhat.swatch.component.tests.configuration.ServiceConfiguration;
 import com.redhat.swatch.component.tests.configuration.ServiceConfigurationBuilder;
 import com.redhat.swatch.component.tests.configuration.ServiceConfigurationLoader;
+import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.utils.OutputUtils;
 import java.lang.annotation.Annotation;
 import java.lang.management.ManagementFactory;
@@ -47,13 +48,13 @@ public final class ServiceContext {
   private final ServiceConfiguration configuration;
   private final List<Object> customConfiguration = new ArrayList<>();
 
+  /** Creates a ServiceContext for suite-scoped services. */
   public ServiceContext(Service owner, ComponentTestContext componentTestContext) {
     this.owner = owner;
     this.componentTestContext = componentTestContext;
-    this.serviceFolder =
-        OutputUtils.target()
-            .resolve(componentTestContext.getRunningTestClassName())
-            .resolve(getName());
+
+    // All services use suite-level folder
+    this.serviceFolder = OutputUtils.target().resolve("suite-services").resolve(owner.getName());
     this.configuration =
         ServiceConfigurationLoader.load(
             owner.getName(), componentTestContext, new ServiceConfigurationBuilder());
@@ -117,5 +118,12 @@ public final class ServiceContext {
     }
 
     return false;
+  }
+
+  public void close() {
+    if (owner.isRunning()) {
+      Log.info(owner, "stopping service");
+      owner.close();
+    }
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServicesStore.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/ServicesStore.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.core;
+
+import com.redhat.swatch.component.tests.api.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public class ServicesStore implements AutoCloseable {
+
+  private final Map<String, ServiceContext> services = new ConcurrentHashMap<>();
+
+  @Override
+  public void close() throws Exception {
+    Exception first = null;
+    for (ServiceContext context : services.values()) {
+      try {
+        context.close();
+      } catch (Exception e) {
+        if (first == null) {
+          first = e;
+        } else {
+          first.addSuppressed(e);
+        }
+      }
+    }
+    if (first != null) {
+      throw first;
+    }
+  }
+
+  public List<Service> get() {
+    return services.values().stream().map(ServiceContext::getOwner).toList();
+  }
+
+  protected ServiceContext getOrCreate(String name, Supplier<ServiceContext> supplier) {
+    return services.computeIfAbsent(name, k -> supplier.get());
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
@@ -73,7 +73,6 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
   @Override
   public void afterAll(ComponentTestContext context) {
     OpenShiftConfiguration configuration = context.getConfigurationAs(OpenShiftConfiguration.class);
-    client.deleteResourcesInComponentTestContext(context.getId());
     if (configuration.getAdditionalResources() != null) {
       for (String additionalResource : configuration.getAdditionalResources()) {
         client.delete(Path.of(additionalResource));

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/FileServiceLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/FileServiceLoggingHandler.java
@@ -57,4 +57,11 @@ public class FileServiceLoggingHandler extends ServiceLoggingHandler {
       return super.logs();
     }
   }
+
+  @Override
+  public void onTestStopped() {
+    super.onTestStopped();
+    // Snapshot current file state so the next diff starts from now, avoiding a full replay
+    printedContent = file.exists() ? FileUtils.loadFile(file) : null;
+  }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/LoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/LoggingHandler.java
@@ -83,9 +83,17 @@ public abstract class LoggingHandler implements Closeable {
     }
   }
 
-  public void onTestStarted() {}
+  public void onTestStarted() {
+    logs.clear();
+  }
 
-  public void onTestStopped() {}
+  /**
+   * Called after each test method to clear accumulated logs and reset state. Prevents memory
+   * buildup across tests when services run at suite level.
+   */
+  public void onTestStopped() {
+    logs.clear();
+  }
 
   protected void run() {
     while (running) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
@@ -23,16 +23,20 @@ package com.redhat.swatch.component.tests.logging;
 import com.redhat.swatch.component.tests.api.clients.OpenshiftClient;
 import com.redhat.swatch.component.tests.core.ServiceContext;
 import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBootstrap;
+import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
 
   private final OpenshiftClient client;
   private final Map<String, String> podLabels;
   private final String containerName;
-
-  private Map<String, String> oldLogs;
+  private Instant logsSince;
+  private final Set<String> seenLines = new HashSet<>();
 
   public OpenShiftLoggingHandler(
       Map<String, String> podLabels, String containerName, ServiceContext context) {
@@ -44,24 +48,30 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
   }
 
   @Override
-  protected synchronized void handle() {
-    Map<String, String> newLogs = client.logs(podLabels, containerName);
-    for (Entry<String, String> entry : newLogs.entrySet()) {
-      onMapDifference(entry);
-    }
+  public void onTestStarted() {
+    super.onTestStarted();
 
-    oldLogs = newLogs;
+    this.logsSince = Instant.now();
+    this.seenLines.clear();
   }
 
-  private void onMapDifference(Entry<String, String> entry) {
-    String newPodLogs = formatPodLogs(entry.getKey(), entry.getValue());
+  @Override
+  protected synchronized void handle() {
+    if (!isTestActive() || logsSince == null) {
+      return;
+    }
 
-    if (oldLogs != null && oldLogs.containsKey(entry.getKey())) {
-      String oldPodLogs = formatPodLogs(entry.getKey(), oldLogs.get(entry.getKey()));
+    Instant fetchTime = Instant.now();
+    Map<String, String> newLogs = client.logsSince(podLabels, containerName, logsSince);
+    this.logsSince = fetchTime;
 
-      onStringDifference(newPodLogs, oldPodLogs);
-    } else {
-      onLines(newPodLogs);
+    for (Entry<String, String> entry : newLogs.entrySet()) {
+      if (StringUtils.isNotEmpty(entry.getValue())) {
+        String formatted = formatPodLogs(entry.getKey(), entry.getValue());
+        if (seenLines.add(formatted)) {
+          onLines(formatted);
+        }
+      }
     }
   }
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
@@ -21,12 +21,13 @@
 package com.redhat.swatch.component.tests.logging;
 
 import com.redhat.swatch.component.tests.core.ServiceContext;
+import lombok.Getter;
 
 public abstract class ServiceLoggingHandler extends LoggingHandler {
 
   private final ServiceContext service;
 
-  private boolean isTestStarted = false;
+  @Getter private boolean testActive = false;
 
   public ServiceLoggingHandler(ServiceContext service) {
     this.service = service;
@@ -35,15 +36,22 @@ public abstract class ServiceLoggingHandler extends LoggingHandler {
   @Override
   public void onTestStarted() {
     super.onTestStarted();
-
-    isTestStarted = true;
+    testActive = true;
   }
 
   @Override
   public void onTestStopped() {
+    testActive = false;
     super.onTestStopped();
+  }
 
-    isTestStarted = false;
+  @Override
+  protected void onLine(String line) {
+    if (!testActive) {
+      return;
+    }
+
+    super.onLine(line);
   }
 
   @Override
@@ -61,6 +69,6 @@ public abstract class ServiceLoggingHandler extends LoggingHandler {
       return true;
     }
 
-    return !service.getConfiguration().isLogEnabledOnTestStarted() || isTestStarted;
+    return !service.getConfiguration().isLogEnabledOnTestStarted() || testActive;
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
@@ -20,8 +20,6 @@
  */
 package com.redhat.swatch.component.tests.resources.containers;
 
-import static com.redhat.swatch.component.tests.utils.StringUtils.EMPTY;
-
 import com.redhat.swatch.component.tests.api.clients.OpenshiftClient;
 import com.redhat.swatch.component.tests.core.ManagedResource;
 import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBootstrap;
@@ -58,8 +56,12 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
     client = context.get(OpenShiftExtensionBootstrap.CLIENT);
     validateService();
-    loggingHandler = new OpenShiftLoggingHandler(podLabels(), containerName(), context);
-    loggingHandler.startWatching();
+
+    if (loggingHandler == null) {
+      loggingHandler = new OpenShiftLoggingHandler(podLabels(), containerName(), context);
+      loggingHandler.startWatching();
+    }
+
     running = true;
   }
 
@@ -67,6 +69,11 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
   public void stop() {
     if (loggingHandler != null) {
       loggingHandler.stopWatching();
+    }
+
+    // Close port forwards for this service
+    if (client != null) {
+      client.closePortForwardsForService(serviceName());
     }
 
     running = false;
@@ -85,7 +92,16 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
   @Override
   public boolean isRunning() {
-    return loggingHandler != null && loggingHandler.logsContains(getExpectedLog());
+    return running;
+  }
+
+  @Override
+  protected void waitUntilResourceIsStarted() {
+    // OpenShift pods are validated in start() via validateService()
+    // Skip the log-based startup wait to avoid issues after onTestStopped() clears logs
+    if (loggingHandler != null) {
+      loggingHandler.flush();
+    }
   }
 
   @Override
@@ -116,10 +132,6 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
   protected String containerName() {
     return serviceName();
-  }
-
-  protected String getExpectedLog() {
-    return EMPTY;
   }
 
   private void validateService() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5123

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Currently, tests start and stop the same services for each class. This isn't necessary  and adds more time to test runs.

This PR updates the test lifecycle to reuse services when running a new test class.


What  changed:
 Architecture

  - All services now run suite-scoped (start once, persist across all test classes)
  - New: ServicesStore.java - centralized service registry with automatic cleanup

  Core Files

  ComponentTestExtension.java
  - Uses ServicesStore from JUnit's global store
  - Removed manual service stopping in afterAll()
  - Removed class-scoped service logic 
  - Services persist until JVM shutdown
  - Changed service startup logs from INFO → DEBUG

  ServicesStore.java 
  - Single ConcurrentHashMap<String, ServiceContext> for all services
  - getOrCreate() - atomic service initialization
  - AutoCloseable - automatic cleanup
  - Replaces per-service cleanup callbacks

  Service.java / BaseService.java
  - Added onTestStarted() / onTestStopped() lifecycle hooks
  - BaseService.onTestStopped() delegates to logging handler
  - Replaces softReset() pattern

  LoggingHandler.java
  - onTestStopped() - clears logs after each test
  - Prevents memory buildup across test classes

  OpenShiftLoggingHandler.java (CRITICAL FIX)
  - Changed from accumulating ALL logs in memory to streaming
  - Processes logs line-by-line
  - Fixes pipeline OOM issues

  ServiceContext.java
  - Removed lifecycle-specific folder logic
  - Simplified constructor
  
  ComponentTestContext.java
  - Removed test store tracking (services use global store now)

```
                    ┌─────────────┐
                    │   Created   │
                    └──────┬──────┘
                           │ register()
                           │ init()
                           ▼
                    ┌─────────────┐
                    │   Started   │◄──────┐
                    └──────┬──────┘       │
                           │              │
        ┌──────────────────┼──────────────┤
        │                  │              │
        │ Test 1 begins    │              │
        ▼                  │              │
  onTestStarted()          │              │
   (clear logs)            │              │
        │                  │              │
  [Test runs]              │              │
        │                  │              │
  onTestStopped()          │              │
   (clear logs)            │              │
        │                  │              │
        └──────────────────┘              │
                           │              │
                           │ Repeat for   │
                           │ Test 2, 3... │
                           └──────────────┘
                           │
                           │ JVM Shutdown
                           ▼
                    ┌─────────────┐
                    │   Stopped   │
                    └─────────────┘
```
 
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

```
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
```

### Setup
<!-- Add any steps required to set up the test case -->
For Local Run:
1. `podman-compose down`
2. `podman-compose up -d`

For EE: 
1. `bonfire namespace reserve`
2. Deploy swatch-tally ( or any other service)
```
  bonfire deploy \
    --source=appsre \
    --ref-env insights-production \
    --namespace <EPHEMERAL_NAMESPACE> \
    --timeout 900 \
    --optional-deps-method hybrid \
    --frontends true \
    --component swatch-tally-ct-hbi \
    --component swatch-tally \
    --component wiremock \
    --component swatch-kafka-bridge \
    --component rhsm \
    --component artemis \
    --no-remove-resources app:rhsm \
    -p swatch-tally/RHSM_CONTRACTS_URL=http://wiremock-service:8000 \
    -p swatch-tally/INVENTORY_SECRET_KEY_NAME=swatch-tally-ct-hbi-db \
    --remove-dependencies swatch-tally/host-inventory \
    --remove-dependencies swatch-tally/swatch-contracts \
    --remove-dependencies swatch-tally/export-service \
    rhsm
```
or 

Deploy swatch contracts
```
 bonfire deploy \
    --source=appsre \
    --ref-env insights-production \
    --namespace <EPHEMERAL_NAMESPACE> \
    --timeout 900 \
    --optional-deps-method hybrid \
    --frontends true \
    --component swatch-contracts \
    --component wiremock \
    --component swatch-kafka-bridge \
    --component rhsm \
    --component artemis \
    --no-remove-resources app:rhsm \
    -p swatch-contracts/RHSM_CONTRACTS_URL=http://wiremock-service:8000 \
    rhsm
```

### Steps
<!-- Enter each step of the test below -->
Local:
1. `./mvnw test -Pcomponent-tests -pl swatch-tally/ct -am -Dsurefire.failIfNoSpecifiedTests=false`

EE:
1. `./mvnw test -Pcomponent-tests -pl swatch-tally/ct -am -Dswatch.component-tests.global.target=openshift`
or
3. `./mvnw test -Pcomponent-tests -pl swatch-contracts/ct -am -Dswatch.component-tests.global.target=openshift`


### Verification
<!-- Enter the steps needed to verify the test passed -->
1. In the test logging, you will see logging messages for lifecycle scope
At the start of the run:
```
[INFO] Running tests.AwsUsageContextComponentTest
[11:09:01.783] [INFO] Starting TEST_SUITE scoped service: kafkaBridge (will run until JVM shutdown) 
[11:09:01.812] [INFO] [kafkaBridge] Starting service (kafkaBridge) ... 
[11:09:07.157] [INFO] [kafkaBridge] Service started (kafkaBridge) 
[11:09:07.356] [INFO] Starting TEST_SUITE scoped service: wiremock (will run until JVM shutdown) 
[11:09:07.356] [INFO] [wiremock] Starting service (wiremock) ... 
[11:09:11.394] [INFO] [wiremock] Service started (wiremock) 
[11:09:11.401] [INFO] Starting TEST_SUITE scoped service: service (will run until JVM shutdown) 
[11:09:11.402] [INFO] [service] Starting service (service) ...
```
4. When the next test class starts you will see logging for TEST_SUITE scoped services being reused
```
[INFO] Running tests.AzureUsageContextComponentTest
[11:10:06.811] [INFO] Reusing TEST_SUITE scoped service: kafkaBridge 
[11:10:06.812] [INFO] Reusing TEST_SUITE scoped service: wiremock 
[11:10:06.813] [INFO] Reusing TEST_SUITE scoped service: service 
[11:10:06.814] [INFO] Reusing TEST_SUITE scoped service: unleash 
[11:10:06.815] [INFO] ## Running test AzureUsageContextComponentTest.shouldReturn404WhenAzureUsageContextHasInactiveSubs() 
[11:10:07.176] [INFO] ## Running test AzureUsageContextComponentTest.shouldReturnAzureUsa
```
5. You will see all of the services being shutdown at the end of the test run
```
[11:14:00.078] [INFO] [unleash] Service stopped (unleash) 
[11:14:00.094] [INFO] JVM Shutdown: stopping service service 
[11:14:03.934] [INFO] [service] Service stopped (service) 
[11:14:03.935] [INFO] JVM Shutdown: stopping service wiremock 
[11:14:06.749] [INFO] [wiremock] Service stopped (wiremock) 
[11:14:06.749] [INFO] JVM Shutdown: stopping service kafkaBridge 
[11:14:09.428] [INFO] [kafkaBridge] Service stopped (kafkaBridge) 
[INFO] 
[INFO] Results:
[INFO]
```
6. You should see an decrease in test test time in both ephemeral and local runs   
ex. My local runs
[swatch-tally](https://drive.google.com/file/d/153kpMm8r9wv3f4xIM7JoycUswc57Yb1R/view?usp=sharing)  
[swatch-metrics-hbi](https://drive.google.com/file/d/1DWdAaIXqkDHrigm7B-QhBRXWRycSMLFx/view?usp=drive_link)  
[swatch-contracts](https://drive.google.com/file/d/10DXRsGqS0DTGpqrn93VkdcFUcfj_H5Fe/view?usp=drive_link)  
7.Tests should continue to pass  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Release Changes

* **New Features**
  * Services are now managed at suite scope and reused between tests.
  * Pod log collection is now incremental, starting from the last captured time.
  * Port-forward cleanup is now scoped to a specific service.

* **Bug Fixes**
  * Reset test logging state between test runs to avoid stale/duplicate output.
  * Clear cached per-topic Kafka messages when tests end.
  * Improved OpenShift startup/readiness behavior to rely on runtime state (not log text).
  * File-based logging now snapshots the latest file content for diffs.

* **Documentation**
  * Clarified suite-level service registration lifecycle timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->