### PR TITLE
SWATCH-5276: Use wiremock to replace rbac dependency for swatch-utilization and swatch-contracts

### DIFF
--- a/swatch-billable-usage/ct/README.md
+++ b/swatch-billable-usage/ct/README.md
@@ -25,7 +25,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-bill
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --no-remove-resources app:rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-billable-usage --remove-dependencies swatch-billable-usage/swatch-contracts
+bonfire deploy rhsm --no-remove-resources app:rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-billable-usage --remove-dependencies swatch-billable-usage/swatch-contracts --set-parameter swatch-billable-usage/QUARKUS_PROFILE=ephemeral,component-tests
 ```
 
 You can use a custom image of the service by adding the following parameters to the previous command: `-p swatch-billable-usage/IMAGE=quay.io/jcarvaja/swatch-billable-usage -p swatch-billable-usage/IMAGE_TAG=94b0808`.

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -13,6 +13,8 @@ RBAC_ENABLED=true
 RBAC_ENDPOINT=${clowder.endpoints.rbac-service.url}
 %dev.RBAC_ENDPOINT=http://localhost:8006
 %test.RBAC_ENDPOINT=http://localhost:8080
+%component-tests.RBAC_ENDPOINT=http://wiremock-service:8000
+
 # Note the keystore and truststore values must be prefixed with either "classpath:" or "file:"
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".url=${RBAC_ENDPOINT}/api/rbac/v1
 quarkus.rest-client."com.redhat.swatch.clients.rbac.api.resources.AccessApi".trust-store=${clowder.endpoints.rbac-service.trust-store-path}

--- a/swatch-contracts/ct/README.md
+++ b/swatch-contracts/ct/README.md
@@ -27,7 +27,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-cont
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-contracts --no-remove-resources app:rhsm
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component swatch-database --component wiremock --component artemis --component swatch-contracts --remove-dependencies swatch-contracts --no-remove-dependencies swatch-contracts/swatch-database --no-remove-resources app:rhsm --set-parameter swatch-contracts/QUARKUS_PROFILE=ephemeral,component-tests
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -73,6 +73,11 @@ SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=60d
 %ephemeral.PRODUCT_URL=${WIREMOCK_ENDPOINT}/mock/product
 %prod.PRODUCT_URL=https://product.api.redhat.com/svcrest/product/v3
 
+# Export Service configuration
+EXPORT_SERVICE_ENDPOINT=${clowder.optional-private-endpoints.export-service-service.url}
+%test.EXPORT_SERVICE_ENDPOINT=http://localhost:10000
+%component-tests.EXPORT_SERVICE_ENDPOINT=http://wiremock-service:8000
+
 # dev-specific config items that don't need to be overridden via env var
 # do not use JSON logs in dev mode
 %dev.quarkus.log.console.json=false
@@ -184,17 +189,17 @@ quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi"
 # Setting up the timeout to 60 seconds instead of 30 seconds (default)
 quarkus.rest-client."com.redhat.swatch.clients.product.api.resources.ProductApi".read-timeout=90000
 
-quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".url=${clowder.private-endpoints.export-service-service.url:http://localhost:10000}
-quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store=${clowder.private-endpoints.export-service-service.trust-store-path}
-quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store-password=${clowder.private-endpoints.export-service-service.trust-store-password}
-quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store-type=${clowder.private-endpoints.export-service-service.trust-store-type}
+quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".url=${EXPORT_SERVICE_ENDPOINT}
+quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store=${clowder.optional-private-endpoints.export-service-service.trust-store-path}
+quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store-password=${clowder.optional-private-endpoints.export-service-service.trust-store-password}
+quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".trust-store-type=${clowder.optional-private-endpoints.export-service-service.trust-store-type}
 quarkus.rest-client."com.redhat.swatch.clients.export.api.resources.ExportApi".providers=com.redhat.swatch.contract.service.export.ExportPskHeaderProvider
 
 # avoid duplicate/wrong enum names and other problems by preventing generated interfaces from being
 # added back into the API spec
 mp.openapi.scan.exclude.packages=com.redhat.swatch.contract.openapi
 
-SWATCH_CONTRACT_PRODUCER_ENABLED = false
+SWATCH_CONTRACT_PRODUCER_ENABLED=false
 
 UMB_ENABLED=false
 %ephemeral.UMB_ENABLED=true

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/ExportServiceWireMockResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/ExportServiceWireMockResource.java
@@ -48,7 +48,7 @@ public class ExportServiceWireMockResource implements QuarkusTestResourceLifecyc
   public Map<String, String> start() {
     wireMockServer = startWireMockServer();
     setup();
-    return Map.of("clowder.private-endpoints.export-service-service.url", wireMockServer.baseUrl());
+    return Map.of("EXPORT_SERVICE_ENDPOINT", wireMockServer.baseUrl());
   }
 
   @Override

--- a/swatch-producer-aws/ct/README.md
+++ b/swatch-producer-aws/ct/README.md
@@ -31,7 +31,7 @@ make build component-test swatch-producer-aws
 Deploy only the necessary dependencies for `swatch-producer-aws`:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component wiremock --component swatch-producer-aws --no-remove-resources app:rhsm --remove-dependencies swatch-producer-aws
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component wiremock --component swatch-producer-aws --no-remove-resources app:rhsm --remove-dependencies swatch-producer-aws --set-parameter swatch-producer-aws/QUARKUS_PROFILE=ephemeral,component-tests
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-producer-azure/ct/README.md
+++ b/swatch-producer-azure/ct/README.md
@@ -27,7 +27,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-prod
 Deploy only the necessary dependencies for a specific service:
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component wiremock --component swatch-producer-azure --no-remove-resources app:rhsm --remove-dependencies swatch-producer-azure
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-kafka-bridge --component wiremock --component swatch-producer-azure --no-remove-resources app:rhsm --remove-dependencies swatch-producer-azure --set-parameter swatch-producer-azure/QUARKUS_PROFILE=ephemeral,component-tests
 ```
 
 ### 2. Run Component Tests Against OpenShift

--- a/swatch-utilization/ct/README.md
+++ b/swatch-utilization/ct/README.md
@@ -27,7 +27,7 @@ Execute tests for a specific service. For example, to run tests for `swatch-util
 Deploy only the necessary dependencies for a specific service. For example, for `swatch-utilization` (which only requires wiremock and kafka bridge, as Kafka comes by default):
 
 ```bash
-bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-utilization --remove-dependencies swatch-utilization/swatch-contracts --component swatch-kafka-bridge
+bonfire deploy rhsm --source=appsre --ref-env insights-stage --component rhsm --component swatch-utilization --component swatch-kafka-bridge --remove-dependencies swatch-utilization --no-remove-dependencies swatch-utilization/swatch-database --no-remove-resources app:rhsm --set-parameter swatch-utilization/QUARKUS_PROFILE=ephemeral,component-tests
 ```
 
 ### 2. Run Component Tests Against OpenShift


### PR DESCRIPTION
Jira issue: SWATCH-5276

## Description
Changes:
- start using wiremock instead of the real rbac service for the component tests of swatch-contracts and swatch-utilization
- new pattern to deploy bonfire in component tests: remove all the dependencies except the swatch-database required one. 

Related to the konflux changes: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/20672

## Testing
Run the bonfire commands with `--remove-dependencies swatch-utilization --no-remove-dependencies swatch-utilization/swatch-database` to remove ALL the dependencies except the swatch-database. This was necessary to also not deploy the kessel dependency when added. 

1.- verify swatch-utilization works without the rbac service:
```
bonfire deploy --source=appsre --ref-env insights-production --timeout 900 --optional-deps-method hybrid --frontends true --component swatch-kafka-bridge --component swatch-utilization --component rhsm --no-remove-resources app:rhsm --remove-dependencies swatch-utilization --no-remove-dependencies swatch-utilization/swatch-database --set-template-ref rhsm=6c1507ffb7ad3307f8f17641b1ed3d827041a7db --set-parameter swatch-utilization/QUARKUS_PROFILE=ephemeral,component-tests --set-template-ref swatch-utilization=6c1507ffb7ad3307f8f17641b1ed3d827041a7db --set-parameter swatch-utilization/IMAGE=quay.io/redhat-user-workloads/rh-subs-watch-tenant/rhsm-subscriptions/swatch-utilization@sha256 --set-image-tag quay.io/redhat-user-workloads/rh-subs-watch-tenant/rhsm-subscriptions/swatch-utilization@sha256=9beefd66498f80dd3b3e1d5fd466613e87c967a147b0cde5a40aa33af4eeac64 rhsm
```

2.- run the component tests:

```
./mvnw clean install -Pcomponent-tests -pl swatch-utilization/ct -am -Dswatch.component-tests.global.target=openshift
```

All the tests should pass.

3.- verify the swatch-contracts works without the rbac and export service:

```
bonfire deploy --source=appsre --ref-env insights-production --timeout 900 --optional-deps-method hybrid --frontends true --component wiremock --component swatch-kafka-bridge --component artemis --component swatch-contracts --component rhsm --remove-dependencies swatch-contracts --no-remove-dependencies swatch-contracts/swatch-database --no-remove-resources app:rhsm --set-template-ref rhsm=6c1507ffb7ad3307f8f17641b1ed3d827041a7db --set-parameter swatch-contracts/QUARKUS_PROFILE=ephemeral,component-tests --set-template-ref swatch-contracts=6c1507ffb7ad3307f8f17641b1ed3d827041a7db --set-parameter swatch-contracts/IMAGE=quay.io/redhat-user-workloads/rh-subs-watch-tenant/rhsm-subscriptions/swatch-contracts@sha256 --set-image-tag quay.io/redhat-user-workloads/rh-subs-watch-tenant/rhsm-subscriptions/swatch-contracts@sha256=0a3eb734fd1babe19a1448bec4d83d418e36d9d973184831ea1a85691ee2f22f rhsm
```

4.- run the component tests:

```
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am -Dswatch.component-tests.global.target=openshift
```

All the tests should pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component-test configuration for connecting to WireMock services.
  * Updated export service settings to support profile-specific endpoints and Clowder-managed service configuration.

* **Documentation**
  * Updated OpenShift component-test deployment instructions with refined dependency handling and Quarkus profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->