### PR TITLE
Use our wiremock-consoledot for local and component tests

### DIFF
--- a/config/wiremock/docker-compose.yml
+++ b/config/wiremock/docker-compose.yml
@@ -2,10 +2,10 @@
 version: '3.8'
 services:
   wiremock:
-    image: wiremock/wiremock:3.12.0
+    image: quay.io/redhat-services-prod/rh-subs-watch-tenant/wiremock-consoledot:latest
     container_name: wiremock
     ports:
-      - "8101:8080"
+      - "8101:8000"
     volumes:
       - ./__files:/home/wiremock/__files:z
       - ./mappings:/home/wiremock/mappings:z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./config/wiremock/__files:/home/wiremock/__files:z
       - ./config/wiremock/mappings:/home/wiremock/mappings:z
     ports:
-      - "127.0.0.1:8006:8080"
+      - "127.0.0.1:8006:8000"
     networks:
       swatch-network:
         aliases:

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -11,7 +11,7 @@ SWATCH_TEST_APIS_ENABLED=true
 
 RBAC_ENABLED=true
 RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
-%dev.RBAC_ENDPOINT=http://localhost:8080
+%dev.RBAC_ENDPOINT=http://localhost:8006
 %test.RBAC_ENDPOINT=http://localhost:8080
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/wiremock/LocalWiremockManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/wiremock/LocalWiremockManagedResource.java
@@ -20,11 +20,23 @@
  */
 package com.redhat.swatch.component.tests.resources.wiremock;
 
+import static com.redhat.swatch.component.tests.utils.Ports.WIREMOCK_PORT;
+
 import com.redhat.swatch.component.tests.resources.containers.LocalContainerManagedResource;
+import com.redhat.swatch.component.tests.utils.Ports;
 
 public class LocalWiremockManagedResource extends LocalContainerManagedResource {
 
   public LocalWiremockManagedResource() {
     super(".*wiremock.*");
+  }
+
+  @Override
+  public int getMappedPort(int port) {
+    // Map default port to WireMock default port
+    if (port == Ports.DEFAULT_HTTP_PORT) {
+      return super.getMappedPort(WIREMOCK_PORT);
+    }
+    return super.getMappedPort(port);
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Ports.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Ports.java
@@ -28,6 +28,7 @@ public final class Ports {
   public static final int DEFAULT_HTTP_PORT = 8080;
   public static final int DEFAULT_SSL_PORT = 8443;
   public static final int ARTEMIS_PORT = 5672;
+  public static final int WIREMOCK_PORT = 8000;
   public static final List<Integer> SSL_PORTS = Arrays.asList(DEFAULT_SSL_PORT, 443);
 
   private Ports() {}


### PR DESCRIPTION
## Description
Use our wiremock-consoledot for dev mode and also when running the component tests locally.
This is needed, so the component tests running on openshift behave the same than in local. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated local WireMock services to use the standardized container port.
  * Updated development RBAC configuration to connect through the revised local endpoint.

* **Testing**
  * Improved local test environment port mapping for WireMock.
  * Added support for consistently resolving the configured WireMock port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->