### PR TITLE
SWATCH-5170: Expose Unleash feature flags on Quarkus /info for CT waits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,6 +593,7 @@
         <module>swatch-common-trace-response</module>
         <module>swatch-common-security</module>
         <module>swatch-common-health</module>
+        <module>swatch-common-info</module>
         <module>swatch-common-models</module>
         <module>swatch-common-testcontainers</module>
         <module>swatch-model-events</module>

--- a/swatch-common-info/pom.xml
+++ b/swatch-common-info/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.redhat.swatch</groupId>
+    <artifactId>swatch-quarkus-parent</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <relativePath>../swatch-quarkus-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>swatch-common-info</artifactId>
+  <name>SWATCH - Common - Info for Quarkus</name>
+
+  <properties>
+    <java.version>21</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jsonschema2pojo</groupId>
+        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+        <configuration>
+          <targetPackage>com.redhat.swatch.info.model</targetPackage>
+          <includeAdditionalProperties>false</includeAdditionalProperties>
+          <includeJsr303Annotations>true</includeJsr303Annotations>
+          <initializeCollections>false</initializeCollections>
+          <dateTimeType>java.time.OffsetDateTime</dateTimeType>
+          <sourceType>yamlschema</sourceType>
+          <generateBuilders>true</generateBuilders>
+          <includeGetters>true</includeGetters>
+          <includeSetters>true</includeSetters>
+          <useJakartaValidation>true</useJakartaValidation>
+        </configuration>
+        <executions>
+          <!-- Disable inherited default execution (expects module-local schemas/) -->
+          <execution>
+            <id>default</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>info-feature-flags</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sourceDirectory>${maven.multiModuleProjectDirectory}/swatch-core/schemas</sourceDirectory>
+              <includes>
+                <include>info_feature_flags.yaml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.unleash</groupId>
+      <artifactId>quarkus-unleash</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoAggregator.java
+++ b/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoAggregator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.info;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Builds the {@code /info} JSON payload from all CDI {@link InfoContributor} beans. */
+@ApplicationScoped
+public class InfoAggregator {
+
+  private final Instance<InfoContributor> contributors;
+
+  @Inject
+  public InfoAggregator(Instance<InfoContributor> contributors) {
+    this.contributors = contributors;
+  }
+
+  /**
+   * Aggregates contributor sections. Contributors that return {@code null} or an empty map /
+   * collection are skipped so optional sections (such as feature flags) are absent when unused.
+   */
+  public Map<String, Object> buildInfo() {
+    Map<String, Object> info = new LinkedHashMap<>();
+    for (InfoContributor contributor : contributors) {
+      Object data = contributor.data();
+      if (hasContent(data)) {
+        info.put(contributor.name(), data);
+      }
+    }
+    return info;
+  }
+
+  private static boolean hasContent(Object data) {
+    if (data == null) {
+      return false;
+    }
+    if (data instanceof Map<?, ?> map) {
+      return !map.isEmpty();
+    }
+    if (data instanceof Collection<?> collection) {
+      return !collection.isEmpty();
+    }
+    return true;
+  }
+}

--- a/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoContributor.java
+++ b/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoContributor.java
@@ -18,32 +18,22 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.hbi.events.services;
+package com.redhat.swatch.info;
 
-import com.redhat.swatch.info.InfoFeatureFlagContributor;
-import com.redhat.swatch.info.UnleashInfoFeatureFlags;
-import com.redhat.swatch.info.model.InfoFeatureFlags;
-import io.getunleash.Unleash;
-import jakarta.enterprise.context.ApplicationScoped;
-import lombok.extern.slf4j.Slf4j;
+/**
+ * Contributes a named section to the management {@code /info} endpoint.
+ *
+ * <p>Unlike Quarkus {@code quarkus-info} contributors (evaluated at startup), {@link #data()} is
+ * invoked on every request so services can wire runtime state (for example feature flags).
+ */
+public interface InfoContributor {
 
-@Slf4j
-@ApplicationScoped
-public class FeatureFlags implements InfoFeatureFlagContributor {
-  public static final String EMIT_EVENTS = "swatch.swatch-metrics-hbi.emit-events";
+  /** Top-level JSON key for this contribution (for example {@code feature-flags}). */
+  String name();
 
-  private final Unleash unleash;
-
-  public FeatureFlags(Unleash unleash) {
-    this.unleash = unleash;
-  }
-
-  public boolean emitEvents() {
-    return unleash.isEnabled(FeatureFlags.EMIT_EVENTS);
-  }
-
-  @Override
-  public InfoFeatureFlags getFeatureFlags() {
-    return UnleashInfoFeatureFlags.snapshot(unleash, EMIT_EVENTS);
-  }
+  /**
+   * Section payload evaluated at request time. {@code null} or empty maps/collections are omitted
+   * from the response.
+   */
+  Object data();
 }

--- a/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoFeatureFlagContributor.java
+++ b/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoFeatureFlagContributor.java
@@ -18,32 +18,34 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.hbi.events.services;
+package com.redhat.swatch.info;
 
-import com.redhat.swatch.info.InfoFeatureFlagContributor;
-import com.redhat.swatch.info.UnleashInfoFeatureFlags;
 import com.redhat.swatch.info.model.InfoFeatureFlags;
-import io.getunleash.Unleash;
-import jakarta.enterprise.context.ApplicationScoped;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
-@Slf4j
-@ApplicationScoped
-public class FeatureFlags implements InfoFeatureFlagContributor {
-  public static final String EMIT_EVENTS = "swatch.swatch-metrics-hbi.emit-events";
+/**
+ * Contributes the {@code feature-flags} section of the management {@code /info} endpoint as a list
+ * of flags with enabled state and active Unleash variant.
+ */
+public interface InfoFeatureFlagContributor extends InfoContributor {
 
-  private final Unleash unleash;
+  String FEATURE_FLAGS_SECTION = "feature-flags";
 
-  public FeatureFlags(Unleash unleash) {
-    this.unleash = unleash;
-  }
+  InfoFeatureFlags getFeatureFlags();
 
-  public boolean emitEvents() {
-    return unleash.isEnabled(FeatureFlags.EMIT_EVENTS);
+  @Override
+  default String name() {
+    return FEATURE_FLAGS_SECTION;
   }
 
   @Override
-  public InfoFeatureFlags getFeatureFlags() {
-    return UnleashInfoFeatureFlags.snapshot(unleash, EMIT_EVENTS);
+  default Object data() {
+    InfoFeatureFlags featureFlags = getFeatureFlags();
+    if (featureFlags == null
+        || featureFlags.getFlags() == null
+        || featureFlags.getFlags().isEmpty()) {
+      return List.of();
+    }
+    return featureFlags.getFlags();
   }
 }

--- a/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoRoute.java
+++ b/swatch-common-info/src/main/java/com/redhat/swatch/info/InfoRoute.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.info;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.vertx.http.ManagementInterface;
+import io.vertx.core.buffer.Buffer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+/** Registers {@code GET /info} on the Quarkus management interface. */
+@ApplicationScoped
+public class InfoRoute {
+
+  private static final String CONTENT_TYPE_JSON = "application/json";
+
+  private final InfoAggregator aggregator;
+  private final ObjectMapper objectMapper;
+
+  @Inject
+  public InfoRoute(InfoAggregator aggregator, ObjectMapper objectMapper) {
+    this.aggregator = aggregator;
+    this.objectMapper = objectMapper;
+  }
+
+  void register(@Observes ManagementInterface managementInterface) {
+    managementInterface
+        .router()
+        .get("/info")
+        .handler(
+            routingContext -> {
+              try {
+                byte[] body = objectMapper.writeValueAsBytes(aggregator.buildInfo());
+                routingContext
+                    .response()
+                    .putHeader("Content-Type", CONTENT_TYPE_JSON)
+                    .end(Buffer.buffer(body));
+              } catch (JsonProcessingException e) {
+                routingContext.fail(e);
+              }
+            });
+  }
+}

--- a/swatch-common-info/src/main/java/com/redhat/swatch/info/UnleashInfoFeatureFlags.java
+++ b/swatch-common-info/src/main/java/com/redhat/swatch/info/UnleashInfoFeatureFlags.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.info;
+
+import com.redhat.swatch.info.model.InfoFeatureFlag;
+import com.redhat.swatch.info.model.InfoFeatureFlagVariant;
+import com.redhat.swatch.info.model.InfoFeatureFlagVariantPayload;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
+import io.getunleash.Unleash;
+import io.getunleash.variant.Payload;
+import io.getunleash.variant.Variant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds {@link InfoFeatureFlags} snapshots from an Unleash client for management {@code /info}.
+ */
+public final class UnleashInfoFeatureFlags {
+
+  private UnleashInfoFeatureFlags() {}
+
+  /** Snapshot toggles using {@link Unleash#isEnabled(String)}. */
+  public static InfoFeatureFlags snapshot(Unleash unleash, String... toggleNames) {
+    List<InfoFeatureFlag> flags = new ArrayList<>(toggleNames.length);
+    for (String toggleName : toggleNames) {
+      flags.add(toFlag(unleash, toggleName, null));
+    }
+    return new InfoFeatureFlags().withFlags(flags);
+  }
+
+  /**
+   * Snapshot toggles using {@link Unleash#isEnabled(String, boolean)} when Unleash is unavailable.
+   */
+  public static InfoFeatureFlags snapshot(
+      Unleash unleash, boolean defaultWhenUnavailable, String... toggleNames) {
+    List<InfoFeatureFlag> flags = new ArrayList<>(toggleNames.length);
+    for (String toggleName : toggleNames) {
+      flags.add(toFlag(unleash, toggleName, defaultWhenUnavailable));
+    }
+    return new InfoFeatureFlags().withFlags(flags);
+  }
+
+  private static InfoFeatureFlag toFlag(
+      Unleash unleash, String toggleName, Boolean defaultWhenUnavailable) {
+    boolean enabled =
+        defaultWhenUnavailable == null
+            ? unleash.isEnabled(toggleName)
+            : unleash.isEnabled(toggleName, defaultWhenUnavailable);
+    InfoFeatureFlag flag = new InfoFeatureFlag().withName(toggleName).withEnabled(enabled);
+    Variant variant = unleash.getVariant(toggleName);
+    flag.setVariant(toInfoVariant(variant));
+    return flag;
+  }
+
+  private static InfoFeatureFlagVariant toInfoVariant(Variant variant) {
+    InfoFeatureFlagVariant infoVariant =
+        new InfoFeatureFlagVariant().withName(variant.getName()).withEnabled(variant.isEnabled());
+    variant.getPayload().ifPresent(payload -> infoVariant.setPayload(toInfoPayload(payload)));
+    return infoVariant;
+  }
+
+  private static InfoFeatureFlagVariantPayload toInfoPayload(Payload payload) {
+    return new InfoFeatureFlagVariantPayload()
+        .withType(payload.getType())
+        .withValue(payload.getValue());
+  }
+}

--- a/swatch-common-info/src/test/java/com/redhat/swatch/info/InfoAggregatorTest.java
+++ b/swatch-common-info/src/test/java/com/redhat/swatch/info/InfoAggregatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.info;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.enterprise.inject.Instance;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InfoAggregatorTest {
+
+  @Test
+  void shouldMergeNonEmptyContributorSections() {
+    InfoContributor os = contributor("os", Map.of("name", "Linux", "arch", "amd64"));
+    InfoContributor flags =
+        contributor("feature-flags", List.of(Map.of("name", "swatch.example", "enabled", true)));
+
+    Map<String, Object> info = new InfoAggregator(instanceOf(os, flags)).buildInfo();
+
+    assertEquals(2, info.size());
+    assertEquals("Linux", ((Map<?, ?>) info.get("os")).get("name"));
+    assertTrue(info.containsKey("feature-flags"));
+  }
+
+  @Test
+  void shouldOmitEmptyAndNullContributorData() {
+    InfoContributor emptyList = contributor("feature-flags", List.of());
+    InfoContributor emptyMap = contributor("empty-map", Map.of());
+    InfoContributor nullData =
+        new InfoContributor() {
+          @Override
+          public String name() {
+            return "ignored";
+          }
+
+          @Override
+          public Object data() {
+            return null;
+          }
+        };
+    InfoContributor os = contributor("os", Map.of("name", "Linux"));
+
+    Map<String, Object> info =
+        new InfoAggregator(instanceOf(emptyList, emptyMap, nullData, os)).buildInfo();
+
+    assertEquals(1, info.size());
+    assertTrue(info.containsKey("os"));
+    assertFalse(info.containsKey("feature-flags"));
+    assertFalse(info.containsKey("empty-map"));
+    assertFalse(info.containsKey("ignored"));
+  }
+
+  private static InfoContributor contributor(String name, Object data) {
+    return new InfoContributor() {
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @Override
+      public Object data() {
+        return data;
+      }
+    };
+  }
+
+  @SafeVarargs
+  private static Instance<InfoContributor> instanceOf(InfoContributor... contributors) {
+    @SuppressWarnings("unchecked")
+    Instance<InfoContributor> instance = mock(Instance.class);
+    when(instance.iterator()).thenAnswer(invocation -> List.of(contributors).iterator());
+    return instance;
+  }
+}

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -21,8 +21,6 @@
 package api;
 
 import com.redhat.swatch.component.tests.api.UnleashService;
-import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
-import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 
 public class ContractsUnleashService extends UnleashService {
 
@@ -33,37 +31,10 @@ public class ContractsUnleashService extends UnleashService {
 
   public void enablePartnerGatewayContracts() {
     enableFlag(PARTNER_GATEWAY_CONTRACTS);
-    AwaitilityUtils.until(
-        () -> isFlagEnabled(PARTNER_GATEWAY_CONTRACTS),
-        enabled -> enabled,
-        AwaitilitySettings.defaults()
-            .timeoutMessage(
-                "Unleash toggle '%s' should be enabled".formatted(PARTNER_GATEWAY_CONTRACTS)));
-    waitForUnleashPropagation();
   }
 
   public void enableItSubscriptionService() {
     enableFlag(IT_SUBSCRIPTION_SERVICE);
-    AwaitilityUtils.until(
-        () -> isFlagEnabled(IT_SUBSCRIPTION_SERVICE),
-        enabled -> enabled,
-        AwaitilitySettings.defaults()
-            .timeoutMessage(
-                "Unleash toggle '%s' should be enabled".formatted(IT_SUBSCRIPTION_SERVICE)));
-    waitForUnleashPropagation();
-  }
-
-  /**
-   * Wait for swatch-contracts to pick up the toggle. The harness only checks Unleash admin; the
-   * service polls on {@code quarkus.unleash.fetch-toggles-interval} (1s in dev/ephemeral).
-   */
-  private void waitForUnleashPropagation() {
-    try {
-      Thread.sleep(2000);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IllegalStateException("Interrupted while waiting for Unleash propagation", e);
-    }
   }
 
   public void disablePartnerGatewayContracts() {

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -74,7 +74,8 @@ public class BaseContractComponentTest {
   @Quarkus(service = "swatch-contracts")
   static ContractsSwatchService service = new ContractsSwatchService();
 
-  @Unleash static ContractsUnleashService unleash = new ContractsUnleashService();
+  @Unleash
+  static ContractsUnleashService unleash = new ContractsUnleashService().withSwatchService(service);
 
   protected static final ApplicationClock clock = new ApplicationClock();
 

--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -149,6 +149,10 @@
       <artifactId>swatch-common-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-info</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.contract.model.ItSubscriptionServiceFeatureFlagVariantPayload;
 import com.redhat.swatch.contract.model.PartnerGatewayContractsFeatureFlagVariantPayload;
+import com.redhat.swatch.info.InfoFeatureFlagContributor;
+import com.redhat.swatch.info.UnleashInfoFeatureFlags;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
 import io.getunleash.Unleash;
 import io.getunleash.variant.Variant;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -35,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @ApplicationScoped
 @AllArgsConstructor
-public class FeatureFlags {
+public class FeatureFlags implements InfoFeatureFlagContributor {
   public static final String PARTNER_GATEWAY_CONTRACTS =
       "swatch.swatch-contracts.enable-partner-gateway-contracts";
   public static final String IT_SUBSCRIPTION_SERVICE =
@@ -145,5 +148,11 @@ public class FeatureFlags {
           e);
       return Optional.empty();
     }
+  }
+
+  @Override
+  public InfoFeatureFlags getFeatureFlags() {
+    return UnleashInfoFeatureFlags.snapshot(
+        unleash, DEFAULT_IS_ENABLED, PARTNER_GATEWAY_CONTRACTS, IT_SUBSCRIPTION_SERVICE);
   }
 }

--- a/swatch-core/schemas/info_feature_flags.yaml
+++ b/swatch-core/schemas/info_feature_flags.yaml
@@ -1,0 +1,46 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: InfoFeatureFlags
+description: >
+  Feature flags exposed under the management /info "feature-flags" section.
+  Each entry reports the toggle enabled state and the active Unleash variant.
+type: object
+properties:
+  flags:
+    type: array
+    items:
+      $ref: '#/definitions/InfoFeatureFlag'
+definitions:
+  InfoFeatureFlag:
+    type: object
+    required:
+      - name
+      - enabled
+    properties:
+      name:
+        description: Unleash toggle name
+        type: string
+      enabled:
+        description: Whether the toggle is enabled
+        type: boolean
+      variant:
+        $ref: '#/definitions/InfoFeatureFlagVariant'
+  InfoFeatureFlagVariant:
+    type: object
+    properties:
+      name:
+        description: Unleash variant name
+        type: string
+      enabled:
+        description: Whether the variant is enabled
+        type: boolean
+      payload:
+        $ref: '#/definitions/InfoFeatureFlagVariantPayload'
+  InfoFeatureFlagVariantPayload:
+    type: object
+    properties:
+      type:
+        description: Unleash variant payload type (for example string or json)
+        type: string
+      value:
+        description: Unleash variant payload value
+        type: string

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/FeatureFlagsInfoContributor.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/actuator/FeatureFlagsInfoContributor.java
@@ -21,9 +21,10 @@
 package org.candlepin.subscriptions.actuator;
 
 import jakarta.annotation.Nullable;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import org.candlepin.subscriptions.configuration.FeatureFlags;
+import org.candlepin.subscriptions.json.InfoFeatureFlag;
 import org.springframework.boot.actuate.info.Info.Builder;
 import org.springframework.boot.actuate.info.InfoContributor;
 
@@ -39,15 +40,14 @@ public class FeatureFlagsInfoContributor implements InfoContributor {
   @Override
   public void contribute(Builder builder) {
     if (featureFlags == null) {
-      builder.withDetail("feature-flags", Map.of());
+      builder.withDetail("feature-flags", List.of());
       return;
     }
 
-    Map<String, Boolean> flagStatus = new LinkedHashMap<>();
+    List<InfoFeatureFlag> flags = new ArrayList<>();
     for (String flag : FeatureFlags.FLAG_LIST) {
-      flagStatus.put(flag, featureFlags.isEnabled(flag));
+      flags.add(new InfoFeatureFlag().withName(flag).withEnabled(featureFlags.isEnabled(flag)));
     }
-
-    builder.withDetail("feature-flags", flagStatus);
+    builder.withDetail("feature-flags", flags);
   }
 }

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/actuator/FeatureFlagsInfoContributorTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/actuator/FeatureFlagsInfoContributorTest.java
@@ -27,9 +27,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.candlepin.subscriptions.configuration.FeatureFlags;
+import org.candlepin.subscriptions.json.InfoFeatureFlag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,17 +61,12 @@ class FeatureFlagsInfoContributorTest {
       when(featureFlags.isEnabled(flag)).thenReturn(true);
     }
 
-    Builder builder = new Builder();
-    contributor.contribute(builder);
-    Info info = builder.build();
+    List<InfoFeatureFlag> flagStatus = contributeFlags();
 
-    @SuppressWarnings("unchecked")
-    Map<String, Boolean> flagStatus = (Map<String, Boolean>) info.getDetails().get("feature-flags");
-
-    assertNotNull(flagStatus);
     assertEquals(UNIQUE_FLAGS.size(), flagStatus.size());
-    for (String flag : UNIQUE_FLAGS) {
-      assertEquals(Boolean.TRUE, flagStatus.get(flag));
+    for (InfoFeatureFlag flag : flagStatus) {
+      assertTrue(UNIQUE_FLAGS.contains(flag.getName()));
+      assertEquals(Boolean.TRUE, flag.getEnabled());
     }
   }
 
@@ -79,17 +76,11 @@ class FeatureFlagsInfoContributorTest {
       when(featureFlags.isEnabled(flag)).thenReturn(false);
     }
 
-    Builder builder = new Builder();
-    contributor.contribute(builder);
-    Info info = builder.build();
+    List<InfoFeatureFlag> flagStatus = contributeFlags();
 
-    @SuppressWarnings("unchecked")
-    Map<String, Boolean> flagStatus = (Map<String, Boolean>) info.getDetails().get("feature-flags");
-
-    assertNotNull(flagStatus);
     assertEquals(UNIQUE_FLAGS.size(), flagStatus.size());
-    for (String flag : UNIQUE_FLAGS) {
-      assertEquals(Boolean.FALSE, flagStatus.get(flag));
+    for (InfoFeatureFlag flag : flagStatus) {
+      assertEquals(Boolean.FALSE, flag.getEnabled());
     }
   }
 
@@ -99,15 +90,13 @@ class FeatureFlagsInfoContributorTest {
       when(featureFlags.isEnabled(flag)).thenReturn(false);
     }
 
-    Builder builder = new Builder();
-    contributor.contribute(builder);
-    Info info = builder.build();
+    List<InfoFeatureFlag> flagStatus = contributeFlags();
 
-    @SuppressWarnings("unchecked")
-    Map<String, Boolean> flagStatus = (Map<String, Boolean>) info.getDetails().get("feature-flags");
-
-    assertNotNull(flagStatus);
-    assertEquals(UNIQUE_FLAGS, flagStatus.keySet());
+    assertEquals(
+        UNIQUE_FLAGS,
+        flagStatus.stream()
+            .map(InfoFeatureFlag::getName)
+            .collect(Collectors.toCollection(LinkedHashSet::new)));
   }
 
   @Test
@@ -117,17 +106,11 @@ class FeatureFlagsInfoContributorTest {
       when(featureFlags.isEnabled(flag)).thenReturn(flag.equals(enabledFlag));
     }
 
-    Builder builder = new Builder();
-    contributor.contribute(builder);
-    Info info = builder.build();
+    List<InfoFeatureFlag> flagStatus = contributeFlags();
 
-    @SuppressWarnings("unchecked")
-    Map<String, Boolean> flagStatus = (Map<String, Boolean>) info.getDetails().get("feature-flags");
-
-    assertNotNull(flagStatus);
     assertEquals(UNIQUE_FLAGS.size(), flagStatus.size());
-    for (String flag : UNIQUE_FLAGS) {
-      assertEquals(flag.equals(enabledFlag), flagStatus.get(flag));
+    for (InfoFeatureFlag flag : flagStatus) {
+      assertEquals(flag.getName().equals(enabledFlag), flag.getEnabled());
     }
   }
 
@@ -135,14 +118,20 @@ class FeatureFlagsInfoContributorTest {
   void testNullFeatureFlags() {
     contributor = new FeatureFlagsInfoContributor(null);
 
-    Builder builder = new Builder();
-    contributor.contribute(builder);
-    Info info = builder.build();
-
-    @SuppressWarnings("unchecked")
-    Map<String, Boolean> flagStatus = (Map<String, Boolean>) info.getDetails().get("feature-flags");
+    List<InfoFeatureFlag> flagStatus = contributeFlags();
 
     assertNotNull(flagStatus);
     assertTrue(flagStatus.isEmpty());
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<InfoFeatureFlag> contributeFlags() {
+    Builder builder = new Builder();
+    contributor.contribute(builder);
+    Info info = builder.build();
+    List<InfoFeatureFlag> flagStatus =
+        (List<InfoFeatureFlag>) info.getDetails().get("feature-flags");
+    assertNotNull(flagStatus);
+    return flagStatus;
   }
 }

--- a/swatch-metrics-hbi/ct/java/com/redhat/swatch/hbi/events/ct/tests/BaseSMHBIComponentTest.java
+++ b/swatch-metrics-hbi/ct/java/com/redhat/swatch/hbi/events/ct/tests/BaseSMHBIComponentTest.java
@@ -39,10 +39,10 @@ public class BaseSMHBIComponentTest {
   static KafkaBridgeService kafkaBridge =
       new KafkaBridgeService().subscribeToTopic(Topics.SWATCH_SERVICE_INSTANCE_INGRESS);
 
-  @Unleash static UnleashService unleash = new UnleashService();
-
   @Quarkus(service = "swatch-metrics-hbi")
   static SwatchMetricsHbiRestService service = new SwatchMetricsHbiRestService();
+
+  @Unleash static UnleashService unleash = new UnleashService().withSwatchService(service);
 
   protected static final String EMIT_EVENTS = "swatch.swatch-metrics-hbi.emit-events";
 

--- a/swatch-metrics-hbi/pom.xml
+++ b/swatch-metrics-hbi/pom.xml
@@ -29,6 +29,10 @@
       <artifactId>swatch-common-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-info</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>

--- a/swatch-producer-aws/ct/java/api/AwsUnleashService.java
+++ b/swatch-producer-aws/ct/java/api/AwsUnleashService.java
@@ -29,24 +29,9 @@ public class AwsUnleashService extends UnleashService {
 
   public void enableUseCustomerAwsAccountId() {
     enableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
-    waitForUnleashPropagation();
   }
 
   public void disableUseCustomerAwsAccountId() {
     disableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
-    waitForUnleashPropagation();
-  }
-
-  /**
-   * Wait for swatch-producer-aws to pick up the toggle. Unleash admin updates are atomic; the
-   * service polls on {@code quarkus.unleash.fetch-toggles-interval} (1s in dev/ephemeral).
-   */
-  private void waitForUnleashPropagation() {
-    try {
-      Thread.sleep(2000);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IllegalStateException("Interrupted while waiting for Unleash propagation", e);
-    }
   }
 }

--- a/swatch-producer-aws/ct/java/tests/BaseAwsComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/BaseAwsComponentTest.java
@@ -50,10 +50,10 @@ public class BaseAwsComponentTest {
 
   @Wiremock static AwsWiremockService wiremock = new AwsWiremockService();
 
-  @Unleash static AwsUnleashService unleash = new AwsUnleashService();
-
   @Quarkus(service = "swatch-producer-aws")
   static SwatchService service = new SwatchService();
+
+  @Unleash static AwsUnleashService unleash = new AwsUnleashService().withSwatchService(service);
 
   protected String orgId;
   protected String awsAccountId;

--- a/swatch-producer-aws/pom.xml
+++ b/swatch-producer-aws/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>swatch-common-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-info</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
@@ -20,11 +20,14 @@
  */
 package com.redhat.swatch.aws.config;
 
+import com.redhat.swatch.info.InfoFeatureFlagContributor;
+import com.redhat.swatch.info.UnleashInfoFeatureFlags;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
 import io.getunleash.Unleash;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class FeatureFlags {
+public class FeatureFlags implements InfoFeatureFlagContributor {
   public static final String USE_CUSTOMER_AWS_ACCOUNT_ID =
       "swatch.swatch-producer-aws.use-customer-aws-account-id";
 
@@ -36,5 +39,10 @@ public class FeatureFlags {
 
   public boolean useCustomerAwsAccountId() {
     return unleash.isEnabled(USE_CUSTOMER_AWS_ACCOUNT_ID);
+  }
+
+  @Override
+  public InfoFeatureFlags getFeatureFlags() {
+    return UnleashInfoFeatureFlags.snapshot(unleash, USE_CUSTOMER_AWS_ACCOUNT_ID);
   }
 }

--- a/swatch-quarkus-parent/pom.xml
+++ b/swatch-quarkus-parent/pom.xml
@@ -105,6 +105,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.redhat.swatch</groupId>
+        <artifactId>swatch-common-info</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.persistence</groupId>
         <artifactId>jakarta.persistence-api</artifactId>
         <version>${jakarta.persistence-api.version}</version>

--- a/swatch-tally/ct/java/api/TallySwatchService.java
+++ b/swatch-tally/ct/java/api/TallySwatchService.java
@@ -77,28 +77,6 @@ public class TallySwatchService extends SwatchService {
     return response.as(VersionInfo.class);
   }
 
-  /**
-   * Retrieves application info including feature flags from the management endpoint.
-   *
-   * @return the info response as a Map
-   */
-  @SuppressWarnings("unchecked")
-  public Map<String, Object> getInfo() {
-    Response response = managementServer().get("/info").then().extract().response();
-
-    assertEquals(
-        HttpStatus.SC_OK,
-        response.getStatusCode(),
-        "Get info failed with status code: "
-            + response.getStatusCode()
-            + ", response body: "
-            + response.getBody().asString());
-
-    Log.trace(this, "Info endpoint response: %s", response.getBody().asString());
-
-    return response.as(Map.class);
-  }
-
   // --- Configuration methods ---
 
   /**

--- a/swatch-tally/ct/java/api/TallyUnleashService.java
+++ b/swatch-tally/ct/java/api/TallyUnleashService.java
@@ -20,59 +20,17 @@
  */
 package api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.redhat.swatch.component.tests.api.UnleashService;
-import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
-import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
-import java.time.Duration;
-import java.util.Map;
 
 public class TallyUnleashService extends UnleashService {
   private static final String ENABLE_PRIMARY_ROW_SEARCHES =
       "swatch.swatch-tally.enable-primary-row-searches";
-  private TallySwatchService tallyService;
-
-  public TallyUnleashService(TallySwatchService service) {
-    super();
-    this.tallyService = service;
-  }
 
   public void enablePrimaryRowSearches() {
     enableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
-    waitForFlagToBe(ENABLE_PRIMARY_ROW_SEARCHES, true);
   }
 
   public void disablePrimaryRowSearches() {
     disableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
-    waitForFlagToBe(ENABLE_PRIMARY_ROW_SEARCHES, false);
-  }
-
-  private void waitForFlagToBe(String flag, boolean expectedState) {
-    // Wait for the feature flag to be reflected in the /info endpoint
-    AwaitilitySettings settings =
-        AwaitilitySettings.using(Duration.ofMillis(100), Duration.ofSeconds(20))
-            .withService(tallyService)
-            .timeoutMessage(
-                "Feature flag '%s' did not reach expected state: %s", flag, expectedState);
-
-    AwaitilityUtils.untilAsserted(
-        () -> {
-          @SuppressWarnings("unchecked")
-          Map<String, Object> info = tallyService.getInfo();
-
-          @SuppressWarnings("unchecked")
-          Map<String, Boolean> featureFlags = (Map<String, Boolean>) info.get("feature-flags");
-
-          assertNotNull(featureFlags, "feature-flags section should be present in /info response");
-
-          Boolean actualValue = featureFlags.get(flag);
-
-          assertNotNull(actualValue, "Feature flag '" + flag + "' should be present");
-
-          assertEquals(expectedState, actualValue, "Feature flag should match configured value");
-        },
-        settings);
   }
 }

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -83,7 +83,8 @@ public class BaseTallyComponentTest {
   @SpringBoot(service = "swatch-tally")
   static TallySwatchService service = new TallySwatchService();
 
-  @Unleash static TallyUnleashService unleash = new TallyUnleashService(service);
+  @Unleash
+  static TallyUnleashService unleash = new TallyUnleashService().withSwatchService(service);
 
   @SwatchDatabase static DatabaseService swatchDatabase = new DatabaseService();
 

--- a/swatch-test-framework/pom.xml
+++ b/swatch-test-framework/pom.xml
@@ -102,6 +102,42 @@
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jsonschema2pojo</groupId>
+        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+        <configuration>
+          <targetPackage>com.redhat.swatch.component.tests.model</targetPackage>
+          <includeAdditionalProperties>false</includeAdditionalProperties>
+          <includeJsr303Annotations>false</includeJsr303Annotations>
+          <initializeCollections>false</initializeCollections>
+          <dateTimeType>java.time.OffsetDateTime</dateTimeType>
+          <sourceType>yamlschema</sourceType>
+          <generateBuilders>true</generateBuilders>
+          <includeGetters>true</includeGetters>
+          <includeSetters>true</includeSetters>
+          <useJakartaValidation>false</useJakartaValidation>
+        </configuration>
+        <executions>
+          <!-- Disable inherited default execution (expects module-local schemas/) -->
+          <execution>
+            <id>default</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>info-feature-flags</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sourceDirectory>${maven.multiModuleProjectDirectory}/swatch-core/schemas</sourceDirectory>
+              <includes>
+                <include>info_feature_flags.yaml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
@@ -21,11 +21,19 @@
 package com.redhat.swatch.component.tests.api;
 
 import static com.redhat.swatch.component.tests.utils.SwatchUtils.MANAGEMENT_PORT;
+import static org.apache.http.HttpStatus.SC_OK;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.swatch.component.tests.logging.Log;
+import com.redhat.swatch.component.tests.model.InfoFeatureFlag;
+import com.redhat.swatch.component.tests.model.InfoFeatureFlags;
+import com.redhat.swatch.component.tests.utils.JsonUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -33,6 +41,7 @@ import java.util.stream.Stream;
 public class SwatchService extends RestService {
 
   protected static final String SWATCH_PSK = "placeholder";
+  private static final String FEATURE_FLAGS_SECTION = "feature-flags";
 
   public RequestSpecification managementServer() {
     return RestAssured.given()
@@ -71,6 +80,38 @@ public class SwatchService extends RestService {
    */
   private Response getMetrics() {
     return managementServer().get("/metrics").then().extract().response();
+  }
+
+  /**
+   * Retrieves the {@code feature-flags} list from the management {@code /info} endpoint when
+   * available.
+   *
+   * @return feature flags when {@code /info} exposes them; empty when the endpoint or section is
+   *     missing
+   */
+  @SuppressWarnings("unchecked")
+  public Optional<InfoFeatureFlags> getFeatureFlags() {
+    Response response = managementServer().get("/info").then().extract().response();
+    if (response.getStatusCode() != SC_OK) {
+      Log.debug(this, "Management /info not available (status %s)", response.getStatusCode());
+      return Optional.empty();
+    }
+
+    Log.trace(this, "Info endpoint response: %s", response.getBody().asString());
+
+    Map<String, Object> info = response.as(Map.class);
+    if (!info.containsKey(FEATURE_FLAGS_SECTION)) {
+      Log.debug(this, "Management /info has no feature-flags section");
+      return Optional.empty();
+    }
+
+    return Optional.ofNullable(info.get(FEATURE_FLAGS_SECTION))
+        .map(
+            f ->
+                new InfoFeatureFlags()
+                    .withFlags(
+                        JsonUtils.getObjectMapper()
+                            .convertValue(f, new TypeReference<List<InfoFeatureFlag>>() {})));
   }
 
   /**

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/UnleashService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/UnleashService.java
@@ -21,9 +21,19 @@
 package com.redhat.swatch.component.tests.api;
 
 import static com.redhat.swatch.component.tests.utils.StringUtils.EMPTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.redhat.swatch.component.tests.model.InfoFeatureFlag;
+import com.redhat.swatch.component.tests.model.InfoFeatureFlags;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.JsonUtils;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import org.apache.http.HttpStatus;
 
 public class UnleashService extends RestService {
@@ -37,6 +47,19 @@ public class UnleashService extends RestService {
       UNLEASH_BASE_PATH + "/projects/" + PROJECT_ID + "/features";
   private static final String UNLEASH_ENVIRONMENT_PATH =
       UNLEASH_FEATURES_PATH + "/%s/environments/" + ENVIRONMENT;
+  private static final String DISABLED_VARIANT = "disabled";
+
+  private SwatchService swatchService;
+
+  /**
+   * Sets the Swatch service whose management {@code /info} endpoint is used to wait until feature
+   * flag changes are reflected.
+   */
+  @SuppressWarnings("unchecked")
+  public <T extends UnleashService> T withSwatchService(SwatchService swatchService) {
+    this.swatchService = swatchService;
+    return (T) this;
+  }
 
   public void createFlag(String flag) {
     String payload =
@@ -58,7 +81,9 @@ public class UnleashService extends RestService {
     if (response.statusCode() == HttpStatus.SC_NOT_FOUND) {
       createFlag(flag);
       enableFlag(flag);
+      return;
     }
+    waitForFlag(flag, true, null, null);
   }
 
   public void disableFlag(String flag) {
@@ -67,24 +92,25 @@ public class UnleashService extends RestService {
     if (response.statusCode() == HttpStatus.SC_NOT_FOUND) {
       createFlag(flag);
       disableFlag(flag);
+      return;
     }
+    waitForFlag(flag, false, null, null);
   }
 
   public void setVariant(String flag, String variantName, String payloadValue) {
+    String value = payloadValue == null ? "" : payloadValue;
     String payload =
-        String.format(
-            """
-        [{
-          "name": "%s",
-          "weight": 1000,
-          "weightType": "variable",
-          "payload": {
-            "type": "string",
-            "value": "%s"
-          }
-        }]
-        """,
-            variantName, payloadValue);
+        JsonUtils.toJson(
+            List.of(
+                Map.of(
+                    "name",
+                    variantName,
+                    "weight",
+                    1000,
+                    "weightType",
+                    "variable",
+                    "payload",
+                    Map.of("type", "string", "value", value))));
 
     var response =
         given().body(payload).when().put(UNLEASH_FEATURES_PATH + "/" + flag + "/variants");
@@ -93,15 +119,20 @@ public class UnleashService extends RestService {
       createFlag(flag);
       enableFlag(flag);
       setVariant(flag, variantName, payloadValue);
+      return;
     }
+    waitForFlag(flag, isFlagEnabled(flag), variantName, payloadValue);
   }
 
   public void clearVariants(String flag) {
-    given().body("[]").when().put(UNLEASH_FEATURES_PATH + "/" + flag + "/variants");
-  }
-
-  public void listFlags() {
-    given().get(UNLEASH_FEATURES_PATH).then().log().all();
+    given()
+        .body("[]")
+        .when()
+        .put(UNLEASH_FEATURES_PATH + "/" + flag + "/variants")
+        .then()
+        .log()
+        .ifError();
+    waitForFlag(flag, isFlagEnabled(flag), DISABLED_VARIANT, null);
   }
 
   public boolean isFlagEnabled(String flag) {
@@ -116,6 +147,58 @@ public class UnleashService extends RestService {
   @Override
   public RequestSpecification given() {
     return super.given().header("Authorization", adminToken()).contentType(ContentType.JSON);
+  }
+
+  private void waitForFlag(
+      String flag, boolean expectedEnabled, String expectedVariantName, String expectedPayload) {
+    if (swatchService == null) {
+      throw new IllegalStateException(
+          "UnleashService.withSwatchService(...) is required so feature-flag waits can use management /info");
+    }
+
+    AwaitilitySettings settings =
+        AwaitilitySettings.using(Duration.ofMillis(100), Duration.ofSeconds(20))
+            .withService(swatchService)
+            .timeoutMessage(
+                "Feature flag '%s' did not reach expected state enabled=%s variant=%s payload=%s",
+                flag, expectedEnabled, expectedVariantName, expectedPayload);
+
+    AwaitilityUtils.untilAsserted(
+        () -> assertFlagMatches(flag, expectedEnabled, expectedVariantName, expectedPayload),
+        settings);
+  }
+
+  private void assertFlagMatches(
+      String flag, boolean expectedEnabled, String expectedVariantName, String expectedPayload) {
+    InfoFeatureFlags featureFlags =
+        swatchService
+            .getFeatureFlags()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "Management /info must expose a feature-flags section for Unleash waits"));
+    assertNotNull(featureFlags.getFlags(), "feature-flags list should be present in /info");
+
+    InfoFeatureFlag actual =
+        featureFlags.getFlags().stream()
+            .filter(entry -> flag.equals(entry.getName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(actual, "Feature flag '" + flag + "' should be present");
+    assertEquals(expectedEnabled, actual.getEnabled(), "Feature flag enabled state mismatch");
+
+    if (expectedVariantName != null) {
+      assertNotNull(actual.getVariant(), "Feature flag variant should be present");
+      assertEquals(
+          expectedVariantName, actual.getVariant().getName(), "Feature flag variant name mismatch");
+      if (expectedPayload != null) {
+        assertNotNull(actual.getVariant().getPayload(), "Variant payload should be present");
+        assertEquals(
+            expectedPayload,
+            actual.getVariant().getPayload().getValue(),
+            "Variant payload value mismatch");
+      }
+    }
   }
 
   private String adminToken() {

--- a/swatch-utilization/ct/java/api/UtilizationUnleashService.java
+++ b/swatch-utilization/ct/java/api/UtilizationUnleashService.java
@@ -34,59 +34,37 @@ public class UtilizationUnleashService extends UnleashService {
 
   public void enableSendNotificationsFlag() {
     enableFlag(SEND_NOTIFICATIONS);
-    waitForUnleashPropagation();
   }
 
   public void enableSendNotificationsFlagForOrgs(String... orgs) {
     enableFlag(SEND_NOTIFICATIONS_ORGS_ALLOWLIST);
     setVariant(SEND_NOTIFICATIONS_ORGS_ALLOWLIST, ORGS_VARIANT, String.join(",", orgs));
-    waitForUnleashPropagation();
   }
 
   public void disableSendNotificationsFlag() {
     disableFlag(SEND_NOTIFICATIONS);
-    waitForUnleashPropagation();
   }
 
   public void disableSendNotificationsFlagForOrgs() {
     clearVariants(SEND_NOTIFICATIONS_ORGS_ALLOWLIST);
     disableFlag(SEND_NOTIFICATIONS_ORGS_ALLOWLIST);
-    waitForUnleashPropagation();
   }
 
   public void enableSendNotificationsWithEventTypesDenylist(String... eventTypes) {
     enableFlag(SEND_NOTIFICATIONS);
-    String json = buildEventTypesDenylistJson(eventTypes);
     setVariant(
         SEND_NOTIFICATIONS,
         SEND_NOTIFICATIONS_CONFIG_VARIANT,
-        escapeForUnleashVariantStringValue(json));
-    waitForUnleashPropagation();
+        buildEventTypesDenylistJson(eventTypes));
   }
 
   public void clearSendNotificationsVariants() {
     clearVariants(SEND_NOTIFICATIONS);
-    waitForUnleashPropagation();
   }
 
   private static String buildEventTypesDenylistJson(String... eventTypes) {
     var payload = new SendNotificationVariantPayload();
     payload.setEventTypesDenylist(List.of(eventTypes));
     return JsonUtils.toJson(payload);
-  }
-
-  private static String escapeForUnleashVariantStringValue(String value) {
-    return value.replace("\\", "\\\\").replace("\"", "\\\"");
-  }
-
-  private void waitForUnleashPropagation() {
-    // wait more than 1 sec, so the change is propagated to the app
-    // the duration is configured using the property `quarkus.unleash.fetch-toggles-interval`
-    // which uses 1 second
-    try {
-      Thread.sleep(2000);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
+++ b/swatch-utilization/ct/java/tests/BaseUtilizationComponentTest.java
@@ -62,10 +62,12 @@ public class BaseUtilizationComponentTest {
   @KafkaBridge
   static KafkaBridgeService kafkaBridge = new KafkaBridgeService().subscribeToTopic(NOTIFICATIONS);
 
-  @Unleash static UtilizationUnleashService unleash = new UtilizationUnleashService();
-
   @Quarkus(service = "swatch-utilization")
   static UtilizationSwatchService service = new UtilizationSwatchService();
+
+  @Unleash
+  static UtilizationUnleashService unleash =
+      new UtilizationUnleashService().withSwatchService(service);
 
   protected String orgId;
 

--- a/swatch-utilization/pom.xml
+++ b/swatch-utilization/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>swatch-common-health</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.redhat.swatch</groupId>
+      <artifactId>swatch-common-info</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-security</artifactId>
     </dependency>

--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/configuration/FeatureFlags.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/configuration/FeatureFlags.java
@@ -22,6 +22,9 @@ package com.redhat.swatch.utilization.configuration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.info.InfoFeatureFlagContributor;
+import com.redhat.swatch.info.UnleashInfoFeatureFlags;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
 import com.redhat.swatch.utilization.model.SendNotificationVariantPayload;
 import io.getunleash.Unleash;
 import io.getunleash.variant.Variant;
@@ -35,7 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @ApplicationScoped
 @AllArgsConstructor
-public class FeatureFlags {
+public class FeatureFlags implements InfoFeatureFlagContributor {
+
   public static final String SEND_NOTIFICATIONS = "swatch.swatch-notifications.send-notifications";
   public static final String SEND_NOTIFICATIONS_CONFIG_VARIANT = "send-notifications-config";
   public static final String SEND_NOTIFICATIONS_ORGS_ALLOWLIST =
@@ -104,6 +108,12 @@ public class FeatureFlags {
         value);
 
     return Arrays.stream(value.split(",")).map(String::trim).anyMatch(orgId::equals);
+  }
+
+  @Override
+  public InfoFeatureFlags getFeatureFlags() {
+    return UnleashInfoFeatureFlags.snapshot(
+        unleash, SEND_NOTIFICATIONS, SEND_NOTIFICATIONS_ORGS_ALLOWLIST);
   }
 
   private Optional<SendNotificationVariantPayload> mapToSendNotificationPayload(Variant variant) {

--- a/swatch-utilization/src/test/java/com/redhat/swatch/utilization/configuration/FeatureFlagsTest.java
+++ b/swatch-utilization/src/test/java/com/redhat/swatch/utilization/configuration/FeatureFlagsTest.java
@@ -21,14 +21,19 @@
 package com.redhat.swatch.utilization.configuration;
 
 import static com.redhat.swatch.utilization.configuration.FeatureFlags.SEND_NOTIFICATIONS_CONFIG_VARIANT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.info.InfoFeatureFlagContributor;
+import com.redhat.swatch.info.model.InfoFeatureFlag;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
 import io.getunleash.Unleash;
 import io.getunleash.variant.Payload;
 import io.getunleash.variant.Variant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +52,44 @@ class FeatureFlagsTest {
   @BeforeEach
   void setUp() {
     featureFlags = new FeatureFlags(unleash, OBJECT_MAPPER);
+  }
+
+  @Test
+  void infoContributorShouldUseFeatureFlagsSectionName() {
+    assertEquals(InfoFeatureFlagContributor.FEATURE_FLAGS_SECTION, featureFlags.name());
+  }
+
+  @Test
+  void infoContributorDataShouldExposeEnabledAndVariant() {
+    Payload payload = new Payload("json", "{\"event_types_denylist\":[]}");
+    Variant sendNotificationsVariant =
+        new Variant(SEND_NOTIFICATIONS_CONFIG_VARIANT, payload, true, "any", true);
+    Variant allowlistVariant = Variant.DISABLED_VARIANT;
+
+    when(unleash.isEnabled(FeatureFlags.SEND_NOTIFICATIONS)).thenReturn(true);
+    when(unleash.getVariant(FeatureFlags.SEND_NOTIFICATIONS)).thenReturn(sendNotificationsVariant);
+    when(unleash.isEnabled(FeatureFlags.SEND_NOTIFICATIONS_ORGS_ALLOWLIST)).thenReturn(false);
+    when(unleash.getVariant(FeatureFlags.SEND_NOTIFICATIONS_ORGS_ALLOWLIST))
+        .thenReturn(allowlistVariant);
+
+    InfoFeatureFlags info = featureFlags.getFeatureFlags();
+    assertEquals(2, info.getFlags().size());
+
+    InfoFeatureFlag sendNotifications = findFlag(info, FeatureFlags.SEND_NOTIFICATIONS);
+    assertTrue(sendNotifications.getEnabled());
+    assertEquals(SEND_NOTIFICATIONS_CONFIG_VARIANT, sendNotifications.getVariant().getName());
+    assertTrue(sendNotifications.getVariant().getEnabled());
+    assertEquals("json", sendNotifications.getVariant().getPayload().getType());
+    assertEquals(
+        "{\"event_types_denylist\":[]}", sendNotifications.getVariant().getPayload().getValue());
+
+    InfoFeatureFlag allowlist = findFlag(info, FeatureFlags.SEND_NOTIFICATIONS_ORGS_ALLOWLIST);
+    assertFalse(allowlist.getEnabled());
+    assertEquals("disabled", allowlist.getVariant().getName());
+
+    @SuppressWarnings("unchecked")
+    List<InfoFeatureFlag> data = (List<InfoFeatureFlag>) featureFlags.data();
+    assertEquals(2, data.size());
   }
 
   @Test
@@ -126,6 +169,13 @@ class FeatureFlagsTest {
     givenAllowlistFlagEnabledForOrgs("org1");
 
     assertTrue(featureFlags.isOrgAllowlistedForNotifications("org1"));
+  }
+
+  private static InfoFeatureFlag findFlag(InfoFeatureFlags info, String name) {
+    return info.getFlags().stream()
+        .filter(flag -> name.equals(flag.getName()))
+        .findFirst()
+        .orElseThrow();
   }
 
   private void givenSendNotificationsEnabledWithByEventTypesPayload(String json) {


### PR DESCRIPTION
Jira issue: SWATCH-5170

## Description
This PR makes the feature-flag state observable on management `GET /info` for Quarkus services (same was already done for Spring Boot services in https://github.com/RedHatInsights/rhsm-subscriptions/pull/6351).
Moreover, it improves the component test framework to **wait on feature flag changes** instead of sleeping 2 seconds.

### What changed
* New Quarkus module `swatch-common-info`: Vert.x management `GET /info`, `InfoContributor` / `InfoFeatureFlagContributor` SPI, `UnleashInfoFeatureFlags` helper.
* Quarkus services with Unleash `FeatureFlags` contribute to `/info`: **utilization**, **contracts**, **producer-aws**, **metrics-hbi**.
* Shared schema `swatch-core/schemas/info_feature_flags.yaml` → generated models for Quarkus / Spring Boot / test-framework.
* Spring `FeatureFlagsInfoContributor` now emits a **list** of `InfoFeatureFlag` (same contract as Quarkus), not `Map<String,Boolean>`.
* `UnleashService` waits on management `/info` after enable/disable/setVariant; **no sleep fallback**

### Example `/info` shape
```json
"feature-flags": [
  {
    "name": "swatch.swatch-notifications.send-notifications",
    "enabled": true,
    "variant": {
      "name": "send-notifications-config",
      "enabled": true,
      "payload": { "type": "string", "value": "{\"event_types_denylist\":[...]}" }
    }
  }
```

### Design decisions

- Why not quarkus-info / the standard Quarkus info extension?

We evaluated Quarkus’s built-in info support (quarkus-info / similar Actuator-style contributors) and did not use it for this use case because this extension captures build/Git/Java details at startup (or caches contributor output) does not reliably reflect Unleash client refreshes mid-test at runtime.

- Why a list, not a map of booleans?
#6351 originally exposed "feature-flags": { "toggle": true|false } for tally. For Quarkus CT we need variant payload equality in waits (denylist JSON, org allowlist strings). The list+variant shape is the richer contract; tally was updated to the same list (enabled only, no variant when Unleash has none) so the harness stays unified.

## Testing
CI is green and passing faster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized management `/info` endpoint across services.
  * Exposed feature flags with enabled states, variants, and payload details.
  * Added support for retrieving feature flags through the test framework.
  * Added consistent feature-flag schemas and shared information models.

* **Bug Fixes**
  * Improved feature-flag configuration checks and JSON payload handling in test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->