### PR TITLE
fix: IQE ephemeral integration pipeline deploy error w/ puptoo

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -46,6 +46,7 @@ spec:
         --timeout 1800
         --exclude-components puptoo,ingress,storage-broker,swatch-tally-ct-hbi
         --remove-dependencies host-inventory/ingress
+        --remove-dependencies host-inventory/puptoo
         -p rbac/CELERY_INITIAL_DELAY_SEC=10
         -p rbac/MAX_SEED_THREADS=8
         -p rbac/MIN_POSTGRES_EXPORTER_REPLICAS=0


### PR DESCRIPTION

## Description
Due to host-inventory recently making puptoo a hard dependency in their clowdapp, our IQE ephemeral integration tests pipeline started to fail in every PR due to a deployment timeout. This is because we did not explicitly strip `host-inventory/puptoo` before and did not need to when puptoo was not a hard dependency of host-inventory. This change adds a line to remove that specific dependency as well.

## Testing

### Steps
1. Run this deploy command on EE:
```
bonfire deploy rhsm \
  --reserve \
  --duration 2h \
  --source=appsre \
  --ref-env insights-stage \
  --optional-deps-method none \
  --frontends false \
  --no-remove-resources app:rhsm \
  --no-remove-resources app:export-service \
  --timeout 800 \
  --exclude-components puptoo,ingress,storage-broker,swatch-tally-ct-hbi \
  --remove-dependencies host-inventory/ingress \
  --remove-dependencies host-inventory/puptoo \
  -p rbac/CELERY_INITIAL_DELAY_SEC=10 \
  -p rbac/MAX_SEED_THREADS=8 \
  -p rbac/MIN_POSTGRES_EXPORTER_REPLICAS=0 \
  -p rbac/NOTIFICATIONS_ENABLED=False \
  -p rbac/NOTIFICATIONS_RH_ENABLED=False \
  -p rbac/KAFKA_ENABLED=False \
  -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0 \
  -p host-inventory/GUNICORN_WORKERS=1 \
  -p host-inventory/GUNICORN_THREADS=1 \
  -p host-inventory/REPLICAS_EXPORT_SVC=0 \
  -p host-inventory/REPLICAS_WORKSPACES=0 \
  -p host-inventory/REPLICAS_WORKSPACES_BULK=0 \
  -p host-inventory/REPLICAS_HOST_APP_DATA=0
```

### Verification
1. Successful deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test deployment configuration to exclude the `host-inventory/puptoo` dependency alongside the existing exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->