### PR TITLE
Skip the github-delete-comment if no pr

### DIFF
--- a/.tekton/tasks/github-delete-comment.yaml
+++ b/.tekton/tasks/github-delete-comment.yaml
@@ -42,6 +42,13 @@ spec:
         echo "MARKER: ${MARKER}"
         echo "Token length: ${#GITHUB_TOKEN}"
         echo ""
+        
+        #Skip this task if there is no PR specified
+        if [[ "$PR" == "" || "$PR" == "none" ]]; then
+          echo "PR is empty, skipping comment."
+          exit 0
+        fi
+
 
         page=1
         while true; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary comment lookup and deletion attempts when no valid pull request number is provided.
  * Such tasks now exit successfully with a clear status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->