### PR TITLE
SWATCH-4836: Apply logging sidecar solution to swatch-producer-azure

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -145,6 +145,11 @@
     </dependency>
     <dependency>
       <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-logging</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.swatch</groupId>
       <artifactId>swatch-model-billable-usage</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/deploy/rhsm-clowdapp.yaml
+++ b/deploy/rhsm-clowdapp.yaml
@@ -47,7 +47,7 @@ objects:
               listen_address: '0.0.0.0:54526'
           filelog:
             include:
-              - /logs/server.log
+              - /logs/server.log*
             start_at: end
             operators:
               - type: json_parser
@@ -67,6 +67,11 @@ objects:
               statements:
               - set(body, attributes) where IsMap(attributes)
               - keep_keys(body, ["message", "severity", "properties"])
+          resource/add_log_origin:
+            attributes:
+            - action: upsert
+              key: log_origin
+              value: otel-collector
         exporters:
           debug:
             verbosity: detailed
@@ -84,7 +89,7 @@ objects:
               exporters: [debug]
             logs/file:
               receivers: [filelog]
-              processors: [batch, transform/file_logs]
+              processors: [batch, resource/add_log_origin, transform/file_logs]
               exporters: [debug]
           telemetry:
             logs:

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,7 @@
         <module>swatch-common-kafka</module>
         <module>swatch-common-smallrye-fault-tolerance</module>
         <module>swatch-common-splunk</module>
+        <module>swatch-common-logging</module>
         <module>swatch-common-trace-response</module>
         <module>swatch-common-security</module>
         <module>swatch-common-health</module>

--- a/swatch-common-logging/pom.xml
+++ b/swatch-common-logging/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.redhat.swatch</groupId>
+    <artifactId>swatch-quarkus-parent</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <relativePath>../swatch-quarkus-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>swatch-common-logging</artifactId>
+  <name>SWATCH - Common - Logging for Quarkus</name>
+
+  <properties>
+    <java.version>21</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-logging-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/swatch-common-logging/src/main/java/com/redhat/swatch/logging/LoggingFileJsonConfiguration.java
+++ b/swatch-common-logging/src/main/java/com/redhat/swatch/logging/LoggingFileJsonConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.logging;
+
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+import org.jboss.logmanager.handlers.FileHandler;
+
+/** Attaches {@link LoggingFileJsonFormatter} to Quarkus file log handlers at startup. */
+@ApplicationScoped
+public class LoggingFileJsonConfiguration {
+
+  private static final Logger LOG = Logger.getLogger(LoggingFileJsonConfiguration.class);
+
+  @ConfigProperty(name = "LOGGING_FILE_LOG_ENABLED", defaultValue = "false")
+  boolean loggingFileLogEnabled;
+
+  void onStart(@Observes StartupEvent event) { // NOSONAR
+    if (!loggingFileLogEnabled) {
+      return;
+    }
+    for (Handler handler : findFileHandlers()) {
+      replaceFormatter(handler);
+    }
+  }
+
+  private void replaceFormatter(Handler handler) {
+    Formatter formatter = handler.getFormatter();
+    if (formatter instanceof LoggingFileJsonFormatter) {
+      return;
+    }
+    if (formatter instanceof JsonFormatter jsonFormatter) {
+      handler.setFormatter(LoggingFileJsonFormatter.fromQuarkusJsonFormatter(jsonFormatter));
+      LOG.infof("Installed LoggingFileJsonFormatter on file handler %s", handler);
+    }
+  }
+
+  private static List<Handler> findFileHandlers() {
+    List<Handler> fileHandlers = new ArrayList<>();
+    collectHandlers(LogManager.getLogManager().getLogger("").getHandlers(), fileHandlers);
+    return fileHandlers;
+  }
+
+  private static void collectHandlers(Handler[] handlers, List<Handler> fileHandlers) {
+    if (handlers == null) {
+      return;
+    }
+    for (Handler handler : handlers) {
+      if (handler instanceof FileHandler) {
+        fileHandlers.add(handler);
+      } else if (handler instanceof QuarkusDelayedHandler delayedHandler) {
+        collectHandlers(delayedHandler.getHandlers(), fileHandlers);
+      }
+    }
+  }
+}

--- a/swatch-common-logging/src/main/java/com/redhat/swatch/logging/LoggingFileJsonFormatter.java
+++ b/swatch-common-logging/src/main/java/com/redhat/swatch/logging/LoggingFileJsonFormatter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.logging.json.runtime.JsonFormatter;
+import java.util.Map;
+import java.util.logging.Formatter;
+import org.jboss.logmanager.ExtFormatter;
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.formatters.PatternFormatter;
+
+/**
+ * JSON formatter for the Quarkus file log handler: {@code message}, {@code severity}, and optional
+ * {@code properties} (MDC). Log origin for the sidecar path is set by the OTEL collector ({@code
+ * log_origin=otel-collector}), not in this JSON payload.
+ */
+public class LoggingFileJsonFormatter extends ExtFormatter {
+
+  private static final String FIELD_MESSAGE = "message";
+  private static final String FIELD_SEVERITY = "severity";
+  private static final String FIELD_PROPERTIES = "properties";
+
+  private static final String MESSAGE_FORMAT =
+      "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static volatile Formatter messageFormatter;
+
+  private String recordDelimiter = "\n";
+
+  public static LoggingFileJsonFormatter fromQuarkusJsonFormatter(JsonFormatter source) {
+    LoggingFileJsonFormatter target = new LoggingFileJsonFormatter();
+    String delimiter = source.getRecordDelimiter();
+    if (delimiter != null) {
+      target.recordDelimiter = delimiter;
+    }
+    return target;
+  }
+
+  @Override
+  public String format(ExtLogRecord record) {
+    try {
+      ObjectNode json = MAPPER.createObjectNode();
+      json.put(FIELD_MESSAGE, formatMessage(record));
+      json.put(FIELD_SEVERITY, record.getLevel().getName());
+
+      Map<String, String> mdc = record.getMdcCopy();
+      if (!mdc.isEmpty()) {
+        ObjectNode properties = json.putObject(FIELD_PROPERTIES);
+        mdc.forEach(properties::put);
+      }
+
+      return json + recordDelimiter;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to format file JSON log record", e);
+    }
+  }
+
+  private static String formatMessage(ExtLogRecord record) {
+    return getMessageFormatter().format(record).stripTrailing();
+  }
+
+  private static Formatter getMessageFormatter() {
+    Formatter formatter = messageFormatter;
+    if (formatter == null) {
+      synchronized (LoggingFileJsonFormatter.class) {
+        formatter = messageFormatter;
+        if (formatter == null) {
+          messageFormatter = new PatternFormatter(MESSAGE_FORMAT);
+          formatter = messageFormatter;
+        }
+      }
+    }
+    return formatter;
+  }
+}

--- a/swatch-common-logging/src/test/java/com/redhat/swatch/logging/LoggingFileJsonFormatterTest.java
+++ b/swatch-common-logging/src/test/java/com/redhat/swatch/logging/LoggingFileJsonFormatterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+import org.junit.jupiter.api.Test;
+
+class LoggingFileJsonFormatterTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void emitsFlatJsonWithoutDefaultFields() throws Exception {
+    ExtLogRecord record = new ExtLogRecord(Level.INFO, "Hello", null);
+    record.setLoggerName("com.redhat.swatch.test");
+    record.setThreadName("main");
+
+    JsonNode node = MAPPER.readTree(new LoggingFileJsonFormatter().format(record));
+
+    assertEquals(2, countFields(node));
+    assertTrue(node.has("message"));
+    assertTrue(node.has("severity"));
+    assertEquals("INFO", node.get("severity").asText());
+    assertTrue(node.get("message").asText().contains("Hello"));
+    assertFalse(node.has("properties"));
+    assertFalse(node.has("timestamp"));
+    assertFalse(node.has("mdc"));
+  }
+
+  @Test
+  void mdcIsMappedToProperties() throws Exception {
+    ExtLogRecord record = new ExtLogRecord(Level.WARN, "With trace", null);
+    record.setLoggerName("com.redhat.swatch.test");
+    record.putMdc("traceId", "abc123");
+
+    JsonNode node = MAPPER.readTree(new LoggingFileJsonFormatter().format(record));
+
+    assertTrue(node.has("properties"));
+    assertEquals("abc123", node.get("properties").get("traceId").asText());
+    assertEquals("WARN", node.get("severity").asText());
+  }
+
+  private static long countFields(JsonNode node) {
+    long count = 0;
+    var fields = node.fieldNames();
+    while (fields.hasNext()) {
+      fields.next();
+      count++;
+    }
+    return count;
+  }
+}

--- a/swatch-producer-azure/deploy/clowdapp.yaml
+++ b/swatch-producer-azure/deploy/clowdapp.yaml
@@ -45,6 +45,10 @@ parameters:
     value: '3'
   - name: LOGGING_HEC_INCLUDE_EX
     value: 'true'
+  - name: LOGGING_FILE_LOG_ENABLED
+    value: 'true'
+  - name: LOGGING_FILE_MAX_SIZE
+    value: '10M'
   - name: LOGGING_LEVEL_ROOT
     value: 'INFO'
   - name: LOGGING_LEVEL_COM_REDHAT_SWATCH
@@ -110,6 +114,8 @@ objects:
             enabled: true
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
+          # Extra grace time so the otel sidecar can finish reading /logs/server.log and export to HEC before the shared volume is torn down.
+          terminationGracePeriodSeconds: 90
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -179,6 +185,10 @@ objects:
               value: ${LOGGING_HEC_RETRY_COUNT}
             - name: LOGGING_HEC_INCLUDE_EX
               value: ${LOGGING_HEC_INCLUDE_EX}
+            - name: LOGGING_FILE_LOG_ENABLED
+              value: ${LOGGING_FILE_LOG_ENABLED}
+            - name: LOGGING_FILE_MAX_SIZE
+              value: ${LOGGING_FILE_MAX_SIZE}
             - name: SWATCH_SELF_PSK
               valueFrom:
                 secretKeyRef:
@@ -204,12 +214,15 @@ objects:
               mountPath: /logs
           volumes:
             - name: logs
-              emptyDir:
+              emptyDir: {}
           sidecars:
           - name: otel-collector
             enabled: true
             configMap: ${OTEL_SIDECAR_CONFIG_MAP}
             image: ${OTEL_SIDECAR_IMAGE}
+            volumeMounts:
+              - name: logs
+                mountPath: /logs
             envVars:
               - name: ENV_NAME
                 value: ${OTEL_ENV_NAME}

--- a/swatch-producer-azure/pom.xml
+++ b/swatch-producer-azure/pom.xml
@@ -105,6 +105,10 @@
       <artifactId>swatch-common-splunk</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>

--- a/swatch-producer-azure/src/main/resources/application.properties
+++ b/swatch-producer-azure/src/main/resources/application.properties
@@ -10,6 +10,8 @@ LOGGING_HEC_BATCH_SIZE=1000
 LOGGING_HEC_BATCH_INTERVAL=10S
 LOGGING_HEC_RETRY_COUNT=3
 LOGGING_HEC_INCLUDE_EX=true
+LOGGING_FILE_LOG_ENABLED=false
+LOGGING_FILE_MAX_SIZE=10M
 USAGE_AGGREGATE_FAIL_ON_DESER_FAILURE=false
 WIREMOCK_ENDPOINT=http://wiremock-service:8000
 CORS_ORIGINS=/.+\\\\.redhat\\\\.com/
@@ -86,6 +88,14 @@ AZURE_OIDC_SAAS_MARKETPLACE_RESOURCE=20e940b3-4c77-4b0b-9a53-9e16a1b010a7
 quarkus.log.level=${LOGGING_LEVEL_ROOT}
 quarkus.log.category."com.redhat.swatch".level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
 quarkus.log.category."org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext".level=DEBUG
+quarkus.log.console.json.enabled=false
+quarkus.log.file.enabled=${LOGGING_FILE_LOG_ENABLED}
+# Must match swatch-otel-config filelog include (/logs/server.log*).
+quarkus.log.file.path=/logs/server.log
+quarkus.log.file.level=${LOGGING_LEVEL_COM_REDHAT_SWATCH}
+quarkus.log.file.json.enabled=true
+quarkus.log.file.rotation.max-file-size=${LOGGING_FILE_MAX_SIZE}
+quarkus.log.file.rotation.max-backup-index=2
 
 quarkus.http.port=${SERVER_PORT}
 # make quarkus choose a dynamic port for testing to avoid port collisions w/ simultaneous tests
@@ -174,6 +184,8 @@ quarkus.log.handler.splunk.batch-size-count=${LOGGING_HEC_BATCH_SIZE:1000}
 quarkus.log.handler.splunk.batch-interval=${LOGGING_HEC_BATCH_INTERVAL:10S}
 quarkus.log.handler.splunk.max-retries=${LOGGING_HEC_RETRY_COUNT:0}
 quarkus.log.handler.splunk.metadata-fields.namespace=${LOGGING_NAMESPACE:local}
+# Distinguishes runtime HEC from file -> otel-collector -> HEC
+quarkus.log.handler.splunk.metadata-fields.log_origin=runtime
 quarkus.log.handler.splunk.format=%d %-5p [%c{3.}] (%t) %s%e%n
 quarkus.log.handler.splunk.include-exception=${LOGGING_HEC_INCLUDE_EX:false}
 # otel config

--- a/swatch-quarkus-parent/pom.xml
+++ b/swatch-quarkus-parent/pom.xml
@@ -96,6 +96,11 @@
       </dependency>
       <dependency>
         <groupId>com.redhat.swatch</groupId>
+        <artifactId>swatch-common-logging</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.redhat.swatch</groupId>
         <artifactId>swatch-model-billable-usage</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Jira issue: SWATCH-4836

## Description
Changes:
- Apply the solution agreed in SWATCH-4753: https://docs.google.com/document/d/1sHx2BAhvF016X5DeQTuZwAf2gVHSyhGqrLgnj2oPjGc/edit?usp=sharing
- Added swatch-common-logging module for Quarkus services + configure swatch-producer-azure
- Added new metadata "log_origin" with optional values: "runtime" or "otel-collector": https://gitlab.cee.redhat.com/rhsm/swatch-otel-config/-/merge_requests/1

## Testing
Follow steps from https://privatebin.corp.redhat.com/?21682108e15105a1#EBLRVehnz1uabF5YRminZCeAtnYE712fE2QMLSnHjp59.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional JSON file logging with configurable file size and rotation settings.
  * Added structured log fields, including severity, message properties, and log origin.
  * Added support for collecting rotated server log files through OpenTelemetry.
  * Improved shutdown handling to allow pending logs to be exported.
* **Configuration**
  * Added shared logging support and application settings for enabling and tuning file-based logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->