### PR TITLE
SWATCH-5164: Adding billable usage calculation component tests.

### DIFF
--- a/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
@@ -43,7 +43,7 @@ public class BillableUsageSwatchService extends SwatchService {
    * @param tallyId the tally ID to look up
    * @return list of remittances for the given tally ID
    */
-  public List<TallyRemittance> getRemittancesByTallyId(String tallyId) {
+  public List<TallyRemittance> getRemittancesByTally(String tallyId) {
     return given()
         .get(REMITTANCE_ENDPOINT_BY_TALLY_ID, tallyId)
         .then()

--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -119,43 +119,25 @@ public class BaseBillableUsageComponentTest {
   }
 
   protected BillableUsage givenFirstRemittanceSucceeded(double value, String billingAccountId) {
-    givenNoContractCoverageForRhelAddon();
-    var tallySummary =
-        createTallySummary(
-            orgId,
-            RHEL_PAYG_ADDON.getName(),
-            VCPUS.toString(),
-            value,
-            BillingProvider.AWS,
-            billingAccountId);
-    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
-
-    List<BillableUsage> billableUsages =
-        kafkaBridge.waitForKafkaMessage(
-            BILLABLE_USAGE,
-            MessageValidators.billableUsageMatchesWithValue(
-                orgId, RHEL_PAYG_ADDON.getName(), value),
-            1);
-    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage for first tally");
-    BillableUsage billableUsage = billableUsages.get(0);
-    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.PENDING);
-
-    kafkaBridge.produceKafkaMessage(
-        BILLABLE_USAGE_STATUS,
-        buildBillableUsageAggregate(
-            orgId,
-            RHEL_PAYG_ADDON.getName(),
-            VCPUS.toString(),
-            billingAccountId,
-            BillableUsage.Status.SUCCEEDED,
-            null,
-            OffsetDateTime.now(ZoneOffset.UTC),
-            List.of(billableUsage.getUuid().toString())));
-    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
-    return billableUsage;
+    return givenFirstRemittanceWithStatus(
+        value, billingAccountId, BillableUsage.Status.SUCCEEDED, null, RemittanceStatus.SUCCEEDED);
   }
 
   protected BillableUsage givenFirstRemittanceFailed(double value, String billingAccountId) {
+    return givenFirstRemittanceWithStatus(
+        value,
+        billingAccountId,
+        BillableUsage.Status.FAILED,
+        BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND,
+        RemittanceStatus.FAILED);
+  }
+
+  private BillableUsage givenFirstRemittanceWithStatus(
+      double value,
+      String billingAccountId,
+      BillableUsage.Status status,
+      BillableUsage.ErrorCode errorCode,
+      RemittanceStatus expectedRemittanceStatus) {
     givenNoContractCoverageForRhelAddon();
     var tallySummary =
         createTallySummary(
@@ -177,6 +159,8 @@ public class BaseBillableUsageComponentTest {
     BillableUsage billableUsage = billableUsages.get(0);
     waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.PENDING);
 
+    OffsetDateTime billedOn =
+        status == BillableUsage.Status.SUCCEEDED ? OffsetDateTime.now(ZoneOffset.UTC) : null;
     kafkaBridge.produceKafkaMessage(
         BILLABLE_USAGE_STATUS,
         buildBillableUsageAggregate(
@@ -184,11 +168,11 @@ public class BaseBillableUsageComponentTest {
             RHEL_PAYG_ADDON.getName(),
             VCPUS.toString(),
             billingAccountId,
-            BillableUsage.Status.FAILED,
-            BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND,
-            null,
+            status,
+            errorCode,
+            billedOn,
             List.of(billableUsage.getUuid().toString())));
-    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.FAILED);
+    waitForRemittanceStatus(billableUsage.getTallyId().toString(), expectedRemittanceStatus);
     return billableUsage;
   }
 

--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -20,13 +20,17 @@
  */
 package tests;
 
+import static api.BillableUsageTestHelper.createTallySummary;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import api.BillableUsageSwatchService;
 import api.ContractsWiremockService;
+import api.MessageValidators;
 import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
 import com.redhat.swatch.component.tests.api.ComponentTest;
 import com.redhat.swatch.component.tests.api.KafkaBridge;
@@ -36,11 +40,21 @@ import com.redhat.swatch.component.tests.api.Wiremock;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
+import domain.BillingProvider;
 import domain.Product;
 import domain.RemittanceStatus;
+import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import org.awaitility.Awaitility;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.junit.jupiter.api.BeforeEach;
 
 @ComponentTest(name = "swatch-billable-usage")
@@ -72,7 +86,7 @@ public class BaseBillableUsageComponentTest {
         .pollInterval(Duration.ofSeconds(2))
         .untilAsserted(
             () -> {
-              List<TallyRemittance> remittances = service.getRemittancesByTallyId(tallyId);
+              List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
               assertNotNull(remittances, "Remittances should exist for tallyId: " + tallyId);
               assertFalse(remittances.isEmpty(), "Should have at least one remittance");
               assertEquals(
@@ -83,5 +97,135 @@ public class BaseBillableUsageComponentTest {
                       + " but got "
                       + remittances.get(0).getStatus());
             });
+  }
+
+  protected void thenRemittanceStatusIs(String tallyId, RemittanceStatus expectedStatus) {
+    waitForRemittanceStatus(tallyId, expectedStatus);
+  }
+
+  protected void thenRemittanceHasValue(String tallyId, double expectedValue) {
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+    assertNotNull(remittances, "Remittances should exist for tallyId: " + tallyId);
+    assertEquals(1, remittances.size(), "Exactly one remittance per tally");
+    assertEquals(
+        expectedValue,
+        remittances.get(0).getRemittedPendingValue(),
+        0.001,
+        "Remittance should have value " + expectedValue);
+  }
+
+  protected void givenNoContractCoverageForRhelAddon() {
+    contractsWiremock.setupNoContractCoverage(orgId, RHEL_PAYG_ADDON.getName());
+  }
+
+  protected BillableUsage givenFirstRemittanceSucceeded(double value, String billingAccountId) {
+    givenNoContractCoverageForRhelAddon();
+    var tallySummary =
+        createTallySummary(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            value,
+            BillingProvider.AWS,
+            billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+
+    List<BillableUsage> billableUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatchesWithValue(
+                orgId, RHEL_PAYG_ADDON.getName(), value),
+            1);
+    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage for first tally");
+    BillableUsage billableUsage = billableUsages.get(0);
+    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.PENDING);
+
+    kafkaBridge.produceKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        buildBillableUsageAggregate(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            billingAccountId,
+            BillableUsage.Status.SUCCEEDED,
+            null,
+            OffsetDateTime.now(ZoneOffset.UTC),
+            List.of(billableUsage.getUuid().toString())));
+    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
+    return billableUsage;
+  }
+
+  protected BillableUsage givenFirstRemittanceFailed(double value, String billingAccountId) {
+    givenNoContractCoverageForRhelAddon();
+    var tallySummary =
+        createTallySummary(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            value,
+            BillingProvider.AWS,
+            billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+
+    List<BillableUsage> billableUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatchesWithValue(
+                orgId, RHEL_PAYG_ADDON.getName(), value),
+            1);
+    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage for first tally");
+    BillableUsage billableUsage = billableUsages.get(0);
+    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.PENDING);
+
+    kafkaBridge.produceKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        buildBillableUsageAggregate(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            billingAccountId,
+            BillableUsage.Status.FAILED,
+            BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND,
+            null,
+            List.of(billableUsage.getUuid().toString())));
+    waitForRemittanceStatus(billableUsage.getTallyId().toString(), RemittanceStatus.FAILED);
+    return billableUsage;
+  }
+
+  private BillableUsageAggregate buildBillableUsageAggregate(
+      String orgId,
+      String productId,
+      String metricId,
+      String billingAccountId,
+      BillableUsage.Status status,
+      BillableUsage.ErrorCode errorCode,
+      OffsetDateTime billedOn,
+      List<String> remittanceUuids) {
+    var aggregateKey = new BillableUsageAggregateKey();
+    aggregateKey.setOrgId(orgId);
+    aggregateKey.setProductId(productId);
+    aggregateKey.setMetricId(metricId);
+    aggregateKey.setSla("Premium");
+    aggregateKey.setUsage("Production");
+    aggregateKey.setBillingProvider(BillingProvider.AWS.name());
+    aggregateKey.setBillingAccountId(billingAccountId);
+
+    var aggregate = new BillableUsageAggregate();
+    aggregate.setAggregateKey(aggregateKey);
+    aggregate.setStatus(status);
+    aggregate.setRemittanceUuids(remittanceUuids);
+    aggregate.setTotalValue(BigDecimal.valueOf(5.0));
+    aggregate.setWindowTimestamp(OffsetDateTime.now(ZoneOffset.UTC).minusDays(3));
+    aggregate.setAggregateId(UUID.randomUUID());
+    Set<OffsetDateTime> snapshotDateSet = new HashSet<>();
+    snapshotDateSet.add(OffsetDateTime.now(ZoneOffset.UTC).minusDays(3));
+    aggregate.setSnapshotDates(snapshotDateSet);
+    if (errorCode != null) {
+      aggregate.setErrorCode(errorCode);
+    }
+    if (billedOn != null) {
+      aggregate.setBilledOn(billedOn);
+    }
+    return aggregate;
   }
 }

--- a/swatch-billable-usage/ct/java/tests/BillingCalculationComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillingCalculationComponentTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageTestHelper.createTallySummaryWithCurrentTotal;
+import static api.BillableUsageTestHelper.createTallySummaryWithDefaults;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import api.MessageValidators;
+import com.redhat.swatch.billable.usage.openapi.model.MonthlyRemittance;
+import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import domain.BillingProvider;
+import domain.RemittanceStatus;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.TallySummary;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class BillingCalculationComponentTest extends BaseBillableUsageComponentTest {
+
+  @AfterEach
+  void flushAggregates() {
+    service.flushBillableUsageAggregationTopic();
+  }
+
+  /** Verify current_total decrease does not create a new remittance (delta floors at zero). */
+  @TestPlanName("billable-usage-billing-calculation-TC001")
+  @Test
+  void shouldNotCreateNewRemittanceWhenCurrentTotalDecreases() {
+    // Given: First remittance (value 10) has SUCCEEDED
+    double firstValue = 10.0;
+    double decreasedTotal = 6.0;
+    String billingAccountId = RandomUtils.generateRandom();
+    BillableUsage firstBillableUsage = givenFirstRemittanceSucceeded(firstValue, billingAccountId);
+
+    // When: Second tally summary with current_total = 6 (below the remitted 10)
+    TallySummary secondTally =
+        createTallySummaryWithCurrentTotal(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            decreasedTotal,
+            decreasedTotal,
+            BillingProvider.AWS,
+            billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, secondTally);
+
+    // Then: Billable usage is emitted with value 0 (nothing billable when total decreased)
+    List<BillableUsage> secondUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatchesWithValue(orgId, RHEL_PAYG_ADDON.getName(), 0.0),
+            1);
+    assertEquals(
+        1, secondUsages.size(), "Expected exactly one billable usage message emitted with value 0");
+
+    // Then: Monthly total unchanged — no new remittance row for the second tally
+    List<MonthlyRemittance> monthlyRemittances =
+        service.getRemittances(
+            RHEL_PAYG_ADDON.getName(),
+            orgId,
+            VCPUS.toString(),
+            BillingProvider.AWS.toTallyApiModel().value(),
+            billingAccountId);
+    assertEquals(1, monthlyRemittances.size(), "Only one monthly accumulation period expected");
+    assertEquals(
+        firstValue,
+        monthlyRemittances.get(0).getRemittedValue(),
+        0.001,
+        "Monthly total should equal the first remittance only — no second remittance created");
+
+    // Then: Original remittance unchanged
+    thenRemittanceHasValue(firstBillableUsage.getTallyId().toString(), firstValue);
+  }
+
+  /** Verify failed remittances are excluded from the already-remitted total. */
+  @TestPlanName("billable-usage-billing-calculation-TC002")
+  @Test
+  void shouldExcludeFailedRemittancesFromTotalRemitted() {
+    // Given: First remittance (value 10) has FAILED
+    double firstValue = 10.0;
+    double secondTotal = 6.0;
+    String billingAccountId = RandomUtils.generateRandom();
+    BillableUsage firstBillableUsage = givenFirstRemittanceFailed(firstValue, billingAccountId);
+
+    // When: Second tally summary with current_total = 6 (failed remittance is excluded)
+    TallySummary secondTally =
+        createTallySummaryWithCurrentTotal(
+            orgId,
+            RHEL_PAYG_ADDON.getName(),
+            VCPUS.toString(),
+            secondTotal,
+            secondTotal,
+            BillingProvider.AWS,
+            billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, secondTally);
+
+    // Then: Billable usage is emitted with full current_total (failed not counted as remitted)
+    List<BillableUsage> secondUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatchesWithValue(
+                orgId, RHEL_PAYG_ADDON.getName(), secondTotal),
+            1);
+    assertEquals(
+        1, secondUsages.size(), "Expected exactly one billable usage message with value 6");
+
+    // Then: Two remittance rows — first FAILED, second PENDING with value 6
+    List<TallyRemittance> firstRemittances =
+        service.getRemittancesByTally(firstBillableUsage.getTallyId().toString());
+    assertEquals(1, firstRemittances.size(), "First tally should have exactly one remittance");
+    assertEquals(
+        RemittanceStatus.FAILED.name(),
+        firstRemittances.get(0).getStatus(),
+        "First remittance should be FAILED");
+
+    thenRemittanceStatusIs(secondUsages.get(0).getTallyId().toString(), RemittanceStatus.PENDING);
+    thenRemittanceHasValue(secondUsages.get(0).getTallyId().toString(), secondTotal);
+  }
+
+  /**
+   * Verify emitted BillableUsage.snapshotDate is set to remittance creation time, not original
+   * tally date.
+   */
+  @TestPlanName("billable-usage-billing-calculation-TC003")
+  @Test
+  void shouldUpdateSnapshotDateToRemittanceDateOnOutput() {
+    // Given: Tally with snapshot date one hour in the past
+    givenNoContractCoverageForRhelAddon();
+    OffsetDateTime beforeRemittance = OffsetDateTime.now(ZoneOffset.UTC);
+    TallySummary tallySummary =
+        createTallySummaryWithDefaults(orgId, RHEL_PAYG_ADDON.getName(), VCPUS.toString(), 8.0);
+    OffsetDateTime originalSnapshotDate = tallySummary.getTallySnapshots().get(0).getSnapshotDate();
+
+    // When: Tally is published
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+
+    // Then: Billable usage is emitted on Kafka
+    List<BillableUsage> billableUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatches(orgId, RHEL_PAYG_ADDON.getName()),
+            1);
+    assertEquals(1, billableUsages.size(), "Expected exactly one billable usage message");
+    OffsetDateTime emittedSnapshotDate = billableUsages.get(0).getSnapshotDate();
+
+    // Then: emitted snapshot_date is not the original tally date (which was ~1 hour ago)
+    assertTrue(
+        emittedSnapshotDate.isAfter(originalSnapshotDate.plusMinutes(59)),
+        String.format(
+            "Emitted snapshot_date %s should be updated from the original tally date %s to the remittance creation time",
+            emittedSnapshotDate, originalSnapshotDate));
+
+    // Then: emitted snapshot_date is close to the remittance creation time
+    assertTrue(
+        Duration.between(beforeRemittance, emittedSnapshotDate).abs().toSeconds() <= 10,
+        String.format(
+            "Emitted snapshot_date %s should be within 10 seconds of remittance creation time %s",
+            emittedSnapshotDate, beforeRemittance));
+  }
+}

--- a/swatch-billable-usage/ct/java/tests/TallyIngestionComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/TallyIngestionComponentTest.java
@@ -257,7 +257,7 @@ public class TallyIngestionComponentTest extends BaseBillableUsageComponentTest 
 
     // Collect remittances by metric ID — toMap enforces uniqueness (one per metric)
     Map<String, Double> remittedValueByMetric =
-        service.getRemittancesByTallyId(tallyId).stream()
+        service.getRemittancesByTally(tallyId).stream()
             .collect(
                 Collectors.toMap(
                     TallyRemittance::getMetricId, TallyRemittance::getRemittedPendingValue));

--- a/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
@@ -261,7 +261,7 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     waitForRemittanceStatus(tallyId, RemittanceStatus.SUCCEEDED);
 
     // Verify billed_on field was populated with proper timestamp
-    List<TallyRemittance> remittances = service.getRemittancesByTallyId(tallyId);
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
     assertNotNull(remittances, "Remittances should exist");
     assertFalse(remittances.isEmpty(), "Should have at least one remittance");
     verifyBilledOnTimestamp(remittances.get(0), expectedBilledOnTime);
@@ -294,7 +294,7 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     waitForRemittanceStatus(tallyId, RemittanceStatus.FAILED);
 
     // Verify error code was populated properly
-    List<TallyRemittance> remittances = service.getRemittancesByTallyId(tallyId);
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
     assertNotNull(remittances, "Remittances should exist");
     assertFalse(remittances.isEmpty(), "Should have at least one remittance");
     verifyErrorCode(remittances.get(0), RemittanceErrorCode.SUBSCRIPTION_NOT_FOUND.name());
@@ -524,10 +524,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
   }
 
-  private void givenNoContractCoverageForRhelAddon() {
-    contractsWiremock.setupNoContractCoverage(orgId, RHEL_PAYG_ADDON.getName());
-  }
-
   /**
    * Sets up test preconditions: creates tally summary, waits for billable usage with pending
    * remittance
@@ -551,50 +547,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
 
     assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage message");
     return billableUsages.get(0);
-  }
-
-  /**
-   * Sets up first remittance (RHEL addon, billing factor 1.0): sends tally, waits for billable
-   * usage, sends SUCCEEDED status update.
-   */
-  private BillableUsage givenFirstRemittanceSucceeded(double value, String billingAccountId) {
-    givenNoContractCoverageForRhelAddon();
-
-    TallySummary firstTallySummary =
-        createTallySummary(
-            orgId,
-            RHEL_PAYG_ADDON.getName(),
-            VCPUS.toString(),
-            value,
-            BillingProvider.AWS,
-            billingAccountId);
-    kafkaBridge.produceKafkaMessage(TALLY, firstTallySummary);
-
-    List<BillableUsage> firstBillableUsages =
-        kafkaBridge.waitForKafkaMessage(
-            BILLABLE_USAGE,
-            MessageValidators.billableUsageMatchesWithValue(
-                orgId, RHEL_PAYG_ADDON.getName(), value),
-            1);
-    assertEquals(
-        1, firstBillableUsages.size(), "Expected exactly 1 billable usage for first tally");
-    BillableUsage firstBillableUsage = firstBillableUsages.get(0);
-    waitForRemittanceStatus(firstBillableUsage.getTallyId().toString(), RemittanceStatus.PENDING);
-
-    BillableUsageAggregate statusUpdate =
-        givenBillableUsageAggregate(
-            orgId,
-            RHEL_PAYG_ADDON.getName(),
-            VCPUS.toString(),
-            billingAccountId,
-            BillableUsage.Status.SUCCEEDED,
-            null,
-            OffsetDateTime.now(ZoneOffset.UTC),
-            List.of(firstBillableUsage.getUuid().toString()));
-    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_STATUS, statusUpdate);
-    waitForRemittanceStatus(firstBillableUsage.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
-
-    return firstBillableUsage;
   }
 
   /** Builds a billable usage aggregate (status update) for use in status consumer tests. */
@@ -860,22 +812,11 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     for (BillableUsage usage : billableUsages) {
       String tallyId = usage.getTallyId().toString();
       waitForRemittanceStatus(tallyId, RemittanceStatus.PENDING);
-      List<TallyRemittance> remittances = service.getRemittancesByTallyId(tallyId);
+      List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
       assertNotNull(remittances, "Remittances should exist for tallyId: " + tallyId);
       assertFalse(
           remittances.isEmpty(), "Should have at least one remittance for org " + usage.getOrgId());
     }
-  }
-
-  private void thenRemittanceHasValue(String tallyId, double expectedValue) {
-    List<TallyRemittance> remittances = service.getRemittancesByTallyId(tallyId);
-    assertNotNull(remittances, "Remittances should exist for tallyId: " + tallyId);
-    assertEquals(1, remittances.size(), "Exactly one remittance per tally");
-    assertEquals(
-        expectedValue,
-        remittances.get(0).getRemittedPendingValue(),
-        0.001,
-        "Remittance should have value " + expectedValue);
   }
 
   private BillableUsageAggregate thenBillableUsageAggregateIsFoundForMetric(
@@ -970,7 +911,7 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     for (BillableUsage usage : billableUsages) {
       waitForRemittanceStatus(usage.getTallyId().toString(), RemittanceStatus.PENDING);
       List<TallyRemittance> remittances =
-          service.getRemittancesByTallyId(usage.getTallyId().toString());
+          service.getRemittancesByTally(usage.getTallyId().toString());
       assertNotNull(remittances, "Remittances should exist for tallyId: " + usage.getTallyId());
       assertEquals(1, remittances.size(), "Exactly one remittance per tally");
       TallyRemittance remittance = remittances.get(0);
@@ -994,7 +935,7 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
             .map(
                 u ->
                     service
-                        .getRemittancesByTallyId(u.getTallyId().toString())
+                        .getRemittancesByTally(u.getTallyId().toString())
                         .get(0)
                         .getAccumulationPeriod())
             .sorted()


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5164

## Description
This PR adds the following tests in the billable usage ct suite:
billable-usage-billing-calculation-TC001 - No new remittance when current_total decreases
billable-usage-billing-calculation-TC002 - Exclude failed remittances from total remitted calculation
billable-usage-billing-calculation-TC003 - Update snapshot_date to remittance date on output

I also moved some methods to base class since they are shared. getRemittancesByTally was also renamed to match api spec

## Testing
podman compose up -d
make build component-test swatch-billable-usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billable-usage billing behavior for repeated updates, including clamping emitted values to zero when totals decrease.
  * Ensured failed remittances are excluded from already-remitted totals.
  * Updated billable-usage snapshot timing to reflect remittance creation time.

* **Tests**
  * Added new component test coverage for billing calculation scenarios (including decreases, failures, and timing).
  * Expanded end-to-end test flows to validate remittance status/value transitions and ingestion-to-usage mapping with updated remittance lookup usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->