### PR TITLE
Configure component tests for Quarkus services to use the "component-tests" profile

### DIFF
--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -294,6 +294,8 @@ spec:
           value: "$(params.EXTRA_DEPLOY_ARGS)"
         - name: COMPONENTS
           value: "$(params.COMPONENTS)"
+        - name: COMPONENT_NAME
+          value: "$(params.COMPONENT_NAME)"
         - name: GIT_REVISION
           value: "$(tasks.extract-metadata.results.GIT_REVISION)"
       taskSpec:
@@ -301,6 +303,8 @@ spec:
           - name: EXTRA_DEPLOY_ARGS
             type: string
           - name: COMPONENTS
+            type: string
+          - name: COMPONENT_NAME
             type: string
           - name: GIT_REVISION
             type: string
@@ -314,10 +318,12 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
               COMPONENTS="$(params.COMPONENTS)"
+              COMPONENT_NAME="$(params.COMPONENT_NAME)"
               EXTRA_DEPLOY_ARGS="$(params.EXTRA_DEPLOY_ARGS)"
               GIT_REVISION="$(params.GIT_REVISION)"
 
               echo "update-extra-deploy-args: COMPONENTS='$COMPONENTS'"
+              echo "update-extra-deploy-args: COMPONENT_NAME='$COMPONENT_NAME'"
               echo "update-extra-deploy-args: EXTRA_DEPLOY_ARGS='$EXTRA_DEPLOY_ARGS'"
               echo "update-extra-deploy-args: GIT_REVISION='$GIT_REVISION'"
 
@@ -330,6 +336,14 @@ spec:
                   break
                 fi
               done
+
+              # Add component-tests profile (only for Quarkus services for now)
+              if [ -n "$COMPONENT_NAME" ]; then
+                SPRING_BOOT_CT_COMPONENTS="swatch-api swatch-tally swatch-system-conduit"
+                if [[ " ${SPRING_BOOT_CT_COMPONENTS} " != *" ${COMPONENT_NAME} "* ]]; then
+                  UPDATED_ARGS="$UPDATED_ARGS --set-parameter ${COMPONENT_NAME}/QUARKUS_PROFILE=ephemeral,component-tests"
+                fi
+              fi
 
               echo "update-extra-deploy-args: final args='$UPDATED_ARGS'"
               printf "%s" "$UPDATED_ARGS" > $(results.UPDATED_EXTRA_DEPLOY_ARGS.path)

--- a/docs/quarkus-profiles.md
+++ b/docs/quarkus-profiles.md
@@ -74,6 +74,30 @@ Quarkus profiles allow different configurations to be applied based on the runti
 
 **Usage**: Set via deployment configurations in CI/CD pipelines
 
+### `component-tests` - Component Tests Profile
+
+**Purpose**: Extra Quarkus config for OpenShift **component-test** deploys. Compose it with
+`ephemeral` so CT keeps ephemeral defaults while applying CT-only overrides
+(`%component-tests.*`).
+
+**Why a separate profile**: `ephemeral` is also used for IQE / manual ephemeral work and should
+stay aligned with that environment. Component tests often need different wiring (mocks,
+removed dependencies, tighter timeouts, etc.) without changing plain ephemeral behavior.
+
+**Usage** (Bonfire / OpenShift CT) — **scope to the service under test**:
+```bash
+# component/PARAM — do not set QUARKUS_PROFILE for the whole deploy
+--set-parameter swatch-contracts/QUARKUS_PROFILE=ephemeral,component-tests
+```
+
+List `component-tests` last so it wins on overlapping keys. 
+
+**Local CT**: keep using `dev` (`quarkus:dev`); do not activate `component-tests` locally
+unless you intentionally override OpenShift-oriented `%component-tests.*` values.
+
+Services can define any `%component-tests.*` keys they need under their own
+`application.properties` (or shared modules).
+
 ### `stage` - Staging Environment Profile
 
 **Purpose**: Pre-production staging environment
@@ -150,7 +174,11 @@ export QUARKUS_PROFILE=dev,ephemeral
 Profiles can be combined using comma separation:
 ```bash
 QUARKUS_PROFILE=dev,kafka-queue
+QUARKUS_PROFILE=ephemeral,component-tests
 ```
+
+When multiple profiles are active, **the last profile has priority** for overlapping
+keys (Quarkus checks profiles from last to first).
 
 ## Common Configuration Patterns
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfiguration.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfiguration.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -47,7 +48,7 @@ public class AwsProfileFileConfiguration {
       @ConfigProperty(name = "aws.marketplace.test-credentials.secret-access-key")
           String secretAccessKey) {
 
-    if (TEST_CREDENTIAL_PROFILES.contains(profile)) {
+    if (usesTestCredentials(profile)) {
       log.debug(
           "Using test AWS marketplace credentials profile '{}' for quarkus profile '{}'",
           sellerProfile,
@@ -65,6 +66,17 @@ public class AwsProfileFileConfiguration {
     }
 
     return ProfileFile.defaultProfileFile();
+  }
+
+  /**
+   * {@code quarkus.profile} may be a comma-separated list (e.g. {@code ephemeral,component-tests}).
+   * Use synthetic creds when any active profile is a test profile.
+   */
+  static boolean usesTestCredentials(String profile) {
+    return Arrays.stream(profile.split(","))
+        .map(String::trim)
+        .filter(name -> !name.isEmpty())
+        .anyMatch(TEST_CREDENTIAL_PROFILES::contains);
   }
 
   private static ProfileFile syntheticProfileFile(

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfigurationTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/configuration/AwsProfileFileConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AwsProfileFileConfigurationTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ephemeral", "dev", "test", "ephemeral,component-tests"})
+  void usesTestCredentialsWhenAnyActiveProfileIsTestProfile(String profile) {
+    assertTrue(AwsProfileFileConfiguration.usesTestCredentials(profile));
+  }
+
+  @Test
+  void doesNotUseTestCredentialsForProd() {
+    assertFalse(AwsProfileFileConfiguration.usesTestCredentials("prod"));
+  }
+
+  @Test
+  void doesNotUseTestCredentialsForComponentTestsAlone() {
+    assertFalse(AwsProfileFileConfiguration.usesTestCredentials("component-tests"));
+  }
+}


### PR DESCRIPTION
## Description
Add the "component-tests" profile only to the Quarkus services when running the component-tests test suite. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component-test deployments now automatically apply the `component-tests` Quarkus profile for eligible services.
  * Updated documentation on composing and prioritizing multiple Quarkus profiles, including `ephemeral,component-tests`.

* **Bug Fixes**
  * Test credentials selection now correctly handles comma-separated `quarkus.profile` values, using test credentials when any active profile matches.

* **Tests**
  * Added coverage for profile parsing and `component-tests`/`ephemeral,component-tests` credential-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->