### PR TITLE
SWATCH-5298: Add licenseId to billable_usage_remittance.

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceEntity.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceEntity.java
@@ -97,6 +97,9 @@ public class BillableUsageRemittanceEntity implements Serializable {
   @Column(name = "updated_at")
   private OffsetDateTime updatedAt;
 
+  @Column(name = "license_id")
+  private String licenseId;
+
   @PreUpdate
   @PrePersist
   public void onCreateOrUpdate() {

--- a/swatch-billable-usage/src/main/resources/db/202607231000-add-license-id-to-billable-usage-remittance.xml
+++ b/swatch-billable-usage/src/main/resources/db/202607231000-add-license-id-to-billable-usage-remittance.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202607231000-001" author="gmantzou">
+    <!-- Idempotent: skip if column already exists (e.g. manually applied or partial rollout). -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="billable_usage_remittance" columnName="license_id"/>
+      </not>
+    </preConditions>
+    <comment>Add nullable license_id column to billable_usage_remittance for AWS concurrent agreement troubleshooting</comment>
+    <addColumn tableName="billable_usage_remittance">
+      <column name="license_id" type="VARCHAR(255)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+
+    <rollback>
+      <dropColumn tableName="billable_usage_remittance" columnName="license_id"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/swatch-billable-usage/src/main/resources/db/changelog.xml
+++ b/swatch-billable-usage/src/main/resources/db/changelog.xml
@@ -8,5 +8,6 @@
 
   <include file="/db/202510051200-create-billable-usage-remittance-table.xml"/>
   <include file="/db/202604021015-add-primary-key-to-changelog-table.xml"/>
+  <include file="/db/202607231000-add-license-id-to-billable-usage-remittance.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5298

## Description
Schema-only change. Adds nullable license_id to billable_usage_remittance table and entity to support troubleshooting of concurrent AWS agreements where multiple contracts share the same billingAccountId.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for associating billable usage remittances with a license ID.

* **Database**
  * Added a nullable license ID field to billable usage remittance records.
  * Included a reversible database migration for the new field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->