### PR TITLE
ci: do not log all the services in component tests

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -693,7 +693,7 @@ spec:
                 value: "$(params.SERVICE)"
             script: |
               #!/bin/bash
-              mvn -s .mvn/maven-settings.xml clean install --no-transfer-progress -Pcomponent-tests -am -pl ${SERVICE}/ct -Dswatch.component-tests.global.target=openshift -Dlog.disable-color=true -Dlog.level=FINE -Dlog.print-errors-to-std-err=true -Dswatch.component-tests.services.all.log.enabled=true
+              mvn -s .mvn/maven-settings.xml clean install --no-transfer-progress -Pcomponent-tests -am -pl ${SERVICE}/ct -Dswatch.component-tests.global.target=openshift -Dlog.disable-color=true -Dlog.level=FINE -Dlog.print-errors-to-std-err=true
     - name: send-results-task
       onError: continue
       params:


### PR DESCRIPTION
## Description
Having `swatch.component-tests.services.all.log.enabled=true` in place is doing that all the services capture the log when running the component tests in openshift.

Since the component tests are now stable enough, we don't need to log all the services and also this adds a stress to the konflux pods because the logs kept in memory during test execution. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated component test execution configuration while preserving the existing Maven build and test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->