### PR TITLE
SWATCH-5161: Inflated hypervisor usage for a customer account

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
+++ b/src/main/java/org/candlepin/subscriptions/resource/api/v1/TallyResource.java
@@ -168,8 +168,10 @@ public class TallyResource implements TallyApi {
             : Collections.emptyMap();
 
     // Execute query based on feature flag - each path returns unified result
+    // Note that ReportCategory.HYPERVISOR is not supported by the primary row search
     TallyQueryResult queryResult =
         featureFlags.isEnabled(FeatureFlags.ENABLE_PRIMARY_ROW_SEARCHES)
+                && !ReportCategory.HYPERVISOR.equals(category)
             ? executeAggregateQuery(reportCriteria, metricId, category)
             : executeSnapshotBasedQuery(reportCriteria, metricId, category);
     List<UnroundedTallyReportDataPoint> snaps = queryResult.dataPoints();
@@ -408,7 +410,7 @@ public class TallyResource implements TallyApi {
   private TallyQueryResult executeAggregateQuery(
       ReportCriteria reportCriteria, MetricId metricId, ReportCategory category) {
 
-    log.info("Using primary row searches for tally report");
+    log.debug("Using primary row searches for tally report");
 
     Set<HardwareMeasurementType> measurementTypes = determineMeasurementTypes(category);
 

--- a/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/resource/api/v1/TallyResourceTest.java
@@ -461,7 +461,9 @@ class TallyResourceTest {
       assertEquals(48, response.getMeta().getTotalMonthly().getValue());
     }
 
-    @EnumSource(names = "CLOUD", mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(
+        names = {"CLOUD", "HYPERVISOR"},
+        mode = EnumSource.Mode.EXCLUDE)
     @ParameterizedTest(name = DISPLAY_NAME_PLACEHOLDER + " " + DEFAULT_DISPLAY_NAME)
     void testTallyReportDataCategoriesUsingHardwareMeasurements(ReportCategory category) {
       List<TallyMeasurementAggregate> aggregates = new ArrayList<>();
@@ -495,6 +497,43 @@ class TallyResourceTest {
               null);
       assertEquals(
           4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+    }
+
+    @Test
+    void testTallyReportDataHypervisorCategoryUsingHardwareMeasurements() {
+      TallySnapshot snapshot = new TallySnapshot();
+      snapshot.setSnapshotDate(OffsetDateTime.parse("2021-10-05T00:00Z"));
+      for (HardwareMeasurementType hardwareMeasurementType : HardwareMeasurementType.values()) {
+        snapshot.setMeasurement(hardwareMeasurementType, MetricIdUtils.getCores(), 4.0);
+      }
+      when(repository.findSnapshot(
+              any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+          .thenReturn(new PageImpl<>(List.of(snapshot)));
+
+      TallyReportData response =
+          resource.getTallyReportData(
+              RHEL_FOR_X86,
+              METRIC_ID_CORES,
+              GranularityType.DAILY,
+              OffsetDateTime.parse("2021-10-01T00:00Z"),
+              OffsetDateTime.parse("2021-10-30T00:00Z"),
+              ReportCategory.HYPERVISOR,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              false,
+              null);
+      assertEquals(
+          4.0, response.getData().stream().mapToDouble(TallyReportDataPoint::getValue).sum());
+      Mockito.verify(repository)
+          .findSnapshot(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+      Mockito.verify(repository, Mockito.never())
+          .findSummedMeasurements(
+              any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+              any());
     }
 
     @Test

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportHypervisorSocketsTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportHypervisorSocketsTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static utils.TallyTestProducts.RHEL_FOR_X86;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import utils.TallyHbiDbSeeder;
+
+/**
+ * SWATCH-5161: Verify hypervisor socket counts are not inflated.
+ *
+ * <p>Tests the scenario where multiple ESX hypervisor hosts have virtual guests. The tally report
+ * filtered by category=hypervisor should reflect only the sum of the hypervisors' own socket
+ * counts, not be inflated by guest VM counts or double-counting.
+ */
+public class TallyReportHypervisorSocketsTest extends BaseTallyComponentTest {
+
+  private TallyHbiDbSeeder hbiSeeder;
+
+  @BeforeEach
+  void setupHbiSeeder() {
+    hbiSeeder = new TallyHbiDbSeeder(hbiDatabase);
+  }
+
+  @AfterEach
+  void cleanupHbiHosts() {
+    if (hbiSeeder != null) {
+      hbiSeeder.deleteAllInsertedHosts();
+    }
+  }
+
+  /**
+   * SWATCH-5161: Hypervisor socket count should equal the sum of actual hypervisor host sockets.
+   *
+   * <p>Setup: 3 ESX hypervisor hosts (4 + 4 + 2 = 10 total sockets) with 4 virtual guests spread
+   * across them. The guests have their own socket counts which should NOT inflate the hypervisor
+   * total.
+   *
+   * <p>Expected: category=hypervisor report shows exactly 10 sockets.
+   */
+  @Test
+  @TestPlanName("tally-hypervisor-TC008")
+  void testHypervisorSocketCountNotInflated() {
+    givenFeatureFlagIsConfigured(true);
+    service.createOptInConfig(orgId);
+
+    String hypSubmanId1 = helpers.generateUUIDOfSize(false, 36);
+    String hypSubmanId2 = helpers.generateUUIDOfSize(false, 36);
+    String hypSubmanId3 = helpers.generateUUIDOfSize(false, 36);
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId1)
+        .displayName("ESX-Host-1")
+        .sockets(4)
+        .cores(16)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId2)
+        .displayName("ESX-Host-2")
+        .sockets(4)
+        .cores(16)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId3)
+        .displayName("ESX-Host-3")
+        .sockets(2)
+        .cores(8)
+        .insert();
+
+    // 4 virtual guests linked to the hypervisors via virtualHostUuid
+    // 3 hypervisors: 4 + 4 + 2 = 10 total sockets
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("VM-Guest-1")
+        .sockets(2)
+        .cores(4)
+        .hypervisorUuid(hypSubmanId1)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("VM-Guest-2")
+        .sockets(2)
+        .cores(4)
+        .hypervisorUuid(hypSubmanId1)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("VM-Guest-3")
+        .sockets(4)
+        .cores(8)
+        .hypervisorUuid(hypSubmanId2)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("VM-Guest-4")
+        .sockets(2)
+        .cores(2)
+        .hypervisorUuid(hypSubmanId3)
+        .insert();
+
+    service.tallyOrg(orgId);
+
+    OffsetDateTime beginning = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime ending = OffsetDateTime.now().plusDays(1);
+
+    var reportData =
+        service.getTallyReportData(
+            orgId,
+            RHEL_FOR_X86.productTag(),
+            "Sockets",
+            Map.of(
+                "granularity",
+                "Daily",
+                "beginning",
+                beginning.toString(),
+                "ending",
+                ending.toString(),
+                "category",
+                "hypervisor"));
+
+    assertNotNull(reportData, "Tally report should be created");
+    assertNotNull(reportData.getData(), "Report should have data");
+    assertFalse(reportData.getData().isEmpty(), "Report should not be empty");
+
+    boolean hasExpectedSockets =
+        reportData.getData().stream()
+            .anyMatch(point -> point.getValue() != null && point.getValue() == 10);
+    assertTrue(
+        hasExpectedSockets,
+        "Hypervisor socket count should be 10 (sum of hypervisor host sockets 4+4+2),"
+            + " not inflated by guest VM socket counts. Actual data points: "
+            + reportData.getData().stream()
+                .map(TallyReportDataPoint::getValue)
+                .collect(Collectors.toList()));
+  }
+
+  /**
+   * SWATCH-5161: Virtual guests with known hypervisors should not contribute sockets to the virtual
+   * category.
+   *
+   * <p>For RHEL VDC products, guests mapped to a known hypervisor should not produce their own
+   * tally buckets. Only unmapped guests contribute to the virtual category.
+   */
+  @Test
+  @TestPlanName("tally-hypervisor-TC009")
+  void testMappedGuestsDoNotContributeToVirtualCategory() {
+    givenFeatureFlagIsConfigured(true);
+    service.createOptInConfig(orgId);
+
+    String hypSubmanId = helpers.generateUUIDOfSize(false, 36);
+
+    // 1 hypervisor with 4 sockets
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId)
+        .displayName("ESX-Hypervisor")
+        .sockets(4)
+        .cores(16)
+        .insert();
+
+    // 2 guests mapped to the hypervisor
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Mapped-Guest-1")
+        .sockets(2)
+        .cores(4)
+        .hypervisorUuid(hypSubmanId)
+        .insert();
+
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Mapped-Guest-2")
+        .sockets(2)
+        .cores(4)
+        .hypervisorUuid(hypSubmanId)
+        .insert();
+
+    service.tallyOrg(orgId);
+
+    OffsetDateTime beginning = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime ending = OffsetDateTime.now().plusDays(1);
+
+    // Mapped guests should not appear in the virtual category
+    var virtualReport =
+        service.getTallyReportData(
+            orgId,
+            RHEL_FOR_X86.productTag(),
+            "Sockets",
+            Map.of(
+                "granularity",
+                "Daily",
+                "beginning",
+                beginning.toString(),
+                "ending",
+                ending.toString(),
+                "category",
+                "virtual"));
+
+    assertNotNull(virtualReport, "Virtual category report should be created");
+    assertNotNull(virtualReport.getData(), "Virtual category report should have data");
+    int virtualSockets =
+        virtualReport.getData().stream()
+            .filter(p -> p.getValue() != null)
+            .mapToInt(TallyReportDataPoint::getValue)
+            .sum();
+    assertEquals(
+        0,
+        virtualSockets,
+        "Guests mapped to a known hypervisor should not contribute sockets to virtual category");
+  }
+
+  /**
+   * Demonstrates that a hypervisor with guests of different SLAs/usages produces multiple tally
+   * buckets, each carrying the hypervisor's full socket count. Individual SLA-filtered queries may
+   * overlap (e.g. Premium=8, Standard=12, sum=20 > actual total of 12), but the wildcard query (no
+   * SLA filter) correctly returns the actual hypervisor socket total because it reads from the _ANY
+   * rows rather than summing per-SLA buckets.
+   */
+  @Test
+  @TestPlanName("tally-hypervisor-TC010")
+  void testHypervisorSocketCountNotInflatedByMixedSlaUsage() {
+    givenFeatureFlagIsConfigured(true);
+    service.createOptInConfig(orgId);
+
+    String hypSubmanId1 = helpers.generateUUIDOfSize(false, 36);
+    String hypSubmanId2 = helpers.generateUUIDOfSize(false, 36);
+
+    // Hypervisor 1 with 8 sockets
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId1)
+        .displayName("ESX-Mixed-SLA-Host-1")
+        .sockets(8)
+        .cores(16)
+        .sla("")
+        .usage("")
+        .insert();
+
+    // Hypervisor 2 with 4 sockets
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(hypSubmanId2)
+        .displayName("ESX-Mixed-SLA-Host-2")
+        .sockets(4)
+        .cores(16)
+        .sla("")
+        .usage("")
+        .insert();
+
+    // Guest on Hyp1 with SLA=Premium, Usage=Production
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Guest-Hyp1-Premium")
+        .sockets(2)
+        .cores(4)
+        .sla("Premium")
+        .usage("Production")
+        .hypervisorUuid(hypSubmanId1)
+        .insert();
+
+    // Guest on Hyp1 with SLA=Standard, Usage=Development/Test
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Guest-Hyp1-Standard-Dev")
+        .sockets(2)
+        .cores(4)
+        .sla("Standard")
+        .usage("Development/Test")
+        .hypervisorUuid(hypSubmanId1)
+        .insert();
+
+    // Guest on Hyp2 with SLA=Standard, Usage=Development/Test
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Guest-Hyp2-Standard-Dev")
+        .sockets(2)
+        .cores(4)
+        .sla("Standard")
+        .usage("Development/Test")
+        .hypervisorUuid(hypSubmanId2)
+        .insert();
+
+    // Guest on Hyp1 with SLA=Standard, Usage=Production
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Guest-Hyp1-Standard-Prod")
+        .sockets(2)
+        .cores(4)
+        .sla("Standard")
+        .usage("Production")
+        .hypervisorUuid(hypSubmanId1)
+        .insert();
+
+    // Guest on Hyp2 with SLA=Standard, Usage=""
+    hbiSeeder
+        .rhelHost(orgId)
+        .subscriptionManagerId(helpers.generateUUIDOfSize(false, 36))
+        .displayName("Guest-Hyp2-Standard-Empty")
+        .sockets(2)
+        .cores(4)
+        .sla("Standard")
+        .usage("")
+        .hypervisorUuid(hypSubmanId2)
+        .insert();
+
+    service.tallyOrg(orgId);
+
+    OffsetDateTime beginning = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime ending = OffsetDateTime.now().plusDays(1);
+
+    // Query hypervisor report filtered by SLA=Premium
+    var premiumReport =
+        service.getTallyReportData(
+            orgId,
+            RHEL_FOR_X86.productTag(),
+            "Sockets",
+            Map.of(
+                "granularity", "Daily",
+                "beginning", beginning.toString(),
+                "ending", ending.toString(),
+                "category", "hypervisor",
+                "sla", "Premium"));
+
+    // Query hypervisor report filtered by SLA=Standard
+    var standardReport =
+        service.getTallyReportData(
+            orgId,
+            RHEL_FOR_X86.productTag(),
+            "Sockets",
+            Map.of(
+                "granularity", "Daily",
+                "beginning", beginning.toString(),
+                "ending", ending.toString(),
+                "category", "hypervisor",
+                "sla", "Standard"));
+
+    assertNotNull(premiumReport, "Premium report should be created");
+    assertNotNull(premiumReport.getData(), "Premium report should have data");
+    assertNotNull(standardReport, "Standard report should be created");
+    assertNotNull(standardReport.getData(), "Standard report should have data");
+
+    int premiumSockets =
+        premiumReport.getData().stream()
+            .filter(p -> p.getValue() != null && p.getValue() > 0)
+            .mapToInt(TallyReportDataPoint::getValue)
+            .max()
+            .orElse(0);
+
+    int standardSockets =
+        standardReport.getData().stream()
+            .filter(p -> p.getValue() != null && p.getValue() > 0)
+            .mapToInt(TallyReportDataPoint::getValue)
+            .max()
+            .orElse(0);
+
+    int actualPremiumHypervisorSockets = 8; // 1 hypervisor with 8 sockets
+    int totalHypervisorSockets = 12; // 2 hypervisors with 4 and 8 sockets
+
+    // Each SLA-specific query reports hypervisors' sockets
+    assertEquals(
+        actualPremiumHypervisorSockets,
+        premiumSockets,
+        "Premium SLA hypervisor report shows Hyp1's socket count (only hypervisor with Premium guests)");
+    assertEquals(
+        totalHypervisorSockets,
+        standardSockets,
+        "Standard SLA hypervisor report shows both hypervisors' socket count");
+
+    // Query hypervisor report without specifying SLA (wildcard)
+    var noSlaReport =
+        service.getTallyReportData(
+            orgId,
+            RHEL_FOR_X86.productTag(),
+            "Sockets",
+            Map.of(
+                "granularity",
+                "Daily",
+                "beginning",
+                beginning.toString(),
+                "ending",
+                ending.toString(),
+                "category",
+                "hypervisor"));
+
+    assertNotNull(noSlaReport, "No-SLA report should be created");
+    assertNotNull(noSlaReport.getData(), "No-SLA report should have data");
+
+    int noSlaSockets =
+        noSlaReport.getData().stream()
+            .filter(p -> p.getValue() != null && p.getValue() > 0)
+            .mapToInt(TallyReportDataPoint::getValue)
+            .max()
+            .orElse(0);
+
+    // The wildcard (no SLA filter) report correctly shows the combined hypervisor total
+    assertEquals(
+        totalHypervisorSockets,
+        noSlaSockets,
+        String.format(
+            "Wildcard SLA report (%d) should equal actual hypervisor sockets (%d)",
+            noSlaSockets, totalHypervisorSockets));
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5161

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

When we changed over to the is_primary rows for report queries, we found a problem with the implementation. For other report categories outside of HYPERVISOR, summing the values across the search filter result gave the correct answer.

For the HYPERVISOR category, the summation would lead to largely excessive values. The solution in the near term is to revert the query to the '_ANY' version regardless of the unleash flag setting for is_primary.

## Testing

### Setup
<!-- Add any steps required to set up the test case -->
1. You need to pull the most current swatch-support-scripts
2. ```podman compose up -d```
3. oc login to prod
4. in your swatch-support-scripts directory, run
```./import_hbi_hosts_by_org.sh --org 15327614```

### Steps
<!-- Enter each step of the test below -->
1. ```make swatch-tally```
2. Opt in (you may need to add the org to the org_config table first)
```http PUT ":8010/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/15327614" x-rh-swatch-psk:placeholder```
3. Run the nightly tally
```http PUT ":8010/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/15327614" x-rh-swatch-psk:placeholder```

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run the report command adjusting for the current date
```http GET ':8010/api/rhsm-subscriptions/v1/tally/products/RHEL for x86/Sockets' x-rh-identity:$(echo '{"identity":{"internal":{"org_id":"15327614"}}}' | base64 -w0) granularity==DAILY category==hypervisor beginning=='2026-08-04T00:00Z' ending=='2026-08-06T23:59Z'```
2. You should see a valid value for the daily. It cannot exceed the number of hypervisor sockets for the org, Note that this is the data from the org in the bug.

```
{
    "data": [
        {
            "date": "2026-08-04T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2026-08-05T00:00:00Z",
            "has_data": false,
            "value": 0
        },
        {
            "date": "2026-08-06T00:00:00Z",
            "has_data": true,
            "value": 44
        }
    ],
    "meta": {
        "count": 3,
        "granularity": "Daily",
        "metric_id": "Sockets",
        "product": "RHEL for x86"
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Hypervisor reports now use snapshot data when primary row searches are enabled.
  * Hypervisor socket totals correctly exclude guest sockets and handle mapped guests, SLA filters, and wildcard reports.

* **Tests**
  * Added coverage for snapshot-based hypervisor reports and socket tally scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->