### PR TITLE
SWATCH-4766: Updated tally test plan and additional changes

### DIFF
--- a/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/EventRecordRepositoryTest.java
@@ -40,6 +40,8 @@ import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
 import org.candlepin.subscriptions.test.TestClockConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -75,6 +77,30 @@ class EventRecordRepositoryTest implements ExtendWithSwatchDatabase {
     assertNotNull(found.getEvent().getDisplayName());
     assertFalse(found.getEvent().getDisplayName().isPresent());
     assertEquals(record, found);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "b682126b-88d8-40b7-ada6-212f0e65e30a/extra-segment",
+        "aaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbb/cccccccccccccccccc"
+      })
+  void testSaveEventWithSlashSeparatedLongInstanceId(String instanceId) {
+    Event event = new Event();
+    event.setOrgId("org123");
+    event.setTimestamp(OffsetDateTime.now(CLOCK));
+    event.setInstanceId(instanceId);
+    event.setServiceType("RHEL System");
+    event.setEventId(UUID.randomUUID());
+    event.setEventSource("eventSource");
+    event.setDisplayName(Optional.empty());
+    event.setEventType("Prometheus");
+
+    EventRecord record = new EventRecord(event);
+    repository.saveAndFlush(record);
+
+    EventRecord found = repository.getReferenceById(record.getEventId());
+    assertEquals(instanceId, found.getInstanceId());
   }
 
   @Test

--- a/swatch-tally/TEST_PLAN.md
+++ b/swatch-tally/TEST_PLAN.md
@@ -118,9 +118,66 @@ Test cases should be testable locally and in deployed environments.
     - Service aggregates metrics across multiple hours
     - Instance deduplication works across time ranges
 
-## PAYG Product Tag Filtering
+**tally-conflicts-TC005 - Counter backfill amends hourly totals**
 
-**tally-payg-filter-TC001 - Mixed PAYG and TRADITIONAL tags filtered correctly**
+- **Description**: Verify late events for earliest and latest hours in range add to hourly totals without removing intermediate snapshot values
+- **Setup**:
+    - Product OpenShift-dedicated-metrics, random billing account for events
+    - Create 5 hourly events across 7-hour window with value V
+- **Action**:
+    - Run hourly tally; capture hourly report total for range
+    - Add amendment event at oldest hour (value v1)
+    - Add amendment event at newest hour (value v2)
+    - Run hourly tally again
+- **Verification**:
+    - New hourly total = prior total + v1 + v2 (per metric under test)
+- **Expected Result**:
+    - Counter metric hourly snapshots are amended in-place; no regression on unaffected hours
+
+**tally-conflicts-TC006 - Ansible counter amendments at two timestamps**
+
+- **Description**: Verify two late Instance-hours (counter) events for ansible-aap-managed; one at an early hour and one at the latest hour — each add their value to the hourly report total without clearing intermediate snapshots
+- **Setup**:
+    - Product ansible-aap-managed, fixed billing account
+    - 7-hour report window; baseline hourly total for Instance-hours already established (or start from zero)
+- **Action**:
+    - Capture baseline hourly Instance-hours total for the window
+    - Publish amendment event at hour T-5: distinct instance_id, measurement Instance-hours = A
+    - Publish amendment event at current hour: distinct instance_id, measurement Instance-hours = A
+    - Run hourly tally again
+- **Verification**:
+    - New hourly Instance-hours total = prior total + (2 × A)
+    - Intermediate hours in the window are not zeroed or removed
+- **Expected Result**:
+    - Counter amendments accumulate by event value across timestamps; swatch does not require a producer “cluster” or control/managed pair for this behavior
+
+**tally-conflicts-TC007 - Shared instance_id product isolation**
+
+- **Description**: Verify when a PAYG metered cluster and a traditional non-PAYG cloud host share the same instance_id, hourly PAYG tally is unchanged after nightly non-PAYG reconcile, and the non-PAYG host appears only on the expected traditional product with cloud category socket contribution
+- **Setup**:
+    - Organization is opted in
+    - Fixed instance_id / instance_uuid
+    - Fixed AWS billing_provider and billing_account_id for PAYG events
+    - Step A — PAYG:
+        - Publish mock PAYG cluster event for rhel-for-x86-els-payg with that instance_uuid, billing fields above, and a known vCPUs value
+        - Run hourly tally for the PAYG product
+        - Record PAYG instances report vCPUs for that instance
+    - Step B — Non-PAYG:
+        - Seed AWS public cloud non-PAYG host (RHEL for x86) with the same instance_id, no marketplace extra facts (aws_billing_products omitted)
+        - Run nightly tally
+- **Action**:
+    - Query PAYG instances report for the PAYG product, filtered by instance_id / display name
+    - Query non-PAYG instances/system table for the traditional product and host display name
+- **Verification**:
+    - PAYG row: vCPUs unchanged from Step A baseline
+    - Non-PAYG row: present on expected traditional product only
+    - Non-PAYG row: category=cloud, cloud_provider=aws, sockets=1
+- **Expected Result**:
+    - Shared instance identity does not cross-contaminate PAYG and traditional non-PAYG tally contributions; each product retains its own measurements after reconcile
+
+## Product Tag and Metric Filtering
+
+**tally-product-filter-TC001 - Mixed PAYG and TRADITIONAL tags filtered correctly**
 
 - **Description**: Verify that hourly tally filters out non-PAYG (TRADITIONAL) product tags from events with mixed tags
 - **Setup**:
@@ -139,7 +196,7 @@ Test cases should be testable locally and in deployed environments.
     - Only PAYG product tags are processed during hourly tally
     - TRADITIONAL product tags are filtered out and not included in hourly billing
 
-**tally-payg-filter-TC002 - Event with only TRADITIONAL tags not tallied hourly**
+**tally-product-filter-TC002 - Event with only TRADITIONAL tags not tallied hourly**
 
 - **Description**: Verify that events containing only TRADITIONAL product tags are not processed by hourly tally
 - **Setup**:
@@ -156,7 +213,7 @@ Test cases should be testable locally and in deployed environments.
     - Events with only TRADITIONAL tags are excluded from hourly processing
     - product_tag field is cleared when no PAYG tags remain
 
-**tally-payg-filter-TC003 - Event with only PAYG tags processed normally**
+**tally-product-filter-TC003 - Event with only PAYG tags processed normally**
 
 - **Description**: Verify that events containing only PAYG product tags are processed normally without filtering
 - **Setup**:
@@ -173,7 +230,7 @@ Test cases should be testable locally and in deployed environments.
     - PAYG-only events are processed normally by hourly tally
     - No filtering occurs when all tags are PAYG-eligible
 
-**tally-payg-filter-TC004 - Multiple events with mixed tags filtered correctly**
+**tally-product-filter-TC004 - Multiple events with mixed tags filtered correctly**
 
 - **Description**: Verify that multiple events with different tag combinations are all filtered correctly
 - **Setup**:
@@ -192,7 +249,7 @@ Test cases should be testable locally and in deployed environments.
     - PAYG product correctly aggregates using max value per hour
     - TRADITIONAL product excluded from all hourly processing
 
-**tally-payg-filter-TC005 - Conflict resolution with mixed PAYG and TRADITIONAL tags**
+**tally-product-filter-TC005 - Conflict resolution with mixed PAYG and TRADITIONAL tags**
 
 - **Description**: Verify that conflict resolution correctly handles events with mixed tags, updating PAYG measurements while keeping TRADITIONAL tags filtered out
 - **Setup**:
@@ -217,7 +274,7 @@ Test cases should be testable locally and in deployed environments.
     - TRADITIONAL tags remain filtered out during conflict resolution
     - Instance data reflects the resolved measurement value
 
-**tally-payg-filter-TC006 - Mixed tags with single-metric edge case**
+**tally-product-filter-TC006 - Mixed tags with single-metric edge case**
 
 - **Description**: Verify mixed PAYG/TRADITIONAL tag events still process correctly when only PAYG metric data is present.
 - **Setup**:
@@ -235,7 +292,7 @@ Test cases should be testable locally and in deployed environments.
     - PAYG data is retained and tallied
     - TRADITIONAL tag remains filtered out, even with incomplete metric payload
 
-**tally-payg-filter-TC007 - Role-based product tag lookup filters non-PAYG metrics**
+**tally-product-filter-TC007 - Role-based product tag lookup filters non-PAYG metrics**
 
 - **Description**: Verify that when product tag is derived from role (not explicitly provided), only metrics supported by the PAYG product are tallied and unsupported metrics are filtered out during normalization.
 - **Setup**:
@@ -259,6 +316,23 @@ Test cases should be testable locally and in deployed environments.
     - Role-based product tag derivation works correctly for PAYG products
     - Only metrics supported by the derived PAYG product are retained after normalization
     - Unsupported metrics (like Sockets for rosa) are filtered out and do not cause incorrect product tallies
+
+**tally-product-filter-TC008 - Metrics filtering drops unknown metrics**
+
+- **Description**: Verify events carrying a metric not defined in product configuration do not appear in hourly tally measurements
+- **Setup**:
+    - Product rosa, billing account scoped for events
+    - Event A: all valid rosa metrics (Cores, Instance-hours) at value 10
+    - Event B: valid metrics set at 20, invalid metric at 99
+- **Action**:
+    - Publish events to service instance ingress
+    - Run hourly tally
+    - Inspect hourly tally report and instances measurements for billing account
+- **Verification**:
+    - Valid metrics present with expected values
+    - Invalid metric absent from all measurements / snapshots
+- **Expected Result**:
+    - Product-config-driven metric filtering drops unknown metrics at ingest/normalization
 
 ## Hypervisor Handling
 
@@ -338,6 +412,39 @@ Test cases should be testable locally and in deployed environments.
     - Only hosts with RHEL buckets contribute to aggregated RHEL metrics
     - Hypervisor platform type does not create RHEL usage where none exists
 
+**tally-hypervisor-TC005 - RHEL hypervisor with guests increases total sockets**
+
+- **Description**: Verify hypervisor with guest mapping increases hypervisor socket totals and hypervisor appears in instances report
+- **Setup**:
+    - Capture baseline daily tally (all metrics) for RHEL for x86
+    - Create hypervisor (1 socket) + 2 guests
+- **Action**:
+    - Sync nightly tally
+    - Query instances report category hypervisor filtered by hypervisor display name
+- **Verification**:
+    - hypervisor_sockets increases by at least 1
+    - Total sockets increases by at least 1
+    - cloud_sockets / cloud_cores unchanged
+    - Hypervisor row in instances; all rows category hypervisor
+    - Guest count on hypervisor = 2
+- **Expected Result**:
+    - Hypervisor topology reflected in tally totals and instances category filter
+
+**tally-hypervisor-TC006 - RHEL hypervisor updates guest mapping**
+
+- **Description**: Verify remapping guest from hypervisor A to hypervisor B updates instances presence
+- **Setup**:
+    - Hypervisor A + 1 guest (synced, instance present)
+    - Hypervisor B with 0 guests (instance not present initially)
+- **Action**:
+    - Move guest from A to B (update hypervisor mapping)
+    - Sync nightly tally
+- **Verification**:
+    - Hypervisor A no longer in system table as a present instance
+    - Hypervisor B present with 1 guest
+- **Expected Result**:
+    - Guest mapping updates change hypervisor visibility in tally inventory
+
 ## Data Persistence
 
 **tally-persistence-TC001 - Tally report is idempotent across separate tally runs**
@@ -377,28 +484,45 @@ Test cases should be testable locally and in deployed environments.
     - Instance reports are idempotent
     - Re-running tally does not modify instance metadata
 
-## Report Granularity and Filtering
+**tally-persistence-TC003 - Previous-month backfill leaves current month unchanged**
+
+- **Description**: Verify hourly tally over a previous-month range includes late-added events for that month without changing current-month daily totals
+- **Setup**:
+    - Product OpenShift-dedicated-metrics used for events
+    - Capture current-month daily total for metric
+    - Capture previous-month daily total for days 1–3 of prior month
+    - Create three PAYG events dated in previous month (days 1–3)
+- **Action**:
+    - Run hourly tally scoped to previous-month range
+- **Verification**:
+    - Previous-month daily sum increases by 3 (one per event)
+    - Current-month daily sum unchanged before vs after
+- **Expected Result**:
+    - Month-scoped hourly processing backfills historical snapshots without cross-month contamination
+
+## Report Granularity and Filtering (PAYG)
 
 ### Test Organization
 
-The tally report filtering test cases are organized into two component test files:
+The PAYG tally report filtering test cases are organized into two component test files:
 
-- **TallyReportFiltersPaygTest.java** - Contains 21 test cases (TC001-TC023, TC025, excluding TC009, TC010, TC024) covering PAYG (Pay-As-You-Go) scenarios:
+- **TallyReportFiltersPaygTest.java** - Contains 23 PAYG test cases (`tally-report-filters-payg-TC***`; TC009, TC010, TC023 live in EdgeCaseTest):
   - TC001-TC008: Basic filtering by granularity, SLA, usage, billing provider, and billing account ID
   - TC011-TC014: Validation errors and metadata verification
-  - TC016-TC023: Daily granularity filtering, monthly/quarterly/yearly granularity support
-  - TC025: Invalid granularity enum value
+  - TC015-TC022: Unfiltered aggregation, daily filtering after nightly tally, monthly/quarterly/yearly granularity
+  - TC024: Invalid granularity enum value
+  - TC025: Daily report totals equal sum of hourly values
   - Product: RHEL for x86 ELS PAYG (supports hourly granularity)
 
-- **TallyReportFiltersEdgeCaseTest.java** - Contains 3 test cases for edge cases requiring special event patterns:
+- **TallyReportFiltersEdgeCaseTest.java** - Contains 3 PAYG edge cases requiring special event patterns:
   - TC009: Multiple events aggregation with same filter attributes
   - TC010: Three distinct SLA values filtering
-  - TC024: Billing account change for same instance
+  - TC023: Billing account change for same instance
   - Product: RHEL for x86 ELS PAYG (supports hourly granularity)
 
 All test files use `@BeforeAll` to create test data once and share it across all test methods. Each test is parameterized with `@ValueSource(booleans = {true, false})` to verify behavior with both the legacy query path and the primary row searches feature flag enabled.
 
-**tally-report-filters-TC001 - Daily granularity with all filters**
+**tally-report-filters-payg-TC001 - Daily granularity with all filters**
 
 - **Description**: Verify that tally report API returns daily granularity data with all filter parameters
 - **Setup**:
@@ -416,7 +540,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API returns daily tally data with all specified filters
     - Metadata accurately reflects the request parameters
 
-**tally-report-filters-TC002 - Hourly granularity filtered by SLA**
+**tally-report-filters-payg-TC002 - Hourly granularity filtered by SLA**
 
 - **Description**: Verify that tally report API filters data by SLA parameter
 - **Setup**:
@@ -435,7 +559,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters tally data by SLA parameter
     - Only data matching the specified SLA is returned
 
-**tally-report-filters-TC003 - Hourly granularity filtered by usage**
+**tally-report-filters-payg-TC003 - Hourly granularity filtered by usage**
 
 - **Description**: Verify that tally report API filters data by usage parameter
 - **Setup**:
@@ -454,7 +578,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters tally data by usage parameter
     - Only data matching the specified usage is returned
 
-**tally-report-filters-TC004 - Hourly granularity filtered by billing provider**
+**tally-report-filters-payg-TC004 - Hourly granularity filtered by billing provider**
 
 - **Description**: Verify that tally report API filters data by billing provider parameter
 - **Setup**:
@@ -473,7 +597,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters tally data by billing provider parameter
     - Only data matching the specified billing provider is returned
 
-**tally-report-filters-TC005 - Hourly granularity filtered by billing account ID**
+**tally-report-filters-payg-TC005 - Hourly granularity filtered by billing account ID**
 
 - **Description**: Verify that tally report API filters data by billing account ID parameter
 - **Setup**:
@@ -492,7 +616,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters tally data by billing account ID parameter
     - Only data matching the specified billing account ID is returned
 
-**tally-report-filters-TC006 - Daily granularity with partial filters**
+**tally-report-filters-payg-TC006 - Daily granularity with partial filters**
 
 - **Description**: Verify that tally report API returns daily granularity data with only some filter parameters
 - **Setup**:
@@ -509,7 +633,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API accepts partial filter sets
     - Unspecified filters are not present in metadata
 
-**tally-report-filters-TC007 - Hourly granularity with all filters**
+**tally-report-filters-payg-TC007 - Hourly granularity with all filters**
 
 - **Description**: Verify that tally report API returns hourly granularity data with all filter parameters
 - **Setup**:
@@ -525,7 +649,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API returns hourly tally data
     - Hourly granularity data includes all applied filters
 
-**tally-report-filters-TC008 - Invalid request without granularity**
+**tally-report-filters-payg-TC008 - Invalid request without granularity**
 
 - **Description**: Verify that tally report API returns validation error when granularity parameter is missing
 - **Setup**:
@@ -540,7 +664,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API validates required parameters
     - Appropriate error message is returned
 
-**tally-report-filters-TC009 - Multiple events with same filter values are aggregated**
+**tally-report-filters-payg-TC009 - Multiple events with same filter values are aggregated**
 
 - **Description**: Verify that multiple events with identical filter attributes are properly aggregated in tally reports
 - **Setup**:
@@ -558,7 +682,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API correctly aggregates multiple events with same filter values
     - Total reflects sum of all matching events
 
-**tally-report-filters-TC010 - Three distinct filter value combinations**
+**tally-report-filters-payg-TC010 - Three distinct filter value combinations**
 
 - **Description**: Verify that filtering works correctly when three different SLA values exist in the same hour
 - **Setup**:
@@ -578,7 +702,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API correctly isolates data by filter value
     - Only matching SLA data is returned when multiple SLA values exist
 
-**tally-report-filters-TC011 - Invalid request without beginning timestamp**
+**tally-report-filters-payg-TC011 - Invalid request without beginning timestamp**
 
 - **Description**: Verify that tally report API returns validation error when beginning parameter is missing
 - **Setup**:
@@ -593,7 +717,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API validates required beginning parameter
     - Appropriate error message is returned
 
-**tally-report-filters-TC012 - Invalid request without ending timestamp**
+**tally-report-filters-payg-TC012 - Invalid request without ending timestamp**
 
 - **Description**: Verify that tally report API returns validation error when ending parameter is missing
 - **Setup**:
@@ -608,7 +732,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API validates required ending parameter
     - Appropriate error message is returned
 
-**tally-report-filters-TC013 - Metadata reflects no filters when omitted**
+**tally-report-filters-payg-TC013 - Metadata reflects no filters when omitted**
 
 - **Description**: Verify that response metadata correctly shows null values for optional filters when they are not provided
 - **Setup**:
@@ -624,7 +748,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API properly differentiates between filtered and unfiltered requests
     - Null values indicate no filter was applied
 
-**tally-report-filters-TC014 - Metadata with EMPTY filter value**
+**tally-report-filters-payg-TC014 - Metadata with EMPTY filter value**
 
 - **Description**: Verify that response metadata correctly reflects EMPTY enum filter values
 - **Setup**:
@@ -640,7 +764,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API properly handles EMPTY enum values in filters
     - EMPTY is treated as a valid filter value distinct from null
 
-**tally-report-filters-TC016 - All data returned when no optional filters applied**
+**tally-report-filters-payg-TC015 - All data returned when no optional filters applied**
 
 - **Description**: Verify that tally report API returns all event data aggregated when querying without optional filter parameters
 - **Setup**:
@@ -661,7 +785,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Total reflects sum of all events regardless of SLA, usage, or billing attributes
     - Metadata correctly indicates no filters were applied (null values)
 
-**tally-report-filters-TC017 - Daily granularity filtered by SLA after nightly tally**
+**tally-report-filters-payg-TC016 - Daily granularity filtered by SLA after nightly tally**
 
 - **Description**: Verify that tally report API filters daily snapshots by SLA after running hourly tally followed by nightly tally
 - **Setup**:
@@ -682,7 +806,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters daily snapshot data by SLA parameter
     - Only data matching the specified SLA is returned from daily aggregation
 
-**tally-report-filters-TC018 - Daily granularity filtered by usage after nightly tally**
+**tally-report-filters-payg-TC017 - Daily granularity filtered by usage after nightly tally**
 
 - **Description**: Verify that tally report API filters daily snapshots by usage after running hourly tally followed by nightly tally
 - **Setup**:
@@ -703,7 +827,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters daily snapshot data by usage parameter
     - Only data matching the specified usage is returned from daily aggregation
 
-**tally-report-filters-TC019 - Daily granularity filtered by billing provider after nightly tally**
+**tally-report-filters-payg-TC018 - Daily granularity filtered by billing provider after nightly tally**
 
 - **Description**: Verify that tally report API filters daily snapshots by billing provider after running hourly tally followed by nightly tally
 - **Setup**:
@@ -724,7 +848,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters daily snapshot data by billing provider parameter
     - Only data matching the specified billing provider is returned from daily aggregation
 
-**tally-report-filters-TC020 - Daily granularity filtered by billing account ID after nightly tally**
+**tally-report-filters-payg-TC019 - Daily granularity filtered by billing account ID after nightly tally**
 
 - **Description**: Verify that tally report API filters daily snapshots by billing account ID after running hourly tally followed by nightly tally
 - **Setup**:
@@ -745,7 +869,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API filters daily snapshot data by billing account ID parameter
     - Only data matching the specified billing account ID is returned from daily aggregation
 
-**tally-report-filters-TC021 - Monthly granularity with all filters**
+**tally-report-filters-payg-TC020 - Monthly granularity with all filters**
 
 - **Description**: Verify that tally report API accepts monthly granularity and returns correct metadata with all filter parameters
 - **Setup**:
@@ -762,7 +886,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API accepts and processes monthly granularity queries
     - All filter parameters are properly reflected in response metadata
 
-**tally-report-filters-TC022 - Quarterly granularity with all filters**
+**tally-report-filters-payg-TC021 - Quarterly granularity with all filters**
 
 - **Description**: Verify that tally report API accepts quarterly granularity and returns correct metadata with all filter parameters
 - **Setup**:
@@ -779,7 +903,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API accepts and processes quarterly granularity queries
     - All filter parameters are properly reflected in response metadata
 
-**tally-report-filters-TC023 - Yearly granularity with all filters**
+**tally-report-filters-payg-TC022 - Yearly granularity with all filters**
 
 - **Description**: Verify that tally report API accepts yearly granularity and returns correct metadata with all filter parameters
 - **Setup**:
@@ -796,19 +920,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - API accepts and processes yearly granularity queries
     - All filter parameters are properly reflected in response metadata
 
-**tally-report-filters-TC025 - Invalid granularity enum value**
-
-- **Description**: Verify that tally report API returns validation error when granularity is not a valid enum value
-- **Setup**:
-    - Organization is opted in
-- **Action**:
-    - Request tally report with granularity=HOURLLY (typo)
-- **Verification**:
-    - HTTP 400 Bad Request
-- **Expected Result**:
-    - Invalid enum query parameters return client error instead of server error
-
-**tally-report-filters-TC024 - Daily report tracks billing account change for same instance**
+**tally-report-filters-payg-TC023 - Daily report tracks billing account change for same instance**
 
 - **Description**: Verify that daily tally reports correctly track measurements when a single instance changes its billing account ID
 - **Setup**:
@@ -830,9 +942,37 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Daily reports correctly attribute measurements to respective billing accounts when an instance changes billing account ID
     - Total aggregated value equals the sum of individual billing account values
 
-## Report Has Data Based on Category
+**tally-report-filters-payg-TC024 - Invalid granularity enum value**
 
-**tally-report-has-data-TC001 - has_data matches category contribution**
+- **Description**: Verify that tally report API returns validation error when granularity is not a valid enum value
+- **Setup**:
+    - Organization is opted in
+- **Action**:
+    - Request tally report with granularity=HOURLLY (typo)
+- **Verification**:
+    - HTTP 400 Bad Request
+- **Expected Result**:
+    - Invalid enum query parameters return client error instead of server error
+
+**tally-report-filters-payg-TC025 - Daily report totals sum of hourly values in same time window**
+
+- **Description**: Verify for PAYG that sum of hourly report values (has_data hours) for yesterday equals daily report value for same window
+- **Setup**:
+    - Reset org
+    - Two PAYG events yesterday (hours 07:00 and 10:00 UTC) + one event today (all with cores + instance-hours)
+- **Action**:
+    - Run hourly tally
+    - Query hourly cores and instance-hours for yesterday’s beginning/ending
+    - Query daily cores and instance-hours for same window
+- **Verification**:
+    - Report Sum(hourly values where has_data) = daily data point value for cores
+    - Same for instance-hours
+- **Expected Result**:
+    - Daily snapshot equals aggregation of hourly snapshots for the period
+
+## Report Has Data Based on Category (PAYG)
+
+**tally-report-has-data-payg-TC001 - has_data matches category contribution**
 
 - **Description**: Verify that hourly tally reports with a category filter set has_data from that category’s measurements only, not from snapshot presence or other hardware categories.
 - **Setup**:
@@ -854,7 +994,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Gap-filled hours report has_data=false even when value=0
     - Non-contributing categories do not report has_data=true when a cloud-only snapshot exists
 
-**tally-report-has-data-TC002 - Zero-value category measurements still report has_data**
+**tally-report-has-data-payg-TC002 - Zero-value category measurements still report has_data**
 
 - **Description**: Verify that a zero-quantity measurement for a contributing category still returns has_data=true with value=0 and that other categories at the same hour remain has_data=false when only cloud contributed.
 - **Setup**:
@@ -871,7 +1011,7 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Existing zero-value measurements for the filtered category are treated as present (has_data=true)
     - Categories that did not contribute at that hour still report has_data=false with value=0
 
-**tally-report-has-data-TC003 - Data gaps indicated by hasData field**
+**tally-report-has-data-payg-TC003 - Data gaps indicated by hasData field**
 
 - **Description**: Verify that an unfiltered hourly tally report sets has_data per bucket.
 - **Setup**:
@@ -891,129 +1031,390 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Event hours report has_data=true with the expected tallied values
     - Gap-filled hours without a snapshot for that period report value=0 and has_data=false
 
-## Summary Messages Separated By Attribute Value
+## Report Granularity and Filtering (Non-PAYG)
 
-**tally-summary-by-attributes-TC001 - Tally summary separates measurements by SLA**
+Shared **non-PAYG physical RHEL fixture** (TC001–TC006): product RHEL for x86, category=physical, three nightly-tallied hosts — Host A: 4 sockets / Premium / Production; Host B: 6 sockets / Standard / Development/Test; Host C: 2 sockets / Premium / Development/Test; **total 12 sockets**. CT: seed via shared fixture helper.
 
-- **Description**: Verify that tally summary messages contain separate measurement values for each SLA level
-- **Setup**:
-    - Events created for each SLA type (PREMIUM, STANDARD, SELF_SUPPORT)
-    - One event with no SLA
-- **Action**:
-    - Produce events to Kafka
-    - Poll for tally summaries with HOURLY granularity
-- **Verification**:
-    - Sum of all per-SLA measurement values equals total minus the no-SLA value
-    - Sum of per-SLA values plus no-SLA value equals the total
-- **Expected Result**:
-    - Tally produces separate snapshot measurements for each SLA attribute value
-    - No-SLA measurements are tracked separately from defined SLA values
+**tally-report-filters-nonpayg-TC001 - Physical RHEL daily report SLA filter returns correct socket totals**
 
-**tally-summary-by-attributes-TC002 - Tally summary separates measurements by usage**
-
-- **Description**: Verify that tally summary messages contain separate measurement values for each usage type
-- **Setup**:
-    - Events created for each Usage type (PRODUCTION, DEVELOPMENT_TEST, DISASTER_RECOVERY)
-    - One event with no Usage
-- **Action**:
-    - Produce events to Kafka
-    - Poll for tally summaries with HOURLY granularity
-- **Verification**:
-    - Sum of all per-usage measurement values equals total minus the no-usage value
-    - Sum of per-usage values plus no-usage value equals the total
-- **Expected Result**:
-    - Tally produces separate snapshot measurements for each usage attribute value
-    - No-usage measurements are tracked separately from defined usage values
-
-**tally-summary-by-attributes-TC003 - Tally summary separates measurements by billing account ID**
-
-- **Description**: Verify that tally summary messages contain separate measurement values for each billing account ID
-- **Setup**:
-    - Two events created from different instances with different billing account IDs and different metric values
-- **Action**:
-    - Produce events to Kafka
-    - Poll for tally summaries with HOURLY granularity
-- **Verification**:
-    - Each billing account ID has its expected measurement value
-    - Sum of per-billing-account values equals the total
-- **Expected Result**:
-    - Tally produces separate snapshot measurements for each billing account ID
-    - Per-billing-account measurement values sum to the overall total
-
-**tally-summary-by-attributes-TC004 - Tally summary correctly attributes measurements when a single host changes billing account ID**
-
-- **Description**: Verify that when a single host sends events under different billing account IDs at different times, tally correctly attributes each measurement to the respective billing account
-- **Setup**:
-    - Same host sends one event with billing account A at T-2 hours
-    - Same host sends another event with billing account B at T-1 hours
-- **Action**:
-    - Produce events to Kafka
-    - Poll for tally summaries with HOURLY granularity
-- **Verification**:
-    - Billing account A has the measurement value from the first event (5.0)
-    - Billing account B has the measurement value from the second event (8.0)
-    - Sum of per-billing-account values equals the total
-- **Expected Result**:
-    - Tally correctly attributes measurements to the billing account from each event
-    - A billing account change on a single instance does not merge or lose measurement values
-
-**tally-summary-by-attributes-TC005 - Tally summary separates measurements by billing provider**
-
-- **Description**: Verify that tally summary messages contain separate measurement values for each billing provider
-- **Setup**:
-    - Two events created from different instances with different billing providers (AWS, Azure) and different metric values
-- **Action**:
-    - Produce events to Kafka
-    - Poll for tally summaries with HOURLY granularity
-- **Verification**:
-    - Each billing provider has its expected measurement value
-    - Sum of per-billing-provider values equals the total
-- **Expected Result**:
-    - Tally produces separate snapshot measurements for each billing provider attribute value
-    - Per-billing-provider measurement values sum to the overall total
-
-## Tally Summary Messages
-
-**tally-summary-TC001 - Nightly tally emits daily granularity**
-
-- **Description**: Verify that nightly tally operation produces summary messages with DAILY granularity
+- **Description**: Verify daily tally report SLA filters return correct socket totals for non-PAYG physical RHEL
 - **Setup**:
     - Organization is opted in
-    - Nightly tally host buckets are seeded in database
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query daily report, metric Sockets, category=physical, sla=Premium
+    - Query with sla=Standard
+- **Verification**:
+    - Premium = 6 (Hosts A + C)
+    - Standard = 6 (Host B)
+- **Expected Result**:
+    - Daily SLA filters match host totals
+
+**tally-report-filters-nonpayg-TC002 - Physical RHEL daily report usage filter returns correct socket totals**
+
+- **Description**: Verify daily usage filters return correct socket totals
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query usage=Production, category=physical
+    - Query usage=Development/Test, category=physical
+- **Verification**:
+    - Production = 4 (Host A)
+    - Development/Test = 8 (Hosts B + C)
+- **Expected Result**:
+    - Daily usage filters match host totals
+
+**tally-report-filters-nonpayg-TC003 - Physical RHEL daily report combined SLA and usage filters return per-host totals**
+
+- **Description**: Verify combined SLA and usage filters return per-host socket totals; invalid combo returns zero; response metadata echoes applied filters
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query Premium + Production; Standard + Development/Test; Premium + Development/Test; Standard + Production (category=physical)
+    - For Premium + Production, query full report object (not value-only)
+- **Verification**:
+    - Premium + Production = 4 (Host A)
+    - Standard + Development/Test = 6 (Host B)
+    - Premium + Development/Test = 2 (Host C)
+    - Standard + Production = 0 (no matching host)
+    - Premium + Production report metadata includes SLA=Premium and usage=Production
+    - Metadata granularity is DAILY; billing provider and billing account ID are null (not applied)
+- **Expected Result**:
+    - Combined daily filters match per-host values; metadata documents applied SLA and usage filters
+
+**tally-report-filters-nonpayg-TC004 - Physical RHEL unfiltered daily report aggregates hosts; SLA slices partition total**
+
+- **Description**: Verify unfiltered daily total and that Premium + Standard equals unfiltered total
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query without SLA/usage filters, category=physical
+    - Query Premium and Standard separately
+- **Verification**:
+    - Unfiltered = 12
+    - Premium = 6, Standard = 6
+    - Premium + Standard = unfiltered
+- **Expected Result**:
+    - Unfiltered daily report aggregates all hosts; SLA slices partition total
+
+**tally-report-filters-nonpayg-TC005 - Physical non-PAYG daily report excludes AWS billing provider filter**
+
+- **Description**: Verify billing_provider=aws on non-PAYG daily report returns zero sockets (traditional snapshots use billing_provider=_ANY)
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query unfiltered, category=physical
+    - Query with billing_provider=aws, category=physical
+- **Verification**:
+    - Unfiltered = 12
+    - billing_provider=aws, filtered = 0
+- **Expected Result**:
+    - AWS billing provider filter excludes traditional non-PAYG nightly snapshots
+
+**tally-report-filters-nonpayg-TC006 - Physical non-PAYG daily report excludes non-matching billing account ID**
+
+- **Description**: Verify arbitrary billing account ID returns zero on non-PAYG daily report
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total; hosts have no billing_account_id)
+- **Action**:
+    - Run nightly tally
+    - Query unfiltered, category=physical
+    - Query with billing_account_id=test123, category=physical
+- **Verification**:
+    - Unfiltered = 12
+    - billing_account_id=test123, filtered = 0
+- **Expected Result**:
+    - Billing account ID filter yields no matching nightly snapshot rows
+
+**tally-report-filters-nonpayg-TC007 - Virtual RHEL daily report increments sockets and cores for matching SLA and usage**
+
+- **Description**: Verify adding a virtual RHEL host increases daily tally report values under category=virtual for matching SLA and usage
+- **Setup**:
+    - Organization is opted in
+    - Baseline daily virtual report for chosen SLA/usage (e.g. Premium + Production)
+    - One virtual host: VIRTUAL buckets, 2 raw sockets normalized to 1 in tally, known cores value; SLA/usage match filter under test
+- **Action**:
+    - Run nightly tally
+    - Query daily report for Sockets and Cores with same SLA, usage, and category=virtual
+- **Verification**:
+    - Sockets report value increases by 1 from baseline
+    - Cores report value increases by expected increment (virtual guest cores rule)
+    - Filtered SLA/usage totals unchanged for non-matching filters
+- **Expected Result**:
+    - Virtual category daily report filters track new virtual host socket and core contributions
+
+**tally-report-filters-nonpayg-TC008 - Virtual RHEL empty-SLA socket partition equals all minus defined SLAs**
+
+- **Description**: Verify empty-SLA virtual socket total equals all minus (Premium + Standard + Self-Support)
+- **Setup**:
+    - Organization is opted in
+    - Three virtual hosts: Premium, Standard, and Self-Support SLAs (each normalized to 1 socket under category=virtual)
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets report with category=virtual for each SLA, empty SLA (sla=""), and unfiltered (no SLA param)
+- **Verification**:
+    - Per-SLA socket values are each > 0
+    - empty_sla.sockets = all.sockets - (premium + standard + self_support)
+    - all.sockets = filtered_sum + empty_sla.sockets
+- **Expected Result**:
+    - Virtual SLA partition including empty SLA is consistent on daily report
+
+**tally-report-filters-nonpayg-TC009 - category=virtual daily report excludes physical contributions**
+
+- **Description**: Verify category=virtual filter on daily tally report returns only virtual socket totals and does not include physical or hypervisor hosts in the same org
+- **Setup**:
+    - Organization is opted in
+    - One physical host (e.g. 4 sockets, Premium, Production) and one virtual host (e.g. 1 normalized socket) in same org
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets for category=physical, category=virtual, and unfiltered (no category)
+- **Verification**:
+    - category=virtual value equals virtual host contribution only
+    - category=physical value equals physical host contribution only
+    - Unfiltered total equals sum of category contributions present in org
+- **Expected Result**:
+    - Daily report category filter isolates virtual measurements from physical (and other) hardware types
+
+**tally-report-filters-nonpayg-TC010 - Non-marketplace AWS cloud host increases daily category=cloud report totals**
+
+- **Description**: Verify adding a non-marketplace AWS public cloud host increases unfiltered daily category=cloud totals for sockets, cores, and instance_count
+- **Setup**:
+    - Organization is opted in
+    - Capture baseline daily cloud report for RHEL for x86, category=cloud, today's window (record sockets, cores, instance_count)
+    - Seed one AWS public cloud host for RHEL for x86:
+        - number_of_sockets=2, cores_per_socket=2 (4 raw cores)
+        - is_virtual=true, cloud_provider=aws
+        - No marketplace extra facts (no aws_billing_products)
+- **Action**:
+    - Run nightly tally
+    - Query daily tally report with metrics filter (Cores anchor), category=cloud, same window as baseline
+- **Verification**:
+    - sockets increased by +1 vs baseline (public cloud normalizes to 1 socket regardless of raw count)
+    - instance_count increased by +1 vs baseline
+    - cores increased by +2 vs baseline (ceil(4 / 2) with CT threads_per_core=2.0)
+- **Expected Result**:
+    - Unfiltered daily category=cloud report reflects new non-marketplace public cloud host
+
+## Report Has Data Based on Category (Non-PAYG)
+
+**tally-report-has-data-nonpayg-TC001 - Physical-only org daily has_data matches category contribution**
+
+- **Description**: Verify has_data is never true when a category contributed zero sockets; physical buckets with positive sockets have has_data=true; virtual/hypervisor/cloud stay has_data=false when empty
+- **Setup**:
+    - Organization is opted in
+    - Three hosts: physical total = 12 sockets; virtual/hypervisor/cloud remain empty
+- **Action**:
+    - Run nightly tally; 12-day window ending today
+    - For each category in (physical, virtual, hypervisor, cloud), fetch daily sockets series over window
+    - Compare latest physical bucket to system-table physical socket sum
+    - Fetch narrow virtual window (yesterday–today)
+- **Verification**:
+    - No data point has value=0 and has_data=true in any category over wide window
+    - Latest physical: has_data=true, value=12
+    - Any physical point with value>0 should have has_data=true
+    - Latest virtual: value=0, has_data not true
+- **Expected Result**:
+    - has_data truthfully indicates category-specific presence for daily non-PAYG reports
+
+**tally-report-has-data-nonpayg-TC002 - Virtual category has_data true when virtual sockets contribute**
+
+- **Description**: Verify daily tally report with category=virtual reports has_data=true when virtual socket contribution is present
+- **Setup**:
+    - Organization is opted in
+    - At least one virtual RHEL host with VIRTUAL buckets and sockets > 0 after nightly tally
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets report with category=virtual for a window including today
+- **Verification**:
+    - Latest (or today) data point has value > 0 and has_data=true
+    - No data point in range has value=0 and has_data=true unless that day had no virtual contribution
+- **Expected Result**:
+    - has_data reflects virtual category measurement presence on daily report
+
+**tally-report-has-data-nonpayg-TC003 - Mixed physical and virtual org: has_data per category only where category contributes**
+
+- **Description**: Verify in an org with both physical and virtual hosts, each contributing category reports has_data=true with value > 0 on the same day; complements single-category cases in TC001 and TC002
+- **Setup**:
+    - Organization is opted in
+    - One physical host (sockets > 0) and one virtual host (normalized sockets > 0) after nightly tally
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets for category=physical and category=virtual for the same day/window
+- **Verification**:
+    - category=physical: value > 0, has_data=true
+    - category=virtual: value > 0, has_data=true
+    - Physical report value equals physical host contribution only (no virtual sockets)
+    - Virtual report value equals virtual host contribution only (no physical sockets)
+- **Expected Result**:
+    - has_data and value are category-specific when multiple traditional categories contribute in the same org
+
+**tally-report-has-data-nonpayg-TC004 - Cloud-only org daily has_data true on category=cloud only**
+
+- **Description**: Verify a non-PAYG AWS public cloud host sets has_data=true on category=cloud daily report only; physical, virtual, and hypervisor stay has_data=false
+- **Setup**:
+    - Organization is opted in
+    - One AWS public cloud non-PAYG host for RHEL for x86:
+        - No marketplace extra facts (no aws_billing_products)
+        - Normalized to 1 socket on instances report after tally
+    - No physical, virtual, or hypervisor hosts contributing in org
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets for category=cloud for a window including today
+    - Query daily Sockets for category=physical, virtual, and hypervisor for the same day/window
+- **Verification**:
+    - category=cloud: latest (or today) data point has value > 0 and has_data=true
+    - category=physical, virtual, hypervisor: value=0 and has_data=false for the same day
+    - No data point in the cloud series has value=0 and has_data=true unless that day had no cloud contribution
+- **Expected Result**:
+    - Cloud has_data reflects cloud category presence only; other categories do not report has_data=true when empty
+
+## Tally Summary Messages (Non-PAYG / Nightly)
+
+### Message Verification
+
+**tally-summary-nonpayg-TC001 - Nightly tally emits daily granularity**
+
+- **Description**: Verify that nightly tally for traditional non-PAYG products produces summary messages with DAILY granularity
+- **Setup**:
+    - Organization is opted in
+    - One physical RHEL host with 2 sockets seeded (shared non-PAYG fixture)
 - **Action**:
     - Trigger nightly tally (snapshots creation)
-    - Wait for tally summary Kafka messages
+    - Wait for tally summary Kafka messages on tally topic
 - **Verification**:
     - Tally summary messages are received
     - Messages have DAILY granularity
-    - Messages contain expected product and metric
+    - Messages contain expected product (e.g. RHEL for x86) and metric (Sockets)
 - **Expected Result**:
-    - Nightly tally produces DAILY granularity summaries
+    - Nightly tally produces DAILY granularity summaries for non-PAYG products
     - Messages are published to tally topic
 
-**tally-summary-TC002 - Nightly tally has no TOTAL measurements**
+**tally-summary-nonpayg-TC002 - Nightly tally has no TOTAL measurements**
 
-- **Description**: Verify that nightly tally snapshots do not emit TOTAL hardware measurement type
+- **Description**: Verify that nightly tally DAILY snapshots for non-PAYG products do not emit TOTAL hardware measurement type
 - **Setup**:
     - Organization is opted in
-    - Nightly tally host buckets are seeded
+    - One physical RHEL host with 2 sockets seeded (shared non-PAYG fixture)
 - **Action**:
     - Trigger nightly tally
-    - Wait for and capture tally summary messages
+    - Read DAILY tally summary from Kafka for sockets measurement
 - **Verification**:
     - Summary messages are not empty
-    - No measurements have hardware type "TOTAL"
+    - No measurements have hardware type TOTAL
     - All measurements are specific types (PHYSICAL, VIRTUAL, etc.)
 - **Expected Result**:
     - Nightly snapshots do not include TOTAL aggregations
     - Only granular measurement types are present
 
-**tally-summary-TC003 - Hourly tally emits no daily granularity**
+**tally-summary-nonpayg-TC003 - Nightly gauge currentTotal equals value**
 
-- **Description**: Verify that hourly tally operation does not produce summary messages with DAILY granularity
+- **Description**: Verify gauge metric sockets in DAILY summary has currentTotal equals value (not a cumulative SUM)
 - **Setup**:
     - Organization is opted in
-    - Events for last 4 hours are created
+    - One physical RHEL host with 2 sockets seeded
+- **Action**:
+    - Trigger nightly tally
+    - Read DAILY tally summary from Kafka for Sockets measurement
+- **Verification**:
+    - Value is present and non-null
+    - currentTotal is present and non-null
+    - currentTotal equals value
+- **Expected Result**:
+    - Sockets measurement should be a point-in-time total, not month-to-date accumulation in currentTotal
+
+**tally-summary-nonpayg-TC004 - Nightly gauge reflects current state not accumulation**
+
+- **Description**: Verify gauge sockets reflects current inventory state when a second host is added, not historical accumulation
+- **Setup**:
+    - Organization is opted in
+    - Capture baseline DAILY summary sockets value (may be 0)
+    - Host A: 2 sockets, synced/tallied
+    - Host B: 4 sockets, added after first nightly tally
+- **Action**:
+    - Run nightly tally after Host A; record value / currentTotal
+    - Add Host B; run nightly tally again; record value / currentTotal
+- **Verification**:
+    - After first tally: currentTotal equals value; increase reflects Host A (+2 from prior baseline)
+    - After second tally: currentTotal equals value; increase from first tally is +4 (Host B only), not +6 accumulated history
+- **Expected Result**:
+    - Gauge shows current socket total across hosts, not sum of all prior daily snapshot values
+
+**tally-summary-nonpayg-TC005 - Nightly gauge drops when one host loses product buckets**
+
+- **Description**: Verify nightly daily totals reflect current bucket state when one host no longer contributes RHEL for x86 buckets (decrement mirror of TC004)
+- **Setup**:
+    - Organization is opted in
+    - Shared non-PAYG physical RHEL fixture (3 hosts, 12 sockets total)
+- **Action**:
+    - Run nightly tally
+    - Query daily Sockets report (category=physical) and DAILY tally summary for RHEL for x86; record totals
+    - Remove all host_tally_buckets for RHEL for x86 on one host (e.g. Host B, 6 sockets) — CT may use DB helper; production path is inventory reconcile marking buckets stale
+    - Run nightly tally again
+    - Query daily report and DAILY summary again
+- **Verification**:
+    - Before removal: daily report = 12; summary value and currentTotal both = 12
+    - After removal: daily report = 6 (Hosts A + C only)
+    - Summary value and currentTotal both = 6; decrease is −6 (removed host only), not a stale 12
+    - Instances report meta.count decreases by 1 for the affected host
+- **Expected Result**:
+    - Nightly gauge totals drop when a host's product buckets are removed; snapshots do not retain the removed host's socket contribution
+
+### Attribute partitioning
+
+**tally-summary-by-attributes-nonpayg-TC001 - Nightly tally summary separates measurements by SLA**
+
+- **Description**: Verify DAILY tally summary messages for traditional non-PAYG product separate measurement values by SLA
+- **Setup**:
+    - Organization is opted in
+    - Host A: Premium SLA, 2 sockets
+    - Host B: Standard SLA, 2 sockets
+- **Action**:
+    - Run nightly tally
+    - Poll DAILY summaries for RHEL for x86
+- **Verification**:
+    - Snapshots exist for both Premium and Standard SLA values
+    - Per-SLA sums are each > 0
+    - Sum of Premium + Standard measurement values equals unfiltered total for the metric
+- **Expected Result**:
+    - Nightly tally produces separate DAILY snapshot measurements per SLA attribute value
+
+**tally-summary-by-attributes-nonpayg-TC002 - Nightly tally summary separates measurements by usage**
+
+- **Description**: Verify DAILY tally summary messages for traditional non-PAYG product separate measurement values by usage
+- **Setup**:
+    - Organization is opted in
+    - Host A: Production usage
+    - Host B: Development/Test usage
+- **Action**:
+    - Run nightly tally
+    - Poll DAILY summaries for RHEL for x86
+- **Verification**:
+    - Snapshots contain both Production and Development/Test
+    - Per-usage sums > 0
+    - Per-usage sums add up to unfiltered total
+- **Expected Result**:
+    - Nightly tally produces separate DAILY snapshot measurements per usage attribute value
+
+## Tally Summary Messages (PAYG / Hourly)
+
+### Message Verification
+
+**tally-summary-payg-TC001 - Hourly tally emits no daily granularity**
+
+- **Description**: Verify that hourly tally for PAYG products does not produce summary messages with DAILY granularity
+- **Setup**:
+    - Organization is opted in
+    - PAYG metering events for the last 4 hours
 - **Action**:
     - Produce events to Kafka
     - Poll for tally summaries with DAILY granularity
@@ -1021,15 +1422,15 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Expected message count is 0 for DAILY granularity
     - No DAILY messages are found
 - **Expected Result**:
-    - Hourly tally does not produce DAILY granularity summaries
+    - Hourly tally does not produce DAILY granularity summaries for PAYG products
     - Only HOURLY summaries are emitted
 
-**tally-summary-TC004 - Hourly tally emits hourly granularity**
+**tally-summary-payg-TC002 - Hourly tally emits hourly granularity**
 
-- **Description**: Verify that hourly tally operation produces summary messages with HOURLY granularity and no TOTAL measurements
+- **Description**: Verify that hourly tally for PAYG products produces summary messages with HOURLY granularity and no TOTAL measurements
 - **Setup**:
     - Organization is opted in
-    - Events for last 4 hours are created
+    - PAYG metering events for the last 4 hours
 - **Action**:
     - Produce events to Kafka
     - Poll for tally summaries with HOURLY granularity
@@ -1042,78 +1443,166 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - One summary per event hour
     - TOTAL measurements are excluded
 
+### Attribute partitioning
+
+**tally-summary-by-attributes-payg-TC001 - Hourly tally summary separates measurements by SLA**
+
+- **Description**: Verify HOURLY tally summary messages for PAYG product contain separate measurement values for each SLA level
+- **Setup**:
+    - Organization is opted in
+    - PAYG events created for each SLA type (PREMIUM, STANDARD, SELF_SUPPORT)
+    - One event with no SLA
+- **Action**:
+    - Produce events to Kafka
+    - Poll for tally summaries with HOURLY granularity
+- **Verification**:
+    - Sum of all per-SLA measurement values equals total minus the no-SLA value
+    - Sum of per-SLA values plus no-SLA value equals the total
+- **Expected Result**:
+    - Hourly tally produces separate snapshot measurements for each SLA attribute value
+    - No-SLA measurements are tracked separately from defined SLA values
+
+**tally-summary-by-attributes-payg-TC002 - Hourly tally summary separates measurements by usage**
+
+- **Description**: Verify HOURLY tally summary messages for PAYG product contain separate measurement values for each usage type
+- **Setup**:
+    - Organization is opted in
+    - PAYG events created for each Usage type (PRODUCTION, DEVELOPMENT_TEST, DISASTER_RECOVERY)
+    - One event with no Usage
+- **Action**:
+    - Produce events to Kafka
+    - Poll for tally summaries with HOURLY granularity
+- **Verification**:
+    - Sum of all per-usage measurement values equals total minus the no-usage value
+    - Sum of per-usage values plus no-usage value equals the total
+- **Expected Result**:
+    - Hourly tally produces separate snapshot measurements for each usage attribute value
+    - No-usage measurements are tracked separately from defined usage values
+
+**tally-summary-by-attributes-payg-TC003 - Hourly tally summary separates measurements by billing account ID**
+
+- **Description**: Verify HOURLY tally summary messages for PAYG product contain separate measurement values for each billing account ID
+- **Setup**:
+    - Organization is opted in
+    - Two PAYG events from different instances with different billing account IDs and different metric values
+- **Action**:
+    - Produce events to Kafka
+    - Poll for tally summaries with HOURLY granularity
+- **Verification**:
+    - Each billing account ID has its expected measurement value
+    - Sum of per-billing-account values equals the total
+- **Expected Result**:
+    - Hourly tally produces separate snapshot measurements for each billing account ID
+    - Per-billing-account measurement values sum to the overall total
+
+**tally-summary-by-attributes-payg-TC004 - Hourly tally summary attributes measurements when a host changes billing account ID**
+
+- **Description**: Verify that when a single PAYG host sends events under different billing account IDs at different times, hourly tally correctly attributes each measurement to the respective billing account
+- **Setup**:
+    - Organization is opted in
+    - Same host sends one event with billing account A at T-2 hours
+    - Same host sends another event with billing account B at T-1 hours
+- **Action**:
+    - Produce events to Kafka
+    - Poll for tally summaries with HOURLY granularity
+- **Verification**:
+    - Billing account A has the measurement value from the first event (5.0)
+    - Billing account B has the measurement value from the second event (8.0)
+    - Sum of per-billing-account values equals the total
+- **Expected Result**:
+    - Hourly tally correctly attributes measurements to the billing account from each event
+    - A billing account change on a single instance does not merge or lose measurement values
+
+**tally-summary-by-attributes-payg-TC005 - Hourly tally summary separates measurements by billing provider**
+
+- **Description**: Verify HOURLY tally summary messages for PAYG product contain separate measurement values for each billing provider
+- **Setup**:
+    - Organization is opted in
+    - Two PAYG events from different instances with different billing providers (AWS, Azure) and different metric values
+- **Action**:
+    - Produce events to Kafka
+    - Poll for tally summaries with HOURLY granularity
+- **Verification**:
+    - Each billing provider has its expected measurement value
+    - Sum of per-billing-provider values equals the total
+- **Expected Result**:
+    - Hourly tally produces separate snapshot measurements for each billing provider attribute value
+    - Per-billing-provider measurement values sum to the overall total
+
 ## Instance Reporting for Billing Account IDs
 
 **tally-instances-billing-account-TC001 - Billing account IDs exclude old month data**
 
 - **Description**: Verify that the billing account IDs endpoint only returns accounts with activity in the current month
 - **Setup**:
-  - Organization is opted in
-  - Host with billing account ID created with last_seen date from 35 days ago (previous month)
+    - Organization is opted in
+    - Host with billing account ID created with last_seen at the first instant of the previous calendar month (UTC), e.g. YearMonth.now(UTC).minusMonths(1).atDay(1).atStartOfDay()
 - **Action**:
-  - Call get billing account IDs endpoint
+    - Call get billing account IDs endpoint
 - **Verification**:
-  - Response does not contain the billing account from last month
-  - Only current month billing accounts are included
+    - Response does not contain the billing account from last month
+    - Only current month billing accounts are included
 - **Expected Result**:
-  - Service filters billing accounts by current month boundary
-  - Old billing account data is excluded from response
+    - Service filters billing accounts by current month boundary
+    - Old billing account data is excluded from response
 
 **tally-instances-billing-account-TC002 - Multiple billing account IDs returned**
 
 - **Description**: Verify that the billing account IDs endpoint returns distinct billing accounts after PAYG events are ingested and tallied
 - **Setup**:
-  - Organization is opted in
-  - Two PAYG instance events produced to ingress with different billing account IDs
-  - Same product tag and AWS billing provider on both events
+    - Organization is opted in
+    - Two PAYG instance events produced to ingress with different billing account IDs
+    - Same product tag and AWS billing provider on both events
 - **Action**:
-  - Perform hourly tally until materialized
-  - Call get billing account IDs endpoint
+    - Perform hourly tally until materialized
+    - Call get billing account IDs endpoint
 - **Verification**:
-  - Response contains exactly 2 billing account entries
-  - Both billing account IDs are present in response
-  - Each entry has correct org_id, product_tag, and billing_provider fields
-  - Billing provider is set to "aws"
+    - Response contains exactly 2 billing account entries
+    - Both billing account IDs are present in response
+    - Each entry has correct org_id, product_tag, and billing_provider fields
+    - Billing provider is set to "aws"
 - **Expected Result**:
-  - Each distinct billing account from tallied activity appears once in the list
-  - Response structure includes all required fields
-  - Multiple billing accounts are properly differentiated
+    - Each distinct billing account from tallied activity appears once in the list
+    - Response structure includes all required fields
+    - Multiple billing accounts are properly differentiated
 
 **tally-instances-billing-account-TC003 - Billing account IDs: three distinct accounts**
 
 - **Description**: Verify the billing_account_ids endpoint with three tuples
 - **Setup**:
-  - Three PAYG events with distinct billing account IDs, same provider/product
+    - Three PAYG events with distinct billing account IDs, same provider/product
 - **Action**:
-  - Hourly tally; call billing account IDs
+    - Hourly tally; call billing account IDs
 - **Verification**:
-  - Three entries; each id present with correct org, product_tag, provider
+    - Three entries; each id present with correct org, product_tag, provider
 - **Expected Result**:
-  - Endpoint scales to multiple accounts beyond the pair in TC002
+    - Endpoint scales to multiple accounts beyond the pair in TC002
 
 **tally-instances-billing-account-TC004 - Billing account IDs: duplicate billing account across instances**
 
-- **Description**: Verify behavior when two instance events share the same billing account ID
+- **Description**: Verify two PAYG instance events that share the same billing account ID dedupe to a single billing_account_ids row
 - **Setup**:
-  - Two events, same billing account ID, different instance IDs
+    - Organization is opted in
+    - Two PAYG events with the same billing account ID and AWS billing provider, different instance IDs; hourly tally materialized
 - **Action**:
-  - Call billing account IDs endpoint
+    - Call billing account IDs endpoint
 - **Verification**:
-  - Response reflects one logical account entry or two, per product rules
+    - Exactly one row for the shared billing account ID (deduplicated, not two)
+    - That row has the expected org_id, product_tag, and billing_provide (aws)
 - **Expected Result**:
-  - Duplicate account handling is stable and documented
+    - Duplicate billing account activity collapses to one stable list entry per org/product/provider tuple
 
 **tally-instances-billing-account-TC005 - Billing account IDs: mixed billing providers**
 
 - **Description**: Verify entries include distinct billing_provider values
 - **Setup**:
-  - Events with different billing_provider values
+    - Events with different billing_provider values
 - **Action**:
-  - Call billing account IDs
+    - Call billing account IDs
 - **Verification**:
-  - Each returned tuple has the expected provider field per event
+    - Each returned tuple has the expected provider field per event
 - **Expected Result**:
-  - Provider dimension is visible in the billing account list
+    - Provider dimension is visible in the billing account list
 
 ## Instance Reporting with Parameters for PAYG Products
 
@@ -1121,163 +1610,182 @@ All test files use `@BeforeAll` to create test data once and share it across all
 
 - **Description**: Verify that PAYG instances are metered and reported based on the month boundary of the event timestamp
 - **Setup**:
-  - Organization is opted in
-  - Event created with timestamp from first day of previous month
-  - Event includes billing account ID and AWS provider information
+    - Organization is opted in
+    - Event created with timestamp from first day of previous month
+    - Event includes billing account ID and AWS provider information
 - **Action**:
-  - Produce event to Kafka
-  - Perform hourly tally
-  - Query instances for current month
-  - Query instances for previous month
+    - Produce event to Kafka
+    - Perform hourly tally
+    - Query instances for current month
+    - Query instances for previous month
 - **Verification**:
-  - Current month instances report shows 0 metered value
-  - Previous month instances report shows metered value > 0
-  - Metered values are attributed to the month of the event
+    - Current month instances report shows 0 metered value
+    - Previous month instances report shows metered value > 0
+    - Metered values are attributed to the month of the event
 - **Expected Result**:
-  - Service assigns metered values to the appropriate month
-  - Month boundaries are respected for PAYG billing
-  - Instance data is segregated by month
+    - Service assigns metered values to the appropriate month
+    - Month boundaries are respected for PAYG billing
+    - Instance data is segregated by month
 
 **tally-instances-payg-TC002 - Instances report filtered by SLA**
 
 - **Description**: Verify that SLA query parameter restricts rows to hosts matching that service level when two instances differ only by SLA
 - **Setup**:
-  - Organization is opted in
-  - Two PAYG events in the same time window with distinct SLA values
+    - Organization is opted in
+    - Two PAYG events in the same time window with distinct SLA values
 - **Action**:
-  - Hourly tally; query instances by product with SLA value set to first host’s SLA
-  - Repeat with SLA value set to second host’s SLA
+    - Hourly tally; query instances by product with SLA value set to first host’s SLA
+    - Repeat with SLA value set to second host’s SLA
 - **Verification**:
-  - Each query returns only the matching instance (or equivalent count)
-  - Query with a non-existent SLA combination returns no matching rows
+    - Each query returns only the matching instance (or equivalent count)
+    - Query with a non-existent SLA combination returns no matching rows
 - **Expected Result**:
-  - SLA filter is applied consistently on the instances API
+    - SLA filter is applied consistently on the instances API
 
 **tally-instances-payg-TC003 - Instances report filtered by usage**
 
 - **Description**: Verify that usage query parameter restricts rows when two instances differ only by usage type
 - **Setup**:
-  - Organization is opted in
-  - Two PAYG events in the same window with distinct usage values
+    - Organization is opted in
+    - Two PAYG events in the same window with distinct usage values
 - **Action**:
-  - Query instances with usage matching each event in turn
+    - Query instances with usage matching each event in turn
 - **Verification**:
-  - Only the matching usage row appears per query
+    - Only the matching usage row appears per query
 - **Expected Result**:
-  - Usage filter behaves as documented for instances
+    - Usage filter behaves as documented for instances
 
 **tally-instances-payg-TC004 - Instances report filtered by billing provider**
 
 - **Description**: Verify that billing_provider restricts rows when instances differ only by provider
 - **Setup**:
-  - Organization is opted in
-  - Two events with different billing providers, same product and window
+    - Organization is opted in
+    - Two events with different billing providers, same product and window
 - **Action**:
-  - Query instances with each billing_provider value
+    - Query instances with each billing_provider value
 - **Verification**:
-  - Each query returns only instances for that provider
+    - Each query returns only instances for that provider
 - **Expected Result**:
-  - Billing provider filter is enforced on the instances report
+    - Billing provider filter is enforced on the instances report
 
 **tally-instances-payg-TC005 - Instances report excludes wrong billing account**
 
 - **Description**: Verify that querying with a non-matching billing_account_id returns no instance rows
 - **Setup**:
-  - Organization is opted in
-  - One PAYG event with a known billing account ID
+    - Organization is opted in
+    - One PAYG event with a known billing account ID
 - **Action**:
-  - Hourly tally; query instances with billing_account_id set to a different UUID than the event
+    - Hourly tally; query instances with billing_account_id set to a different UUID than the event
 - **Verification**:
-  - Response has no data rows (or zero measurements) for the mismatched account
+    - Response has no data rows (or zero measurements) for the mismatched account
 - **Expected Result**:
-  - Billing account filter rejects non-matching accounts
+    - Billing account filter rejects non-matching accounts
 
 **tally-instances-payg-TC006 - Instances report with all optional filters and meta**
 
 - **Description**: Verify response meta echoes sla, usage, billing_provider, and billing_account_id when all are supplied
 - **Setup**:
-  - One event whose attributes align with all filter values
+    - One event whose attributes align with all filter values
 - **Action**:
-  - Query with every optional filter set to that event’s values
+    - Query with every optional filter set to that event’s values
 - **Verification**:
-  - Meta fields reflect the query parameters; data includes the instance
+    - Meta fields reflect the query parameters; data includes the instance
 - **Expected Result**:
-  - Full filter surface is consistent for a single matching host
+    - Full filter surface is consistent for a single matching host
 
 **tally-instances-payg-TC007- Partial filters return multiple billing accounts**
 
 - **Description**: Verify that omitting billing_account_id returns both instances when they share SLA and usage but differ by billing account
 - **Setup**:
-  - Two instances: same SLA and usage, different billing_account_id
+    - Two instances: same SLA and usage, different billing_account_id
 - **Action**:
-  - Query with sla and usage only (no billing account filter)
+    - Query with sla and usage only (no billing account filter)
 - **Verification**:
-  - Two rows (or meta.count reflects both)
+    - Two rows (or meta.count reflects both)
 - **Expected Result**:
-  - Partial filters do not over-restrict when account is omitted
+    - Partial filters do not over-restrict when account is omitted
 
 **tally-instances-payg-TC008 - Partial filters narrow to one billing account**
 
 - **Description**: Verify combining sla, usage, and billing_account_id returns a single row
 - **Setup**:
-  - Two instances: same SLA and usage, different billing_account_id
+    - Two instances: same SLA and usage, different billing_account_id
 - **Action**:
-  - Query with all three dimensions set to one host’s values
+    - Query with all three dimensions set to one host’s values
 - **Verification**:
-  - Exactly one instance in the result set
+    - Exactly one instance in the result set
 - **Expected Result**:
-  - Account filter distinguishes otherwise identical rows
+    - Account filter distinguishes otherwise identical rows
 
 **tally-instances-payg-TC009 - No optional filters returns full in-range set**
 
 - **Description**: Verify that only beginning, ending, and product identify all tallied instances in range (no SLA/usage/provider/account params)
 - **Setup**:
-  - Multiple instances in the same valid time range
+    - Multiple instances in the same valid time range
 - **Action**:
-  - Query without optional filters
+    - Query without optional filters
 - **Verification**:
-  - All seeded instances appear; meta.count matches
+    - All seeded instances appear; meta.count matches
 - **Expected Result**:
-  - Default query path returns complete in-window population
+    - Default query path returns complete in-window population
 
 **tally-instances-payg-TC010 - Two events in different months; current month query**
 
 - **Description**: Verify month discrimination when two events exist: one instance active last month, one this month; querying current month returns only the current-month instance
 - **Setup**:
-  - Two PAYG events with different instance IDs and timestamps in adjacent months
+    - Two PAYG events with different instance IDs and timestamps in adjacent months
 - **Action**:
-  - Query instances with beginning/ending covering current month only
+    - Query instances with beginning/ending covering current month only
 - **Verification**:
-  - Only the current-month instance id is present
-  - Last month’s is absent
+    - Only the current-month instance id is present
+    - Last month’s is absent
 - **Expected Result**:
-  - Multi-event orgs do not leak prior-month instances into the current window
+    - Multi-event orgs do not leak prior-month instances into the current window
 
 **tally-instances-payg-TC011 - PAYG instances API rejects cross-month beginning/ending**
 
 - **Description**: Verify that beginning and ending for a PAYG product must fall in the same calendar month; otherwise the API returns HTTP 400 Bad Request
 - **Setup**:
-  - Organization is opted in (shared PAYG instances fixture)
+    - Organization is opted in (shared PAYG instances fixture)
 - **Action**:
-  - Call instances by product with beginning in one month and ending in the next month (e.g. 10th 12:00 UTC to following month 10th 12:00 UTC)
+    - Call instances by product with beginning in one month and ending in the next month (e.g. 10th 12:00 UTC to following month 10th 12:00 UTC)
 - **Verification**:
-  - Response status is 400
-  - Error payload references the same-month restriction
+    - Response status is 400
+    - Error payload references the same-month restriction
 - **Expected Result**:
-  - Invalid date ranges are rejected before instance data is returned
+    - Invalid date ranges are rejected before instance data is returned
 
 **tally-instances-payg-TC012 - PAYG instances report over full UTC calendar month**
 
 - **Description**: Verify instances can be queried with beginning at the first instant of the month and ending at the last instant of that month (full calendar span), not only [firstOfMonth, now] partial windows used elsewhere
 - **Setup**:
-  - Shared PAYG instances fixture; filter by a billing_account_id known to have current-month metered rows (TC004 billing account)
+    - Shared PAYG instances fixture from TallyInstancesReportFiltersPaygTest (setupSharedFixture); filter by sla.billingAccountId() — a billing account seeded with current-month Premium SLA metered rows
 - **Action**:
-  - Query instances for the product with month start 00:00:00 UTC through month end 23:59:59.999 UTC and billing_account_id set
+    - Query instances for the product with month start 00:00:00 UTC through month end 23:59:59.999 UTC and billing_account_id set
 - **Verification**:
-  - At least one data row
-  - Summed metered measurements > 0
+    - At least one data row
+    - Summed metered measurements > 0
 - **Expected Result**:
-  - Full-month same-month windows return expected PAYG instance rows for the fixture
+    - Full-month same-month windows return expected PAYG instance rows for the fixture
+
+**tally-instances-payg-TC013 - PAYG instances report has two rows for distinct Ansible events**
+
+- **Description**: Verify hourly tally materializes one instances-report row per distinct instance_id, applying only that event's measurements (swatch does not remap metrics by producer role)
+- **Setup**:
+    - Organization opted in
+    - Publish two Kafka events for ansible-aap-managed (same billing account / window):
+        - Event A: distinct instance_id A, measurement Managed-nodes = 2.0 only
+        - Event B: distinct instance_id B, measurement Instance-hours = 1.0 only
+- **Action**:
+    - Run hourly tally
+    - Query instances report for ansible-aap-managed in event window
+    - Locate rows by instance_id A and B
+- **Verification**:
+    - Exactly two instance rows; meta.count = 2
+    - Row A: Managed-nodes = 2.0; no Instance-hours measurement on that row
+    - Row B: Instance-hours = 1.0; no Managed-nodes measurement on that row
+- **Expected Result**:
+    - Each event's instance_id becomes its own instances row with only the metrics and values present on that event
 
 ## Instance Reporting based on Pagination and Sorting
 
@@ -1352,6 +1860,281 @@ All test files use `@BeforeAll` to create test data once and share it across all
     - Only matching category rows return
 - **Expected Result**:
     - Category sorting works and shows expected results
+
+**tally-instances-sorting-TC007 - Pagination limit and offset (non-PAYG)**
+
+- **Description**: Verify limit/offset paging and meta.count for non-PAYG physical instances
+- **Setup**:
+    - Organization is opted in
+    - Three hosts: meta.count must be 3
+- **Action**:
+    - Run nightly tally
+    - Query unfiltered merged set (reference count = 3)
+    - Query with limit=1, offset=0
+    - Query with limit=1, offset=1
+- **Verification**:
+    - Each paged response has at most 1 row
+    - Both responses report meta.count = 3
+- **Expected Result**:
+    - Pagination limits rows but preserves total count metadata
+
+**tally-instances-sorting-TC008 - Pagination links when offset or limit present (non-PAYG)**
+
+- **Description**: Verify pagination links and page sizing for non-PAYG instances
+- **Setup**:
+    - Organization is opted in
+    - Three hosts
+- **Action**:
+    - Run nightly tally
+    - Query without limit (expect 3 rows)
+    - Query with limit=2, offset=0
+- **Verification**:
+    - Unpaged: 3 rows
+    - Limited: at most 2 rows; meta present
+    - If links object present, at least one of first/last/previous/next is non-null
+- **Expected Result**:
+    - Pagination metadata and links behave for non-PAYG product (no PAYG same-month restriction)
+
+**tally-instances-sorting-TC009 - Sort by number_of_guests ascending and descending (hypervisor)**
+
+- **Description**: Verify instances API sorts hypervisor category by number_of_guests asc/desc
+- **Setup**:
+    - At least two hypervisor hosts with different guest counts in org
+- **Action**:
+    - Run nightly tally
+    - Query hypervisor instances unfiltered; collect guest counts
+    - Query with sort=number_of_guests, dir=asc
+    - Query with sort=number_of_guests, dir=desc
+- **Verification**:
+    - Ascending guest list equals sorted ascending of unfiltered list
+    - Descending guest list equals sorted descending of unfiltered list
+- **Expected Result**:
+    - Hypervisor sort by guest count works on instances report
+
+**tally-instances-sorting-TC010 - Sort by sockets ascending and descending (non-PAYG)**
+
+- **Description**: Verify instances API sorts non-PAYG nightly hosts by sockets asc/desc (non-PAYG-only sort field)
+- **Setup**:
+    - Organization is opted in
+    - At least two physical non-PAYG hosts with different socket counts in buckets (e.g. 2 and 6)
+- **Action**:
+    - Run nightly tally
+    - Query instances for the product; note socket values per row
+    - Query with sort=sockets, dir=asc
+    - Query with sort=sockets, dir=desc
+- **Verification**:
+    - Ascending order matches increasing socket counts
+    - Descending order reverses ascending order
+- **Expected Result**:
+    - Sockets sort parameter is honored for non-PAYG instances report
+
+**tally-instances-sorting-TC011 - Sort by cores ascending and descending (non-PAYG)**
+
+- **Description**: Verify instances API sorts non-PAYG nightly hosts by cores asc/desc (non-PAYG-only sort field)
+- **Setup**:
+    - Organization is opted in
+    - At least two physical non-PAYG hosts with different core counts in buckets (e.g. 2 and 8)
+- **Action**:
+    - Run nightly tally
+    - Query instances for the product; note core values per row
+    - Query with sort=cores, dir=asc
+    - Query with sort=cores, dir=desc
+- **Verification**:
+    - Ascending order matches increasing core counts
+    - Descending order reverses ascending order
+- **Expected Result**:
+    - Cores sort parameter is honored for non-PAYG instances report
+
+## Instance Reporting with Parameters for Non-PAYG Products
+
+**tally-instances-nonpayg-TC001 - Physical RHEL unfiltered instances report lists all hosts**
+
+- **Description**: Verify unfiltered instances report lists all three physical RHEL hosts with correct socket totals
+- **Setup**:
+    - Organization opted in
+    - Three hosts with sockets: A (4/Premium/Production), B (6/Standard/Development/Test), C (2/Premium/Development/Test)
+- **Action**:
+    - Run nightly tally
+    - Query instances API: product RHEL for x86, category physical, metric sockets, today's window
+- **Verification**:
+    - meta.count equals 3
+    - Row count equals 3
+    - Display names match fixture hosts
+    - Sum of row socket measurements equals 12
+- **Expected Result**:
+    - Unfiltered physical instances report reflects full org state
+
+**tally-instances-nonpayg-TC002 - Physical RHEL instances SLA filter partitions meta.count and sockets**
+
+- **Description**: Verify SLA filters return correct socket totals and row counts
+- **Setup**:
+    - Organization opted in
+    - Three hosts: Premium=2 hosts, Standard=1 host
+- **Action**:
+    - Run nightly tally
+    - Query with each SLA value (Premium, Standard, Self-Support, ``)
+- **Verification**:
+    - Premium: 6 sockets, 2 rows
+    - Standard: 6 sockets, 1 row
+    - Self-Support and empty SLA: 0 rows
+    - Sum of SLA bucket meta.count values equals unfiltered meta.count (3)
+- **Expected Result**:
+    - SLA filtering and meta.count partition behave correctly for non-PAYG physical hosts
+
+**tally-instances-nonpayg-TC003 - Physical RHEL instances usage filter partitions meta.count and sockets**
+
+- **Description**: Verify usage filters return correct totals
+- **Setup**:
+    - Organization opted in
+    - Three hosts: Production=1 host, Development/Test=2 hosts
+- **Action**:
+    - Run nightly tally
+    - Query all usage types (Production, Development/Test, Disaster Recovery, ``)
+- **Verification**:
+    - Production: 4 sockets, 1 row
+    - Development/Test: 8 sockets, 2 rows
+    - Disaster Recovery and empty usage: 0 rows
+    - Usage bucket counts sum to 3
+- **Expected Result**:
+    - Usage filtering and meta.count partition are consistent
+
+**tally-instances-nonpayg-TC004 - Physical RHEL instances combined SLA and usage filters narrow to one host**
+
+- **Description**: Verify combined SLA+usage filters return expected single-host rows
+- **Setup**:
+    - Organization opted in
+    - Three hosts: each valid SLA+usage pair maps to one host; Standard+Production has no matching host
+- **Action**:
+    - Run nightly tally
+    - Query Premium + Production
+    - Query Standard + Development/Test
+    - Query Premium + Development/Test
+    - Query Standard + Production
+- **Verification**:
+    - Premium+Production: 4 sockets, 1 row
+    - Standard+Dev/Test: 6 sockets, 1 row
+    - Premium+Dev/Test: 2 sockets, 1 row
+    - Standard+Production: 0 rows, 0 sockets
+- **Expected Result**:
+    - Combined filters narrow to exactly one host per valid SLA/usage pair
+
+**tally-instances-nonpayg-TC005 - Physical non-PAYG instances exclude AWS billing provider filter**
+
+- **Description**: Verify non-PAYG physical instances do not match marketplace billing provider filters
+- **Setup**:
+    - Organization opted in
+    - Physical host exists with no billing_provider set
+- **Action**:
+    - Run nightly tally
+    - Query instances with billing_provider=aws, category physical
+- **Verification**:
+    - Zero rows returned
+- **Expected Result**:
+    - AWS billing provider filter excludes traditional non-PAYG hosts
+
+**tally-instances-nonpayg-TC006 - Physical non-PAYG instances exclude non-matching billing account ID**
+
+- **Description**: Verify random billing account ID does not match non-PAYG physical rows
+- **Setup**:
+    - Organization opted in
+    - Physical host exists with no billing_account_id set
+- **Action**:
+    - Run nightly tally
+    - Query with random UUID billing_account_id
+- **Verification**:
+    - Zero rows returned
+- **Expected Result**:
+    - Billing account filter correctly returns empty for non-matching account
+
+**tally-instances-nonpayg-TC007 - Physical host SLA and usage change migrates instances filter buckets**
+
+- **Description**: Verify after host SLA/usage changes, instances appear under new filters and disappear from old filters
+- **Setup**:
+    - Organization opted in
+    - One physical host: Premium + Production (4 sockets)
+- **Action**:
+    - Confirm host under Premium + Production filters after nightly tally
+    - Update host to Standard + Development/Test
+    - Run nightly tally again
+- **Verification**:
+    - Host present under Standard + Development/Test
+    - Host absent under Premium + Production
+    - last_seen increases after update
+- **Expected Result**:
+    - Tally migrates host across SLA/usage partition buckets on host attribute change
+
+**tally-instances-nonpayg-TC008 - Marketplace AWS cloud host instances report shows zero sockets**
+
+- **Description**: Verify a non-PAYG AWS marketplace public cloud host appears on the instances report as category=cloud with zero sockets, even when raw socket count is high
+- **Setup**:
+    - Organization opted in
+    - Seed one AWS public cloud host for RHEL for x86:
+        - number_of_sockets=7, cores_per_socket=3 (high raw count)
+        - Marketplace extra fact: aws_billing_products=yes
+        - is_virtual=true, product tag rhel-for-x86
+- **Action**:
+    - Run nightly tally
+    - Query instances report for RHEL for x86, metric Sockets, today's window, host display name
+- **Verification**:
+    - Exactly one row for the host
+    - category=cloud
+    - cloud_provider=aws
+    - Sockets measurement = 0
+- **Expected Result**:
+    - Marketplace public cloud hosts normalize to zero sockets on the instances report; raw socket facts do not leak through
+
+**tally-instances-nonpayg-TC009 - Non-marketplace AWS cloud host instances report normalizes to one socket**
+
+- **Description**: Verify a non-PAYG AWS public cloud host without marketplace facts appears on the instances report as category=cloud with one normalized socket
+- **Setup**:
+    - Organization opted in
+    - Seed one AWS public cloud host for RHEL for x86:
+        - number_of_sockets=2, cores_per_socket=1
+        - No marketplace extra facts (no aws_billing_products)
+        - is_virtual=true, product tag rhel-for-x86
+- **Action**:
+    - Run nightly tally
+    - Query instances report for RHEL for x86, metric sockets, today's window, host display name
+- **Verification**:
+    - Exactly one row for the host
+    - category=cloud
+    - cloud_provider=aws
+    - Sockets measurement = 1
+- **Expected Result**:
+    - Non-marketplace public cloud RHEL contributes one socket on the instances report regardless of raw socket count > 1
+
+**tally-instances-nonpayg-TC010 - Virtual RHEL instances meta.count increases for matching SLA and usage**
+
+- **Description**: Verify adding a virtual RHEL host increases instances report meta.count by 1 under category=virtual for matching SLA and usage
+- **Setup**:
+    - Organization is opted in
+    - Baseline instances query: category=virtual, chosen SLA/usage, metric Sockets, today's window
+    - One additional virtual host seeded with matching SLA and usage
+- **Action**:
+    - Run nightly tally
+    - Query instances report with category=virtual, same SLA and usage
+- **Verification**:
+    - meta.count increases by 1 from baseline
+    - New row display_name matches seeded virtual host
+    - category=virtual
+- **Expected Result**:
+    - Virtual instances API filters and meta.count track new virtual hosts
+
+**tally-instances-nonpayg-TC011 - Virtual RHEL instance sockets normalized to one**
+
+- **Description**: Verify nightly tally normalizes an unmapped virtual RHEL guest from a high raw socket fact (5) to Sockets = 1.0 on the instances report
+- **Setup**:
+    - Organization is opted in
+    - Inventory-driven seed: virtual RHEL unmapped guest in HBI/inventory with system_profile.number_of_sockets = 5, product RHEL for x86 / rhel-for-x86, no hypervisor mapping
+- **Action**:
+    - Run nightly tally (reconcile from inventory)
+    - Query instances report for host by display_name, category=virtual, metric Sockets
+- **Verification**:
+    - Exactly one row for the host
+    - category=virtual
+    - Sockets measurement = 1.0 (normalized from raw 5, not 5.0)
+- **Expected Result**:
+    - Virtual guests contribute one socket on instances report after tally reconcile normalizes raw inventory facts
 
 ## Version API
 

--- a/swatch-tally/ct/java/tests/TallyFilterProductConfigTest.java
+++ b/swatch-tally/ct/java/tests/TallyFilterProductConfigTest.java
@@ -42,15 +42,7 @@ import org.candlepin.subscriptions.json.Measurement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Component tests verifying that hourly tally correctly filters out non-PAYG product tags from
- * events.
- *
- * <p>These tests ensure that when events contain mixed PAYG and TRADITIONAL product tags, only the
- * PAYG tags are processed during hourly tally operations. This prevents TRADITIONAL products from
- * being incorrectly included in marketplace billing.
- */
-public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
+public class TallyFilterProductConfigTest extends BaseTallyComponentTest {
   private TestSetup setup;
 
   @BeforeEach
@@ -60,7 +52,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC001")
+  @TestPlanName("tally-product-filter-TC001")
   public void testHourlyTallyFiltersNonPaygoProductTags() {
     // Given: An event with mixed PAYG and TRADITIONAL product tags with realistic metrics
     // rhel-for-x86-els-payg-addon is PAYG (supports vCPUs metric)
@@ -109,7 +101,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC002")
+  @TestPlanName("tally-product-filter-TC002")
   public void testEventWithOnlyTraditionalTagsNotTalliedHourly() {
     // Given: An event with ONLY TRADITIONAL product tag (no PAYG tags)
     // For TRADITIONAL products, we don't set billing provider/account
@@ -157,7 +149,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC003")
+  @TestPlanName("tally-product-filter-TC003")
   public void testEventWithOnlyPaygoTagsProcessedNormally() {
     // Given: An event with ONLY PAYG product tags (no TRADITIONAL tags)
     String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
@@ -189,7 +181,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC004")
+  @TestPlanName("tally-product-filter-TC004")
   public void testMultipleEventsWithMixedTagsFilteredCorrectly() {
     // Given: Multiple events with different tag combinations at the same hour-truncated timestamp
     // (matching real-world behavior where events are sent with timestamps truncated to the hour)
@@ -242,7 +234,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC005")
+  @TestPlanName("tally-product-filter-TC005")
   public void testConflictResolutionWithMixedTags() {
     // Given: First event with mixed PAYG and TRADITIONAL tags with realistic metrics
     String paygoProductTag = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
@@ -316,7 +308,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC006")
+  @TestPlanName("tally-product-filter-TC006")
   public void testMixedTagsWithSingleMetricEdgeCase() {
     // Given: An unrealistic edge-case event with mixed PAYG and TRADITIONAL tags
     // but only includes one product's metric (vCPUs for PAYG, not Sockets for TRADITIONAL)
@@ -359,7 +351,7 @@ public class TallyFilterNonPaygoProductsTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-payg-filter-TC007")
+  @TestPlanName("tally-product-filter-TC007")
   public void testRoleBasedProductTagLookupFiltersNonPaygoMetrics() {
     // Given: An event with NO product tag but WITH a role and mixed metrics
     // - Role "moa" maps to PAYG product "rosa" (supports Cores, Instance-hours)

--- a/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
@@ -30,6 +30,7 @@ import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import io.restassured.response.Response;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -230,7 +231,12 @@ class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
     final String isolatedOrg = RandomUtils.generateRandom();
     final String testInventoryId = UUID.randomUUID().toString();
     final String billingAccountId = UUID.randomUUID().toString();
-    final OffsetDateTime lastMonthDate = OffsetDateTime.now(ZoneOffset.UTC).minusDays(35);
+    final OffsetDateTime lastMonthDate =
+        YearMonth.now(ZoneOffset.UTC)
+            .minusMonths(1)
+            .atDay(1)
+            .atStartOfDay()
+            .atOffset(ZoneOffset.UTC);
 
     service.createOptInConfig(isolatedOrg);
 
@@ -314,6 +320,14 @@ class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
         1,
         rowsForShared,
         "Same billing account from two instances should dedupe to one billing_account_ids row");
+    Map<String, String> sharedRow =
+        ids.stream()
+            .filter(m -> shared.id().equals(m.get("billing_account_id")))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(testOrgId, sharedRow.get("org_id"));
+    assertEquals(RHEL_FOR_X86_ELS_PAYG.productTag(), sharedRow.get("product_tag"));
+    assertEquals("aws", sharedRow.get("billing_provider"));
   }
 
   @Test

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -114,7 +114,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-has-data-TC001")
+  @TestPlanName("tally-report-has-data-payg-TC001")
   void shouldIndicateHasDataMatchesCategoryContribution(boolean primaryRowSearches) {
     // Given: Positive cloud PAYG is tallied and the primary-row flag is configured
     givenFeatureFlagIsConfigured(primaryRowSearches);
@@ -150,7 +150,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-has-data-TC002")
+  @TestPlanName("tally-report-has-data-payg-TC002")
   void shouldIndicateExistingZeroValueMeasurementsStillReportHasData(boolean primaryRowSearches) {
     // Given: Zero cloud PAYG is published and tallied
     givenFeatureFlagIsConfigured(primaryRowSearches);
@@ -177,7 +177,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-has-data-TC003")
+  @TestPlanName("tally-report-has-data-payg-TC003")
   void shouldIndicateDataGapsWithHasDataField(boolean primaryRowSearches) {
     // Given: Events at hours 0 and 2 are tallied; hours 1 and 3 are gaps
     givenFeatureFlagIsConfigured(primaryRowSearches);

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * Edge case tests requiring special event patterns.
  *
  * <p>Tests: - TC009: Multiple events aggregation (same filter attributes) - TC010: Three distinct
- * SLA values - TC024: Billing account change for same instance
+ * SLA values - TC023: Billing account change for same instance
  */
 public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
   private static String testOrgId;
@@ -119,7 +119,7 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
     givenPaygEventPublished(
         threeSlaTest.timestamp(), threeSlaTest.selfSupportValue(), Event.Sla.SELF_SUPPORT);
 
-    // TC024: Billing account change for same instance
+    // TC023: Billing account change for same instance
     OffsetDateTime changeTime = OffsetDateTime.now(ZoneOffset.UTC).minusHours(3);
     billingChangeTest =
         new BillingAccountChangeScenario(
@@ -152,7 +152,7 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC009")
+  @TestPlanName("tally-report-filters-payg-TC009")
   void shouldAggregateMultipleEventsWithSameFilters(boolean enablePrimaryRowSearches) {
     // Given: Three PREMIUM events at the same hour are tallied
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -179,7 +179,7 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC010")
+  @TestPlanName("tally-report-filters-payg-TC010")
   void shouldFilterWithThreeDistinctSlaValues(boolean enablePrimaryRowSearches) {
     // Given: Three SLA events at the same hour are tallied
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -206,7 +206,7 @@ public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC024")
+  @TestPlanName("tally-report-filters-payg-TC023")
   void shouldTrackBillingAccountChangeForSameInstance(boolean enablePrimaryRowSearches) {
     // Given: Same instance reported usage under two billing accounts
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
@@ -190,7 +190,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC001")
+  @TestPlanName("tally-report-filters-payg-TC001")
   void shouldReturnDailyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with various attributes exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -231,7 +231,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC002")
+  @TestPlanName("tally-report-filters-payg-TC002")
   void shouldFilterHourlyReportBySla(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with different SLA values exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -264,7 +264,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC003")
+  @TestPlanName("tally-report-filters-payg-TC003")
   void shouldFilterHourlyReportByUsage(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with different usage types exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -297,7 +297,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC004")
+  @TestPlanName("tally-report-filters-payg-TC004")
   void shouldFilterHourlyReportByBillingProvider(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with billing provider exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -319,7 +319,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC005")
+  @TestPlanName("tally-report-filters-payg-TC005")
   void shouldFilterHourlyReportByBillingAccountId(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with different billing accounts exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -352,7 +352,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC006")
+  @TestPlanName("tally-report-filters-payg-TC006")
   void shouldReturnDailyReportWithPartialFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with various attributes exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -378,7 +378,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC007")
+  @TestPlanName("tally-report-filters-payg-TC007")
   void shouldReturnHourlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and events with various attributes exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -407,7 +407,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC008")
+  @TestPlanName("tally-report-filters-payg-TC008")
   void shouldReturnBadRequestWithoutGranularity(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -432,7 +432,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC011")
+  @TestPlanName("tally-report-filters-payg-TC011")
   void shouldReturnBadRequestWithoutBeginning(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -453,7 +453,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC012")
+  @TestPlanName("tally-report-filters-payg-TC012")
   void shouldReturnBadRequestWithoutEnding(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -474,7 +474,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC013")
+  @TestPlanName("tally-report-filters-payg-TC013")
   void shouldReturnNullMetadataWhenFiltersOmitted(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -500,7 +500,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC014")
+  @TestPlanName("tally-report-filters-payg-TC014")
   void shouldReflectEmptyFilterInMetadata(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -524,7 +524,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC016")
+  @TestPlanName("tally-report-filters-payg-TC015")
   void shouldReturnAllDataWhenNoOptionalFiltersApplied(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and multiple events exist
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -546,7 +546,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC017")
+  @TestPlanName("tally-report-filters-payg-TC016")
   void shouldFilterDailyReportBySlaAfterNightlyTally(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and nightly tally has run
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -579,7 +579,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC018")
+  @TestPlanName("tally-report-filters-payg-TC017")
   void shouldFilterDailyReportByUsageAfterNightlyTally(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and nightly tally has run
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -612,7 +612,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC019")
+  @TestPlanName("tally-report-filters-payg-TC018")
   void shouldFilterDailyByBillingProviderAfterNightly(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and nightly tally has run
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -634,7 +634,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC020")
+  @TestPlanName("tally-report-filters-payg-TC019")
   void shouldFilterDailyByBillingAccountAfterNightly(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured and nightly tally has run
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -668,7 +668,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC021")
+  @TestPlanName("tally-report-filters-payg-TC020")
   void shouldReturnMonthlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -691,7 +691,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC022")
+  @TestPlanName("tally-report-filters-payg-TC021")
   void shouldReturnQuarterlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -718,7 +718,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
 
   @ParameterizedTest(name = "with primaryRowSearches={0}")
   @ValueSource(booleans = {true, false})
-  @TestPlanName("tally-report-filters-TC023")
+  @TestPlanName("tally-report-filters-payg-TC022")
   void shouldReturnYearlyReportWithAllFilters(boolean enablePrimaryRowSearches) {
     // Given: Feature flag is configured
     givenFeatureFlagIsConfigured(enablePrimaryRowSearches);
@@ -743,7 +743,7 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
     assertEquals(GranularityType.YEARLY, meta.getGranularity(), "Granularity should be YEARLY");
   }
 
-  @TestPlanName("tally-report-filters-TC025")
+  @TestPlanName("tally-report-filters-payg-TC024")
   @Test
   void shouldReturnBadRequestForInvalidGranularity() {
     // When: Querying report with an invalid granularity enum value

--- a/swatch-tally/ct/java/tests/TallySummaryMessagesByAttributesPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallySummaryMessagesByAttributesPaygTest.java
@@ -37,7 +37,7 @@ import org.candlepin.subscriptions.json.Event.Usage;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest {
+public class TallySummaryMessagesByAttributesPaygTest extends BaseTallyComponentTest {
 
   private static final String TEST_PRODUCT_TAG = RHEL_FOR_X86_ELS_PAYG_ADDON.productTag();
   private static final String TEST_METRIC_ID = RHEL_FOR_X86_ELS_PAYG_ADDON.metricIds().get(1);
@@ -53,7 +53,7 @@ public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest
   // ---- SLA tests ----
 
   @Test
-  @TestPlanName("tally-summary-by-attributes-TC001")
+  @TestPlanName("tally-summary-by-attributes-payg-TC001")
   public void testTallySummarySeparatesMeasurementsBySla() {
     // Given: Events for each SLA type and one event with no SLA
     OffsetDateTime now = OffsetDateTime.now();
@@ -91,7 +91,7 @@ public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest
   // ---- Usage tests ----
 
   @Test
-  @TestPlanName("tally-summary-by-attributes-TC002")
+  @TestPlanName("tally-summary-by-attributes-payg-TC002")
   public void testTallySummarySeparatesMeasurementsByUsage() {
     // Given: Events for each Usage type and one event with no Usage
     OffsetDateTime now = OffsetDateTime.now();
@@ -129,7 +129,7 @@ public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest
   // ---- Billing account ID tests ----
 
   @Test
-  @TestPlanName("tally-summary-by-attributes-TC003")
+  @TestPlanName("tally-summary-by-attributes-payg-TC003")
   public void testTallySummarySeparatesMeasurementsByBillingAccountId() {
     // Given: Events for two different billing account IDs
     OffsetDateTime now = OffsetDateTime.now();
@@ -162,7 +162,7 @@ public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest
   }
 
   @Test
-  @TestPlanName("tally-summary-by-attributes-TC004")
+  @TestPlanName("tally-summary-by-attributes-payg-TC004")
   public void testTallySummaryMeasurementsWhenSingleHostChangesBillingAccountId() {
     // Given: Same instance sends events under two different billing account IDs
     OffsetDateTime now = OffsetDateTime.now();
@@ -206,7 +206,7 @@ public class TallySummaryMessagesByAttributesTest extends BaseTallyComponentTest
   // ---- Billing provider tests ----
 
   @Test
-  @TestPlanName("tally-summary-by-attributes-TC005")
+  @TestPlanName("tally-summary-by-attributes-payg-TC005")
   public void testTallySummarySeparatesMeasurementsByBillingProvider() {
     // Given: Events for two different billing providers
     OffsetDateTime now = OffsetDateTime.now();

--- a/swatch-tally/ct/java/tests/TallySummaryPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallySummaryPaygTest.java
@@ -35,10 +35,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-class TallySummaryComponentTest extends BaseTallyComponentTest {
+class TallySummaryPaygTest extends BaseTallyComponentTest {
 
   @Test
-  @TestPlanName("tally-summary-TC003")
+  @TestPlanName("tally-summary-payg-TC001")
   void testTallyHourlySummaryEmitsNoGranularityDaily() {
     // Given: Events within the last day for hourly tally
     final String testInstanceId = UUID.randomUUID().toString();
@@ -75,7 +75,7 @@ class TallySummaryComponentTest extends BaseTallyComponentTest {
   }
 
   @Test
-  @TestPlanName("tally-summary-TC004")
+  @TestPlanName("tally-summary-payg-TC002")
   void testTallyHourlySummaryEmitsGranularityHourly() {
     // Given: Events within the last day for hourly tally
     final String testInstanceId = UUID.randomUUID().toString();


### PR DESCRIPTION
Jira issue: SWATCH-4766

## Description

These changes add:

- 49 new tally tests to TEST_PLAN.md
- Updates to existing tally component test files to match their correct codes in the test plan (mostly changed some to include payg/non-payg)
- Added one new unit test to cover a scenario previously in IQE (MR to remove this test and other repetitive ones in IQE: [MR 1555](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1555)

Document with more IQE test porting details: [Updated Tally Test Plan](https://docs.google.com/document/d/1-S3WVZDhTww3HxCLaCRxh5QyzQ8YoGSLu20SC5-THz8/edit?usp=sharing)

## Verification

1. Check that all tally tests (unit and component) are still working as expected.
2. Confirm all new tests to be ported over are listed in TEST_PLAN.md and their codes match the tests listed in corresponding Jira cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Added a new parameterized persistence/retrieval validation for path-like instance identifiers, ensuring exact instanceId round-trips.
  - Expanded and adjusted end-to-end coverage for PAYG and non-PAYG tally/report filtering, “has data” semantics, conflict handling, summary message validation, and instance query behavior.
  - Renamed several test classes and refreshed test-plan identifiers to use PAYG-specific naming where applicable.
  - Updated billing-account reporting scenarios, including month-boundary cutoff and deduplication assertions.

- **Documentation**
  - Reorganized and significantly expanded the swatch-tally test plan with refreshed scenario groupings and identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->