### PR TITLE
swatch-5166: Add component test for swatch-billable-usage hourly aggegation

### DIFF
--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -22,6 +22,7 @@ package tests;
 
 import static api.BillableUsageTestHelper.createTallySummary;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
 import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,7 +66,10 @@ public class BaseBillableUsageComponentTest {
   static final Product RHEL_PAYG_ADDON = Product.RHEL_PAYG_ADDON;
 
   @KafkaBridge
-  static KafkaBridgeService kafkaBridge = new KafkaBridgeService().subscribeToTopic(BILLABLE_USAGE);
+  static KafkaBridgeService kafkaBridge =
+      new KafkaBridgeService()
+          .subscribeToTopic(BILLABLE_USAGE)
+          .subscribeToTopic(BILLABLE_USAGE_HOURLY_AGGREGATE);
 
   @Wiremock static ContractsWiremockService contractsWiremock = new ContractsWiremockService();
 

--- a/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
@@ -48,44 +48,26 @@ public class BillableUsageAggregationComponentTest extends BaseBillableUsageComp
     contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
     String billingAccountId = RandomUtils.generateRandom();
 
-    double currentTotal1 = 10.0;
-    double currentTotal2 = 16.0;
-    double currentTotal3 = 23.0;
+    double[] currentTotals = {10.0, 16.0, 23.0};
+    TallySummary[] tallies = new TallySummary[currentTotals.length];
 
-    TallySummary tally1 =
-        createTallySummaryWithCurrentTotal(
-            orgId,
-            ROSA.getName(),
-            CORES.toString(),
-            currentTotal1,
-            currentTotal1,
-            BillingProvider.AWS,
-            billingAccountId);
-
-    TallySummary tally2 =
-        createTallySummaryWithCurrentTotal(
-            orgId,
-            ROSA.getName(),
-            CORES.toString(),
-            currentTotal2 - currentTotal1,
-            currentTotal2,
-            BillingProvider.AWS,
-            billingAccountId);
-
-    TallySummary tally3 =
-        createTallySummaryWithCurrentTotal(
-            orgId,
-            ROSA.getName(),
-            CORES.toString(),
-            currentTotal3 - currentTotal2,
-            currentTotal3,
-            BillingProvider.AWS,
-            billingAccountId);
+    for (int i = 0; i < currentTotals.length; i++) {
+      double previousTotal = i > 0 ? currentTotals[i - 1] : 0.0;
+      tallies[i] =
+          createTallySummaryWithCurrentTotal(
+              orgId,
+              ROSA.getName(),
+              CORES.toString(),
+              currentTotals[i] - previousTotal,
+              currentTotals[i],
+              BillingProvider.AWS,
+              billingAccountId);
+    }
 
     // When: All three tallies are published to the TALLY topic
-    kafkaBridge.produceKafkaMessage(TALLY, tally1);
-    kafkaBridge.produceKafkaMessage(TALLY, tally2);
-    kafkaBridge.produceKafkaMessage(TALLY, tally3);
+    for (TallySummary tally : tallies) {
+      kafkaBridge.produceKafkaMessage(TALLY, tally);
+    }
 
     // And: Wait for all three billable-usage messages to be produced (ensures they're in the
     // stream)
@@ -96,7 +78,7 @@ public class BillableUsageAggregationComponentTest extends BaseBillableUsageComp
     // values. The service stores remittedValue = billableValue / billingFactor to prevent
     // double-ceiling, so the aggregate equals ceil(finalCurrentTotal × factor) = ceil(23 × 0.25) =
     // 6
-    double expectedTotalValue = Math.ceil(currentTotal3 * BILLING_FACTOR);
+    double expectedTotalValue = Math.ceil(currentTotals[currentTotals.length - 1] * BILLING_FACTOR);
 
     BillableUsageAggregate aggregate =
         kafkaBridge

--- a/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageTestHelper.createTallySummaryWithCurrentTotal;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import api.MessageValidators;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import domain.BillingProvider;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
+import org.candlepin.subscriptions.billable.usage.TallySummary;
+import org.junit.jupiter.api.Test;
+
+public class BillableUsageAggregationComponentTest extends BaseBillableUsageComponentTest {
+
+  private static final double BILLING_FACTOR = ROSA.getBillingFactor(CORES);
+
+  @Test
+  @TestPlanName("billable-usage-aggregation-TC001")
+  public void shouldAggregateMultipleTalliesIntoSingleHourlyMessage() {
+    // Given: No contract coverage; a billing account ID shared across all tallies
+    contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
+    String billingAccountId = RandomUtils.generateRandom();
+
+    double currentTotal1 = 10.0;
+    double currentTotal2 = 16.0;
+    double currentTotal3 = 23.0;
+
+    TallySummary tally1 =
+        createTallySummaryWithCurrentTotal(
+            orgId,
+            ROSA.getName(),
+            CORES.toString(),
+            currentTotal1,
+            currentTotal1,
+            BillingProvider.AWS,
+            billingAccountId);
+
+    TallySummary tally2 =
+        createTallySummaryWithCurrentTotal(
+            orgId,
+            ROSA.getName(),
+            CORES.toString(),
+            currentTotal2 - currentTotal1,
+            currentTotal2,
+            BillingProvider.AWS,
+            billingAccountId);
+
+    TallySummary tally3 =
+        createTallySummaryWithCurrentTotal(
+            orgId,
+            ROSA.getName(),
+            CORES.toString(),
+            currentTotal3 - currentTotal2,
+            currentTotal3,
+            BillingProvider.AWS,
+            billingAccountId);
+
+    // When: All three tallies are published to the TALLY topic
+    kafkaBridge.produceKafkaMessage(TALLY, tally1);
+    kafkaBridge.produceKafkaMessage(TALLY, tally2);
+    kafkaBridge.produceKafkaMessage(TALLY, tally3);
+
+    // And: Wait for all three billable-usage messages to be produced (ensures they're in the
+    // stream)
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE, MessageValidators.billableUsageMatches(orgId, ROSA.getName()), 3);
+
+    // Then: One hourly aggregate message is emitted with totalValue = sum of individual billable
+    // values. The service stores remittedValue = billableValue / billingFactor to prevent
+    // double-ceiling, so the aggregate equals ceil(finalCurrentTotal × factor) = ceil(23 × 0.25) =
+    // 6
+    double expectedTotalValue = Math.ceil(currentTotal3 * BILLING_FACTOR);
+
+    BillableUsageAggregate aggregate =
+        kafkaBridge
+            .waitForKafkaMessage(
+                BILLABLE_USAGE_HOURLY_AGGREGATE,
+                MessageValidators.billableUsageAggregateMatchesOrg(orgId),
+                1,
+                AwaitilitySettings.defaults()
+                    .onConditionNotMet(service::flushBillableUsageAggregationTopic))
+            .get(0);
+
+    // Verify the aggregate exists and has the expected key dimensions
+    assertNotNull(aggregate, "Aggregate should not be null");
+    BillableUsageAggregateKey key = aggregate.getAggregateKey();
+    assertNotNull(key, "Aggregate key should not be null");
+    assertEquals(orgId, key.getOrgId(), "Aggregate org ID should match");
+    assertEquals(ROSA.getName(), key.getProductId(), "Aggregate product ID should match");
+    assertEquals(CORES.toString(), key.getMetricId(), "Aggregate metric ID should match");
+    assertEquals(
+        billingAccountId, key.getBillingAccountId(), "Aggregate billing account ID should match");
+    assertEquals("aws", key.getBillingProvider(), "Aggregate billing provider should match");
+
+    // Verify the aggregate value is the sum of individual billable values
+    assertEquals(
+        expectedTotalValue,
+        aggregate.getTotalValue().doubleValue(),
+        0.001,
+        "Total value should be ceil(finalCurrentTotal × factor) = ceil(23 × 0.25) = 6");
+    assertEquals(
+        3, aggregate.getRemittanceUuids().size(), "Should have 3 remittance UUIDs (one per tally)");
+  }
+}

--- a/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
@@ -55,7 +55,6 @@ import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.candlepin.subscriptions.billable.usage.TallySnapshot;
 import org.candlepin.subscriptions.billable.usage.TallySummary;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponentTest {
@@ -65,11 +64,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
   private static final String AWS_DIMENSION = ROSA.getMetric(CORES).getAwsDimension();
   private static final double CONTRACT_COVERAGE = 1.0;
   private static final MetricId INSTANCE_HOURS = MetricIdUtils.getInstanceHours();
-
-  @BeforeAll
-  static void subscribeToBillableUsageTopics() {
-    kafkaBridge.subscribeToTopic(BILLABLE_USAGE_HOURLY_AGGREGATE);
-  }
 
   /** Verify tally summary is processed and billable usage is produced with no contract coverage. */
   @Test

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
@@ -57,6 +57,9 @@ public class KafkaBridgeService extends RestService {
   private final Map<String, CopyOnWriteArrayList<Object>> messageCache = new ConcurrentHashMap<>();
 
   public KafkaBridgeService subscribeToTopic(String topic) {
+    if (consumers.containsKey(topic)) {
+      return this;
+    }
     String consumerId = UUID.randomUUID().toString();
     // If service is already running, create consumer for topic
     if (isRunning()) {


### PR DESCRIPTION
Jira issue: SWATCH-5166

## Description
Implements the hourly aggregation component test from `swatch-billable-usage/TEST_PLAN.md` .

## Testing
```
  podman-compose up -d
  cd ~/devel/subscriptions/rhsm-subscriptions/swatch-billable-usage/ct/
  mvn test -Dtest=BillableUsageAggregationComponentTest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new component test that publishes multiple tally summaries and verifies they are aggregated into a single hourly billable-usage message.
  * Validates the hourly aggregate key dimensions (including billing provider) and confirms the total is calculated using the expected billing factor.
  * Ensures the hourly aggregate references the expected set of remittance identifiers.
* **Test Infrastructure**
  * Updated shared test setup to listen for both raw billable-usage and hourly aggregate topics.
  * Made topic subscription idempotent to prevent duplicate consumer setup during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->