### PR TITLE
SWATCH-5167: Add negative and resilience component tests.

### DIFF
--- a/swatch-billable-usage/TEST_PLAN.md
+++ b/swatch-billable-usage/TEST_PLAN.md
@@ -286,23 +286,23 @@ This document defines the **component-level test plan** for `swatch-billable-usa
 
 **billable-usage-negative-TC001 - Service survives null tally message**
 
-- **Description:** Verify null payload to tally topic is rejected without crashing the service.  
+- **Description:** Verify null payload to tally topic is silently dropped without crashing the service.  
 - **Action:**  
   - Attempt to produce null to tally topic
 - **Verification:**  
-  - Null message rejected with client error  
+  - Null message silently dropped by consumer (no billable usage produced)
   - Service healthy after subsequent valid messages
 - **Expected Result:**  
   - Invalid tally message does not crash the service
 
 **billable-usage-negative-TC002 - Service survives malformed tally deserialization**
 
-- **Description:** Verify invalid JSON on tally topic does not crash consumer.  
+- **Description:** Verify a message that cannot be deserialized as TallySummary does not crash the consumer.  
 - **Action:**  
-  - Publish malformed message
+  - Publish malformed message (wrong JSON type)
 - **Verification:**  
   - Service remains ready  
-  - No remittance created
+  - No billable usage produced for the malformed message (subsequent valid tally processed normally)
 - **Expected Result:**  
   - Malformed tally message does not crash the service
 

--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -27,6 +27,7 @@ import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import api.BillableUsageSwatchService;
 import api.ContractsWiremockService;
@@ -77,6 +78,22 @@ public class BaseBillableUsageComponentTest {
   @BeforeEach
   void setUp() {
     orgId = RandomUtils.generateRandom();
+  }
+
+  /**
+   * Asserts that exactly 1 billable usage message matching {@code expectedOrgId} arrived and the
+   * service health is intact. Call immediately after publishing an invalid payload followed by a
+   * single valid probe to the tally topic. The count of 1 proves the invalid payload produced no
+   * matching output — null values carry no orgId and malformed payloads fail deserialization.
+   */
+  protected void assertInvalidTallyIsDropped(String expectedOrgId) {
+    var matched =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatches(expectedOrgId, ROSA.getName()),
+            1);
+    assertEquals(1, matched.size(), "Only probe tally should produce billable usage");
+    assertTrue(service.isRunning(), "Service should remain healthy after invalid tally message");
   }
 
   /** Wait for remittance to reach expected status using API polling */

--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -80,12 +80,7 @@ public class BaseBillableUsageComponentTest {
     orgId = RandomUtils.generateRandom();
   }
 
-  /**
-   * Asserts that exactly 1 billable usage message matching {@code expectedOrgId} arrived and the
-   * service health is intact. Call immediately after publishing an invalid payload followed by a
-   * single valid probe to the tally topic. The count of 1 proves the invalid payload produced no
-   * matching output — null values carry no orgId and malformed payloads fail deserialization.
-   */
+  /** Asserts only the valid probe produced billable usage and service remains healthy. */
   protected void assertInvalidTallyIsDropped(String expectedOrgId) {
     var matched =
         kafkaBridge.waitForKafkaMessage(

--- a/swatch-billable-usage/ct/java/tests/BillableUsageNegativeComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillableUsageNegativeComponentTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageTestHelper.createTallySummaryWithDefaults;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import org.junit.jupiter.api.Test;
+
+public class BillableUsageNegativeComponentTest extends BaseBillableUsageComponentTest {
+
+  @Test
+  @TestPlanName("billable-usage-negative-TC001")
+  public void shouldSurviveNullTallyMessage() {
+    // Given: Contract with zero coverage so all probe usage becomes billable
+    contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
+
+    // When: Null message published; valid probe follows to confirm consumer is still alive
+    kafkaBridge.produceKafkaMessage(TALLY, null);
+    kafkaBridge.produceKafkaMessage(
+        TALLY, createTallySummaryWithDefaults(orgId, ROSA.getName(), CORES.toString(), 8.0));
+
+    // Then: Only probe produces billable usage; service remains healthy
+    assertInvalidTallyIsDropped(orgId);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-negative-TC002")
+  public void shouldSurviveMalformedTallyDeserialization() {
+    // Given: Contract with zero coverage so all probe usage becomes billable
+    contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
+
+    // When: Malformed message published; valid probe follows to confirm consumer is still alive
+    kafkaBridge.produceKafkaMessage(TALLY, "not-a-valid-tally-summary");
+    kafkaBridge.produceKafkaMessage(
+        TALLY, createTallySummaryWithDefaults(orgId, ROSA.getName(), CORES.toString(), 8.0));
+
+    // Then: Only probe produces billable usage; service remains healthy
+    assertInvalidTallyIsDropped(orgId);
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5167

## Description
This PR implements the following tests:

billable-usage-negative-TC001 - Service survives null tally message

billable-usage-negative-TC002 - Service survives malformed tally deserialization

## Testing
podman compose up -d
make build component-test swatch-billable-usage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for null and malformed tally messages.
  * Confirmed invalid messages are safely dropped without generating billable usage.
  * Verified the service remains healthy and processes subsequent valid messages normally.

* **Documentation**
  * Updated the component test plan to reflect expected behavior for invalid tally messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->