### PR TITLE
SWATCH-5295: Persist Partner Gateway licenseArn as contract licenseId

### DIFF
--- a/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
+++ b/clients/rh-partner-gateway-client/rh-partner-gateway-api-spec.yaml
@@ -119,6 +119,10 @@ components:
           type: string
         sellerAccountId:
           type: string
+        licenseArn:
+          description: AWS License Manager ARN for the entitlement.
+          type: string
+          nullable: true
         azureSubscriptionId:
           type: string
         azureTenantId:

--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -863,6 +863,43 @@ This section verifies the automatic contract termination behavior when contracts
   - Contract synced with upstream end_date
   - Subscription retains all contract-provided state
 
+**contracts-sync-TC019 - Two AWS contracts with same billingProviderId both persist**
+- **Description**: Two AWS contracts for the same org/product/AWS account (same `billingProviderId`) but different `subscriptionNumber` and `partnerIdentities.licenseArn` must both survive sync. Syncing must not delete one when processing the other.
+- **Setup**:
+  - Stub Partner Gateway with two AWS ROSA entitlements sharing product code, aws customer id, and seller account id
+  - Different `subscriptionNumber` and `partnerIdentities.licenseArn` on each
+  - Stub Search API for both subscription numbers
+  - Sync offering for the shared SKU
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{org_id}`
+- **Verification**:
+  - Two contracts for the org
+  - Each `subscriptionNumber` present
+  - Re-sync with the same upstream stubs leaves both contracts (stable UUIDs)
+- **Expected Result**: HTTP 200. Both contracts persisted. Second sync is idempotent
+
+**contracts-sync-TC020 - Re-sync updates only one of two AWS contracts sharing billingProviderId**
+- **Description**: After two AWS contracts with the same `billingProviderId` exist, changing capacity/`endDate` for contract A only must update A and leave B unchanged.
+- **Setup**:
+  - Stub Partner Gateway with two AWS ROSA entitlements that share product code, aws customer id, and seller account id (same `billingProviderId`)
+  - Different `subscriptionNumber` and `partnerIdentities.licenseArn` on each entitlement
+  - Stub Search API for both subscription numbers and sync the shared SKU offering
+  - Sync contracts once so both contracts exist
+  - Re-stub Partner Gateway with A’s metrics/`endDate` changed and B unchanged
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{org_id}`
+- **Verification**:
+  - Contract for A’s `subscriptionNumber` reflects the new end date / capacity
+  - Contract for B’s `subscriptionNumber` keeps prior UUID and end date
+- **Expected Result**: HTTP 200. Only contract A updated
+
+**contracts-sync-TC021 - Entitlement without Partner Gateway licenseArn syncs with null licenseId**
+- **Description**: Legacy entitlements with no `partnerIdentities.licenseArn` still sync successfully; contract is created with `licenseId` null (no failure when the field is absent).
+- **Setup**:
+  - Stub one AWS ROSA entitlement **without** `partnerIdentities.licenseArn`
+  - Stub Search API and sync offering
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{org_id}`
+- **Verification**: One contract for the org; sync status SUCCESS
+- **Expected Result**: HTTP 200; sync succeeds with no failure when `partnerIdentities.licenseArn` is absent
+
 ## Subscription Management via IT Subscription
 
 **subscriptions-creation-TC001 - Process a valid UMB subscription XML message from UMB**  

--- a/swatch-contracts/ct/java/api/PartnerApiStubs.java
+++ b/swatch-contracts/ct/java/api/PartnerApiStubs.java
@@ -235,15 +235,14 @@ public class PartnerApiStubs {
     body.put("rhAccountId", contract.getOrgId());
     body.put("sourcePartner", "aws_marketplace");
     body.put("entitlementDates", buildEntitlementDates(contract));
-    body.put(
-        "partnerIdentities",
-        Map.of(
-            "awsCustomerId",
-            contract.getCustomerId(),
-            "customerAwsAccountId",
-            contract.getBillingAccountId(),
-            "sellerAccountId",
-            contract.getSellerAccountId()));
+    var partnerIdentities = new HashMap<String, Object>();
+    partnerIdentities.put("awsCustomerId", contract.getCustomerId());
+    partnerIdentities.put("customerAwsAccountId", contract.getBillingAccountId());
+    partnerIdentities.put("sellerAccountId", contract.getSellerAccountId());
+    if (contract.getLicenseId() != null) {
+      partnerIdentities.put("licenseArn", contract.getLicenseId());
+    }
+    body.put("partnerIdentities", partnerIdentities);
     body.put(
         "purchase",
         Map.of(

--- a/swatch-contracts/ct/java/domain/Contract.java
+++ b/swatch-contracts/ct/java/domain/Contract.java
@@ -46,6 +46,9 @@ public class Contract extends Subscription {
   /** Product Code */
   private final String productCode;
 
+  /** Marketplace license id (Partner Gateway partnerIdentities.licenseArn for AWS). */
+  private final String licenseId;
+
   /** Plan ID (only relevant for Azure contracts) */
   private final String planId;
 

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -37,9 +37,11 @@ import api.PartnerApiStubs;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.contract.test.model.SkuCapacitySubscription;
 import domain.BillingProvider;
 import domain.Contract;
+import domain.Product;
 import io.restassured.response.Response;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -64,16 +66,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     Contract azureContract =
         Contract.buildRosaContract(orgId, BillingProvider.AZURE, Map.of(CORES, 20.0), sku);
 
-    // Stub offering and partner API
-    wiremock.forProductAPI().stubOfferingData(awsContract.getOffering());
-    wiremock
-        .forPartnerAPI()
-        .stubPartnerSubscriptions(forContractsInOrgId(orgId, awsContract, azureContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(awsContract, azureContract);
-
-    // Sync offering needed for contracts to persist with the SKU
-    Response syncOffering = service.syncOffering(sku);
-    assertThat("Sync offering should succeed", syncOffering.statusCode(), is(HttpStatus.SC_OK));
+    stubContractsForOrgSync(awsContract, azureContract);
 
     // When: Sync contracts for the organization
     Response syncResponse = service.syncContractsByOrg(orgId);
@@ -161,8 +154,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     // Setup new upstream contracts (different from existing - same SKU, different provider)
     Contract newContract =
         Contract.buildRosaContract(orgId, BillingProvider.AZURE, Map.of(CORES, 20.0), sku);
-    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId, newContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(newContract);
+    stubPartnerAndSearch(newContract);
 
     // When: Delete existing data and re-sync contracts
     service.deleteDataForOrg(orgId);
@@ -320,10 +312,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
 
     wiremock.forProductAPI().stubOfferingData(awsContract.getOffering());
     // Both contracts are returned by the partner API for this org
-    wiremock
-        .forPartnerAPI()
-        .stubPartnerSubscriptions(forContractsInOrgId(orgId, awsContract, azureContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(awsContract, azureContract);
+    stubPartnerAndSearch(awsContract, azureContract);
 
     assertThat(
         "Sync offering should succeed",
@@ -388,8 +377,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
         Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, coresCapacity), sku);
 
     wiremock.forProductAPI().stubOfferingData(contract.getOffering());
-    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId, contract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+    stubPartnerAndSearch(contract);
 
     assertThat(
         "Sync offering should succeed",
@@ -540,8 +528,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     // Stub upstream to return a different entitlement (different billing_provider_id)
     Contract newContract =
         Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 20.0), sku);
-    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId, newContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(newContract);
+    stubPartnerAndSearch(newContract);
 
     // Action: Sync contracts
     Response syncResponse = service.syncContractsByOrg(orgId);
@@ -644,8 +631,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertNotNull(endDateBefore, "Contract should have an end_date");
 
     // Stub upstream to return the same Azure entitlement
-    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId, azureContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(azureContract);
+    stubPartnerAndSearch(azureContract);
 
     // When: Sync contracts
     Response syncResponse = service.syncContractsByOrg(orgId);
@@ -776,10 +762,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     // Given: Upstream now returns the same contract but with end_date in the past
     Contract terminatedContract =
         contract.toBuilder().endDate(OffsetDateTime.now().minusDays(1)).build();
-    wiremock
-        .forPartnerAPI()
-        .stubPartnerSubscriptions(forContractsInOrgId(orgId, terminatedContract));
-    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(terminatedContract);
+    stubPartnerAndSearch(terminatedContract);
 
     // When: Sync contracts
     Response syncResponse = service.syncContractsByOrg(orgId);
@@ -799,6 +782,122 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertFalse(
         subsAfter.get(0).getMetrics().isEmpty(),
         "Subscription measurements should be preserved after legitimate termination");
+  }
+
+  @TestPlanName("contracts-sync-TC019")
+  @Test
+  void shouldPersistBothAwsContractsSharingBillingProviderId() {
+    // Given: two AWS contracts, same billingProviderId, different subscriptionNumbers
+    Contract shared =
+        Contract.buildRosaContract(
+            orgId, BillingProvider.AWS, Map.of(CORES, 10.0), RandomUtils.generateRandom());
+    Contract contractA =
+        shared.toBuilder().licenseId(awsLicenseArn(shared.getSubscriptionNumber())).build();
+    String subscriptionB = RandomUtils.generateRandom();
+    Contract contractB =
+        shared.toBuilder()
+            .subscriptionNumber(subscriptionB)
+            .subscriptionId(subscriptionB)
+            .licenseId(awsLicenseArn(subscriptionB))
+            .build();
+    stubContractsForOrgSync(contractA, contractB);
+
+    // When / Then: both persist, and re-sync keeps stable UUIDs
+    assertThat(
+        "Sync should succeed",
+        service.syncContractsByOrg(orgId).statusCode(),
+        is(HttpStatus.SC_OK));
+    thenAssertContractsPresentBySubscriptionNumber(contractA, contractB);
+    String uuidA = getPersistedContract(contractA).getUuid();
+    String uuidB = getPersistedContract(contractB).getUuid();
+
+    assertThat(
+        "Second sync should succeed",
+        service.syncContractsByOrg(orgId).statusCode(),
+        is(HttpStatus.SC_OK));
+    thenAssertContractsPresentBySubscriptionNumber(contractA, contractB);
+    assertEquals(
+        uuidA,
+        getPersistedContract(contractA).getUuid(),
+        "Contract A UUID must be stable across sync");
+    assertEquals(
+        uuidB,
+        getPersistedContract(contractB).getUuid(),
+        "Contract B UUID must be stable across sync");
+  }
+
+  @TestPlanName("contracts-sync-TC020")
+  @Test
+  void shouldUpdateOnlyOneAwsContractSharingBillingProviderIdOnResync() {
+    // Given: two AWS contracts sharing billingProviderId, both synced
+    Contract shared =
+        Contract.buildRosaContract(
+            orgId, BillingProvider.AWS, Map.of(CORES, 10.0), RandomUtils.generateRandom());
+    Contract contractA =
+        shared.toBuilder().licenseId(awsLicenseArn(shared.getSubscriptionNumber())).build();
+    String subscriptionB = RandomUtils.generateRandom();
+    Contract contractB =
+        shared.toBuilder()
+            .subscriptionNumber(subscriptionB)
+            .subscriptionId(subscriptionB)
+            .licenseId(awsLicenseArn(subscriptionB))
+            .build();
+    stubContractsForOrgSync(contractA, contractB);
+    assertThat(
+        "Initial sync should succeed",
+        service.syncContractsByOrg(orgId).statusCode(),
+        is(HttpStatus.SC_OK));
+    thenAssertContractsPresentBySubscriptionNumber(contractA, contractB);
+
+    var beforeB = getPersistedContract(contractB);
+    Contract updatedA =
+        contractA.toBuilder()
+            .endDate(contractA.getEndDate().plusDays(7))
+            .subscriptionMeasurements(
+                Map.of(CORES, contractA.getSubscriptionMeasurements().get(CORES) + 10.0))
+            .build();
+    stubPartnerAndSearch(updatedA, contractB);
+
+    // When: re-sync with only contract A changed
+    assertThat(
+        "Sync should succeed",
+        service.syncContractsByOrg(orgId).statusCode(),
+        is(HttpStatus.SC_OK));
+
+    // Then: A updated; B unchanged
+    var afterA = getPersistedContract(contractA);
+    var afterB = getPersistedContract(contractB);
+    assertDatesAreEqual(updatedA.getEndDate(), afterA.getEndDate());
+    assertEquals(
+        updatedA.getContractMetrics().get(awsDimensionFor(CORES)),
+        getAwsMetricValue(afterA, CORES),
+        "Contract A CORES metric must be updated");
+    assertDatesAreEqual(beforeB.getEndDate(), afterB.getEndDate());
+    assertEquals(
+        getAwsMetricValue(beforeB, CORES),
+        getAwsMetricValue(afterB, CORES),
+        "Contract B CORES metric must be unchanged");
+    assertEquals(beforeB.getUuid(), afterB.getUuid(), "Contract B UUID must not change");
+  }
+
+  @TestPlanName("contracts-sync-TC021")
+  @Test
+  void shouldSyncAwsEntitlementWhenLicenseArnIsAbsent() {
+    // Given: AWS entitlement without partnerIdentities.licenseArn
+    String sku = RandomUtils.generateRandom();
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0), sku);
+    assertNull(
+        contract.getLicenseId(), "Fixture must omit partnerIdentities.licenseArn for legacy path");
+    stubContractsForOrgSync(contract);
+
+    // When
+    Response syncResponse = service.syncContractsByOrg(orgId);
+
+    // Then
+    assertThat("Sync should succeed", syncResponse.statusCode(), is(HttpStatus.SC_OK));
+    syncResponse.then().body("status", equalTo(STATUS_SUCCESS));
+    thenContractsSizeAre(1);
   }
 
   protected String getContractUuidByProvider(String orgId, BillingProvider provider) {
@@ -989,15 +1088,71 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
           Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0), sku));
     }
     wiremock.forProductAPI().stubOfferingData(contracts.get(0).getOffering());
-    wiremock
-        .forPartnerAPI()
-        .stubPartnerSubscriptions(
-            PartnerApiStubs.PartnerSubscriptionsStubRequest.forContractsInOrgId(
-                orgId, contracts.toArray(new Contract[0])));
-    wiremock
-        .forSearchApi()
-        .stubGetSubscriptionBySubscriptionNumber(contracts.toArray(new Contract[0]));
+    stubPartnerAndSearch(contracts.toArray(new Contract[0]));
     Response sync = service.syncOffering(sku);
     assertEquals(HttpStatus.SC_OK, sync.statusCode(), "Sync offering should succeed");
+  }
+
+  private static String awsLicenseArn(String subscriptionNumber) {
+    return "arn:aws:license-manager:us-east-1:000000000000:license:" + subscriptionNumber;
+  }
+
+  private void stubContractsForOrgSync(Contract... contracts) {
+    assertTrue(contracts.length > 0, "At least one contract is required");
+    wiremock.forProductAPI().stubOfferingData(contracts[0].getOffering());
+    stubPartnerAndSearch(contracts);
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.syncOffering(contracts[0].getOffering().getSku()).statusCode(),
+        "Sync offering should succeed");
+  }
+
+  private void stubPartnerAndSearch(Contract... contracts) {
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContractsInOrgId(orgId, contracts));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contracts);
+  }
+
+  private void thenAssertContractsPresentBySubscriptionNumber(Contract... expected) {
+    thenAssertContractsForOrg(
+        contracts -> {
+          assertEquals(
+              expected.length, contracts.size(), "Expected all stubbed contracts to be present");
+          for (Contract expectedContract : expected) {
+            assertTrue(
+                contracts.stream()
+                    .anyMatch(
+                        c ->
+                            expectedContract
+                                .getSubscriptionNumber()
+                                .equals(c.getSubscriptionNumber())),
+                "subscriptionNumber "
+                    + expectedContract.getSubscriptionNumber()
+                    + " must be present");
+          }
+        });
+  }
+
+  private com.redhat.swatch.contract.test.model.Contract getPersistedContract(Contract expected) {
+    return service.getContractsByOrgId(orgId).stream()
+        .filter(c -> expected.getSubscriptionNumber().equals(c.getSubscriptionNumber()))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "No contract for subscriptionNumber=" + expected.getSubscriptionNumber()));
+  }
+
+  private static String awsDimensionFor(MetricId metricId) {
+    return Product.ROSA.getMetric(metricId).getAwsDimension();
+  }
+
+  private static double getAwsMetricValue(
+      com.redhat.swatch.contract.test.model.Contract contract, MetricId metricId) {
+    String dimension = awsDimensionFor(metricId);
+    return contract.getMetrics().stream()
+        .filter(m -> dimension.equals(m.getMetricId()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Missing metric " + dimension))
+        .getValue();
   }
 }

--- a/swatch-contracts/ct/pom.xml
+++ b/swatch-contracts/ct/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -77,6 +77,10 @@ public interface ContractEntityMapper {
   @Mapping(target = "startDate", expression = "java(extractStartDate(entitlement, contract))")
   @Mapping(target = "endDate", expression = "java(extractEndDate(entitlement, contract))")
   @Mapping(target = "metrics", source = "contract.dimensions", qualifiedByName = "metrics")
+  @Mapping(
+      target = "licenseId",
+      source = "entitlement.partnerIdentities",
+      qualifiedByName = "licenseId")
   @BeanMapping(ignoreByDefault = true)
   ContractEntity mapEntitlementToContractEntity(
       PartnerEntitlementV1 entitlement, SaasContractV1 contract);
@@ -107,6 +111,11 @@ public interface ContractEntityMapper {
       return accountId.getAzureSubscriptionId();
     }
     return null;
+  }
+
+  @Named("licenseId")
+  default String extractLicenseId(PartnerIdentityV1 partnerIdentities) {
+    return partnerIdentities == null ? null : partnerIdentities.getLicenseArn();
   }
 
   /** Extract billingProviderId from Partner Gateway API response */

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/ContractEntity.java
@@ -32,8 +32,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -103,6 +105,10 @@ public class ContractEntity extends ModificationTrackedEntity {
   @Column(name = "vendor_product_code", nullable = false)
   private String vendorProductCode;
 
+  @Basic
+  @Column(name = "license_id")
+  private String licenseId;
+
   @NotNull
   @Builder.Default
   @OneToMany(
@@ -152,7 +158,8 @@ public class ContractEntity extends ModificationTrackedEntity {
         && Objects.equals(metrics, that.metrics)
         && Objects.equals(startDate, that.startDate)
         && Objects.equals(endDate, that.endDate)
-        && Objects.equals(vendorProductCode, that.vendorProductCode);
+        && Objects.equals(vendorProductCode, that.vendorProductCode)
+        && Objects.equals(licenseId, that.licenseId);
   }
 
   @Override
@@ -164,7 +171,8 @@ public class ContractEntity extends ModificationTrackedEntity {
         billingProvider,
         billingAccountId,
         metrics,
-        vendorProductCode);
+        vendorProductCode,
+        licenseId);
   }
 
   public String getAzureResourceId() {
@@ -244,15 +252,46 @@ public class ContractEntity extends ModificationTrackedEntity {
         builder.equal(root.get(ContractEntity_.billingProviderId), billingProviderId);
   }
 
-  public static Specification<ContractEntity> billingProviderIdNullOrNotIn(
-      Set<String> billingProviderIds) {
+  /**
+   * Candidates to terminate after Partner Gateway sync: not an exact match for any {@code
+   * upstreamContracts} row ({@code billingProviderId} + {@code subscriptionNumber}, null-safe).
+   * Empty collection matches all contracts.
+   */
+  public static Specification<ContractEntity> orphanedByUpstreamContracts(
+      Collection<ContractIdentity> upstreamContracts) {
     return (root, query, builder) -> {
-      if (billingProviderIds == null || billingProviderIds.isEmpty()) {
+      if (upstreamContracts == null || upstreamContracts.isEmpty()) {
         return builder.conjunction();
       }
-      return builder.or(
-          builder.isNull(root.get(ContractEntity_.billingProviderId)),
-          builder.not(root.get(ContractEntity_.billingProviderId).in(billingProviderIds)));
+
+      var billingProviderId = root.get(ContractEntity_.billingProviderId);
+      var subscriptionNumber = root.get(ContractEntity_.subscriptionNumber);
+
+      Predicate[] present =
+          upstreamContracts.stream()
+              .filter(identity -> identity.billingProviderId() != null)
+              .map(
+                  identity -> {
+                    Predicate billingProviderIdMatch =
+                        builder.equal(billingProviderId, identity.billingProviderId());
+                    Predicate subscriptionNumberMatch =
+                        identity.subscriptionNumber() == null
+                            ? builder.isNull(subscriptionNumber)
+                            : builder.equal(subscriptionNumber, identity.subscriptionNumber());
+                    return builder.and(billingProviderIdMatch, subscriptionNumberMatch);
+                  })
+              .toArray(Predicate[]::new);
+
+      if (present.length == 0) {
+        return builder.conjunction();
+      }
+      return builder.not(builder.or(present));
     };
   }
+
+  /**
+   * Upstream contract identity used when deciding which contracts are still present after sync
+   * ({@code billingProviderId} + {@code subscriptionNumber}).
+   */
+  public record ContractIdentity(String billingProviderId, String subscriptionNumber) {}
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -460,18 +460,18 @@ public class ContractService {
     StatusResponse statusResponse = new StatusResponse();
 
     try {
-      Set<String> upstreamBillingProviderIds = new HashSet<>();
+      Set<ContractEntity.ContractIdentity> upstreamContracts = new HashSet<>();
       int totalPages = 1;
       for (int pageNumber = 0; pageNumber < totalPages; pageNumber++) {
-        var result = syncContractsByOrgId(contractOrgSync, pageNumber, upstreamBillingProviderIds);
+        var result = syncContractsByOrgId(contractOrgSync, pageNumber, upstreamContracts);
         if (result.getPage() != null && result.getPage().getTotalPages() != null) {
           totalPages = result.getPage().getTotalPages();
         }
       }
 
-      terminateContractsOrphanedByBillingProviders(contractOrgSync, upstreamBillingProviderIds);
+      terminateContractsOrphanedByBillingProviders(contractOrgSync, upstreamContracts);
 
-      if (!upstreamBillingProviderIds.isEmpty()) {
+      if (!upstreamContracts.isEmpty()) {
         statusResponse.setMessage("Contracts Synced for " + contractOrgSync);
         statusResponse.setStatus(SUCCESS_MESSAGE);
       } else {
@@ -493,14 +493,13 @@ public class ContractService {
   }
 
   private void terminateContractsOrphanedByBillingProviders(
-      String orgId, Set<String> upstreamBillingProviderIds) {
+      String orgId, Set<ContractEntity.ContractIdentity> upstreamContracts) {
     var now = OffsetDateTime.now();
 
     Specification<ContractEntity> spec =
         ContractEntity.orgIdEquals(orgId)
             .and(ContractEntity.activeOn(now))
-            .and(ContractEntity.billingProviderIdNullOrNotIn(upstreamBillingProviderIds));
-
+            .and(ContractEntity.orphanedByUpstreamContracts(upstreamContracts));
     var orphanedContracts = contractRepository.findContracts(spec).toList();
 
     if (!orphanedContracts.isEmpty()) {
@@ -509,7 +508,6 @@ public class ContractService {
           orphanedContracts.size(),
           orgId);
       orphanedContracts.forEach(contract -> terminateContract(contract, now));
-
       orphanedContracts.forEach(contract -> terminateActiveSubscriptionsForContract(contract, now));
     }
   }
@@ -565,7 +563,8 @@ public class ContractService {
   }
 
   private PartnerEntitlements syncContractsByOrgId(
-      String orgId, int pageNumber, Set<String> upstreamBillingProviderIds) throws ApiException {
+      String orgId, int pageNumber, Set<ContractEntity.ContractIdentity> upstreamContracts)
+      throws ApiException {
     PageRequest page = new PageRequest();
     page.setSize(PAGE_SIZE);
     page.setNumber(pageNumber);
@@ -579,7 +578,8 @@ public class ContractService {
             && ContractSourcePartnerEnum.isSupported(entitlement.getSourcePartner())) {
           String bpId = contractEntityMapper.extractBillingProviderId(entitlement);
           if (bpId != null) {
-            upstreamBillingProviderIds.add(bpId);
+            upstreamContracts.add(
+                new ContractEntity.ContractIdentity(bpId, findSubscriptionNumber(entitlement)));
             tryUpsertPartnerContract(entitlement);
           } else {
             log.warn(
@@ -680,6 +680,14 @@ public class ContractService {
     Specification<ContractEntity> specification;
     if (contract.getBillingProvider().startsWith("aws")) {
       specification = ContractEntity.billingProviderIdEquals(contract.getBillingProviderId());
+      // AWS contracts can share billingProviderId with different subscriptionNumbers. Scope by
+      // subscription number when present so syncing one does not delete the other. Null
+      // subscription number keeps legacy billingProviderId-only lookup.
+      if (contract.getSubscriptionNumber() != null) {
+        specification =
+            specification.and(
+                ContractEntity.subscriptionNumberEquals(contract.getSubscriptionNumber()));
+      }
     } else if (contract.getBillingProvider().startsWith("azure")) {
       specification = ContractEntity.azureResourceIdEquals(contract.getAzureResourceId());
     } else {

--- a/swatch-contracts/src/main/resources/db/202607221600_add_license_id_to_contracts.xml
+++ b/swatch-contracts/src/main/resources/db/202607221600_add_license_id_to_contracts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202607221600-01" author="tlencion">
+    <addColumn tableName="contracts">
+      <column name="license_id" type="varchar"/>
+    </addColumn>
+    <!-- rollback automatically generated -->
+  </changeSet>
+</databaseChangeLog>

--- a/swatch-contracts/src/main/resources/db/changelog.xml
+++ b/swatch-contracts/src/main/resources/db/changelog.xml
@@ -25,4 +25,5 @@
   <include file="db/202509021332-assume-ownership-of-offerings-and-subscriptions.xml"/>
   <include file="db/202511271435_add_index_on_sku_column_in_sku_oid_table.xml"/>
   <include file="db/202604301203_add_last_modified_columns.xml"/>
+  <include file="db/202607221600_add_license_id_to_contracts.xml"/>
 </databaseChangeLog>

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -167,6 +167,31 @@ class ContractEntityMapperTest {
         result.contains(";;"), "planId should default to empty string when contracts list is null");
   }
 
+  @Test
+  void testMapEntitlementToContractEntitySetsLicenseIdFromLicenseArn() {
+    givenAwsEntitlement();
+    entitlement
+        .getPartnerIdentities()
+        .setLicenseArn(
+            "arn:aws:license-manager:us-east-1:000000000000:license:swatch-test-license");
+    givenContract(10.0);
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(entitlement.getPartnerIdentities().getLicenseArn(), entity.getLicenseId());
+  }
+
+  @Test
+  void testMapEntitlementToContractEntityLeavesLicenseIdNullWhenLicenseArnAbsent() {
+    givenAwsEntitlement();
+    entitlement.getPartnerIdentities().setLicenseArn(null);
+    givenContract(10.0);
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertNull(entity.getLicenseId());
+  }
+
   private void givenContractWithPlanId(String planId) {
     var contract = givenContract(0, null, null);
     contract.setPlanId(planId);
@@ -195,6 +220,18 @@ class ContractEntityMapperTest {
     saasContract.endDate(OffsetDateTime.parse("2021-05-01T00:00Z"));
     entitlement.getPurchase().addContractsItem(saasContract);
     return saasContract;
+  }
+
+  private void givenAwsEntitlement() {
+    entitlement = new PartnerEntitlementV1();
+    entitlement.setPurchase(new PurchaseV1());
+    entitlement.getPurchase().setContracts(new ArrayList<>());
+    entitlement.getPurchase().setVendorProductCode("aws_vendor_code");
+    entitlement.setPartnerIdentities(new PartnerIdentityV1());
+    entitlement.getPartnerIdentities().awsCustomerId("aws_customer");
+    entitlement.getPartnerIdentities().customerAwsAccountId("aws_account");
+    entitlement.getPartnerIdentities().sellerAccountId("aws_seller");
+    entitlement.sourcePartner(ContractSourcePartnerEnum.AWS.getCode());
   }
 
   private void givenAzureEntitlement(

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -105,6 +105,10 @@ class ContractServiceTest extends BaseUnitTest {
   private static final String PRODUCT_TAG = "rosa";
   private static final String SUBSCRIPTION_NUMBER = "13294886";
   private static final String SUBSCRIPTION_ID = "123456";
+
+  /** Matches WireMockResource AWS partnerSubscriptions stub used by createPartnerContract. */
+  private static final String PARTNER_API_AWS_SUBSCRIPTION_NUMBER = "123456";
+
   private static final OffsetDateTime DEFAULT_START_DATE =
       OffsetDateTime.parse("2023-06-09T13:59:43.035365Z");
   private static final OffsetDateTime DEFAULT_END_DATE =
@@ -408,6 +412,152 @@ class ContractServiceTest extends BaseUnitTest {
     assertTrue(
         newContract.getEndDate() == null || newContract.getEndDate().isAfter(OffsetDateTime.now()),
         "New contract from upstream should be active");
+
+    wireMockServer.removeStub(stub);
+  }
+
+  @Test
+  @Transactional
+  void syncContractByOrgTerminatesMissingSiblingAwsContractSharingBillingProviderId()
+      throws Exception {
+    var startDateA = OffsetDateTime.now(ZoneOffset.UTC).minusDays(2).truncatedTo(ChronoUnit.MICROS);
+    var endDate = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1).truncatedTo(ChronoUnit.MICROS);
+
+    var contractA = givenExistingContract();
+    contractA.setStartDate(startDateA);
+    contractA.setEndDate(endDate);
+    contractRepository.persist(contractA);
+    var contractB =
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .subscriptionNumber("sibling-sub-b")
+            .startDate(startDateA.plusDays(1))
+            .endDate(endDate)
+            .orgId(contractA.getOrgId())
+            .offering(contractA.getOffering())
+            .billingProvider(contractA.getBillingProvider())
+            .billingProviderId(contractA.getBillingProviderId())
+            .billingAccountId(contractA.getBillingAccountId())
+            .vendorProductCode(contractA.getVendorProductCode())
+            .lastUpdated(OffsetDateTime.now(ZoneOffset.UTC))
+            .build();
+    contractRepository.persist(contractB);
+    reset(contractRepository);
+
+    var entitlementForA =
+        givenAwsEntitlement(SUBSCRIPTION_NUMBER, startDateA)
+            .partnerIdentities(
+                new PartnerIdentityV1()
+                    .awsCustomerId("HSwCpt6sqkC")
+                    .customerAwsAccountId("billAcct123")
+                    .sellerAccountId("568056954830"));
+    entitlementForA.getPurchase().setVendorProductCode(contractA.getVendorProductCode());
+    entitlementForA.getEntitlementDates().setEndDate(endDate);
+    entitlementForA.getPurchase().getContracts().get(0).setEndDate(endDate);
+
+    var stub = mockPartnerApi(new PartnerEntitlements().content(List.of(entitlementForA)));
+
+    StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
+
+    assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
+    var contracts = contractRepository.getContractsByOrgId(ORG_ID);
+    var syncedA =
+        contracts.stream()
+            .filter(c -> contractA.getUuid().equals(c.getUuid()))
+            .findFirst()
+            .orElseThrow();
+    var syncedB =
+        contracts.stream()
+            .filter(c -> contractB.getUuid().equals(c.getUuid()))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(
+        syncedA.getEndDate() == null || syncedA.getEndDate().isAfter(OffsetDateTime.now()),
+        "Contract A must remain active when still present upstream");
+    assertNotNull(syncedB.getEndDate(), "Contract B missing from upstream must be terminated");
+    assertTrue(
+        syncedB.getEndDate().isAfter(OffsetDateTime.now().minusSeconds(5))
+            && syncedB.getEndDate().isBefore(OffsetDateTime.now().plusSeconds(5)),
+        "Contract B termination endDate should be approximately now");
+
+    wireMockServer.removeStub(stub);
+  }
+
+  @Test
+  @Transactional
+  void syncContractByOrgPreservesBothAwsContractsSharingBillingProviderIdWhenBothPresentUpstream()
+      throws Exception {
+    var startDateA = OffsetDateTime.now(ZoneOffset.UTC).minusDays(2).truncatedTo(ChronoUnit.MICROS);
+    var startDateB = startDateA.plusDays(1);
+    var endDate = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1).truncatedTo(ChronoUnit.MICROS);
+
+    var contractA = givenExistingContract();
+    contractA.setStartDate(startDateA);
+    contractA.setEndDate(endDate);
+    contractRepository.persist(contractA);
+    var contractB =
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .subscriptionNumber("sibling-sub-b")
+            .startDate(startDateB)
+            .endDate(endDate)
+            .orgId(contractA.getOrgId())
+            .offering(contractA.getOffering())
+            .billingProvider(contractA.getBillingProvider())
+            .billingProviderId(contractA.getBillingProviderId())
+            .billingAccountId(contractA.getBillingAccountId())
+            .vendorProductCode(contractA.getVendorProductCode())
+            .lastUpdated(OffsetDateTime.now(ZoneOffset.UTC))
+            .build();
+    contractRepository.persist(contractB);
+    reset(contractRepository);
+
+    var partnerIdentities =
+        new PartnerIdentityV1()
+            .awsCustomerId("HSwCpt6sqkC")
+            .customerAwsAccountId("billAcct123")
+            .sellerAccountId("568056954830");
+    var entitlementForA =
+        givenAwsEntitlement(SUBSCRIPTION_NUMBER, startDateA).partnerIdentities(partnerIdentities);
+    entitlementForA.getPurchase().setVendorProductCode(contractA.getVendorProductCode());
+    entitlementForA.getEntitlementDates().setEndDate(endDate);
+    entitlementForA.getPurchase().getContracts().get(0).setEndDate(endDate);
+
+    var entitlementForB =
+        givenAwsEntitlement("sibling-sub-b", startDateB).partnerIdentities(partnerIdentities);
+    entitlementForB.getPurchase().setVendorProductCode(contractA.getVendorProductCode());
+    entitlementForB.getEntitlementDates().setEndDate(endDate);
+    entitlementForB.getPurchase().getContracts().get(0).setEndDate(endDate);
+
+    var stub =
+        mockPartnerApi(
+            new PartnerEntitlements().content(List.of(entitlementForA, entitlementForB)));
+
+    StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
+
+    assertEquals("Contracts Synced for " + ORG_ID, statusResponse.getMessage());
+    var contracts = contractRepository.getContractsByOrgId(ORG_ID);
+    assertEquals(
+        2,
+        contracts.size(),
+        "Both contracts with the same billingProviderId and different subscriptionNumbers"
+            + " must remain after sync");
+    var syncedA =
+        contracts.stream()
+            .filter(c -> contractA.getUuid().equals(c.getUuid()))
+            .findFirst()
+            .orElseThrow();
+    var syncedB =
+        contracts.stream()
+            .filter(c -> contractB.getUuid().equals(c.getUuid()))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(
+        syncedA.getEndDate() == null || syncedA.getEndDate().isAfter(OffsetDateTime.now()),
+        "Contract A must remain active when still present upstream");
+    assertTrue(
+        syncedB.getEndDate() == null || syncedB.getEndDate().isAfter(OffsetDateTime.now()),
+        "Contract B must remain active when still present upstream");
 
     wireMockServer.removeStub(stub);
   }
@@ -735,7 +885,9 @@ class ContractServiceTest extends BaseUnitTest {
   private ContractEntity givenExistingContractWithSameStartDateThanInPartnerGateway() {
     return givenExistingContract(
         givenContractRequestWithDates(
-            WireMockResource.DEFAULT_START_DATE, WireMockResource.DEFAULT_END_DATE));
+            WireMockResource.DEFAULT_START_DATE,
+            WireMockResource.DEFAULT_END_DATE,
+            PARTNER_API_AWS_SUBSCRIPTION_NUMBER));
   }
 
   private ContractEntity givenExistingContract() {
@@ -743,7 +895,7 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   private ContractEntity givenExistingContractWithExistingMetrics() {
-    var request = givenContractRequest();
+    var request = givenContractRequest(PARTNER_API_AWS_SUBSCRIPTION_NUMBER);
     var contract = request.getPartnerEntitlement().getPurchase().getContracts().get(0);
 
     // existing metrics are coming from WireMockResource.stubForRhPartnerApi() method
@@ -790,10 +942,20 @@ class ContractServiceTest extends BaseUnitTest {
   }
 
   private ContractRequest givenContractRequest() {
-    return givenContractRequestWithDates("2023-03-17T12:29:48.569Z", "2024-03-17T12:29:48.569Z");
+    return givenContractRequest(SUBSCRIPTION_NUMBER);
+  }
+
+  private ContractRequest givenContractRequest(String subscriptionNumber) {
+    return givenContractRequestWithDates(
+        "2023-03-17T12:29:48.569Z", "2024-03-17T12:29:48.569Z", subscriptionNumber);
   }
 
   private ContractRequest givenContractRequestWithDates(String startDate, String endDate) {
+    return givenContractRequestWithDates(startDate, endDate, SUBSCRIPTION_NUMBER);
+  }
+
+  private ContractRequest givenContractRequestWithDates(
+      String startDate, String endDate, String subscriptionNumber) {
     var contract = new PartnerEntitlementContract();
     var entitlement = new PartnerEntitlementV1();
     var cloudIdentifiers = new PartnerEntitlementContractCloudIdentifiers();
@@ -812,8 +974,8 @@ class ContractServiceTest extends BaseUnitTest {
     purchase.setVendorProductCode("1234567890abcdefghijklmno");
     cloudIdentifiers.setProductCode("1234567890abcdefghijklmno");
     entitlement.setRhAccountId(ORG_ID);
-    rhEntitlement.setSubscriptionNumber(SUBSCRIPTION_NUMBER);
-    contract.setRedHatSubscriptionNumber(SUBSCRIPTION_NUMBER);
+    rhEntitlement.setSubscriptionNumber(subscriptionNumber);
+    contract.setRedHatSubscriptionNumber(subscriptionNumber);
 
     var saasContract = new SaasContractV1();
     purchase.setContracts(List.of(saasContract));


### PR DESCRIPTION
Persist AWS `partnerIdentities.licenseArn` from Partner Gateway as nullable `licenseId` on `ContractEntity` (DB column + mapper). No remittance or prepaid math changes. API exposure is out of scope (`SWATCH-5296`).

Also scopes AWS contract matching and orphan termination by `subscriptionNumber` when present so contracts that share `billingProviderId` but have different `subscriptionNumber`s stay distinct (legacy null `subscriptionNumber` still matches on `billingProviderId` only).

Jira: [SWATCH-5295](https://redhat.atlassian.net/browse/SWATCH-5295)

### Verification

Unit:
```bash
./mvnw test -pl swatch-contracts -am -Dtest=ContractEntityMapperTest,ContractServiceTest
```

Component:
```bash
podman compose up -d kafka kafka-bridge kafka-setup unleash amqp wiremock db
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am -Dtest=ContractsSyncComponentTest
```

[SWATCH-5295]: https://redhat.atlassian.net/browse/SWATCH-5295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ