### PR TITLE
SWATCH-5242: Fix contracts API errors deserialization in swatch-producer-aws

### DIFF
--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1248,14 +1248,6 @@ paths:
 
 components:
   schemas:
-    Errors:
-      required:
-        - errors
-      properties:
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error'
     Error:
       required:
         - status
@@ -1906,31 +1898,31 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Errors'
+            $ref: '#/components/schemas/Error'
     BadRequest:
       description: "The server could could not process the current request."
       content:
         application/vnd.api+json:
           schema:
-            $ref: "#/components/schemas/Errors"
+            $ref: "#/components/schemas/Error"
     Forbidden:
       description: "The request was valid, but the request was refused by the server."
       content:
         application/vnd.api+json:
           schema:
-            $ref: "#/components/schemas/Errors"
+            $ref: "#/components/schemas/Error"
     ResourceNotFound:
       description: "The requested resource was not found."
       content:
         application/vnd.api+json:
           schema:
-            $ref: "#/components/schemas/Errors"
+            $ref: "#/components/schemas/Error"
     InternalServerError:
       description: "An internal server error has occurred and is not recoverable."
       content:
         application/vnd.api+json:
           schema:
-            $ref: "#/components/schemas/Errors"
+            $ref: "#/components/schemas/Error"
 
   securitySchemes:
     customer:

--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -95,3 +95,22 @@ When the feature flag is enabled, usage records may use `CustomerAWSAccountId` f
   - Remittance status is `SUCCEEDED`
   - `UsageRecords[0].CustomerIdentifier` equals `customerId`
   - Warning logged about missing `customerAwsAccountId`
+
+## AWS usage context error handling
+
+Contracts `awsUsageContext` lookup failures and remittance error classification. Covered by component tests in `AwsUsageContextComponentTest`.
+
+**producer-aws-usage-context-TC001 - Classify recently terminated subscription**
+
+- **Description**: Verify that when swatch-contracts returns 404 with `CONTRACTS1005`, remittance status is `SUBSCRIPTION_TERMINATED` (not `SUBSCRIPTION_NOT_FOUND`).
+- **Setup**:
+  - Wiremock returns `awsUsageContext` 404 with an `Error` body containing `CONTRACTS1005`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `FAILED` on `billable-usage.status` with error code `SUBSCRIPTION_TERMINATED`
+  - No `BatchMeterUsage` call is sent to AWS
+- **Expected Result**:
+  - Remittance status is `FAILED` with `SUBSCRIPTION_TERMINATED`
+  - AWS Marketplace is not called

--- a/swatch-producer-aws/ct/java/api/AwsWiremockService.java
+++ b/swatch-producer-aws/ct/java/api/AwsWiremockService.java
@@ -35,7 +35,11 @@ import software.amazon.awssdk.services.marketplacemetering.model.UsageRecord;
 public class AwsWiremockService extends WiremockService {
 
   private static final String AWS_USAGE_EVENT_PATH = "/mock/aws";
+  private static final String AWS_USAGE_CONTEXT_PATH =
+      "/mock/contractApi/api/swatch-contracts/internal/subscriptions/awsUsageContext.*";
   private static final String BATCH_METER_USAGE_TARGET = "AWSMPMeteringService.BatchMeterUsage";
+  private static final int CONTRACT_API_STUB_PRIORITY = 9;
+  private static final String SUBSCRIPTION_RECENTLY_TERMINATED_CODE = "CONTRACTS1005";
 
   /**
    * Sets up the AWS usage context endpoint (contracts API) and a wiremock stub for the AWS
@@ -68,65 +72,74 @@ public class AwsWiremockService extends WiremockService {
       contextData.put("customerAwsAccountId", customerAwsAccountId);
     }
 
-    given()
-        .contentType("application/json")
-        .body(
-            Map.of(
-                "request",
-                Map.of(
-                    "method",
-                    "GET",
-                    "urlPathPattern",
-                    "/mock/contractApi/api/swatch-contracts/internal/subscriptions/awsUsageContext.*",
-                    "queryParameters",
-                    Map.of("awsAccountId", Map.of("equalTo", awsAccountId))),
-                "response",
-                Map.of(
-                    "status",
-                    200,
-                    "headers",
-                    Map.of("Content-Type", "application/json"),
-                    "jsonBody",
-                    contextData),
-                // the default mapping defined in config/wiremock uses priority 10,
-                // so we need a higher priority here.
-                "priority",
-                9,
-                "metadata",
-                getMetadataTags()))
-        .when()
-        .post("/__admin/mappings")
-        .then()
-        .statusCode(201);
-
+    registerAwsUsageContextStub(awsAccountId, jsonResponse(200, contextData));
     setupAwsBatchMeterUsage();
   }
 
+  public void setupAwsUsageContextToReturnSubscriptionRecentlyTerminated(String awsAccountId) {
+    registerAwsUsageContextStub(
+        awsAccountId, jsonResponse(404, subscriptionRecentlyTerminatedErrorBody()));
+  }
+
   public void setupAwsUsageContextToReturnSubscriptionNotFound(String awsAccountId) {
+    registerAwsUsageContextStub(awsAccountId, statusOnlyResponse(404));
+  }
+
+  private void registerAwsUsageContextStub(String awsAccountId, Map<String, Object> response) {
     given()
         .contentType("application/json")
         .body(
             Map.of(
                 "request",
-                Map.of(
-                    "method",
-                    "GET",
-                    "urlPathPattern",
-                    "/mock/contractApi/api/swatch-contracts/internal/subscriptions/awsUsageContext.*",
-                    "queryParameters",
-                    Map.of("awsAccountId", Map.of("equalTo", awsAccountId))),
+                awsUsageContextRequest(awsAccountId),
                 "response",
-                Map.of("status", 404),
+                response,
                 // the default mapping defined in config/wiremock uses priority 10,
                 // so we need a higher priority here.
                 "priority",
-                9,
+                CONTRACT_API_STUB_PRIORITY,
                 "metadata",
                 getMetadataTags()))
         .when()
         .post("/__admin/mappings")
         .then()
         .statusCode(201);
+  }
+
+  private static Map<String, Object> awsUsageContextRequest(String awsAccountId) {
+    return Map.of(
+        "method",
+        "GET",
+        "urlPathPattern",
+        AWS_USAGE_CONTEXT_PATH,
+        "queryParameters",
+        Map.of("awsAccountId", Map.of("equalTo", awsAccountId)));
+  }
+
+  private static Map<String, Object> jsonResponse(int status, Object jsonBody) {
+    return Map.of(
+        "status",
+        status,
+        "headers",
+        Map.of("Content-Type", "application/json"),
+        "jsonBody",
+        jsonBody);
+  }
+
+  private static Map<String, Object> statusOnlyResponse(int status) {
+    return Map.of("status", status);
+  }
+
+  private static Map<String, Object> subscriptionRecentlyTerminatedErrorBody() {
+    return Map.of(
+        "code",
+        SUBSCRIPTION_RECENTLY_TERMINATED_CODE,
+        "status",
+        "404",
+        "title",
+        "Subscription recently terminated",
+        "detail",
+        "");
   }
 
   public void verifyBatchMeterUsageCustomerIdentifier(String expectedCustomerIdentifier) {

--- a/swatch-producer-aws/ct/java/tests/AwsUsageContextComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/AwsUsageContextComponentTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.AwsTestHelper.createUsageAggregate;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
+
+import api.MessageValidators;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import domain.Product;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.junit.jupiter.api.Test;
+
+public class AwsUsageContextComponentTest extends BaseAwsComponentTest {
+
+  private static final double TOTAL_VALUE = 2.0;
+
+  @TestPlanName("producer-aws-usage-context-TC001")
+  @Test
+  void shouldClassifyRecentlyTerminatedSubscription() {
+    givenContractsReturnsRecentlyTerminatedSubscription();
+
+    whenBillableUsageAggregateIsProduced();
+
+    thenRemittanceFailsWithSubscriptionTerminated();
+    thenNoAwsUsageIsSent();
+  }
+
+  private void givenContractsReturnsRecentlyTerminatedSubscription() {
+    wiremock.setupAwsUsageContextToReturnSubscriptionRecentlyTerminated(awsAccountId);
+  }
+
+  private void whenBillableUsageAggregateIsProduced() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+    BillableUsageAggregate aggregate =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregate);
+  }
+
+  private void thenRemittanceFailsWithSubscriptionTerminated() {
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateFailure(
+            awsAccountId, BillableUsage.ErrorCode.SUBSCRIPTION_TERMINATED),
+        1);
+  }
+
+  private void thenNoAwsUsageIsSent() {
+    wiremock.verifyNoAwsUsage();
+  }
+}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/DefaultApiException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/DefaultApiException.java
@@ -20,7 +20,7 @@
  */
 package com.redhat.swatch.aws.exception;
 
-import com.redhat.swatch.aws.openapi.model.Errors;
+import com.redhat.swatch.clients.contracts.api.model.Error;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
 import jakarta.ws.rs.core.Response;
 import lombok.Getter;
@@ -28,10 +28,10 @@ import lombok.Getter;
 @Getter
 public class DefaultApiException extends ApiException {
 
-  private final transient Errors errors;
+  private final transient Error error;
 
-  public DefaultApiException(Response response, Errors errors) {
+  public DefaultApiException(Response response, Error error) {
     super(response);
-    this.errors = errors;
+    this.error = error;
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/resource/DefaultApiExceptionMapper.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/resource/DefaultApiExceptionMapper.java
@@ -21,7 +21,7 @@
 package com.redhat.swatch.aws.resource;
 
 import com.redhat.swatch.aws.exception.DefaultApiException;
-import com.redhat.swatch.aws.openapi.model.Errors;
+import com.redhat.swatch.clients.contracts.api.model.Error;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -41,14 +41,14 @@ public class DefaultApiExceptionMapper implements ResponseExceptionMapper<Defaul
 
   @Override
   public DefaultApiException toThrowable(Response response) {
-    return new DefaultApiException(response, parseErrors(response));
+    return new DefaultApiException(response, parseError(response));
   }
 
-  private Errors parseErrors(Response response) {
+  private Error parseError(Response response) {
     try {
-      return response.readEntity(Errors.class);
+      return response.readEntity(Error.class);
     } catch (Exception e) {
-      log.debug("Failed to create Errors from response.", e);
+      log.debug("Failed to create Error from response.", e);
       return null;
     }
   }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -212,14 +212,10 @@ public class AwsBillableUsageAggregateConsumer {
           billableUsageAggregate.getAggregateKey().getUsage(),
           billableUsageAggregate.getAggregateKey().getBillingAccountId());
     } catch (DefaultApiException e) {
-      var optionalErrors = ofNullable(e.getErrors());
-      if (optionalErrors.isPresent()) {
-        var isRecentlyTerminatedError =
-            optionalErrors.get().getErrors().stream()
-                .anyMatch(error -> ("SUBSCRIPTIONS1005").equals(error.getCode()));
-        if (isRecentlyTerminatedError) {
-          throw new SubscriptionRecentlyTerminatedException(e);
-        }
+      if (ofNullable(e.getError())
+          .map(error -> "CONTRACTS1005".equals(error.getCode()))
+          .orElse(false)) {
+        throw new SubscriptionRecentlyTerminatedException(e);
       }
       if (Response.Status.NOT_FOUND.getStatusCode() == e.getResponse().getStatus()) {
         throw new SubscriptionCanNotBeDeterminedException(e);
@@ -266,7 +262,10 @@ public class AwsBillableUsageAggregateConsumer {
                 } else if (result.status() != UsageRecordResultStatus.SUCCESS) {
                   log.warn("{}, aggregate={}", result, billableUsageAggregate);
                 } else {
-                  log.info("{}, aggregate={}", result, billableUsageAggregate);
+                  log.info(
+                      "Sent usage request to AWS: result={}, aggregate={}",
+                      result,
+                      billableUsageAggregate);
                   acceptedCounter.increment(response.results().size());
                 }
               });

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -36,9 +36,8 @@ import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
 import com.redhat.swatch.aws.exception.SubscriptionRecentlyTerminatedException;
-import com.redhat.swatch.aws.openapi.model.Error;
-import com.redhat.swatch.aws.openapi.model.Errors;
 import com.redhat.swatch.clients.contracts.api.model.AwsUsageContext;
+import com.redhat.swatch.clients.contracts.api.model.Error;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
 import com.redhat.swatch.clients.contracts.api.resources.DefaultApi;
 import com.redhat.swatch.configuration.registry.MetricId;
@@ -58,8 +57,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -389,12 +386,10 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void shouldThrowSubscriptionTerminatedException() throws ApiException {
-    Errors errors = new Errors();
     Error error = new Error();
-    error.setCode("SUBSCRIPTIONS1005");
-    errors.setErrors(Arrays.asList(error));
-    var response = Response.serverError().entity(errors).build();
-    var exception = new DefaultApiException(response, errors);
+    error.setCode("CONTRACTS1005");
+    var response = Response.serverError().entity(error).build();
+    var exception = new DefaultApiException(response, error);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenThrow(exception);
 
@@ -407,12 +402,10 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void shouldSkipMessageIfSubscriptionRecentlyTerminated() throws ApiException {
-    Errors errors = new Errors();
     Error error = new Error();
-    error.setCode("SUBSCRIPTIONS1005");
-    errors.setErrors(List.of(error));
-    var response = Response.serverError().entity(errors).build();
-    var exception = new DefaultApiException(response, errors);
+    error.setCode("CONTRACTS1005");
+    var response = Response.serverError().entity(error).build();
+    var exception = new DefaultApiException(response, error);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenThrow(exception);
 

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/DefaultApiException.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/exception/DefaultApiException.java
@@ -20,7 +20,7 @@
  */
 package com.redhat.swatch.azure.exception;
 
-import com.redhat.swatch.clients.contracts.api.model.Errors;
+import com.redhat.swatch.clients.contracts.api.model.Error;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
 import jakarta.ws.rs.core.Response;
 import lombok.Getter;
@@ -28,10 +28,10 @@ import lombok.Getter;
 @Getter
 public class DefaultApiException extends ApiException {
 
-  private final transient Errors errors;
+  private final transient Error error;
 
-  public DefaultApiException(Response response, Errors errors) {
+  public DefaultApiException(Response response, Error error) {
     super(response);
-    this.errors = errors;
+    this.error = error;
   }
 }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/resource/DefaultApiExceptionMapper.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/resource/DefaultApiExceptionMapper.java
@@ -21,7 +21,7 @@
 package com.redhat.swatch.azure.resource;
 
 import com.redhat.swatch.azure.exception.DefaultApiException;
-import com.redhat.swatch.clients.contracts.api.model.Errors;
+import com.redhat.swatch.clients.contracts.api.model.Error;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -41,14 +41,14 @@ public class DefaultApiExceptionMapper implements ResponseExceptionMapper<Defaul
 
   @Override
   public DefaultApiException toThrowable(Response response) {
-    return new DefaultApiException(response, parseErrors(response));
+    return new DefaultApiException(response, parseError(response));
   }
 
-  private Errors parseErrors(Response response) {
+  private Error parseError(Response response) {
     try {
-      return response.readEntity(Errors.class);
+      return response.readEntity(Error.class);
     } catch (Exception e) {
-      log.debug("Failed to create Errors from response.", e);
+      log.debug("Failed to create Error from response.", e);
       return null;
     }
   }

--- a/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
+++ b/swatch-producer-azure/src/main/java/com/redhat/swatch/azure/service/AzureBillableUsageAggregateConsumer.java
@@ -199,7 +199,10 @@ public class AzureBillableUsageAggregateConsumer {
       if (response.getStatus() != UsageEventStatusEnum.ACCEPTED) {
         log.warn("{}, aggregate={}", response, billableUsageAggregate);
       } else {
-        log.info("{}, aggregate={}", response, billableUsageAggregate);
+        log.info(
+            "Sent usage request to Azure: result={}, aggregate={}",
+            response,
+            billableUsageAggregate);
         acceptedCounter.increment();
       }
     } catch (AzureMarketplaceRequestFailedException e) {
@@ -234,14 +237,10 @@ public class AzureBillableUsageAggregateConsumer {
           billableUsageAggregate.getAggregateKey().getUsage(),
           billableUsageAggregate.getAggregateKey().getBillingAccountId());
     } catch (DefaultApiException e) {
-      var optionalErrors = ofNullable(e.getErrors());
-      if (optionalErrors.isPresent()) {
-        var isRecentlyTerminatedError =
-            optionalErrors.get().getErrors().stream()
-                .anyMatch(error -> ("SUBSCRIPTIONS1005").equals(error.getCode()));
-        if (isRecentlyTerminatedError) {
-          throw new SubscriptionRecentlyTerminatedException(e);
-        }
+      if (ofNullable(e.getError())
+          .map(error -> "CONTRACTS1005".equals(error.getCode()))
+          .orElse(false)) {
+        throw new SubscriptionRecentlyTerminatedException(e);
       }
       if (Status.NOT_FOUND.getStatusCode() == e.getResponse().getStatus()) {
         throw new SubscriptionCanNotBeDeterminedException(e);

--- a/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
+++ b/swatch-producer-azure/src/test/java/com/redhat/swatch/azure/service/BillableUsageConsumerTest.java
@@ -39,7 +39,6 @@ import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventOkRespons
 import com.redhat.swatch.clients.azure.marketplace.api.model.UsageEventStatusEnum;
 import com.redhat.swatch.clients.contracts.api.model.AzureUsageContext;
 import com.redhat.swatch.clients.contracts.api.model.Error;
-import com.redhat.swatch.clients.contracts.api.model.Errors;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
 import com.redhat.swatch.clients.contracts.api.resources.DefaultApi;
 import com.redhat.swatch.configuration.registry.Usage;
@@ -284,12 +283,10 @@ class BillableUsageConsumerTest {
 
   @Test
   void shouldThrowSubscriptionTerminatedException() throws ApiException {
-    Errors errors = new Errors();
     Error error = new Error();
-    error.setCode("SUBSCRIPTIONS1005");
-    errors.setErrors(List.of(error));
-    var response = Response.serverError().entity(errors).build();
-    var exception = new DefaultApiException(response, errors);
+    error.setCode("CONTRACTS1005");
+    var response = Response.serverError().entity(error).build();
+    var exception = new DefaultApiException(response, error);
     when(contractsApi.getAzureMarketplaceContext(any(), any(), any(), any(), any(), any()))
         .thenThrow(exception);
 
@@ -302,12 +299,10 @@ class BillableUsageConsumerTest {
 
   @Test
   void shouldSkipMessageIfSubscriptionRecentlyTerminated() throws ApiException {
-    Errors errors = new Errors();
     Error error = new Error();
-    error.setCode("SUBSCRIPTIONS1005");
-    errors.setErrors(List.of(error));
-    var response = Response.serverError().entity(errors).build();
-    var exception = new DefaultApiException(response, errors);
+    error.setCode("CONTRACTS1005");
+    var response = Response.serverError().entity(error).build();
+    var exception = new DefaultApiException(response, error);
     when(contractsApi.getAzureMarketplaceContext(any(), any(), any(), any(), any(), any()))
         .thenThrow(exception);
 


### PR DESCRIPTION
Jira issue: SWATCH-5242

## Description
Since SWATCH-2282 moved awsUsageContext from the monolith to swatch-contracts, producer-aws failed to deserialize contracts error responses and never recognized recently terminated subscriptions.

There were three bugs here:
1. DefaultApiExceptionMapper targeted the wrong Errors type (aws.openapi.model instead of the contracts client model), so RESTEasy could not deserialize the body (RESTEASY003145). 
2. The consumer still checked SUBSCRIPTIONS1005, but contracts has returned CONTRACTS1005 since the migration, so SUBSCRIPTION_TERMINATED was never classified and remittances fell through to SUBSCRIPTION_NOT_FOUND.
3. Contracts has always returned a single Error JSON object, not an Errors wrapper; the OpenAPI spec was wrong and the producers assumed the wrapper. 

Changes:
- Fix swatch-contracts openapi to return a single Error (as already validated in component tests and how it's currently working)
- Fix swatch-producer-aws and swatch-producer-azure to expect CONTRACTS1005 instead of SUBSCRIPTIONS1005
- Update DefaultApiExceptionMapper in swatch-producer-aws and swatch-producer-azure, to parse a single Error object instead of Errors (to validate how swatch-contracts is really working).

## Testing
- Added component test to validate the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Contract**
  - Updated contract error payloads to use a single error object (status, code, title, optional detail) instead of a wrapped errors array.

- **Bug Fixes**
  - Improved “recently terminated” subscription detection for both AWS and Azure using the updated contract error code.
  - Ensures usage is marked failed with `SUBSCRIPTION_TERMINATED` and no marketplace usage is sent for terminated subscriptions.

- **Logging**
  - Refined success messages for AWS/Azure usage submission.

- **Tests / Validation**
  - Added coverage for AWS recently terminated subscription handling and expanded the AWS test plan accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->