### PR TITLE
Disable flaky billable usage aggregation component test.

### DIFF
--- a/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillableUsageAggregationComponentTest.java
@@ -35,6 +35,7 @@ import domain.BillingProvider;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.candlepin.subscriptions.billable.usage.TallySummary;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class BillableUsageAggregationComponentTest extends BaseBillableUsageComponentTest {
@@ -42,6 +43,11 @@ public class BillableUsageAggregationComponentTest extends BaseBillableUsageComp
   private static final double BILLING_FACTOR = ROSA.getBillingFactor(CORES);
 
   @Test
+  @Disabled(
+      """
+          Flaky Kafka Streams hourly aggregation race (partial aggregate before window complete). "
+          Related to SWATCH-5256 and SWATCH-3233.
+          """)
   @TestPlanName("billable-usage-aggregation-TC001")
   public void shouldAggregateMultipleTalliesIntoSingleHourlyMessage() {
     // Given: No contract coverage; a billing account ID shared across all tallies


### PR DESCRIPTION
Kafka Streams can emit a partial hourly aggregate before all three billable usages are rolled up, causing intermittent assertion failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Disabled a flaky hourly aggregation test that intermittently fails due to timing/race behavior in stream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->