### PR TITLE
SWATCH-5176: update swatch-contracts component tests to cover rbac/kessel integration using wiremock

### DIFF
--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -14,6 +14,7 @@ RBAC_ENABLED=true
 RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
 %dev.RBAC_ENDPOINT=http://localhost:8006
 %test.RBAC_ENDPOINT=http://localhost:8080
+%component-tests.RBAC_ENDPOINT=http://wiremock-service:8000
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}
@@ -30,8 +31,9 @@ quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
 
 # Kessel / RBACv2 configuration
 KESSEL_ENDPOINT=${clowder.endpoints.kessel-inventory-api.hostname:localhost}:9000
-%dev.KESSEL_ENDPOINT=localhost:9000
+%dev.KESSEL_ENDPOINT=localhost:8006
 %test.KESSEL_ENDPOINT=localhost:9000
+%component-tests.KESSEL_ENDPOINT=wiremock-service:8000
 KESSEL_INSECURE=true
 %prod.KESSEL_INSECURE=false
 KESSEL_TIMEOUT_MS=5000

--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -2244,12 +2244,19 @@ This section validates the tally-to-utilization pipeline, where `swatch-contract
 **Required role:** `customer` or `service` only (the `test`
 role must not be accepted so `SWATCH_TEST_APIS_ENABLED` cannot bypass RBAC on this path)
 
+**Authorization models (parameterized):** each case below runs for `RBAC` and `KESSEL`.
+- **RBAC**: Unleash `swatch.common-security.use-kessel-rbac` off; stub `GET /api/rbac/v1/access/`
+- **KESSEL**: Unleash flag on; stub gRPC
+  `POST /kessel.inventory.v1beta2.KesselInventoryService/Check` for relation
+  `subscriptions_report_view` (Wiremock gRPC + Kessel descriptor)
+
 **auth-access-TC001 - Customer with subscriptions access can read V2 subscription report**
-- **Description**: Verify that a User identity granted `subscriptions:*:*` receives HTTP 200 from
-  the V2 subscription capacity report API.
+- **Description**: Verify that a User identity granted subscriptions access receives HTTP 200 from
+  the V2 subscription capacity report API (RBAC and Kessel).
 - **Setup**:
-  - Stub RBAC to grant `subscriptions:*:*` for the test identity
-  - Prepare a User `x-rh-identity` header for the test org
+  - **RBAC**: stub RBAC to grant `subscriptions:*:*` for the test identity
+  - **KESSEL**: stub Kessel Check to return `ALLOWED_TRUE` for the test principal / relation
+  - Prepare a User `x-rh-identity` header for the test org (with resolvable `user_id`)
 - **Action**:
   - GET `/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}` with the identity header
 - **Verification**:
@@ -2259,10 +2266,11 @@ role must not be accepted so `SWATCH_TEST_APIS_ENABLED` cannot bypass RBAC on th
 
 **auth-access-TC002 - Customer without subscriptions access is denied V2 subscription report**
 - **Description**: Verify that a User identity with no subscriptions permissions receives HTTP 403
-  from the V2 subscription capacity report API.
+  from the V2 subscription capacity report API (RBAC and Kessel).
 - **Setup**:
-  - Stub RBAC to return no subscriptions permissions for the test identity
-  - Prepare a User `x-rh-identity` header for the test org
+  - **RBAC**: stub RBAC to return no subscriptions permissions for the test identity
+  - **KESSEL**: stub Kessel Check to return `ALLOWED_FALSE` for the test principal / relation
+  - Prepare a User `x-rh-identity` header for the test org (with resolvable `user_id`)
 - **Action**:
   - GET `/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}` with the identity header
 - **Verification**:

--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -2237,3 +2237,36 @@ This section validates the tally-to-utilization pipeline, where `swatch-contract
 - **Expected Result**:  
   - Utilization summary is produced but with `capacity=null` for the Sockets measurement (no subscription matches that SLA/Usage combination)  
   - This snapshot should not be eligible to trigger an over-usage notification
+
+## Customer API access control
+
+**Endpoint:** `GET /api/rhsm-subscriptions/v2/subscriptions/products/{product_id}`  
+**Required role:** `customer` or `service` only (the `test`
+role must not be accepted so `SWATCH_TEST_APIS_ENABLED` cannot bypass RBAC on this path)
+
+**auth-access-TC001 - Customer with subscriptions access can read V2 subscription report**
+- **Description**: Verify that a User identity granted `subscriptions:*:*` receives HTTP 200 from
+  the V2 subscription capacity report API.
+- **Setup**:
+  - Stub RBAC to grant `subscriptions:*:*` for the test identity
+  - Prepare a User `x-rh-identity` header for the test org
+- **Action**:
+  - GET `/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}` with the identity header
+- **Verification**:
+  - HTTP 200
+- **Expected Result**:
+  - Request is authorized and the API responds successfully
+
+**auth-access-TC002 - Customer without subscriptions access is denied V2 subscription report**
+- **Description**: Verify that a User identity with no subscriptions permissions receives HTTP 403
+  from the V2 subscription capacity report API.
+- **Setup**:
+  - Stub RBAC to return no subscriptions permissions for the test identity
+  - Prepare a User `x-rh-identity` header for the test org
+- **Action**:
+  - GET `/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}` with the identity header
+- **Verification**:
+  - HTTP 403
+- **Expected Result**:
+  - Request is denied (Quarkus returns 403 with an empty body on `@RolesAllowed` failure; IQE
+    against Spring rhsm may include `Access Denied` in the JSON error title)

--- a/swatch-contracts/ct/README.md
+++ b/swatch-contracts/ct/README.md
@@ -27,7 +27,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-cont
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-contracts --no-remove-resources app:rhsm
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-contracts --remove-dependencies swatch-contracts/rbac --remove-dependencies swatch-contracts/kessel-inventory --no-remove-resources app:rhsm
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-contracts/ct/java/api/AuthorizationModel.java
+++ b/swatch-contracts/ct/java/api/AuthorizationModel.java
@@ -20,37 +20,7 @@
  */
 package api;
 
-import com.redhat.swatch.component.tests.api.WiremockService;
-
-public class ContractsWiremockService extends WiremockService {
-  /**
-   * Get facade for stubbing Partner Gateway API endpoints.
-   *
-   * @return PartnerGatewayStubs facade
-   */
-  public PartnerApiStubs forPartnerAPI() {
-    return new PartnerApiStubs(this);
-  }
-
-  /**
-   * Get facade for stubbing Product API endpoints.
-   *
-   * @return ProductApiStubs facade
-   */
-  public ProductApiStubs forProductAPI() {
-    return new ProductApiStubs(this);
-  }
-
-  /**
-   * Get facade for stubbing Search API endpoints.
-   *
-   * @return SearchApiStubs facade
-   */
-  public SearchApiStubs forSearchApi() {
-    return new SearchApiStubs(this);
-  }
-
-  public RbacAccessControlStubs forRbacAccessControl() {
-    return new RbacAccessControlStubs(this);
-  }
+/** Authorization model exercised by parameterized access-control component tests. */
+public enum AuthorizationModel {
+  RBAC
 }

--- a/swatch-contracts/ct/java/api/AuthorizationModel.java
+++ b/swatch-contracts/ct/java/api/AuthorizationModel.java
@@ -22,5 +22,6 @@ package api;
 
 /** Authorization model exercised by parameterized access-control component tests. */
 public enum AuthorizationModel {
-  RBAC
+  RBAC,
+  KESSEL
 }

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -244,6 +244,18 @@ public class ContractsSwatchService extends SwatchService {
     return request.get(GET_SKU_ENDPOINT).then().extract().as(SkuCapacityReportV2.class);
   }
 
+  public Response getSkuCapacityByProductId(Product product, Map<String, String> requestHeaders) {
+    Objects.requireNonNull(product, "product must not be null");
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+
+    return given()
+        .headers(requestHeaders)
+        .accept("application/vnd.api+json")
+        .pathParam("product_id", product.getName())
+        .when()
+        .get(GET_SKU_ENDPOINT);
+  }
+
   public CapacityReportByMetricId getCapacityReportByMetricId(
       Product product,
       String orgId,

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -31,6 +31,9 @@ public class ContractsUnleashService extends UnleashService {
   public static final String IT_SUBSCRIPTION_SERVICE =
       "swatch.swatch-contracts.enable-it-subscription-service";
 
+  /** Matches {@code KesselRolesAugmentor.KESSEL_FLAG} in swatch-common-security. */
+  public static final String USE_KESSEL_RBAC = "swatch.common-security.use-kessel-rbac";
+
   public void enablePartnerGatewayContracts() {
     enableFlag(PARTNER_GATEWAY_CONTRACTS);
     AwaitilityUtils.until(
@@ -72,5 +75,15 @@ public class ContractsUnleashService extends UnleashService {
 
   public void disableItSubscriptionService() {
     disableFlag(IT_SUBSCRIPTION_SERVICE);
+  }
+
+  public void enableKesselRbac() {
+    enableFlag(USE_KESSEL_RBAC);
+    waitForUnleashPropagation();
+  }
+
+  public void disableKesselRbac() {
+    disableFlag(USE_KESSEL_RBAC);
+    waitForUnleashPropagation();
   }
 }

--- a/swatch-contracts/ct/java/api/ContractsWiremockService.java
+++ b/swatch-contracts/ct/java/api/ContractsWiremockService.java
@@ -53,4 +53,8 @@ public class ContractsWiremockService extends WiremockService {
   public RbacAccessControlStubs forRbacAccessControl() {
     return new RbacAccessControlStubs(this);
   }
+
+  public KesselAccessControlStubs forKesselAccessControl() {
+    return new KesselAccessControlStubs(this);
+  }
 }

--- a/swatch-contracts/ct/java/api/KesselAccessControlStubs.java
+++ b/swatch-contracts/ct/java/api/KesselAccessControlStubs.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import domain.SubscriptionsAccessLevel;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+
+/** Wiremock gRPC stubs for Kessel inventory Check used by customer-facing APIs. */
+public class KesselAccessControlStubs {
+
+  private static final String CHECK_PATH = "/kessel.inventory.v1beta2.KesselInventoryService/Check";
+  private static final String SUBSCRIPTIONS_REPORT_VIEW = "subscriptions_report_view";
+
+  private final ContractsWiremockService wiremockService;
+
+  KesselAccessControlStubs(ContractsWiremockService wiremockService) {
+    this.wiremockService = wiremockService;
+  }
+
+  public void stubSubscriptionsAccess(String userId, SubscriptionsAccessLevel accessLevel) {
+    String allowed =
+        accessLevel == SubscriptionsAccessLevel.DENIED ? "ALLOWED_FALSE" : "ALLOWED_TRUE";
+
+    wiremockService
+        .given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "POST",
+                    "urlPath",
+                    CHECK_PATH,
+                    "bodyPatterns",
+                    List.of(
+                        Map.of(
+                            "matchesJsonPath",
+                            Map.of(
+                                "expression", "$.relation", "equalTo", SUBSCRIPTIONS_REPORT_VIEW)),
+                        Map.of(
+                            "matchesJsonPath",
+                            Map.of(
+                                "expression",
+                                "$.subject.resource.resourceId",
+                                "equalTo",
+                                userId)))),
+                "response",
+                Map.of(
+                    "status",
+                    HttpStatus.SC_OK,
+                    "headers",
+                    Map.of("grpc-status-name", "OK"),
+                    "jsonBody",
+                    Map.of("allowed", allowed)),
+                "priority",
+                1,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+}

--- a/swatch-contracts/ct/java/api/RbacAccessControlStubs.java
+++ b/swatch-contracts/ct/java/api/RbacAccessControlStubs.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import domain.SubscriptionsAccessLevel;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+
+/** Wiremock stubs for RBAC permission checks used by customer-facing APIs. */
+public class RbacAccessControlStubs {
+
+  // RBAC OpenAPI path is "/access/" — the generated REST client includes the trailing slash.
+  private static final String RBAC_ACCESS_PATH = "/api/rbac/v1/access/";
+  private static final String SUBSCRIPTIONS_APPLICATION = "subscriptions";
+
+  private final ContractsWiremockService wiremockService;
+
+  RbacAccessControlStubs(ContractsWiremockService wiremockService) {
+    this.wiremockService = wiremockService;
+  }
+
+  public void stubSubscriptionsAccess(String identityHeader, SubscriptionsAccessLevel accessLevel) {
+    var responseBody =
+        accessLevel == SubscriptionsAccessLevel.DENIED
+            ? Map.of("data", List.of(), "meta", Map.of("count", 0))
+            : Map.of(
+                "data",
+                List.of(Map.of("permission", accessLevel.permission())),
+                "meta",
+                Map.of("count", 1));
+
+    wiremockService
+        .given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "GET",
+                    "urlPath",
+                    RBAC_ACCESS_PATH,
+                    "queryParameters",
+                    Map.of("application", Map.of("equalTo", SUBSCRIPTIONS_APPLICATION)),
+                    "headers",
+                    Map.of("x-rh-identity", Map.of("equalTo", identityHeader))),
+                "response",
+                Map.of(
+                    "status",
+                    HttpStatus.SC_OK,
+                    "headers",
+                    Map.of("Content-Type", "application/json"),
+                    "jsonBody",
+                    responseBody),
+                "priority",
+                1,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+}

--- a/swatch-contracts/ct/java/domain/SubscriptionsAccessLevel.java
+++ b/swatch-contracts/ct/java/domain/SubscriptionsAccessLevel.java
@@ -18,39 +18,24 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package api;
+package domain;
 
-import com.redhat.swatch.component.tests.api.WiremockService;
+/** Permission outcome stubbed for the subscriptions application. */
+public enum SubscriptionsAccessLevel {
+  GRANTED_ADMIN("subscriptions:*:*"),
+  DENIED;
 
-public class ContractsWiremockService extends WiremockService {
-  /**
-   * Get facade for stubbing Partner Gateway API endpoints.
-   *
-   * @return PartnerGatewayStubs facade
-   */
-  public PartnerApiStubs forPartnerAPI() {
-    return new PartnerApiStubs(this);
+  private final String permission;
+
+  SubscriptionsAccessLevel() {
+    this.permission = null;
   }
 
-  /**
-   * Get facade for stubbing Product API endpoints.
-   *
-   * @return ProductApiStubs facade
-   */
-  public ProductApiStubs forProductAPI() {
-    return new ProductApiStubs(this);
+  SubscriptionsAccessLevel(String permission) {
+    this.permission = permission;
   }
 
-  /**
-   * Get facade for stubbing Search API endpoints.
-   *
-   * @return SearchApiStubs facade
-   */
-  public SearchApiStubs forSearchApi() {
-    return new SearchApiStubs(this);
-  }
-
-  public RbacAccessControlStubs forRbacAccessControl() {
-    return new RbacAccessControlStubs(this);
+  public String permission() {
+    return permission;
   }
 }

--- a/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class SubscriptionReportAccessComponentTest extends BaseContractComponentTest {
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "authorizationModel={0}")
   @EnumSource(AuthorizationModel.class)
   @TestPlanName("auth-access-TC001")
   void shouldAllowV2ReportWhenAccessGranted(AuthorizationModel authorizationModel) {
@@ -45,8 +45,8 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     String userId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
-    givenRbacSubscriptionsAccessStub(
-        authorizationModel, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+    givenSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     // When
     Response response = whenGetV2SkuCapacityReport(requestHeaders);
@@ -63,8 +63,8 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     String userId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
-    givenRbacSubscriptionsAccessStub(
-        authorizationModel, identityHeader, SubscriptionsAccessLevel.DENIED);
+    givenSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     // When
     Response response = whenGetV2SkuCapacityReport(requestHeaders);
@@ -73,11 +73,16 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
   }
 
-  private void givenRbacSubscriptionsAccessStub(
+  private void givenSubscriptionsAccess(
       AuthorizationModel authorizationModel,
+      String userId,
       String identityHeader,
       SubscriptionsAccessLevel accessLevel) {
-    if (authorizationModel == AuthorizationModel.RBAC) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(userId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
       wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
     }
   }

--- a/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.X_RH_IDENTITY_HEADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.component.tests.utils.SwatchUtils;
+import domain.Product;
+import domain.SubscriptionsAccessLevel;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class SubscriptionReportAccessComponentTest extends BaseContractComponentTest {
+
+  @ParameterizedTest
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("auth-access-TC001")
+  void shouldAllowV2ReportWhenAccessGranted(AuthorizationModel authorizationModel) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenRbacSubscriptionsAccessStub(
+        authorizationModel, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When
+    Response response = whenGetV2SkuCapacityReport(requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("auth-access-TC002")
+  void shouldDenyV2ReportWhenAccessMissing(AuthorizationModel authorizationModel) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenRbacSubscriptionsAccessStub(
+        authorizationModel, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    // When
+    Response response = whenGetV2SkuCapacityReport(requestHeaders);
+
+    // Then — Quarkus @RolesAllowed denial returns 403 with an empty body (unlike Spring rhsm IQE).
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  private void givenRbacSubscriptionsAccessStub(
+      AuthorizationModel authorizationModel,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.RBAC) {
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  private Response whenGetV2SkuCapacityReport(Map<String, String> requestHeaders) {
+    return service.getSkuCapacityByProductId(Product.OPENSHIFT, requestHeaders);
+  }
+
+  private void thenResponseStatusIs(Response response, int expectedStatus) {
+    assertEquals(expectedStatus, response.statusCode());
+  }
+}

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -84,8 +84,6 @@ quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.security.deny-unannotated-members=true
 # Enable auth in dev mode to test RBAC/Kessel flow
 quarkus.security.auth.enabled-in-dev-mode=true
-# Disable test role so auth goes through RBAC/Kessel, not the "test" role bypass
-%dev.SWATCH_TEST_APIS_ENABLED=false
 # Set retry delay to 0 to keep tests fast
 %test.Retry/delay=0
 quarkus.transaction-manager.default-transaction-timeout=PT5M

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -64,6 +64,22 @@ public final class SwatchUtils {
     return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
   }
 
+  /** Returns headers for a User identity with org and user identifiers (RBAC component tests). */
+  public static Map<String, String> securityHeadersWithUserRole(String orgId, String userId) {
+    String json =
+        "{\"identity\":{\"type\":\"User\",\"org_id\":\""
+            + orgId
+            + "\",\"internal\":{\"org_id\":\""
+            + orgId
+            + "\"},\"user\":{\"username\":\""
+            + userId
+            + "\",\"user_id\":\""
+            + userId
+            + "\"}}}";
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
+  }
+
   /**
    * This is used to create a User type identity header that includes org_id for Springboot services
    * in DEV_MODE


### PR DESCRIPTION
Jira issue: SWATCH-5176

## Description
Changes:
- configured swatch-contracts to use a new profile "component-tests" (temporal until SWATCH-5263 is refined and finished)
- configured swatch-contracts to use wiremock for rbac and kessel only in dev and component-tests
- added a test plan and component tests to cover a happy path and permission denied case for both rbac and kessel. 