### PR TITLE
fix: dedupe OpenShift CT logs per line to avoid runner OOM

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/LoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/LoggingHandler.java
@@ -22,9 +22,8 @@ package com.redhat.swatch.component.tests.logging;
 
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import java.io.Closeable;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,8 +32,11 @@ public abstract class LoggingHandler implements Closeable {
   private static final long TIMEOUT_IN_MILLIS = 4000;
   private static final String ANY = ".*";
 
+  /** Cap retained lines so chatty OpenShift pods cannot OOM the CT runner. */
+  private static final int MAX_LOG_LINES = 1_000;
+
   private Thread innerThread;
-  private List<String> logs = new CopyOnWriteArrayList<>();
+  private final LinkedBlockingDeque<String> logs = new LinkedBlockingDeque<>(MAX_LOG_LINES);
   private boolean running = false;
 
   protected abstract void handle();
@@ -61,7 +63,7 @@ public abstract class LoggingHandler implements Closeable {
   }
 
   public List<String> logs() {
-    return Collections.unmodifiableList(logs);
+    return List.copyOf(logs);
   }
 
   public boolean logsContains(String expected) {
@@ -109,7 +111,10 @@ public abstract class LoggingHandler implements Closeable {
   }
 
   protected void onLine(String line) {
-    logs.add(line);
+    if (!logs.offerLast(line)) {
+      logs.pollFirst();
+      logs.offerLast(line);
+    }
     if (isLogEnabled()) {
       logInfo(line);
     }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
@@ -24,19 +24,40 @@ import com.redhat.swatch.component.tests.api.clients.OpenshiftClient;
 import com.redhat.swatch.component.tests.core.ServiceContext;
 import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBootstrap;
 import java.time.Instant;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
 
+  /**
+   * Bound for per-line dedupe during a single test. Evicts eldest entries so chatty services cannot
+   * grow the dedupe set without limit.
+   */
+  private static final int MAX_SEEN_LINES = 1_000;
+
+  /** Keep only the newest lines from a large log fetch. */
+  private static final int MAX_LINES_PER_FETCH = 1_000;
+
+  /** Truncate retained lines; assertContains messages are short. */
+  private static final int MAX_LINE_LENGTH = 2_048;
+
   private final OpenshiftClient client;
   private final Map<String, String> podLabels;
   private final String containerName;
   private Instant logsSince;
-  private final Set<String> seenLines = new HashSet<>();
+
+  /** Bounded dedupe of formatted log lines for a single test. */
+  private final Set<String> seenLines =
+      Collections.newSetFromMap(
+          new LinkedHashMap<>() {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest) {
+              return size() > MAX_SEEN_LINES;
+            }
+          });
 
   public OpenShiftLoggingHandler(
       Map<String, String> podLabels, String containerName, ServiceContext context) {
@@ -48,7 +69,7 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
   }
 
   @Override
-  public void onTestStarted() {
+  public synchronized void onTestStarted() {
     super.onTestStarted();
 
     this.logsSince = Instant.now();
@@ -56,8 +77,15 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
   }
 
   @Override
+  public synchronized void onTestStopped() {
+    super.onTestStopped();
+    this.seenLines.clear();
+    this.logsSince = null;
+  }
+
+  @Override
   protected synchronized void handle() {
-    if (!isTestActive() || logsSince == null) {
+    if (!isTestActive() || logsSince == null || !isLogEnabled()) {
       return;
     }
 
@@ -65,14 +93,46 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
     Map<String, String> newLogs = client.logsSince(podLabels, containerName, logsSince);
     this.logsSince = fetchTime;
 
-    for (Entry<String, String> entry : newLogs.entrySet()) {
-      if (StringUtils.isNotEmpty(entry.getValue())) {
-        String formatted = formatPodLogs(entry.getKey(), entry.getValue());
-        if (seenLines.add(formatted)) {
-          onLines(formatted);
-        }
-      }
+    newLogs.forEach(this::appendNewPodLogLines);
+  }
+
+  /**
+   * Lines stay in the bounded {@code logs} buffer for {@code assertContains}; mirroring every line
+   * to INFO floods the CT runner under {@code -Dlog.level=FINE}.
+   */
+  @Override
+  protected void logInfo(String line) {
+    // intentionally empty
+  }
+
+  private void appendNewPodLogLines(String podName, String podLogs) {
+    if (StringUtils.isEmpty(podLogs)) {
+      return;
     }
+
+    String[] lines = podLogs.split("\\r?\\n");
+    int start = Math.max(0, lines.length - MAX_LINES_PER_FETCH);
+    for (int i = start; i < lines.length; i++) {
+      appendNewLine(podName, lines[i]);
+    }
+  }
+
+  private void appendNewLine(String podName, String line) {
+    if (StringUtils.isEmpty(line)) {
+      return;
+    }
+
+    String formatted = truncate(formatPodLogs(podName, truncate(line)));
+    if (seenLines.add(formatted)) {
+      onLine(formatted);
+    }
+  }
+
+  private static String truncate(String line) {
+    if (line.length() <= MAX_LINE_LENGTH) {
+      return line;
+    }
+    return line.substring(0, MAX_LINE_LENGTH);
   }
 
   private String formatPodLogs(String podName, String log) {


### PR DESCRIPTION
## Summary
Component tests on OpenShift were OOM-killing the Konflux Maven runner (exit 137) during the swatch-tally suite. OpenShiftLoggingHandler was adding whole multi-line log blobs into a HashSet for deduplication, so memory grew quickly under chatty pods. This change deduplicates and retains logs line by line, clears that state when a test ends, skips fetching when service logging is disabled, and turns off Unleash log capture in the tally CT properties.

## Test plan
Re-run swatch-tally bonfire component tests on Konflux and confirm the run-tests step completes without exit 137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod log output by emitting non-empty individual lines labeled with their pod name, with truncation for long lines.
  * Prevented duplicate log lines from being emitted by using bounded per-line deduplication.
  * Stopped log fetching when logging is disabled and reset log tracking cleanly when a test ends.
* **Performance / Reliability**
  * Capped retained log lines during a test to avoid unbounded memory growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->