### PR TITLE
SWATCH-4605: Align Kafka IT partner gateway logic with UMB.

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumer.java
@@ -22,9 +22,12 @@ package com.redhat.swatch.contract.resource;
 
 import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.contract.config.FeatureFlags;
+import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
 import com.redhat.swatch.contract.openapi.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.service.ContractService;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -37,52 +40,54 @@ public class ContractsPartnerEntitlementMessageConsumer {
 
   @Inject FeatureFlags featureFlags;
   @Inject ObjectMapper mapper;
+  @Inject ContractService service;
 
   @Blocking
   @Incoming(CONTRACTS_FROM_GATEWAY)
-  public void consumeMessage(String dtoContract) {
-    if (!featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()) {
-      log.debug("IT Partner Kafka consumer for contracts is disabled by feature flag.");
-      return;
-    }
-
+  public void consumeMessage(String dtoContract) throws JsonProcessingException {
     log.debug("IT Partner Kafka consumer was called");
     if (dtoContract == null) {
       return;
     }
-
+    if (!featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()) {
+      log.debug("IT Partner Kafka consumer for contracts is disabled by feature flag.");
+      return;
+    }
     consumeContract(dtoContract);
   }
 
-  public void consumeContract(String dtoContract) {
+  public void consumeContract(String dtoContract) throws JsonProcessingException {
     log.info(dtoContract);
 
+    PartnerEntitlementContract contract;
     try {
-      PartnerEntitlementContract contract =
-          mapper.readValue(dtoContract, PartnerEntitlementContract.class);
-
-      String awsCustomerAccountId = null;
-      String productCode = null;
-      String azureResourceId = null;
-
-      if (contract.getCloudIdentifiers() != null) {
-        awsCustomerAccountId = contract.getCloudIdentifiers().getAwsCustomerAccountId();
-        productCode = contract.getCloudIdentifiers().getProductCode();
-        azureResourceId = contract.getCloudIdentifiers().getAzureResourceId();
-      }
-
-      log.info(
-          "IT Partner message consumed: source=kafka, action={}, "
-              + "awsCustomerAccountId={}, productCode={}, azureResourceId={}, "
-              + "redHatSubscriptionNumber={}",
-          contract.getAction(),
-          awsCustomerAccountId,
-          productCode,
-          azureResourceId,
-          contract.getRedHatSubscriptionNumber());
-
-    } catch (Exception e) {
+      contract = mapper.readValue(dtoContract, PartnerEntitlementContract.class);
+    } catch (JsonProcessingException e) {
       log.warn("Unable to read IT Partner Kafka message from JSON.", e);
+      throw e;
     }
+
+    String awsCustomerAccountId = null;
+    String productCode = null;
+    String azureResourceId = null;
+
+    if (contract.getCloudIdentifiers() != null) {
+      awsCustomerAccountId = contract.getCloudIdentifiers().getAwsCustomerAccountId();
+      productCode = contract.getCloudIdentifiers().getProductCode();
+      azureResourceId = contract.getCloudIdentifiers().getAzureResourceId();
+    }
+
+    log.info(
+        "IT Partner message consumed: source=kafka, action={}, "
+            + "awsCustomerAccountId={}, productCode={}, azureResourceId={}, "
+            + "redHatSubscriptionNumber={}",
+        contract.getAction(),
+        awsCustomerAccountId,
+        productCode,
+        azureResourceId,
+        contract.getRedHatSubscriptionNumber());
+
+    var response = service.createPartnerContract(PartnerEntitlementsRequest.from(contract));
+    log.debug("kafka response: {}", response);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -197,7 +197,7 @@ public class ContractService {
   public StatusResponse createPartnerContract(PartnerEntitlementsRequest request) {
     var partnerEntitlementsProvider = findPartnerEntitlementsProvider(request);
     if (partnerEntitlementsProvider == null) {
-      log.info("Can't process the contract from UMB: {}", request);
+      log.info("Can't process the partner contract: {}", request);
       return INVALID_MESSAGE_UNPROCESSED.toStatus();
     }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsPartnerEntitlementMessageConsumerTest.java
@@ -22,12 +22,16 @@ package com.redhat.swatch.contract.resource;
 
 import static com.redhat.swatch.contract.config.Channels.CONTRACTS_FROM_GATEWAY;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.config.FeatureFlags;
+import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
+import com.redhat.swatch.contract.openapi.model.StatusResponse;
+import com.redhat.swatch.contract.service.ContractService;
 import com.redhat.swatch.contract.test.LoggerCaptor;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -40,6 +44,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @QuarkusTest
 class ContractsPartnerEntitlementMessageConsumerTest {
@@ -85,6 +90,7 @@ class ContractsPartnerEntitlementMessageConsumerTest {
   @Inject @Any InMemoryConnector connector;
 
   @InjectMock FeatureFlags featureFlags;
+  @InjectMock ContractService contractService;
   @InjectSpy ContractsPartnerEntitlementMessageConsumer consumer;
 
   private InMemorySource<Object> contractsKafkaChannel;
@@ -98,13 +104,24 @@ class ContractsPartnerEntitlementMessageConsumerTest {
   void setUp() {
     contractsKafkaChannel = connector.source(CONTRACTS_FROM_GATEWAY);
     LoggerCaptor.clearRecords();
+    Mockito.reset(contractService, featureFlags);
     when(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()).thenReturn(true);
+    StatusResponse mockResponse = new StatusResponse();
+    mockResponse.setMessage("Contract created");
+    when(contractService.createPartnerContract(any(PartnerEntitlementsRequest.class)))
+        .thenReturn(mockResponse);
   }
 
   @Test
   void shouldProcessStringMessage() {
     whenSendMessage(VALID_JSON_MESSAGE);
-    assertMessageIsProcessed();
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeContract(VALID_JSON_MESSAGE);
+              verify(contractService).createPartnerContract(any(PartnerEntitlementsRequest.class));
+            });
   }
 
   @Test
@@ -116,6 +133,7 @@ class ContractsPartnerEntitlementMessageConsumerTest {
             () -> {
               verify(consumer).consumeContract(JSON_WITH_EXTRA_LICENSE_ARN_FIELD);
               thenKafkaContractDeserializedSuccessfully();
+              verify(contractService).createPartnerContract(any(PartnerEntitlementsRequest.class));
             });
   }
 
@@ -123,23 +141,40 @@ class ContractsPartnerEntitlementMessageConsumerTest {
   void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
     when(featureFlags.isPartnerGatewayContractsKafkaConsumerEnabled()).thenReturn(false);
     whenSendMessage(VALID_JSON_MESSAGE);
-    assertMessageIsNotProcessed();
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer, never()).consumeContract(anyString());
+              verify(contractService, never())
+                  .createPartnerContract(any(PartnerEntitlementsRequest.class));
+            });
+  }
+
+  @Test
+  void shouldNotLogSuccessWhenMessageIsInvalidJson() {
+    whenSendMessage("not-valid-json");
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeContract("not-valid-json");
+              LoggerCaptor.thenWarnLogWithMessage("Unable to read IT Partner Kafka message");
+              verify(contractService, never())
+                  .createPartnerContract(any(PartnerEntitlementsRequest.class));
+            });
+  }
+
+  @Test
+  void shouldIgnoreNullMessage() throws Exception {
+    consumer.consumeMessage(null);
+
+    LoggerCaptor.thenLogNothing();
+    verify(contractService, never()).createPartnerContract(any(PartnerEntitlementsRequest.class));
   }
 
   private void whenSendMessage(String message) {
     contractsKafkaChannel.send(message);
-  }
-
-  private void assertMessageIsProcessed() {
-    await()
-        .atMost(Duration.ofMillis(500))
-        .untilAsserted(() -> verify(consumer).consumeContract(anyString()));
-  }
-
-  private void assertMessageIsNotProcessed() {
-    await()
-        .atMost(Duration.ofMillis(500))
-        .untilAsserted(() -> verify(consumer, never()).consumeContract(anyString()));
   }
 
   private static void thenKafkaContractDeserializedSuccessfully() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-4605

## Description
This PR matches the aligns Kafka consumer logic with the existing UMB consumer.
I also changed the log in contract service to be agnostic.

## Testing
Unit tests included

```
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
```

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Incoming partner entitlement messages now automatically create partner contracts.
- **Bug Fixes**
  - JSON parsing failures are now handled more transparently (warned and treated as errors rather than silently ignored).
  - Clearer logging when partner contracts can’t be processed.
  - Null messages are safely ignored before any processing checks.
- **Tests**
  - Expanded and adjusted consumer tests for successful processing, invalid JSON, null inputs, and scenarios where processing is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->