### PR TITLE
SWATCH-4862 Enable isPrimary host tally bucket searches using feature flag

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterService.java
@@ -41,11 +41,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.subscriptions.configuration.FeatureFlags;
-import org.candlepin.subscriptions.db.TallyInstanceNonPaygPrimaryViewRepository;
-import org.candlepin.subscriptions.db.TallyInstanceNonPaygViewRepository;
-import org.candlepin.subscriptions.db.TallyInstancePaygPrimaryViewRepository;
-import org.candlepin.subscriptions.db.TallyInstancePaygViewRepository;
+import org.candlepin.subscriptions.db.TallyInstanceViewRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
@@ -55,7 +51,6 @@ import org.candlepin.subscriptions.db.model.Usage;
 // NOTE(khowell): this couples our export implementation to the v1 REST API
 import org.candlepin.subscriptions.utilization.api.v1.model.ReportCategory;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.stereotype.Component;
 
@@ -96,16 +91,9 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
 
   private static final List<String> MANDATORY_FILTERS = List.of(PRODUCT_ID);
 
-  private final TallyInstancePaygViewRepository paygViewRepository;
-  private final TallyInstanceNonPaygViewRepository nonPaygViewRepository;
-
-  private final TallyInstancePaygPrimaryViewRepository paygPrimaryViewRepository;
-  private final TallyInstanceNonPaygPrimaryViewRepository nonPaygPrimaryViewRepository;
-
+  private final TallyInstanceViewRepository instanceViewRepository;
   private final InstancesJsonDataMapperService jsonDataMapperService;
   private final InstancesCsvDataMapperService csvDataMapperService;
-
-  private final FeatureFlags featureFlags;
 
   @Override
   public boolean handles(ExportServiceRequest request) {
@@ -117,22 +105,11 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
     log.debug("Fetching data for {}", request.getOrgId());
 
     var reportCriteria = extractExportFilter(request);
-    var repository = selectRepository(reportCriteria.getProductId());
+    var repository = instanceViewRepository.selectRepository(reportCriteria);
 
     return repository
         .findBy(buildSearchSpecification(reportCriteria), FluentQuery.FetchableFluentQuery::stream)
         .map(TallyInstanceView.class::cast);
-  }
-
-  private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
-      ProductId productId) {
-    // TODO Enable with featureFlags.isEnabled(FeatureFlags.ENABLE_HTB_PRIMARY_ROW_SEARCHES, false);
-    //  for SWATCH-4862
-    boolean usePrimary = false;
-    if (productId.isPayg()) {
-      return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
-    }
-    return usePrimary ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
   }
 
   @Override
@@ -182,7 +159,7 @@ public class InstancesDataExporterService implements DataExporterService<TallyIn
     if (!report.build().getProductId().isPayg()) {
       report.month(null);
     }
-
+    report.usePrimary(instanceViewRepository.isPrimaryRowSearchEnabled());
     return report.build();
   }
 

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -22,6 +22,7 @@ package org.candlepin.subscriptions.db;
 
 import static com.redhat.swatch.configuration.util.MetricIdUtils.getMetricIdsFromConfigForTag;
 import static org.candlepin.subscriptions.db.TallyInstanceViewRepository.FIELD_SORT_PARAM_MAPPING;
+import static org.candlepin.subscriptions.util.TallyHostBucketFactory.createBucketTuples;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,13 +48,15 @@ import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.Host;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.TallyInstanceView;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.test.ExtendWithSwatchDatabase;
+import org.candlepin.subscriptions.util.PrimaryRecordUtils;
 import org.candlepin.subscriptions.utilization.api.v1.model.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -91,27 +94,59 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
   @Transactional
   @BeforeEach
   void setupTestData() {
-    Host host8 = createHost("inventory8");
-    Host host9 = createHost("inventory9");
-    Host host10 = createHost("inventory10");
+    Host host8 = createBaseHost("inventory8", DEFAULT_ORG_ID);
+    host8.setBillingProvider(BillingProvider.RED_HAT);
+    host8.setBillingAccountId("RH-0008");
+    host8.setLastAppliedEventRecordDate("HBI_EVENT", OffsetDateTime.now());
+
+    Host host9 = createBaseHost("inventory9", DEFAULT_ORG_ID);
+    host9.setBillingProvider(BillingProvider.RED_HAT);
+    host9.setBillingAccountId("RH-0009");
+    host9.setLastAppliedEventRecordDate("HBI_EVENT", OffsetDateTime.now().minusDays(1));
+
+    Host host10 = createBaseHost("inventory10", DEFAULT_ORG_ID);
+    host10.setBillingProvider(BillingProvider.RED_HAT);
+    host10.setBillingAccountId("RH-0010");
+    host10.setLastAppliedEventRecordDate("HBI_EVENT", OffsetDateTime.now().minusDays(2));
 
     for (MetricId metricId : MetricId.getAll()) {
-      host8.addToMonthlyTotal(
-          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC),
-          metricId,
-          100.0);
       host8.setMeasurement(metricId.toString(), 100.0);
-      host9.addToMonthlyTotal(
-          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), metricId, 0.0);
       host9.setMeasurement(metricId.toString(), 0.0);
-      host10.addToMonthlyTotal(
-          OffsetDateTime.of(LocalDateTime.of(2021, 2, 1, 0, 0, 0), ZoneOffset.UTC), metricId, 50.0);
       host10.setMeasurement(metricId.toString(), 50.0);
     }
 
-    addBucketToHost(host8);
-    addBucketToHost(host9);
-    addBucketToHost(host10);
+    addMeasurementsToMonthlyTotals(
+        host8, OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC));
+    withPayGoBuckets(
+        host8,
+        HardwareMeasurementType.PHYSICAL,
+        ROSA,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        100,
+        100);
+
+    addMeasurementsToMonthlyTotals(
+        host9, OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC));
+    withPayGoBuckets(
+        host9,
+        HardwareMeasurementType.PHYSICAL,
+        ROSA,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        0,
+        0);
+
+    addMeasurementsToMonthlyTotals(
+        host10, OffsetDateTime.of(LocalDateTime.of(2021, 2, 1, 0, 0, 0), ZoneOffset.UTC));
+    withPayGoBuckets(
+        host10,
+        HardwareMeasurementType.PHYSICAL,
+        ROSA,
+        ServiceLevel.PREMIUM,
+        Usage.PRODUCTION,
+        50,
+        50);
 
     defaultHosts = persistHosts(host8, host9, host10);
   }
@@ -152,9 +187,29 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
       // previous test.
       MetricId referenceMetricId = MetricIdUtils.getInstanceHours();
 
-      // given two hosts with different values for Instance-Hours
-      var host1 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 5.0);
-      var host2 = givenHostWithMetric(OPENSHIFT_CONTAINER_PLATFORM, referenceMetricId, 10.0);
+      var host1 = createBaseHost(UUID.randomUUID().toString(), DEFAULT_ORG_ID);
+      host1.setMeasurement(referenceMetricId.toString(), 5.0);
+      withTraditionalProductBuckets(
+          host1,
+          HardwareMeasurementType.PHYSICAL,
+          OPENSHIFT_CONTAINER_PLATFORM,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          0,
+          0);
+
+      var host2 = createBaseHost(UUID.randomUUID().toString(), DEFAULT_ORG_ID);
+      host2.setMeasurement(referenceMetricId.toString(), 10.0);
+      withTraditionalProductBuckets(
+          host2,
+          HardwareMeasurementType.PHYSICAL,
+          OPENSHIFT_CONTAINER_PLATFORM,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          0,
+          0);
+
+      persistHosts(host1, host2);
 
       Page<TallyInstanceView> results =
           repo.findAllBy(
@@ -185,60 +240,49 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     void testFilterByBillingModel() {
       Host host1 = createHost("i1", "a1");
       host1.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
+      host1.setBillingAccountId("RH-0001");
+      addMeasurementsToMonthlyTotals(host1, OffsetDateTime.now());
+      withPayGoBuckets(
           host1,
-          RHEL,
+          HardwareMeasurementType.VIRTUAL,
+          ROSA,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.RED_HAT);
-      addBucketToHost(
-          host1,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider._ANY);
+          1,
+          1);
 
       Host host2 = createHost("i2", "a1");
       host2.setBillingProvider(BillingProvider.AWS);
-      addBucketToHost(
+      host2.setBillingAccountId("AWS-0001");
+      addMeasurementsToMonthlyTotals(host2, OffsetDateTime.now());
+      withPayGoBuckets(
           host2,
-          RHEL,
+          HardwareMeasurementType.VIRTUAL,
+          ROSA,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.AWS);
-      addBucketToHost(
-          host2,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider._ANY);
+          1,
+          1);
 
       Host host3 = createHost("i3", "a1");
-      addBucketToHost(
+      host3.setBillingProvider(BillingProvider.GCP);
+      host3.setBillingAccountId("GCP-0001");
+      addMeasurementsToMonthlyTotals(host3, OffsetDateTime.now());
+      withPayGoBuckets(
           host3,
-          RHEL,
+          HardwareMeasurementType.VIRTUAL,
+          ROSA,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.EMPTY);
-      addBucketToHost(
-          host3,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider._ANY);
+          1,
+          1);
 
       persistHosts(host1, host2, host3);
 
       Page<TallyInstanceView> results =
           repo.findAllBy(
               "a1",
-              RHEL,
+              ROSA,
               ServiceLevel.PREMIUM,
               Usage.PRODUCTION,
               "",
@@ -259,7 +303,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
       Page<TallyInstanceView> allResults =
           repo.findAllBy(
               "a1",
-              RHEL,
+              ROSA,
               ServiceLevel.PREMIUM,
               Usage.PRODUCTION,
               "",
@@ -291,7 +335,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
       assertEquals(
           BillingProvider.AWS, hostToBill.get(host2.getInstanceId()).getHostBillingProvider());
       assertEquals(
-          BillingProvider._ANY, hostToBill.get(host3.getInstanceId()).getHostBillingProvider());
+          BillingProvider.GCP, hostToBill.get(host3.getInstanceId()).getHostBillingProvider());
     }
 
     @Test
@@ -397,34 +441,34 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     @Test
     void testFilterByHardwareMeasurementTypes() {
       Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-      host1.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
+      withTraditionalProductBuckets(
           host1,
+          HardwareMeasurementType.PHYSICAL,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.RED_HAT);
+          1,
+          1);
 
       Host host2 = createHost(UUID.randomUUID().toString(), "a1");
-      host2.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
+      withTraditionalProductBuckets(
           host2,
+          HardwareMeasurementType.VIRTUAL,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.VIRTUAL,
-          BillingProvider.RED_HAT);
+          1,
+          1);
 
       Host host3 = createHost(UUID.randomUUID().toString(), "a1");
-      addBucketToHost(
+      withTraditionalProductBuckets(
           host3,
+          HardwareMeasurementType.HYPERVISOR,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.HYPERVISOR,
-          BillingProvider.RED_HAT);
-
+          1,
+          1);
       persistHosts(host1, host2, host3);
 
       Page<TallyInstanceView> results =
@@ -438,7 +482,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               0,
               null,
               MetricIdUtils.getCores(),
-              BillingProvider.RED_HAT,
+              BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
               List.of(HardwareMeasurementType.VIRTUAL),
               0,
@@ -461,7 +505,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               0,
               null,
               MetricIdUtils.getCores(),
-              BillingProvider.RED_HAT,
+              BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
               null,
               0,
@@ -496,9 +540,8 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     @Test
     void testGetResultWithEmptyMeasurementType() {
       Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-      host1.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
-          host1, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, null, BillingProvider.RED_HAT);
+      withTraditionalProductBuckets(
+          host1, null, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, 1, 1);
 
       persistHosts(host1);
 
@@ -513,7 +556,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               0,
               null,
               MetricIdUtils.getCores(),
-              BillingProvider.RED_HAT,
+              BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
               null,
               0,
@@ -529,42 +572,32 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     @Test
     void testFilterByCloudHardwareMeasurementTypes() {
       Host host1 = createHost(UUID.randomUUID().toString(), "a1");
-      host1.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
-          host1,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.AWS,
-          BillingProvider.RED_HAT);
+      withTraditionalProductBuckets(
+          host1, HardwareMeasurementType.AWS, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, 1, 1);
 
       Host host2 = createHost(UUID.randomUUID().toString(), "a1");
-      host2.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
-          host2,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.AZURE,
-          BillingProvider.RED_HAT);
+      withTraditionalProductBuckets(
+          host2, HardwareMeasurementType.AZURE, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, 1, 1);
 
       Host host3 = createHost(UUID.randomUUID().toString(), "a1");
-      addBucketToHost(
+      withTraditionalProductBuckets(
           host3,
+          HardwareMeasurementType.GOOGLE,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.GOOGLE,
-          BillingProvider.RED_HAT);
+          1,
+          1);
 
       Host host5 = createHost(UUID.randomUUID().toString(), "a1");
-      addBucketToHost(
+      withTraditionalProductBuckets(
           host5,
+          HardwareMeasurementType.PHYSICAL,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.RED_HAT);
+          1,
+          1);
 
       persistHosts(host1, host2, host3, host5);
 
@@ -579,7 +612,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               0,
               null,
               MetricIdUtils.getCores(),
-              BillingProvider.RED_HAT,
+              BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
               HardwareMeasurementType.getCloudProviderTypes(),
               0,
@@ -602,45 +635,28 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     @Transactional
     void testFilterByMinCoresAndSockets() {
       Host host1 = createBaseHost("i1", "a1");
-      host1.setBillingProvider(BillingProvider.RED_HAT);
-      addBucketToHost(
+      host1.setMeasurement(MetricIdUtils.getSockets().toString(), 0.0);
+      host1.setMeasurement(MetricIdUtils.getCores().toString(), 4.0);
+      withTraditionalProductBuckets(
           host1,
+          HardwareMeasurementType.PHYSICAL,
           RHEL,
           ServiceLevel.PREMIUM,
           Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.RED_HAT,
           0,
           4);
-      host1.setMeasurement(MetricIdUtils.getCores().toString(), 4.0);
-      host1.setMeasurement(MetricIdUtils.getSockets().toString(), 0.0);
 
       Host host2 = createBaseHost("i2", "a1");
-      host2.setBillingProvider(BillingProvider.AWS);
-      addBucketToHost(
-          host2,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.AWS,
-          2,
-          0);
       host2.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
       host2.setMeasurement(MetricIdUtils.getCores().toString(), 0.0);
+      withTraditionalProductBuckets(
+          host2, HardwareMeasurementType.AWS, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, 2, 0);
 
       Host host3 = createBaseHost("i3", "a1");
-      addBucketToHost(
-          host3,
-          RHEL,
-          ServiceLevel.PREMIUM,
-          Usage.PRODUCTION,
-          HardwareMeasurementType.PHYSICAL,
-          BillingProvider.EMPTY,
-          2,
-          2);
       host3.setMeasurement(MetricIdUtils.getCores().toString(), 2.0);
       host3.setMeasurement(MetricIdUtils.getSockets().toString(), 2.0);
+      withTraditionalProductBuckets(
+          host3, HardwareMeasurementType.EMPTY, RHEL, ServiceLevel.PREMIUM, Usage.PRODUCTION, 2, 2);
 
       persistHosts(host1, host2, host3);
 
@@ -728,6 +744,17 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     }
   }
 
+  private void addMeasurementsToMonthlyTotals(Host host, OffsetDateTime month) {
+    host.getMeasurements()
+        .forEach(
+            (metricId, value) -> {
+              host.addToMonthlyTotal(
+                  InstanceMonthlyTotalKey.formatMonthId(month),
+                  MetricId.fromString(metricId),
+                  value);
+            });
+  }
+
   @Nested
   class WithPrimaryRowSearchesEnabled extends FeatureFlagTests {
     @BeforeEach
@@ -737,7 +764,6 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     }
 
     @Test
-    @Disabled("Enable during SWATCH-4862")
     @Transactional
     void testNonPrimaryBucketIsExcluded() {
       Host primaryHost = createHost("inv-primary", "org-primary");
@@ -749,8 +775,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
           HardwareMeasurementType.PHYSICAL,
           BillingProvider._ANY,
           2,
-          4,
-          true);
+          4);
 
       Host nonPrimaryHost = createHost("inv-non-primary", "org-primary");
       addBucketToHost(
@@ -761,8 +786,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
           HardwareMeasurementType.PHYSICAL,
           BillingProvider._ANY,
           2,
-          4,
-          false);
+          4);
 
       persistHosts(primaryHost, nonPrimaryHost);
 
@@ -810,8 +834,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
           HardwareMeasurementType.PHYSICAL,
           BillingProvider._ANY,
           2,
-          4,
-          true);
+          4);
 
       Host nonPrimaryHost = createHost("inv-non-primary", "org-primary");
       addBucketToHost(
@@ -822,8 +845,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
           HardwareMeasurementType.PHYSICAL,
           BillingProvider._ANY,
           2,
-          4,
-          false);
+          4);
 
       persistHosts(primaryHost, nonPrimaryHost);
 
@@ -882,10 +904,6 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     return host;
   }
 
-  private Host createHost(String inventoryId) {
-    return createHost(inventoryId, DEFAULT_ORG_ID);
-  }
-
   private Host createHost(String inventoryId, String org) {
     Host host = createBaseHost(inventoryId, org);
     host.setMeasurement(MetricIdUtils.getSockets().toString(), 1.0);
@@ -893,34 +911,71 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
     return host;
   }
 
-  private Host givenHostWithMetric(ProductId productId, MetricId metric, Double value) {
-    Host host = createBaseHost(UUID.randomUUID().toString(), DEFAULT_ORG_ID);
-    if (productId.isPayg()) {
-      host.addToMonthlyTotal(
-          OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), ZoneOffset.UTC), metric, value);
-    } else {
-      host.setMeasurement(metric.toString(), value);
-    }
+  private void withTraditionalProductBuckets(
+      Host host,
+      HardwareMeasurementType hmt,
+      ProductId productId,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      double sockets,
+      double cores) {
+    // Traditional products create cartesian product with:
+    // - SLA: {actual, _ANY}
+    // - Usage: {actual, _ANY}
+    // - BillingProvider: {_ANY} (always)
+    // - BillingAccountId: {"_ANY"} (always)
+    // This creates 2 × 2 × 1 × 1 = 4 buckets
 
-    addBucketToHost(
-        host,
-        productId,
-        ServiceLevel._ANY,
-        Usage._ANY,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
-    persistHosts(host);
-    return host;
+    List<HostTallyBucket> buckets =
+        createBucketTuples(
+            productId,
+            hmt,
+            serviceLevel,
+            usage,
+            host.getBillingProvider(),
+            host.getBillingAccountId(),
+            sockets,
+            cores);
+
+    buckets.forEach(host::addBucket);
   }
 
-  private void addBucketToHost(Host host) {
-    addBucketToHost(
-        host,
-        ROSA,
-        ServiceLevel._ANY,
-        Usage._ANY,
-        HardwareMeasurementType.PHYSICAL,
-        BillingProvider._ANY);
+  /**
+   * Creates the cartesian product of buckets for the given host and product.
+   *
+   * @param host the host
+   * @param hmt the hardware measurement type
+   * @param productId the product id
+   * @param serviceLevel the service level
+   * @param usage the usage
+   */
+  private void withPayGoBuckets(
+      Host host,
+      HardwareMeasurementType hmt,
+      ProductId productId,
+      ServiceLevel serviceLevel,
+      Usage usage,
+      double sockets,
+      double cores) {
+    // PAYG products create cartesian product with:
+    // - SLA: {actual, _ANY}
+    // - Usage: {actual, _ANY}
+    // - BillingProvider: {actual, _ANY}
+    // - BillingAccountId: {actual, "_ANY"}
+    // This creates 2 × 2 × 2 × 2 = 16 buckets
+
+    List<HostTallyBucket> buckets =
+        createBucketTuples(
+            productId,
+            hmt,
+            serviceLevel,
+            usage,
+            host.getBillingProvider(),
+            host.getBillingAccountId(),
+            sockets,
+            cores);
+
+    buckets.forEach(host::addBucket);
   }
 
   private void addBucketToHost(
@@ -942,20 +997,6 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
       BillingProvider billingProvider,
       int sockets,
       int cores) {
-    addBucketToHost(
-        host, productId, sla, usage, measurementType, billingProvider, sockets, cores, true);
-  }
-
-  private void addBucketToHost(
-      Host host,
-      ProductId productId,
-      ServiceLevel sla,
-      Usage usage,
-      HardwareMeasurementType measurementType,
-      BillingProvider billingProvider,
-      int sockets,
-      int cores,
-      boolean primary) {
     var bucket =
         host.addBucket(
             productId.toString(),
@@ -967,7 +1008,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
             sockets,
             cores,
             measurementType);
-    bucket.setPrimary(primary);
+    bucket.setPrimary(PrimaryRecordUtils.isPrimaryRecord(bucket));
   }
 
   static String[] instanceSortParams() {

--- a/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
+++ b/src/test/java/org/candlepin/subscriptions/db/TallyInstanceViewRepositoryTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.db.model.AccountServiceInventory;
 import org.candlepin.subscriptions.db.model.AccountServiceInventoryId;
@@ -469,6 +470,14 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
           Usage.PRODUCTION,
           1,
           1);
+      withTraditionalProductBuckets(
+          host3,
+          HardwareMeasurementType.HYPERVISOR,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.DISASTER_RECOVERY,
+          1,
+          1);
       persistHosts(host1, host2, host3);
 
       Page<TallyInstanceView> results =
@@ -499,7 +508,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               "a1",
               RHEL,
               ServiceLevel.PREMIUM,
-              Usage.PRODUCTION,
+              Usage._ANY,
               "",
               0,
               0,
@@ -742,6 +751,74 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
         }
       }
     }
+
+    static Stream<List<HardwareMeasurementType>> hypervisorHardwareMeasurementTypeParams() {
+      return Stream.of(
+          List.of(HardwareMeasurementType.HYPERVISOR),
+          List.of(),
+          List.of(HardwareMeasurementType.HYPERVISOR, HardwareMeasurementType.PHYSICAL),
+          null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hypervisorHardwareMeasurementTypeParams")
+    @Transactional
+    void testNonPrimaryBucketSearchForHypervisorHardwareTypeFilter(
+        List<HardwareMeasurementType> hardwareTypes) {
+      Host hypervisorHost = createHost("inv-hypervisor", "org-hypervisor");
+      addBucketToHost(
+          hypervisorHost,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.PRODUCTION,
+          HardwareMeasurementType.HYPERVISOR,
+          BillingProvider._ANY,
+          2,
+          4);
+      addBucketToHost(
+          hypervisorHost,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage.DISASTER_RECOVERY,
+          HardwareMeasurementType.HYPERVISOR,
+          BillingProvider._ANY,
+          18,
+          36);
+      addBucketToHost(
+          hypervisorHost,
+          RHEL,
+          ServiceLevel.PREMIUM,
+          Usage._ANY,
+          HardwareMeasurementType.HYPERVISOR,
+          BillingProvider._ANY,
+          20,
+          40);
+
+      persistHosts(hypervisorHost);
+
+      Page<TallyInstanceView> hypervisors =
+          repo.findAllBy(
+              hypervisorHost.getOrgId(),
+              RHEL,
+              ServiceLevel.PREMIUM,
+              Usage._ANY,
+              "",
+              0,
+              0,
+              null,
+              MetricIdUtils.getCores(),
+              BillingProvider._ANY,
+              BILLING_ACCOUNT_ID_ANY,
+              hardwareTypes,
+              0,
+              10,
+              SORT_BY_CORES,
+              SortDirection.ASC);
+
+      assertEquals(1, hypervisors.getTotalElements());
+      // Should always pick the non-primary bucket when HMT is HYPERVISOR no matter the flag.
+      assertEquals(20, hypervisors.get().toList().getFirst().getSockets());
+    }
   }
 
   private void addMeasurementsToMonthlyTotals(Host host, OffsetDateTime month) {
@@ -803,7 +880,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               MetricIdUtils.getCores(),
               BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
-              null,
+              List.of(HardwareMeasurementType.PHYSICAL),
               0,
               10,
               SORT_BY_CORES,
@@ -862,7 +939,7 @@ class TallyInstanceViewRepositoryTest implements ExtendWithSwatchDatabase {
               MetricIdUtils.getCores(),
               BillingProvider._ANY,
               BILLING_ACCOUNT_ID_ANY,
-              null,
+              List.of(HardwareMeasurementType.PHYSICAL),
               0,
               10,
               SORT_BY_CORES,

--- a/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
+++ b/src/test/java/org/candlepin/subscriptions/tally/export/InstancesDataExporterServiceTest.java
@@ -21,14 +21,15 @@
 package org.candlepin.subscriptions.tally.export;
 
 import static org.candlepin.subscriptions.db.model.InstanceMonthlyTotalKey.formatMonthId;
-import static org.candlepin.subscriptions.resource.ResourceUtils.ANY;
 import static org.candlepin.subscriptions.resource.api.v1.InstancesResource.getCloudProviderByMeasurementType;
 import static org.candlepin.subscriptions.tally.export.InstancesCsvDataMapperService.METRIC_MAPPER;
 import static org.candlepin.subscriptions.tally.export.InstancesDataExporterService.BEGINNING;
 import static org.candlepin.subscriptions.tally.export.InstancesDataExporterService.PRODUCT_ID;
+import static org.mockito.Mockito.when;
 
 import com.redhat.cloud.event.apps.exportservice.v1.Format;
 import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.ProductId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import java.time.OffsetDateTime;
@@ -38,13 +39,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.db.HostRepository;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
 import org.candlepin.subscriptions.db.model.Host;
-import org.candlepin.subscriptions.db.model.HostBucketKey;
 import org.candlepin.subscriptions.db.model.HostHardwareType;
-import org.candlepin.subscriptions.db.model.HostTallyBucket;
 import org.candlepin.subscriptions.db.model.ServiceLevel;
 import org.candlepin.subscriptions.db.model.Usage;
 import org.candlepin.subscriptions.export.BaseDataExporterServiceTest;
@@ -53,14 +53,19 @@ import org.candlepin.subscriptions.json.InstancesExportJson;
 import org.candlepin.subscriptions.json.InstancesExportJsonGuest;
 import org.candlepin.subscriptions.json.InstancesExportJsonItem;
 import org.candlepin.subscriptions.json.InstancesExportJsonMetric;
+import org.candlepin.subscriptions.resource.ResourceUtils;
 import org.candlepin.subscriptions.util.ApiModelMapperV1;
+import org.candlepin.subscriptions.util.TallyHostBucketFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @Slf4j
 @ActiveProfiles({"worker", "kafka-queue", "test-inventory"})
@@ -77,6 +82,8 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
 
   @Autowired ApiModelMapperV1 mapper;
 
+  @MockitoBean FeatureFlags featureFlags;
+
   @AfterEach
   public void tearDown() {
     repository.deleteAll();
@@ -87,135 +94,137 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     return "instances";
   }
 
-  @Test
-  void testRequestWithoutPermissions() {
-    givenExportRequestWithoutPermissions();
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportServiceWithError(request);
-  }
-
-  @Test
-  void testRequestShouldFailIfItDoesNotFilterByProductId() {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportServiceWithError(request);
-  }
-
-  @Test
-  void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductId() {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportService();
-  }
-
-  @Test
-  void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndMonth() {
-    givenInstanceWithMetrics(ROSA);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, ROSA);
-    givenFilterInExportRequest(BEGINNING, APRIL);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportService();
-  }
-
-  @Test
-  void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByWrongProductId() {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, "wrong!");
-    whenReceiveExportRequest();
-    verifyNoRequestsWereSentToExportServiceWithUploadData();
-    verifyRequestWasSentToExportServiceWithError(request);
-  }
-
-  @Test
-  void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndReturnsNoData() {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, ROSA);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportServiceWithNoDataFound();
-    verifyNoRequestsWereSentToExportServiceWithError();
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {RHEL_FOR_X86, ANSIBLE})
-  void testRequestShouldBeUploadedWithInstancesAsCsv(String productId) {
-    givenInstanceWithMetrics(productId);
-    givenExportRequestWithPermissions(Format.CSV);
-    givenFilterInExportRequest(PRODUCT_ID, productId);
-    if (SubscriptionDefinition.isContractEnabled(productId)) {
-      givenFilterInExportRequest(BEGINNING, APRIL);
+  abstract class ExportTestSuite {
+    @Test
+    void testRequestWithoutPermissions() {
+      givenExportRequestWithoutPermissions();
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportServiceWithError(request);
     }
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportService();
-  }
 
-  @ParameterizedTest
-  @CsvSource(
-      value = {
-        "usage,_ANY",
-        "category,hypervisor",
-        "sla,_ANY",
-        "metric_id,Sockets",
-        "billing_provider,_ANY",
-        "billing_account_id,_ANY",
-        "display_name_contains,ho"
-      })
-  void testFiltersFoundData(String filterName, String exists) {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
-    givenFilterInExportRequest(filterName, exists);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportService();
-    verifyNoRequestsWereSentToExportServiceWithError();
-  }
+    @Test
+    void testRequestShouldFailIfItDoesNotFilterByProductId() {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportServiceWithError(request);
+    }
 
-  @ParameterizedTest
-  @CsvSource(
-      value = {
-        "usage,disaster recovery",
-        "category,virtual",
-        "sla,standard",
-        "metric_id,Instance-hours",
-        "billing_provider,azure",
-        "billing_account_id,345",
-        "display_name_contains,another host"
-      })
-  void testFiltersDoesNotFoundDataAndReportIsEmpty(String filterName, String doesNotExist) {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
-    givenFilterInExportRequest(filterName, doesNotExist);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportServiceWithNoDataFound();
-    verifyNoRequestsWereSentToExportServiceWithError();
-  }
+    @Test
+    void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductId() {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportService();
+    }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"usage", "category", "sla", "metric_id", "billing_provider", BEGINNING})
-  void testFiltersAreInvalid(String filterName) {
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
-    givenFilterInExportRequest(filterName, "wrong!");
-    whenReceiveExportRequest();
-    verifyNoRequestsWereSentToExportServiceWithUploadData();
-    verifyRequestWasSentToExportServiceWithError(request);
-  }
+    @Test
+    void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndMonth() {
+      givenInstanceWithMetrics(ROSA);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, ROSA);
+      givenFilterInExportRequest(BEGINNING, APRIL);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportService();
+    }
 
-  @Test
-  void testRequestShouldFilterByOrgId() {
-    givenInstanceWithMetricsForAnotherOrgId(RHEL_FOR_X86);
-    givenInstanceWithMetrics(RHEL_FOR_X86);
-    givenExportRequestWithPermissions(Format.JSON);
-    givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
-    whenReceiveExportRequest();
-    verifyRequestWasSentToExportService();
+    @Test
+    void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByWrongProductId() {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, "wrong!");
+      whenReceiveExportRequest();
+      verifyNoRequestsWereSentToExportServiceWithUploadData();
+      verifyRequestWasSentToExportServiceWithError(request);
+    }
+
+    @Test
+    void testRequestShouldBeUploadedWithInstancesAsJsonFilteringByProductIdAndReturnsNoData() {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, ROSA);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportServiceWithNoDataFound();
+      verifyNoRequestsWereSentToExportServiceWithError();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {RHEL_FOR_X86, ANSIBLE})
+    void testRequestShouldBeUploadedWithInstancesAsCsv(String productId) {
+      givenInstanceWithMetrics(productId);
+      givenExportRequestWithPermissions(Format.CSV);
+      givenFilterInExportRequest(PRODUCT_ID, productId);
+      if (SubscriptionDefinition.isContractEnabled(productId)) {
+        givenFilterInExportRequest(BEGINNING, APRIL);
+      }
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportService();
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+          "usage,_ANY",
+          "category,hypervisor",
+          "sla,_ANY",
+          "metric_id,Sockets",
+          "billing_provider,_ANY",
+          "billing_account_id,_ANY",
+          "display_name_contains,ho"
+        })
+    void testFiltersFoundData(String filterName, String exists) {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+      givenFilterInExportRequest(filterName, exists);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportService();
+      verifyNoRequestsWereSentToExportServiceWithError();
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+          "usage,disaster recovery",
+          "category,virtual",
+          "sla,standard",
+          "metric_id,Instance-hours",
+          "billing_provider,azure",
+          "billing_account_id,345",
+          "display_name_contains,another host"
+        })
+    void testFiltersDoesNotFoundDataAndReportIsEmpty(String filterName, String doesNotExist) {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+      givenFilterInExportRequest(filterName, doesNotExist);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportServiceWithNoDataFound();
+      verifyNoRequestsWereSentToExportServiceWithError();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"usage", "category", "sla", "metric_id", "billing_provider", BEGINNING})
+    void testFiltersAreInvalid(String filterName) {
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+      givenFilterInExportRequest(filterName, "wrong!");
+      whenReceiveExportRequest();
+      verifyNoRequestsWereSentToExportServiceWithUploadData();
+      verifyRequestWasSentToExportServiceWithError(request);
+    }
+
+    @Test
+    void testRequestShouldFilterByOrgId() {
+      givenInstanceWithMetricsForAnotherOrgId(RHEL_FOR_X86);
+      givenInstanceWithMetrics(RHEL_FOR_X86);
+      givenExportRequestWithPermissions(Format.JSON);
+      givenFilterInExportRequest(PRODUCT_ID, RHEL_FOR_X86);
+      whenReceiveExportRequest();
+      verifyRequestWasSentToExportService();
+    }
   }
 
   @Override
@@ -223,6 +232,24 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     boolean isCsvFormat = request.getData().getResourceRequest().getFormat() == Format.CSV;
     String expected = isCsvFormat ? parseExpectedAsCsv() : parseExpectedAsJson();
     verifyRequestWasSentToExportServiceWithUploadData(request, expected);
+  }
+
+  @Nested
+  class WithPrimarySearchesDisabled extends ExportTestSuite {
+    @BeforeEach
+    void setup() {
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_HTB_PRIMARY_ROW_SEARCHES, false))
+          .thenReturn(false);
+    }
+  }
+
+  @Nested
+  class WithPrimarySearchesEnabled extends ExportTestSuite {
+    @BeforeEach
+    void setup() {
+      when(featureFlags.isEnabled(FeatureFlags.ENABLE_HTB_PRIMARY_ROW_SEARCHES, false))
+          .thenReturn(true);
+    }
   }
 
   private String parseExpectedAsCsv() {
@@ -359,7 +386,60 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     givenInstanceWithMetrics(ORG_ID, productId);
   }
 
-  private HostWithGuests givenInstanceWithMetrics(String orgId, String productId) {
+  private HostWithGuests givenInstanceWithPayGoProduct(String orgId, String productId) {
+    Host instance = new Host();
+    instance.setOrgId(orgId);
+    instance.setNumOfGuests(1);
+    instance.setInstanceId("456");
+    instance.setDisplayName("my host");
+    instance.setBillingProvider(BillingProvider.AWS);
+    instance.setBillingAccountId("123");
+    instance.setInstanceType(INSTANCE_TYPE);
+
+    boolean isAnsible = productId.equals(ANSIBLE);
+    double cores = isAnsible ? 0.0 : 8.0;
+    double sockets = isAnsible ? 0.0 : 7.0;
+
+    var buckets =
+        TallyHostBucketFactory.createBucketTuples(
+            ProductId.fromString(productId),
+            HardwareMeasurementType.AWS,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            instance.getBillingProvider(),
+            instance.getBillingAccountId(),
+            cores,
+            sockets);
+    buckets.forEach(instance::addBucket);
+
+    // metrics for contract enabled products
+    if (isAnsible) {
+      instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getManagedNodes(), 1.0);
+      instance.setMeasurement(MetricIdUtils.getManagedNodes().toUpperCaseFormatted(), 1.0);
+
+      instance.addToMonthlyTotal(
+          OffsetDateTime.parse(APRIL), MetricIdUtils.getInstanceHours(), 2.0);
+      instance.setMeasurement(MetricIdUtils.getInstanceHours().toUpperCaseFormatted(), 2.0);
+    } else {
+      instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getSockets(), sockets);
+      instance.setMeasurement(MetricIdUtils.getSockets().toUpperCaseFormatted(), sockets);
+
+      instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getCores(), cores);
+      instance.setMeasurement(MetricIdUtils.getCores().toUpperCaseFormatted(), cores);
+    }
+
+    repository.save(instance);
+
+    HostWithGuests ret = new HostWithGuests();
+    ret.host = instance;
+    ret.guests = List.of();
+    ret.usePaygProduct = true;
+    return ret;
+  }
+
+  private HostWithGuests givenInstanceWithTraditionalProduct(String orgId, String productId) {
+    // NOTE: A mapped RHEL guest does not have buckets assigned to it as it
+    // contributes to its hypervisor's counts.
     Host guest = new Host();
     guest.setOrgId(orgId);
     guest.setDisplayName("this is the guest");
@@ -368,7 +448,14 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     guest.setInstanceType(INSTANCE_TYPE);
     guest.setInstanceId(UUID.randomUUID().toString());
     guest.setHypervisorUuid(UUID.randomUUID().toString());
+    guest.setMeasurements(
+        Map.of(
+            MetricIdUtils.getSockets().toUpperCaseFormatted(), 1.0,
+            MetricIdUtils.getCores().toUpperCaseFormatted(), 2.0));
     repository.save(guest);
+
+    Double instanceCores = 4.0;
+    Double instanceSockets = 2.0;
 
     Host instance = new Host();
     instance.setOrgId(orgId);
@@ -379,53 +466,43 @@ class InstancesDataExporterServiceTest extends BaseDataExporterServiceTest {
     instance.setBillingAccountId("123");
     instance.setInstanceType(INSTANCE_TYPE);
     instance.setSubscriptionManagerId(guest.getHypervisorUuid());
+    instance.setMeasurements(
+        Map.of(
+            MetricIdUtils.getSockets().toUpperCaseFormatted(), instanceSockets,
+            MetricIdUtils.getCores().toUpperCaseFormatted(), instanceCores));
 
-    // buckets
-    HostTallyBucket bucket = new HostTallyBucket();
-    bucket.setKey(new HostBucketKey());
-    bucket.getKey().setProductId(productId);
-    bucket.getKey().setUsage(Usage._ANY);
-    bucket.getKey().setSla(ServiceLevel._ANY);
-    bucket.getKey().setAsHypervisor(true);
-    bucket.getKey().setBillingProvider(BillingProvider._ANY);
-    bucket.getKey().setBillingAccountId(ANY);
-    bucket.setMeasurementType(HardwareMeasurementType.HYPERVISOR);
-    // in non-payg products, buckets metrics should be used over the instance measurements
-    bucket.setCores(5);
-    bucket.setSockets(6);
-    bucket.setHost(instance);
-    instance.addBucket(bucket);
-    boolean isContractEnabled = SubscriptionDefinition.isContractEnabled(productId);
-
-    if (isContractEnabled) {
-      // metrics for contract enabled products
-      if (productId.equals(ANSIBLE)) {
-        instance.addToMonthlyTotal(
-            OffsetDateTime.parse(APRIL), MetricIdUtils.getManagedNodes(), 1.0);
-        instance.addToMonthlyTotal(
-            OffsetDateTime.parse(APRIL), MetricIdUtils.getInstanceHours(), 2.0);
-      } else {
-        instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getSockets(), 7.0);
-        instance.addToMonthlyTotal(OffsetDateTime.parse(APRIL), MetricIdUtils.getCores(), 8.0);
-      }
-    } else {
-      // metrics for non-contract enabled products
-      instance.setMeasurements(
-          Map.of(
-              MetricIdUtils.getSockets().toUpperCaseFormatted(),
-              9.0,
-              MetricIdUtils.getCores().toUpperCaseFormatted(),
-              10.0));
-    }
+    var buckets =
+        TallyHostBucketFactory.createBucketTuples(
+            ProductId.fromString(productId),
+            HardwareMeasurementType.HYPERVISOR,
+            ServiceLevel.PREMIUM,
+            Usage.PRODUCTION,
+            BillingProvider._ANY,
+            ResourceUtils.ANY,
+            instanceSockets.intValue(),
+            instanceCores.intValue());
+    buckets.forEach(
+        bucket -> {
+          bucket.getKey().setAsHypervisor(true);
+          instance.addBucket(bucket);
+        });
 
     // save
     repository.save(instance);
     HostWithGuests item = new HostWithGuests();
     item.host = instance;
     item.guests = List.of(guest);
-    item.usePaygProduct = isContractEnabled;
-    itemsToBeExported.add(item);
+    item.usePaygProduct = false;
     return item;
+  }
+
+  private HostWithGuests givenInstanceWithMetrics(String orgId, String productId) {
+    var instance =
+        ProductId.fromString(productId).isPayg()
+            ? givenInstanceWithPayGoProduct(orgId, productId)
+            : givenInstanceWithTraditionalProduct(orgId, productId);
+    itemsToBeExported.add(instance);
+    return instance;
   }
 
   private static double resolveMetricValue(HostWithGuests item, MetricId metricId) {

--- a/src/test/java/org/candlepin/subscriptions/util/TallyHostBucketFactory.java
+++ b/src/test/java/org/candlepin/subscriptions/util/TallyHostBucketFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.subscriptions.util;
+
+import com.redhat.swatch.configuration.registry.ProductId;
+import java.util.ArrayList;
+import java.util.List;
+import org.candlepin.subscriptions.db.model.BillingProvider;
+import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
+import org.candlepin.subscriptions.db.model.HostBucketKey;
+import org.candlepin.subscriptions.db.model.HostTallyBucket;
+import org.candlepin.subscriptions.db.model.ServiceLevel;
+import org.candlepin.subscriptions.db.model.Usage;
+
+public class TallyHostBucketFactory {
+  /**
+   * Creates bucket tuples using the cartesian product pattern. Automatically creates buckets with
+   * the provided values AND _ANY variants (matching production tally behavior). Uses a Set to
+   * deduplicate when input values are already _ANY.
+   *
+   * @param productId the product ID for the buckets
+   * @param sla the SLA value (will create buckets with this value and _ANY)
+   * @param usage the usage value (will create buckets with this value and _ANY)
+   * @param billingProvider the billing provider (will create buckets with this value and _ANY)
+   * @param billingAccountId the billing account ID (will create buckets with this value and _ANY if
+   *     not null/blank)
+   * @param sockets the number of sockets
+   * @param cores the number of cores
+   * @return list of HostTallyBucket instances representing all dimension combinations
+   */
+  public static List<HostTallyBucket> createBucketTuples(
+      ProductId productId,
+      HardwareMeasurementType hmt,
+      ServiceLevel sla,
+      Usage usage,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      double sockets,
+      double cores) {
+
+    // Use Sets to automatically handle deduplication when values are already _ANY
+    // e.g., if sla = _ANY, Set.of(_ANY, _ANY) becomes Set.of(_ANY) with 1 element
+    var slas = new java.util.LinkedHashSet<>(List.of(sla, ServiceLevel._ANY));
+    var usages = new java.util.LinkedHashSet<>(List.of(usage, Usage._ANY));
+    var providers = new java.util.LinkedHashSet<>(List.of(billingProvider, BillingProvider._ANY));
+
+    // Billing account ID handling matches production: always include _ANY, conditionally add actual
+    // See: MetricUsageCollector.getBillingAccountIds()
+    var accountIds = new java.util.LinkedHashSet<String>();
+    accountIds.add("_ANY");
+    if (billingAccountId != null && !billingAccountId.isBlank()) {
+      accountIds.add(billingAccountId);
+    }
+
+    List<HostTallyBucket> buckets = new ArrayList<>();
+
+    // Create cartesian product of all dimensions
+    for (ServiceLevel slaValue : slas) {
+      for (Usage usageValue : usages) {
+        for (BillingProvider providerValue : providers) {
+          for (String accountIdValue : accountIds) {
+            HostTallyBucket bucket = new HostTallyBucket();
+            bucket.setKey(
+                new HostBucketKey(
+                    null, // host ID - will be set when added to host
+                    productId.toString(),
+                    slaValue,
+                    usageValue,
+                    providerValue,
+                    accountIdValue,
+                    false)); // asHypervisor
+            bucket.setSockets((int) sockets);
+            bucket.setCores((int) cores);
+            bucket.setMeasurementType(hmt);
+            bucket.setPrimary(PrimaryRecordUtils.isPrimaryRecord(bucket));
+            buckets.add(bucket);
+          }
+        }
+      }
+    }
+
+    return buckets;
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -122,39 +122,56 @@ public class TallyInstanceViewRepository {
       SortDirection dir) {
 
     Objects.requireNonNull(productId, "productId must be provided");
-    var repository = selectRepository(productId);
 
+    TallyInstancesDbReportCriteria searchCriteria =
+        TallyInstancesDbReportCriteria.builder()
+            .orgId(orgId)
+            .productId(productId)
+            .sla(sla)
+            .usage(usage)
+            .displayNameSubstring(displayNameSubstring)
+            .minCores(minCores)
+            .minSockets(minSockets)
+            .month(month)
+            .metricId(referenceMetricId)
+            .billingProvider(billingProvider)
+            .billingAccountId(billingAccountId)
+            .hardwareMeasurementTypes(hardwareMeasurementTypes)
+            .sort(sort)
+            .sortDirection(dir)
+            .usePrimary(isPrimaryRowSearchEnabled())
+            .build();
+    var repository = selectRepository(searchCriteria);
     return (Page<TallyInstanceView>)
         repository.findAll(
-            buildSearchSpecification(
-                TallyInstancesDbReportCriteria.builder()
-                    .orgId(orgId)
-                    .productId(productId)
-                    .sla(sla)
-                    .usage(usage)
-                    .displayNameSubstring(displayNameSubstring)
-                    .minCores(minCores)
-                    .minSockets(minSockets)
-                    .month(month)
-                    .metricId(referenceMetricId)
-                    .billingProvider(billingProvider)
-                    .billingAccountId(billingAccountId)
-                    .hardwareMeasurementTypes(hardwareMeasurementTypes)
-                    .sort(sort)
-                    .sortDirection(dir)
-                    .build()),
-            ResourceUtils.getPageable(offset, limit));
+            buildSearchSpecification(searchCriteria), ResourceUtils.getPageable(offset, limit));
   }
 
-  private JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
-      ProductId productId) {
-    // TODO Enable with featureFlags.isEnabled(FeatureFlags.ENABLE_HTB_PRIMARY_ROW_SEARCHES, false);
-    //  for SWATCH-4862
-    boolean usePrimary = false;
-    if (productId.isPayg()) {
-      return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
+  /**
+   * Selects the appropriate repository based on product type and primary row flag.
+   *
+   * @param criteria the search criteria containing productId and usePrimary
+   * @return the JPA repository executor for the appropriate view
+   */
+  public JpaSpecificationExecutor<? extends TallyInstanceView> selectRepository(
+      TallyInstancesDbReportCriteria criteria) {
+    if (Objects.isNull(criteria.getProductId())) {
+      throw new IllegalArgumentException("productId must be specified in search criteria");
     }
-    return usePrimary ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
+
+    if (criteria.getProductId().isPayg()) {
+      return criteria.isUsePrimary() ? paygPrimaryViewRepository : paygViewRepository;
+    }
+    return criteria.isUsePrimary() ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
+  }
+
+  /**
+   * Determines if primary row searches are enabled via feature flag.
+   *
+   * @return true if the ENABLE_HTB_PRIMARY_ROW_SEARCHES feature flag is enabled
+   */
+  public boolean isPrimaryRowSearchEnabled() {
+    return featureFlags.isEnabled(FeatureFlags.ENABLE_HTB_PRIMARY_ROW_SEARCHES, false);
   }
 
   static <T extends TallyInstanceView> Specification<T> socketsAndCoresGreaterThanOrEqualTo(
@@ -305,6 +322,9 @@ public class TallyInstanceViewRepository {
   @SuppressWarnings("java:S107")
   public static <T extends TallyInstanceView> Specification<T> buildSearchSpecification(
       TallyInstancesDbReportCriteria criteria) {
+    if (criteria.isUsePrimary()) {
+      sanitizeCriteriaForPrimaryRows(criteria);
+    }
     var searchCriteria = Specification.<T>unrestricted();
     searchCriteria =
         searchCriteria.and(
@@ -353,6 +373,21 @@ public class TallyInstanceViewRepository {
     }
 
     return searchCriteria;
+  }
+
+  private static void sanitizeCriteriaForPrimaryRows(TallyInstancesDbReportCriteria criteria) {
+    if (ServiceLevel._ANY.equals(criteria.getSla())) {
+      criteria.setSla(null);
+    }
+    if (Usage._ANY.equals(criteria.getUsage())) {
+      criteria.setUsage(null);
+    }
+    if (BillingProvider._ANY.equals(criteria.getBillingProvider())) {
+      criteria.setBillingProvider(null);
+    }
+    if (ResourceUtils.ANY.equals(criteria.getBillingAccountId())) {
+      criteria.setBillingAccountId(null);
+    }
   }
 
   private static Optional<MetricId> getMetricIdToSort(String sort) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/TallyInstanceViewRepository.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.candlepin.subscriptions.configuration.FeatureFlags;
 import org.candlepin.subscriptions.db.model.BillingProvider;
 import org.candlepin.subscriptions.db.model.HardwareMeasurementType;
@@ -59,6 +60,7 @@ import org.springframework.util.StringUtils;
 @SuppressWarnings({"linelength", "indentation", "unchecked"})
 @Repository
 @AllArgsConstructor
+@Slf4j
 public class TallyInstanceViewRepository {
 
   public static final Map<String, String> FIELD_SORT_PARAM_MAPPING =
@@ -159,10 +161,12 @@ public class TallyInstanceViewRepository {
       throw new IllegalArgumentException("productId must be specified in search criteria");
     }
 
+    boolean usePrimary = usePrimary(criteria);
+    log.debug("Using primary row search for instance view: {}", usePrimary);
     if (criteria.getProductId().isPayg()) {
-      return criteria.isUsePrimary() ? paygPrimaryViewRepository : paygViewRepository;
+      return usePrimary ? paygPrimaryViewRepository : paygViewRepository;
     }
-    return criteria.isUsePrimary() ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
+    return usePrimary ? nonPaygPrimaryViewRepository : nonPaygViewRepository;
   }
 
   /**
@@ -322,9 +326,7 @@ public class TallyInstanceViewRepository {
   @SuppressWarnings("java:S107")
   public static <T extends TallyInstanceView> Specification<T> buildSearchSpecification(
       TallyInstancesDbReportCriteria criteria) {
-    if (criteria.isUsePrimary()) {
-      sanitizeCriteriaForPrimaryRows(criteria);
-    }
+    boolean usePrimary = usePrimary(criteria);
     var searchCriteria = Specification.<T>unrestricted();
     searchCriteria =
         searchCriteria.and(
@@ -336,16 +338,16 @@ public class TallyInstanceViewRepository {
     if (Objects.nonNull(criteria.getProductId())) {
       searchCriteria = searchCriteria.and(productIdEquals(criteria.getProductId()));
     }
-    if (Objects.nonNull(criteria.getSla())) {
+    if (shouldApplyFilter(criteria.getSla(), ServiceLevel._ANY, usePrimary)) {
       searchCriteria = searchCriteria.and(slaEquals(criteria.getSla()));
     }
-    if (Objects.nonNull(criteria.getUsage())) {
+    if (shouldApplyFilter(criteria.getUsage(), Usage._ANY, usePrimary)) {
       searchCriteria = searchCriteria.and(usageEquals(criteria.getUsage()));
     }
-    if (Objects.nonNull(criteria.getBillingProvider())) {
+    if (shouldApplyFilter(criteria.getBillingProvider(), BillingProvider._ANY, usePrimary)) {
       searchCriteria = searchCriteria.and(billingProviderEquals(criteria.getBillingProvider()));
     }
-    if (Objects.nonNull(criteria.getBillingAccountId())) {
+    if (shouldApplyFilter(criteria.getBillingAccountId(), ResourceUtils.ANY, usePrimary)) {
       searchCriteria = searchCriteria.and(billingAccountIdEquals(criteria.getBillingAccountId()));
     }
     if (StringUtils.hasText(criteria.getDisplayNameSubstring())) {
@@ -375,19 +377,26 @@ public class TallyInstanceViewRepository {
     return searchCriteria;
   }
 
-  private static void sanitizeCriteriaForPrimaryRows(TallyInstancesDbReportCriteria criteria) {
-    if (ServiceLevel._ANY.equals(criteria.getSla())) {
-      criteria.setSla(null);
-    }
-    if (Usage._ANY.equals(criteria.getUsage())) {
-      criteria.setUsage(null);
-    }
-    if (BillingProvider._ANY.equals(criteria.getBillingProvider())) {
-      criteria.setBillingProvider(null);
-    }
-    if (ResourceUtils.ANY.equals(criteria.getBillingAccountId())) {
-      criteria.setBillingAccountId(null);
-    }
+  /**
+   * Determines whether a filter predicate should be applied for a given criteria value. A null
+   * value never gets a predicate. When searching primary rows, a value equal to its "any" sentinel
+   * is also skipped, since primary rows are already deduplicated to a single representative row.
+   */
+  private static boolean shouldApplyFilter(
+      Object value, Object anySentinelValue, boolean usePrimary) {
+    return Objects.nonNull(value) && !(usePrimary && anySentinelValue.equals(value));
+  }
+
+  /**
+   * Primary rows only track a single representative bucket per host, so they can't be used to
+   * satisfy a search restricted to the HYPERVISOR hardware measurement type. In that case, fall
+   * back to the non-primary filtering behavior even if primary row searches are enabled.
+   */
+  private static boolean usePrimary(TallyInstancesDbReportCriteria criteria) {
+    boolean searchingHypervisor =
+        ObjectUtils.isEmpty(criteria.getHardwareMeasurementTypes())
+            || criteria.getHardwareMeasurementTypes().contains(HardwareMeasurementType.HYPERVISOR);
+    return criteria.isUsePrimary() && !searchingHypervisor;
   }
 
   private static Optional<MetricId> getMetricIdToSort(String sort) {

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancesDbReportCriteria.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/db/model/TallyInstancesDbReportCriteria.java
@@ -45,4 +45,5 @@ public class TallyInstancesDbReportCriteria {
   private List<HardwareMeasurementType> hardwareMeasurementTypes;
   private String sort;
   private SortDirection sortDirection;
+  private boolean usePrimary;
 }

--- a/swatch-tally/ct/java/api/TallyUnleashService.java
+++ b/swatch-tally/ct/java/api/TallyUnleashService.java
@@ -25,6 +25,8 @@ import com.redhat.swatch.component.tests.api.UnleashService;
 public class TallyUnleashService extends UnleashService {
   private static final String ENABLE_PRIMARY_ROW_SEARCHES =
       "swatch.swatch-tally.enable-primary-row-searches";
+  private static final String ENABLE_HTB_PRIMARY_ROW_SEARCHES =
+      "swatch.swatch-tally.enable-host-tally-bucket-primary-row-searches";
 
   public void enablePrimaryRowSearches() {
     enableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
@@ -32,5 +34,13 @@ public class TallyUnleashService extends UnleashService {
 
   public void disablePrimaryRowSearches() {
     disableFlag(ENABLE_PRIMARY_ROW_SEARCHES);
+  }
+
+  public void enableHostTallyBucketPrimaryRowSearches(boolean enabled) {
+    if (enabled) {
+      enableFlag(ENABLE_HTB_PRIMARY_ROW_SEARCHES);
+    } else {
+      disableFlag(ENABLE_HTB_PRIMARY_ROW_SEARCHES);
+    }
   }
 }

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -111,6 +111,10 @@ public class BaseTallyComponentTest {
     }
   }
 
+  protected void givenPrimaryBucketSearchesEnabled(boolean enablePrimaryBucketSearches) {
+    unleash.enableHostTallyBucketPrimaryRowSearches(enablePrimaryBucketSearches);
+  }
+
   // --- Shared tally report query helpers ---
 
   protected double getHourlyTallySum(

--- a/swatch-tally/ct/java/tests/TallyHypervisorTest.java
+++ b/swatch-tally/ct/java/tests/TallyHypervisorTest.java
@@ -26,6 +26,7 @@ import static utils.TallyTestProducts.RHEL_FOR_X86;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.tally.test.model.InstanceData;
+import com.redhat.swatch.tally.test.model.InstanceResponse;
 import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -35,10 +36,37 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import utils.TallyDbHostSeeder;
+import utils.TallyHbiDbSeeder;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TallyHypervisorTest extends BaseTallyComponentTest {
+
+  private TallyHbiDbSeeder hbiSeeder;
+
+  @BeforeEach
+  void setupHbiSeeder() {
+    hbiSeeder = new TallyHbiDbSeeder(hbiDatabase);
+  }
+
+  @AfterEach
+  void cleanupHbiHosts() {
+    if (hbiSeeder != null) {
+      hbiSeeder.deleteAllInsertedHosts();
+    }
+  }
+
+  @AfterAll
+  void resetPrimaryBucketSearchesFlag() {
+    givenPrimaryBucketSearchesEnabled(false);
+  }
 
   @Test
   @TestPlanName("tally-hypervisor-TC003")
@@ -90,6 +118,69 @@ public class TallyHypervisorTest extends BaseTallyComponentTest {
     long newSockets = getDailySocketsTotal(startOfToday, endOfToday);
     assertEquals(
         initialSockets, newSockets, "Hypervisor without guests should not change total sockets");
+  }
+
+  @ParameterizedTest(name = "Using primary bucket searches: {0}")
+  @ValueSource(booleans = {true, false})
+  @TestPlanName("tally-hypervisor-TC007")
+  void shouldReportHypervisorOnceWhenSlaAndUsageWildcarded(boolean usePrimaryBucketSearches) {
+    // Given: Hypervisor with overlapping guest SLA/usage and primary-bucket flag configured
+    givenPrimaryBucketSearchesEnabled(usePrimaryBucketSearches);
+    service.createOptInConfig(orgId);
+    TallyHbiDbSeeder.SeededHost hypervisor = givenHypervisorWithOverlappingGuestSla();
+    OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.DAYS);
+    OffsetDateTime end = start.plusDays(1).minusNanos(1);
+
+    // When: Fetching instances with category=hypervisor (SLA and usage wildcarded)
+    InstanceResponse response =
+        service.getInstancesByProduct(
+            orgId, RHEL_FOR_X86.productTag(), start, end, Map.of("category", "hypervisor"));
+
+    // Then: Hypervisor appears exactly once despite multiple primary HYPERVISOR buckets
+    long count =
+        response.getData() == null
+            ? 0
+            : response.getData().stream()
+                .filter(
+                    i -> hypervisor.subscriptionManagerId().equals(i.getSubscriptionManagerId()))
+                .count();
+    assertEquals(1, count, "Hypervisor must appear once in instances report");
+  }
+
+  // --- Given helper methods ---
+
+  private TallyHbiDbSeeder.SeededHost givenHypervisorWithOverlappingGuestSla() {
+    // Hypervisor subscription_manager_id must be a UUID so guests can set virtual_host_uuid
+    String hypervisorSubManId = UUID.randomUUID().toString();
+    TallyHbiDbSeeder.SeededHost hypervisor =
+        hbiSeeder
+            .rhelHost(orgId)
+            .subscriptionManagerId(hypervisorSubManId)
+            .displayName("hypervisor-overlapping-guest-sla")
+            .cores(8)
+            .sockets(2)
+            .insert();
+
+    // Guests mapped to the hypervisor with overlapping SLA and different usages
+    hbiSeeder
+        .rhelHost(orgId)
+        .hypervisorUuid(hypervisorSubManId)
+        .sla("Premium")
+        .usage("Production")
+        .cores(4)
+        .sockets(1)
+        .insert();
+    hbiSeeder
+        .rhelHost(orgId)
+        .hypervisorUuid(hypervisorSubManId)
+        .sla("Premium")
+        .usage("Development/Test")
+        .cores(4)
+        .sockets(1)
+        .insert();
+
+    service.tallyOrg(orgId);
+    return hypervisor;
   }
 
   // --- Then helper methods ---

--- a/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
@@ -42,14 +42,23 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.candlepin.subscriptions.json.Event;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest {
 
   private record PriorMonthInstance(String instanceId, String billingAccountId, String eventId) {}
@@ -110,28 +119,28 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
       String previousMonthBilling,
       String currentMonthBilling) {}
 
-  private static String testOrgId;
-  private static OffsetDateTime start;
-  private static OffsetDateTime firstOfCurrentMonth;
-  private static OffsetDateTime firstOfPreviousMonth;
-  private static OffsetDateTime eventHour;
-  private static String metricId;
+  private String testOrgId;
+  private OffsetDateTime start;
+  private OffsetDateTime firstOfCurrentMonth;
+  private OffsetDateTime firstOfPreviousMonth;
+  private OffsetDateTime eventHour;
+  private String metricId;
 
-  private static PriorMonthInstance priorMonth;
-  private static SlaFilterRows sla;
-  private static UsageFilterRows usage;
-  private static CloudProviderPair cloudProviders;
-  private static BillingExclusion billingExclusion;
-  private static AllOptionalFilters allOptional;
-  private static PartialSlaUsagePair partialSlaUsage;
-  private static NarrowedBillingPair narrowedBilling;
-  private static UnfilteredRowTriple unfilteredTriple;
-  private static CrossMonthPair crossMonth;
+  private PriorMonthInstance priorMonth;
+  private SlaFilterRows sla;
+  private UsageFilterRows usage;
+  private CloudProviderPair cloudProviders;
+  private BillingExclusion billingExclusion;
+  private AllOptionalFilters allOptional;
+  private PartialSlaUsagePair partialSlaUsage;
+  private NarrowedBillingPair narrowedBilling;
+  private UnfilteredRowTriple unfilteredTriple;
+  private CrossMonthPair crossMonth;
 
   private static final int EXPECTED_CURRENT_MONTH_INSTANCE_ROWS = 16;
 
   @BeforeAll
-  static void setupSharedFixture() {
+  void setupSharedFixture() {
     testOrgId = RandomUtils.generateRandom();
     start = OffsetDateTime.now(ZoneOffset.UTC);
     firstOfCurrentMonth =
@@ -498,328 +507,371 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
         events.toArray(Event[]::new));
   }
 
-  @Test
-  @TestPlanName("tally-instances-payg-TC001")
-  public void shouldReportPaygInstancesOnlyInEventCalendarMonth() {
-    Map<String, Object> queryParams = Map.of("billing_account_id", priorMonth.billingAccountId());
-    InstanceResponse currentMonthResponse =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, queryParams);
+  // Use a nested test class to isolate the filter setup phase to toggling the primary
+  // bucket search flag, while keeping the test data setup in the main class' beforeAll.
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @ParameterizedClass(name = "Using primary bucket searches: {0}")
+  @ValueSource(booleans = {true, false})
+  class FilterTests {
 
-    assertEquals(
-        0.0,
-        sumMeteredValues(currentMonthResponse),
-        0.001,
-        "Current month should have no metered value for event from previous month");
+    @Parameter boolean usePrimaryBucketSearches;
+    Boolean lastSearchConfig;
 
-    InstanceResponse previousMonthResponse =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfPreviousMonth,
-            firstOfPreviousMonth.plusDays(1),
-            queryParams);
-
-    double meteredValueLastMonth = sumMeteredValues(previousMonthResponse);
-    assertTrue(
-        meteredValueLastMonth > 0.0,
-        "Previous month should have metered value greater than 0. Got: " + meteredValueLastMonth);
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC002")
-  public void shouldFilterInstancesReportBySla() {
-    Map<String, Object> standardParams = new HashMap<>();
-    standardParams.put("sla", ServiceLevelType.STANDARD);
-    standardParams.put("billing_account_id", sla.billingAccountId());
-    InstanceResponse standardOnly =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            standardParams);
-    assertNotNull(standardOnly.getData());
-    assertEquals(1, standardOnly.getData().size(), "STANDARD SLA filter should return one row");
-    assertEquals(
-        sla.standardInstanceId(),
-        standardOnly.getData().get(0).getInstanceId(),
-        "Row should be the STANDARD instance");
-    assertEquals(1.0, sumMeteredValues(standardOnly), 0.001);
-    assertNotNull(standardOnly.getMeta());
-    assertEquals(ServiceLevelType.STANDARD, standardOnly.getMeta().getServiceLevel());
-
-    Map<String, Object> premiumParams = new HashMap<>();
-    premiumParams.put("sla", ServiceLevelType.PREMIUM);
-    premiumParams.put("billing_account_id", sla.billingAccountId());
-    InstanceResponse premiumOnly =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            premiumParams);
-    assertNotNull(premiumOnly.getData());
-    assertEquals(1, premiumOnly.getData().size());
-    assertEquals(sla.premiumInstanceId(), premiumOnly.getData().get(0).getInstanceId());
-    assertEquals(ServiceLevelType.PREMIUM, premiumOnly.getMeta().getServiceLevel());
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC003")
-  public void shouldFilterInstancesReportByUsage() {
-    Map<String, Object> productionParams = new HashMap<>();
-    productionParams.put("usage", UsageType.PRODUCTION);
-    productionParams.put("billing_account_id", usage.billingAccountId());
-    InstanceResponse productionOnly =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            productionParams);
-    assertNotNull(productionOnly.getData());
-    assertEquals(1, productionOnly.getData().size());
-    assertEquals(usage.productionInstanceId(), productionOnly.getData().get(0).getInstanceId());
-    assertEquals(UsageType.PRODUCTION, productionOnly.getMeta().getUsage());
-
-    Map<String, Object> developmentParams = new HashMap<>();
-    developmentParams.put("usage", UsageType.DEVELOPMENT_TEST);
-    developmentParams.put("billing_account_id", usage.billingAccountId());
-    InstanceResponse developmentOnly =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            developmentParams);
-    assertNotNull(developmentOnly.getData());
-    assertEquals(1, developmentOnly.getData().size());
-    assertEquals(usage.developmentInstanceId(), developmentOnly.getData().get(0).getInstanceId());
-    assertEquals(UsageType.DEVELOPMENT_TEST, developmentOnly.getMeta().getUsage());
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC004")
-  public void shouldFilterInstancesReportByBillingProvider() {
-    Map<String, Object> azureParams = new HashMap<>();
-    azureParams.put("billing_provider", BillingProviderType.AZURE);
-    azureParams.put("billing_account_id", cloudProviders.azureBillingAccountId());
-    InstanceResponse azureOnly =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, azureParams);
-    assertNotNull(azureOnly.getData());
-    assertEquals(1, azureOnly.getData().size());
-    assertEquals(cloudProviders.azureInstanceId(), azureOnly.getData().get(0).getInstanceId());
-    assertEquals(BillingProviderType.AZURE, azureOnly.getMeta().getBillingProvider());
-
-    Map<String, Object> awsParams = new HashMap<>();
-    awsParams.put("billing_provider", BillingProviderType.AWS);
-    awsParams.put("billing_account_id", cloudProviders.awsBillingAccountId());
-    InstanceResponse awsOnly =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, awsParams);
-    assertNotNull(awsOnly.getData());
-    assertEquals(1, awsOnly.getData().size());
-    assertEquals(cloudProviders.awsInstanceId(), awsOnly.getData().get(0).getInstanceId());
-    assertEquals(BillingProviderType.AWS, awsOnly.getMeta().getBillingProvider());
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC005")
-  public void shouldExcludeInstancesWithNonMatchingBillingAccountId() {
-    Map<String, Object> wrongAccount =
-        Map.of("billing_account_id", billingExclusion.decoyBillingAccountId());
-    InstanceResponse noMatch =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            wrongAccount);
-    assertEquals(
-        0.0,
-        sumMeteredValues(noMatch),
-        0.001,
-        "Non-matching billing_account_id should yield no metered value");
-
-    Map<String, Object> correctAccount =
-        Map.of("billing_account_id", billingExclusion.matchingBillingAccountId());
-    InstanceResponse match =
-        service.getInstancesByProduct(
-            testOrgId,
-            RHEL_FOR_X86_ELS_PAYG.productTag(),
-            firstOfCurrentMonth,
-            start,
-            correctAccount);
-    assertTrue(
-        sumMeteredValues(match) > 0.0, "Matching billing_account_id should return metered data");
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC006")
-  public void shouldReturnInstancesReportWithAllOptionalFilters() {
-    Map<String, Object> allFilters = new HashMap<>();
-    allFilters.put("sla", ServiceLevelType.PREMIUM);
-    allFilters.put("usage", UsageType.PRODUCTION);
-    allFilters.put("billing_provider", BillingProviderType.AWS);
-    allFilters.put("billing_account_id", allOptional.billingAccountId());
-
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, allFilters);
-    assertNotNull(response.getData());
-    assertEquals(1, response.getData().size());
-    InstanceData row = response.getData().get(0);
-    assertEquals(allOptional.instanceId(), row.getInstanceId());
-    assertTrue(sumMeteredValues(response) > 0.0);
-
-    assertNotNull(response.getMeta());
-    assertEquals(ServiceLevelType.PREMIUM, response.getMeta().getServiceLevel());
-    assertEquals(UsageType.PRODUCTION, response.getMeta().getUsage());
-    assertEquals(BillingProviderType.AWS, response.getMeta().getBillingProvider());
-    assertEquals(allOptional.billingAccountId(), response.getMeta().getBillingAccountId());
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC007")
-  public void shouldReturnInstancesReportWithPartialFiltersAndDifferentBillingAccountIds() {
-    Map<String, Object> partial =
-        Map.of("sla", ServiceLevelType.PREMIUM, "usage", UsageType.PRODUCTION);
-
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, partial);
-    assertNotNull(response.getData());
-    Set<String> ids =
-        response.getData() == null
-            ? Set.of()
-            : response.getData().stream()
-                .map(InstanceData::getInstanceId)
-                .collect(Collectors.toSet());
-    assertTrue(
-        ids.contains(partialSlaUsage.firstInstanceId())
-            && ids.contains(partialSlaUsage.secondInstanceId()),
-        "sla+usage filter should include both fixture instances with different billing accounts");
-    long fixtureRows =
-        response.getData().stream()
-            .filter(
-                d ->
-                    partialSlaUsage.firstInstanceId().equals(d.getInstanceId())
-                        || partialSlaUsage.secondInstanceId().equals(d.getInstanceId()))
-            .count();
-    assertEquals(2, fixtureRows, "Each fixture instance should appear once under partial filters");
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC008")
-  public void shouldReturnInstancesReportWithPartialFiltersAndSameBillingAccountId() {
-    Map<String, Object> narrowed = new HashMap<>();
-    narrowed.put("sla", ServiceLevelType.PREMIUM);
-    narrowed.put("usage", UsageType.PRODUCTION);
-    narrowed.put("billing_account_id", narrowedBilling.matchBillingAccountId());
-
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, narrowed);
-    assertNotNull(response.getData());
-    assertEquals(1, response.getData().size());
-    assertEquals(narrowedBilling.matchInstanceId(), response.getData().get(0).getInstanceId());
-  }
-
-  @Test
-  @TestPlanName("tally-instances-payg-TC009")
-  public void shouldReturnInstancesReportWithNoOptionalFilters() {
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, null);
-    assertNotNull(response.getData());
-    Set<String> returned =
-        response.getData() == null
-            ? Set.of()
-            : response.getData().stream()
-                .map(InstanceData::getInstanceId)
-                .collect(Collectors.toSet());
-    for (String id :
-        List.of(
-            unfilteredTriple.firstInstanceId(),
-            unfilteredTriple.secondInstanceId(),
-            unfilteredTriple.thirdInstanceId())) {
-      assertTrue(returned.contains(id), "Expected instance id " + id);
+    // Ensure we disable primary bucket search after all tests are run
+    // to get it back in the default state.
+    @AfterAll
+    void teardown() {
+      // Disable primary bucket search
+      givenPrimaryBucketSearchesEnabled(false);
     }
-    assertTrue(
-        response.getData().size() >= 3,
-        "Unfiltered report should include at least the three instances used in the unfiltered-triple "
-            + "fixture");
-    assertNotNull(response.getMeta());
-    assertNotNull(response.getMeta().getCount());
-    assertEquals(
-        response.getData().size(),
-        response.getMeta().getCount().intValue(),
-        "Meta count should match row count for the unfiltered query");
-  }
 
-  @Test
-  @TestPlanName("tally-instances-payg-TC010")
-  public void shouldReturnInstancesReportWithTwoEventsInDifferentMonths() {
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, null);
-    Set<String> ids =
-        response.getData() == null
-            ? Set.of()
-            : response.getData().stream()
-                .map(InstanceData::getInstanceId)
-                .collect(Collectors.toSet());
-    assertTrue(
-        ids.contains(crossMonth.currentMonthInstanceId()),
-        "Current-month instance should appear for current-month window");
-    assertFalse(
-        ids.contains(crossMonth.previousMonthInstanceId()),
-        "Previous-month-only instance should not appear in current-month window");
-  }
+    @BeforeEach
+    void setup() {
+      // Check if the parameter value has changed and only toggle the flag if it has. This avoids
+      // needing to make a request to unleash before each test.
+      if (Objects.isNull(lastSearchConfig) || !lastSearchConfig.equals(usePrimaryBucketSearches)) {
+        givenPrimaryBucketSearchesEnabled(usePrimaryBucketSearches);
+      }
+      lastSearchConfig = usePrimaryBucketSearches;
+    }
 
-  @Test
-  @TestPlanName("tally-instances-payg-TC011")
-  public void shouldRejectCrossMonthInstancesQuery() {
-    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-    OffsetDateTime beginning = now.withDayOfMonth(10).truncatedTo(ChronoUnit.DAYS).withHour(12);
-    OffsetDateTime ending = beginning.plusMonths(1).withDayOfMonth(10).withHour(12);
+    @Test
+    @TestPlanName("tally-instances-payg-TC001")
+    public void shouldReportPaygInstancesOnlyInEventCalendarMonth() {
+      Map<String, Object> queryParams = Map.of("billing_account_id", priorMonth.billingAccountId());
+      InstanceResponse currentMonthResponse =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              queryParams);
 
-    Response response =
-        service.getInstancesByProductRaw(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), beginning, ending, null);
+      assertEquals(
+          0.0,
+          sumMeteredValues(currentMonthResponse),
+          0.001,
+          "Current month should have no metered value for event from previous month");
 
-    assertEquals(
-        HttpStatus.SC_BAD_REQUEST,
-        response.getStatusCode(),
-        "PAYG instances must reject beginning/ending in different calendar months: "
-            + response.getBody().asString());
-    assertTrue(
-        response.getBody().asString().toLowerCase().contains("month"),
-        "Error body should mention month restriction: " + response.getBody().asString());
-  }
+      InstanceResponse previousMonthResponse =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfPreviousMonth,
+              firstOfPreviousMonth.plusDays(1),
+              queryParams);
 
-  @Test
-  @TestPlanName("tally-instances-payg-TC012")
-  public void shouldReturnMeteredInstancesForFullCalendarMonthWindow() {
-    ZoneOffset utc = ZoneOffset.UTC;
-    OffsetDateTime monthStart =
-        start.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-    OffsetDateTime monthEnd =
-        YearMonth.from(start).atEndOfMonth().atTime(23, 59, 59, 999_000_000).atOffset(utc);
+      double meteredValueLastMonth = sumMeteredValues(previousMonthResponse);
+      assertTrue(
+          meteredValueLastMonth > 0.0,
+          "Previous month should have metered value greater than 0. Got: " + meteredValueLastMonth);
+    }
 
-    Map<String, Object> filters = Map.of("billing_account_id", sla.billingAccountId());
+    @Test
+    @TestPlanName("tally-instances-payg-TC002")
+    public void shouldFilterInstancesReportBySla() {
+      Map<String, Object> standardParams = new HashMap<>();
+      standardParams.put("sla", ServiceLevelType.STANDARD);
+      standardParams.put("billing_account_id", sla.billingAccountId());
+      InstanceResponse standardOnly =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              standardParams);
+      assertNotNull(standardOnly.getData());
+      assertEquals(1, standardOnly.getData().size(), "STANDARD SLA filter should return one row");
+      assertEquals(
+          sla.standardInstanceId(),
+          standardOnly.getData().get(0).getInstanceId(),
+          "Row should be the STANDARD instance");
+      assertEquals(1.0, sumMeteredValues(standardOnly), 0.001);
+      assertNotNull(standardOnly.getMeta());
+      assertEquals(ServiceLevelType.STANDARD, standardOnly.getMeta().getServiceLevel());
 
-    InstanceResponse response =
-        service.getInstancesByProduct(
-            testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), monthStart, monthEnd, filters);
+      Map<String, Object> premiumParams = new HashMap<>();
+      premiumParams.put("sla", ServiceLevelType.PREMIUM);
+      premiumParams.put("billing_account_id", sla.billingAccountId());
+      InstanceResponse premiumOnly =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              premiumParams);
+      assertNotNull(premiumOnly.getData());
+      assertEquals(1, premiumOnly.getData().size());
+      assertEquals(sla.premiumInstanceId(), premiumOnly.getData().get(0).getInstanceId());
+      assertEquals(ServiceLevelType.PREMIUM, premiumOnly.getMeta().getServiceLevel());
+    }
 
-    assertNotNull(response.getData());
-    assertFalse(response.getData().isEmpty(), "Full-month window should return instance rows");
-    assertTrue(
-        sumMeteredValues(response) > 0.0,
-        "Metered total should be positive for the SLA filter fixture rows in the current month");
+    @Test
+    @TestPlanName("tally-instances-payg-TC003")
+    public void shouldFilterInstancesReportByUsage() {
+      Map<String, Object> productionParams = new HashMap<>();
+      productionParams.put("usage", UsageType.PRODUCTION);
+      productionParams.put("billing_account_id", usage.billingAccountId());
+      InstanceResponse productionOnly =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              productionParams);
+      assertNotNull(productionOnly.getData());
+      assertEquals(1, productionOnly.getData().size());
+      assertEquals(usage.productionInstanceId(), productionOnly.getData().get(0).getInstanceId());
+      assertEquals(UsageType.PRODUCTION, productionOnly.getMeta().getUsage());
+
+      Map<String, Object> developmentParams = new HashMap<>();
+      developmentParams.put("usage", UsageType.DEVELOPMENT_TEST);
+      developmentParams.put("billing_account_id", usage.billingAccountId());
+      InstanceResponse developmentOnly =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              developmentParams);
+      assertNotNull(developmentOnly.getData());
+      assertEquals(1, developmentOnly.getData().size());
+      assertEquals(usage.developmentInstanceId(), developmentOnly.getData().get(0).getInstanceId());
+      assertEquals(UsageType.DEVELOPMENT_TEST, developmentOnly.getMeta().getUsage());
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC004")
+    public void shouldFilterInstancesReportByBillingProvider() {
+      Map<String, Object> azureParams = new HashMap<>();
+      azureParams.put("billing_provider", BillingProviderType.AZURE);
+      azureParams.put("billing_account_id", cloudProviders.azureBillingAccountId());
+      InstanceResponse azureOnly =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              azureParams);
+      assertNotNull(azureOnly.getData());
+      assertEquals(1, azureOnly.getData().size());
+      assertEquals(cloudProviders.azureInstanceId(), azureOnly.getData().get(0).getInstanceId());
+      assertEquals(BillingProviderType.AZURE, azureOnly.getMeta().getBillingProvider());
+
+      Map<String, Object> awsParams = new HashMap<>();
+      awsParams.put("billing_provider", BillingProviderType.AWS);
+      awsParams.put("billing_account_id", cloudProviders.awsBillingAccountId());
+      InstanceResponse awsOnly =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, awsParams);
+      assertNotNull(awsOnly.getData());
+      assertEquals(1, awsOnly.getData().size());
+      assertEquals(cloudProviders.awsInstanceId(), awsOnly.getData().get(0).getInstanceId());
+      assertEquals(BillingProviderType.AWS, awsOnly.getMeta().getBillingProvider());
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC005")
+    public void shouldExcludeInstancesWithNonMatchingBillingAccountId() {
+      Map<String, Object> wrongAccount =
+          Map.of("billing_account_id", billingExclusion.decoyBillingAccountId());
+      InstanceResponse noMatch =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              wrongAccount);
+      assertEquals(
+          0.0,
+          sumMeteredValues(noMatch),
+          0.001,
+          "Non-matching billing_account_id should yield no metered value");
+
+      Map<String, Object> correctAccount =
+          Map.of("billing_account_id", billingExclusion.matchingBillingAccountId());
+      InstanceResponse match =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              correctAccount);
+      assertTrue(
+          sumMeteredValues(match) > 0.0, "Matching billing_account_id should return metered data");
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC006")
+    public void shouldReturnInstancesReportWithAllOptionalFilters() {
+      Map<String, Object> allFilters = new HashMap<>();
+      allFilters.put("sla", ServiceLevelType.PREMIUM);
+      allFilters.put("usage", UsageType.PRODUCTION);
+      allFilters.put("billing_provider", BillingProviderType.AWS);
+      allFilters.put("billing_account_id", allOptional.billingAccountId());
+
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId,
+              RHEL_FOR_X86_ELS_PAYG.productTag(),
+              firstOfCurrentMonth,
+              start,
+              allFilters);
+      assertNotNull(response.getData());
+      assertEquals(1, response.getData().size());
+      InstanceData row = response.getData().get(0);
+      assertEquals(allOptional.instanceId(), row.getInstanceId());
+      assertTrue(sumMeteredValues(response) > 0.0);
+
+      assertNotNull(response.getMeta());
+      assertEquals(ServiceLevelType.PREMIUM, response.getMeta().getServiceLevel());
+      assertEquals(UsageType.PRODUCTION, response.getMeta().getUsage());
+      assertEquals(BillingProviderType.AWS, response.getMeta().getBillingProvider());
+      assertEquals(allOptional.billingAccountId(), response.getMeta().getBillingAccountId());
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC007")
+    public void shouldReturnInstancesReportWithPartialFiltersAndDifferentBillingAccountIds() {
+      Map<String, Object> partial =
+          Map.of("sla", ServiceLevelType.PREMIUM, "usage", UsageType.PRODUCTION);
+
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, partial);
+      assertNotNull(response.getData());
+      Set<String> ids =
+          response.getData() == null
+              ? Set.of()
+              : response.getData().stream()
+                  .map(InstanceData::getInstanceId)
+                  .collect(Collectors.toSet());
+      assertTrue(
+          ids.contains(partialSlaUsage.firstInstanceId())
+              && ids.contains(partialSlaUsage.secondInstanceId()),
+          "sla+usage filter should include both fixture instances with different billing accounts");
+      long fixtureRows =
+          response.getData().stream()
+              .filter(
+                  d ->
+                      partialSlaUsage.firstInstanceId().equals(d.getInstanceId())
+                          || partialSlaUsage.secondInstanceId().equals(d.getInstanceId()))
+              .count();
+      assertEquals(
+          2, fixtureRows, "Each fixture instance should appear once under partial filters");
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC008")
+    public void shouldReturnInstancesReportWithPartialFiltersAndSameBillingAccountId() {
+      Map<String, Object> narrowed = new HashMap<>();
+      narrowed.put("sla", ServiceLevelType.PREMIUM);
+      narrowed.put("usage", UsageType.PRODUCTION);
+      narrowed.put("billing_account_id", narrowedBilling.matchBillingAccountId());
+
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, narrowed);
+      assertNotNull(response.getData());
+      assertEquals(1, response.getData().size());
+      assertEquals(narrowedBilling.matchInstanceId(), response.getData().get(0).getInstanceId());
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC009")
+    public void shouldReturnInstancesReportWithNoOptionalFilters() {
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, null);
+      assertNotNull(response.getData());
+      Set<String> returned =
+          response.getData() == null
+              ? Set.of()
+              : response.getData().stream()
+                  .map(InstanceData::getInstanceId)
+                  .collect(Collectors.toSet());
+      for (String id :
+          List.of(
+              unfilteredTriple.firstInstanceId(),
+              unfilteredTriple.secondInstanceId(),
+              unfilteredTriple.thirdInstanceId())) {
+        assertTrue(returned.contains(id), "Expected instance id " + id);
+      }
+      assertTrue(
+          response.getData().size() >= 3,
+          "Unfiltered report should include at least the three instances used in the unfiltered-triple "
+              + "fixture");
+      assertNotNull(response.getMeta());
+      assertNotNull(response.getMeta().getCount());
+      assertEquals(
+          response.getData().size(),
+          response.getMeta().getCount().intValue(),
+          "Meta count should match row count for the unfiltered query");
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC010")
+    public void shouldReturnInstancesReportWithTwoEventsInDifferentMonths() {
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), firstOfCurrentMonth, start, null);
+      Set<String> ids =
+          response.getData() == null
+              ? Set.of()
+              : response.getData().stream()
+                  .map(InstanceData::getInstanceId)
+                  .collect(Collectors.toSet());
+      assertTrue(
+          ids.contains(crossMonth.currentMonthInstanceId()),
+          "Current-month instance should appear for current-month window");
+      assertFalse(
+          ids.contains(crossMonth.previousMonthInstanceId()),
+          "Previous-month-only instance should not appear in current-month window");
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC011")
+    public void shouldRejectCrossMonthInstancesQuery() {
+      OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+      OffsetDateTime beginning = now.withDayOfMonth(10).truncatedTo(ChronoUnit.DAYS).withHour(12);
+      OffsetDateTime ending = beginning.plusMonths(1).withDayOfMonth(10).withHour(12);
+
+      Response response =
+          service.getInstancesByProductRaw(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), beginning, ending, null);
+
+      assertEquals(
+          HttpStatus.SC_BAD_REQUEST,
+          response.getStatusCode(),
+          "PAYG instances must reject beginning/ending in different calendar months: "
+              + response.getBody().asString());
+      assertTrue(
+          response.getBody().asString().toLowerCase().contains("month"),
+          "Error body should mention month restriction: " + response.getBody().asString());
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC012")
+    public void shouldReturnMeteredInstancesForFullCalendarMonthWindow() {
+      ZoneOffset utc = ZoneOffset.UTC;
+      OffsetDateTime monthStart =
+          start.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+      OffsetDateTime monthEnd =
+          YearMonth.from(start).atEndOfMonth().atTime(23, 59, 59, 999_000_000).atOffset(utc);
+
+      Map<String, Object> filters = Map.of("billing_account_id", sla.billingAccountId());
+
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              testOrgId, RHEL_FOR_X86_ELS_PAYG.productTag(), monthStart, monthEnd, filters);
+
+      assertNotNull(response.getData());
+      assertFalse(response.getData().isEmpty(), "Full-month window should return instance rows");
+      assertTrue(
+          sumMeteredValues(response) > 0.0,
+          "Metered total should be positive for the SLA filter fixture rows in the current month");
+    }
   }
 
   private double sumMeteredValues(InstanceResponse response) {

--- a/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -50,7 +49,6 @@ import org.apache.http.HttpStatus;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -507,8 +505,14 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
         events.toArray(Event[]::new));
   }
 
+  @AfterAll
+  void resetPrimaryBucketSearchesFlag() {
+    // Reset once after all parameterized FilterTests instances finish.
+    givenPrimaryBucketSearchesEnabled(false);
+  }
+
   // Use a nested test class to isolate the filter setup phase to toggling the primary
-  // bucket search flag, while keeping the test data setup in the main class' beforeAll.
+  // bucket search flag, while keeping the test data setup in the main class beforeAll.
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   @ParameterizedClass(name = "Using primary bucket searches: {0}")
@@ -516,24 +520,10 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
   class FilterTests {
 
     @Parameter boolean usePrimaryBucketSearches;
-    Boolean lastSearchConfig;
 
-    // Ensure we disable primary bucket search after all tests are run
-    // to get it back in the default state.
-    @AfterAll
-    void teardown() {
-      // Disable primary bucket search
-      givenPrimaryBucketSearchesEnabled(false);
-    }
-
-    @BeforeEach
+    @BeforeAll
     void setup() {
-      // Check if the parameter value has changed and only toggle the flag if it has. This avoids
-      // needing to make a request to unleash before each test.
-      if (Objects.isNull(lastSearchConfig) || !lastSearchConfig.equals(usePrimaryBucketSearches)) {
-        givenPrimaryBucketSearchesEnabled(usePrimaryBucketSearches);
-      }
-      lastSearchConfig = usePrimaryBucketSearches;
+      givenPrimaryBucketSearchesEnabled(usePrimaryBucketSearches);
     }
 
     @Test

--- a/swatch-tally/ct/java/utils/TallyHbiDbSeeder.java
+++ b/swatch-tally/ct/java/utils/TallyHbiDbSeeder.java
@@ -117,25 +117,32 @@ public final class TallyHbiDbSeeder {
   }
 
   /** Record of RHEL facts. */
+  @com.fasterxml.jackson.annotation.JsonInclude(
+      com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
   private record RhsmFacts(
       @JsonProperty("RH_PROD") List<String> rhProd,
       @JsonProperty("IS_VIRTUAL") String isVirtual,
       @JsonProperty("ARCHITECTURE") String architecture,
       @JsonProperty("CORES") String cores,
-      @JsonProperty("SOCKETS") String sockets) {}
+      @JsonProperty("SOCKETS") String sockets,
+      @JsonProperty("SYSPURPOSE_SLA") String syspurposeSla,
+      @JsonProperty("SYSPURPOSE_USAGE") String syspurposeUsage) {}
 
   /** Record of the top level facts */
   private record Facts(RhsmFacts rhsm) {}
 
-  /** Build facts JSON for RHEL host with product and capacity information. */
-  private String buildRhelFacts(int cores, int sockets) {
+  /** Build facts JSON for a RHEL host, optionally virtual and with syspurpose SLA/usage. */
+  private String buildRhelFacts(
+      int cores, int sockets, boolean isVirtual, String sla, String usage) {
     RhsmFacts rhsm =
         new RhsmFacts(
             List.of(RHEL_PRODUCT_ID),
-            "false",
+            String.valueOf(isVirtual),
             "x86_64",
             String.valueOf(cores),
-            String.valueOf(sockets));
+            String.valueOf(sockets),
+            sla,
+            usage);
 
     Facts facts = new Facts(rhsm);
     try {
@@ -196,6 +203,9 @@ public final class TallyHbiDbSeeder {
     private String[] reporters = new String[] {"component-test"};
     private String cloudProvider;
     private String providerId;
+    private String sla;
+    private String usage;
+    private String hypervisorUuid;
 
     private RhelHostBuilder(String orgId) {
       this.orgId = Objects.requireNonNull(orgId, "orgId is required");
@@ -250,6 +260,28 @@ public final class TallyHbiDbSeeder {
       return this;
     }
 
+    /** Set syspurpose SLA (e.g. {Premium}, {Standard}). */
+    public RhelHostBuilder sla(String sla) {
+      this.sla = sla;
+      return this;
+    }
+
+    /** Set syspurpose usage (e.g. {Production}, {Development/Test}). */
+    public RhelHostBuilder usage(String usage) {
+      this.usage = usage;
+      return this;
+    }
+
+    /**
+     * Map this host as a guest of the given hypervisor. Sets infrastructure to virtual and stores
+     * the value as {system_profiles_static.virtual_host_uuid} (must be a UUID string matching the
+     * hypervisor's subscription_manager_id).
+     */
+    public RhelHostBuilder hypervisorUuid(String hypervisorUuid) {
+      this.hypervisorUuid = hypervisorUuid;
+      return this;
+    }
+
     public SeededHost insert() {
       return insertRhelHost(
           orgId,
@@ -261,7 +293,10 @@ public final class TallyHbiDbSeeder {
           reporter,
           reporters,
           cloudProvider,
-          providerId);
+          providerId,
+          sla,
+          usage,
+          hypervisorUuid);
     }
   }
 
@@ -435,12 +470,16 @@ public final class TallyHbiDbSeeder {
         reporter,
         reporters,
         null,
+        null,
+        null,
+        null,
         null);
   }
 
   /**
    * Insert a RHEL host into the HBI database. When cloudProvider is null, creates a physical host.
    * When cloudProvider is set (e.g. "aws"), creates a virtual cloud host with RHEL product facts.
+   * When hypervisorUuid is set, creates a virtual guest mapped to that hypervisor.
    *
    * @param orgId the organization ID
    * @param inventoryId the inventory ID (must be unique)
@@ -465,9 +504,47 @@ public final class TallyHbiDbSeeder {
       String[] reporters,
       String cloudProvider,
       String providerId) {
+    return insertRhelHost(
+        orgId,
+        inventoryId,
+        subscriptionManagerId,
+        displayName,
+        cores,
+        sockets,
+        reporter,
+        reporters,
+        cloudProvider,
+        providerId,
+        null,
+        null,
+        null);
+  }
+
+  /**
+   * Insert a RHEL host into the HBI database with optional syspurpose and guest mapping.
+   *
+   * @param sla syspurpose SLA (e.g. Premium), or null
+   * @param usage syspurpose usage (e.g. Production), or null
+   * @param hypervisorUuid hypervisor subscription_manager_id to map this guest, or null
+   */
+  public SeededHost insertRhelHost(
+      String orgId,
+      String inventoryId,
+      String subscriptionManagerId,
+      String displayName,
+      int cores,
+      int sockets,
+      String reporter,
+      String[] reporters,
+      String cloudProvider,
+      String providerId,
+      String sla,
+      String usage,
+      String hypervisorUuid) {
     waitForSchemaReady();
     Objects.requireNonNull(orgId, "orgId is required");
 
+    boolean isGuest = hypervisorUuid != null;
     boolean isCloud = cloudProvider != null;
 
     // Use defaults if null values passed
@@ -499,6 +576,16 @@ public final class TallyHbiDbSeeder {
           "Sockets cannot be 0 (would cause division by zero when calculating cores_per_socket)");
     }
 
+    if (isGuest) {
+      try {
+        UUID.fromString(hypervisorUuid);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            "hypervisorUuid must be a UUID string matching the hypervisor subscription_manager_id",
+            e);
+      }
+    }
+
     // Track host after validation but before INSERT, so cleanup works even if INSERT fails
     insertedHostIds.add(hostId);
 
@@ -525,7 +612,7 @@ public final class TallyHbiDbSeeder {
         ps.setObject(7, now);
         ps.setObject(8, now);
         ps.setObject(9, now);
-        ps.setString(10, buildRhelFacts(cores, sockets));
+        ps.setString(10, buildRhelFacts(cores, sockets, isGuest || isCloud, sla, usage));
         ps.setString(11, "[]");
         ps.setString(12, actualReporter);
         ps.setArray(13, conn.createArrayOf("varchar", actualReporters));
@@ -536,10 +623,10 @@ public final class TallyHbiDbSeeder {
           """
           INSERT INTO hbi.system_profiles_static
             (org_id, host_id, cores_per_socket, number_of_sockets,
-             infrastructure_type, cloud_provider, arch)
+             infrastructure_type, cloud_provider, arch, virtual_host_uuid)
           VALUES
             (?, ?, ?, ?,
-             ?, ?, ?)
+             ?, ?, ?, ?)
           """;
 
       try (PreparedStatement ps = conn.prepareStatement(profileSql)) {
@@ -547,9 +634,14 @@ public final class TallyHbiDbSeeder {
         ps.setObject(2, hostId);
         ps.setInt(3, cores / sockets);
         ps.setInt(4, sockets);
-        ps.setString(5, isCloud ? "virtual" : "physical");
-        ps.setString(6, cloudProvider); // null for physical hosts
+        ps.setString(5, (isGuest || isCloud) ? "virtual" : "physical");
+        ps.setString(6, cloudProvider); // null for physical/guest hosts
         ps.setString(7, "x86_64");
+        if (isGuest) {
+          ps.setObject(8, UUID.fromString(hypervisorUuid));
+        } else {
+          ps.setObject(8, null);
+        }
         ps.executeUpdate();
       }
     } catch (SQLException e) {

--- a/swatch-tally/test-plans/tally-processing.md
+++ b/swatch-tally/test-plans/tally-processing.md
@@ -420,6 +420,26 @@ This test plan covers the core tally processing pipeline:
 - **Expected Result**:
     - Guest mapping updates change hypervisor visibility in tally inventory
 
+**tally-hypervisor-TC007 - RHEL hypervisor with overlapping guest SLA appears once in instances**
+
+- **Description**: Verify a hypervisor that inherited multiple guest SLA/usage combinations (multiple primary HYPERVISOR host tally buckets) appears only once in the instances report when SLA and USAGE are wildcarded, for both primary bucket search flag states
+- **Setup**:
+    - Organization is opted in
+    - Feature flag `swatch.swatch-tally.enable-host-tally-bucket-primary-row-searches` is toggled on and off (parameterized)
+    - HBI hypervisor host seeded for RHEL for x86
+    - Two HBI guests mapped to that hypervisor with overlapping SLA and different usages:
+        - Premium + Production
+        - Premium + Development/Test
+    - Nightly tally run for the organization
+- **Action**:
+    - GET instances report with category=hypervisor (SLA and usage wildcarded / default \_ANY)
+- **Verification**:
+    - Hypervisor subscription manager ID appears exactly once
+    - Result count is the same with primary bucket searches enabled and disabled
+- **Expected Result**:
+    - Guest-derived overlapping SLA/usage buckets do not duplicate the hypervisor row when wildcard filters are used
+    - Primary-row search behavior matches non-primary for hypervisor category queries
+
 ## Data Persistence
 
 **tally-persistence-TC001 - Tally report is idempotent across separate tally runs**


### PR DESCRIPTION
Jira issue: SWATCH-4862

## Description
Enable isPrimary instance views for the instances repository when the swatch.swatch-tally.enable-host-tally-bucket-primary-row-searches feature flag is true.

When enabled, instance query criteria is sanitized by removing any _ANY matching on isPrimary related columns (any match).

Tests now create hosts with all permutations of buckets to support testing both flag states.

# Testing

Start the swatch-tally service: `make swatch-tally`.

## Setup Data

### Create the Hosts
Download the [kafka-produce-event.sh](https://github.com/user-attachments/files/30346181/kafka-produce-event.sh) script that is attached.

```aiignore
ORG=12345678 && \
OTHER_ORG=99999999 && \
./kafka-produce-event.sh -p rosa -o $ORG -i rosa-aws-host -b aws -a aws-billing -s Premium -u Production -D 3 && \
./kafka-produce-event.sh -p rosa -o $ORG -i rosa-azure-host -b azure -a azure-billing -s Standard -u "Development/Test" -D 3 && \
./kafka-produce-event.sh -p rosa -o $OTHER_ORG -i rosa-other-org-host -b aws -a other-billing -D 3
```

From the checkout's root directory run:
```aiignore
ORG=12345678 && \
OTHER_ORG=99999999 && \
./bin/insert-mock-hosts --hbi --org $ORG --product 204 --sla Premium --usage Production --num-aws 1 --cores 4 --sockets 1 && \
./bin/insert-mock-hosts --hbi --org $ORG --product 204 --sla Standard --usage "Development/Test" --num-physical 1 --cores 4 --sockets 1 && \
./bin/insert-mock-hosts --hbi --org $ORG --product 204 --sla Premium --usage Production --num-hypervisors 1 --num-guests 3 --cores 8 --sockets 2 && \
./bin/insert-mock-hosts --hbi --org $OTHER_ORG --product 204 --sla Premium --usage Production --num-hypervisors 1 --num-guests 3 --cores 8 --sockets 2
```

Run the hourly and nightly tally processes for all orgs involved:
```aiignore
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/$ORG" x-rh-swatch-psk:placeholder x-rh-swatch-synchronous-request:true && \
http PUT ":8000/api/rhsm-subscriptions/v1/internal/rpc/tally/snapshots/$OTHER_ORG" x-rh-swatch-psk:placeholder x-rh-swatch-synchronous-request:true
```
```aiignore
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=$ORG" x-rh-swatch-psk:placeholder && \
http POST ":8000/api/rhsm-subscriptions/v1/internal/tally/hourly?org=$OTHER_ORG" x-rh-swatch-psk:placeholder
```

Opt in both orgs:
```aiignore
ORG_1_IDENTITY=$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"12345678"}}}' | base64 -w 0) && \
ORG_2_IDENTITY=$(echo -n '{"identity":{"account_number":"","type":"User","user":{"is_org_admin":true},"internal":{"org_id":"99999999"}}}' | base64 -w 0)
```
```aiignore
curl -X 'PUT' 'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' -H 'accept: application/vnd.api+json' -H "x-rh-identity: $ORG_1_IDENTITY" && \
curl -X 'PUT' 'http://localhost:8000/api/rhsm-subscriptions/v1/opt-in' -H 'accept: application/vnd.api+json' -H "x-rh-identity: $ORG_2_IDENTITY"
```

## Target Test Data

### ROSA PAYG — org `12345678` (2 instances)

| Instance ID | Billing Provider | Billing Account | SLA | Usage | Cloud Provider |
|---|---|---|---|---|---|
| `rosa-aws-host` | aws | aws-billing | Premium | Production | AWS |
| `rosa-azure-host` | azure | azure-billing | Standard | Development/Test | Azure |

### ROSA PAYG — org `99999999` (1 instance)

| Instance ID | Billing Provider | Billing Account | SLA | Usage | Cloud Provider |
|---|---|---|---|---|---|
| `rosa-other-org-host` | aws | other-billing | Premium (default) | Production (default) | AWS |

### RHEL Traditional HBI — org `12345678` (6 instances total including the guests)

| # | SLA | Usage | Type | Count | Cores | Sockets |
|---|---|---|---|---|---|---|
| 1 | Premium | Production | AWS (cloud) | 1 | 4 | 1 |
| 2 | Standard | Development/Test | Physical | 1 | 4 | 1 |
| 3 | Premium | Production | Hypervisor + guests | 1 hypervisor, 3 guests | 8 | 2 |

**NOTE:** Mapped RHEL guests should not be returned by the Instances API and should only be found
using the guests end-point: `GET /v1/instances/{host_id}/guests`

---

## Testing The Instance API

### Feature Flag
The feature flag can be toggled using the API.
```aiignore
# ON
http post :4242/api/admin/projects/default/features/swatch.swatch-tally.enable-host-tally-bucket-primary-row-searches/environments/development/on Authorization:"*:*.unleash-insecure-admin-api-token"

# OFF
http post :4242/api/admin/projects/default/features/swatch.swatch-tally.enable-host-tally-bucket-primary-row-searches/environments/development/off Authorization:"*:*.unleash-insecure-admin-api-token"
```

**Any query that is tested should return the same result no matter what the feature flag is set to.**

Heavy testing focus should be given to API parameters that accept `_ANY` since that is the key change
in this PR (`_ANY` is considered a "wildcard" and should return all results).

### ROSA — Specific Filters

| httpie command | Expected |
|---|---|
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY` | 2 instances |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY billing_provider==aws` | `rosa-aws-host` |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY billing_provider==azure` | `rosa-azure-host` |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==Premium` | `rosa-aws-host` |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==Standard` | `rosa-azure-host` |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY billing_account_id==aws-billing` | `rosa-aws-host` |

### ROSA — `_ANY` Filters

| httpie command | Expected |
|---|---|
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==_ANY` | 2 instances (both SLAs) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY usage==_ANY` | 2 instances (both usages) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY billing_provider==_ANY` | 2 instances (aws + azure) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY billing_account_id==_ANY` | 2 instances (both accounts) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==_ANY usage==_ANY billing_provider==_ANY billing_account_id==_ANY` | 2 instances |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==_ANY usage==Production` | `rosa-aws-host` |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_1_IDENTITY sla==Premium usage==_ANY` | `rosa-aws-host` |

### RHEL Traditional — Specific Filters

| httpie command | Expected |
|---|---|
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY` | all hosts |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY category==cloud` | 1 AWS host |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY category==physical` | 1 physical host |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY category==hypervisor` | 1 hypervisor |

### RHEL Traditional — `_ANY` Filters

| httpie command | Expected |
|---|---|
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY sla==_ANY` | all hosts (Premium + Standard) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY usage==_ANY` | all hosts (Production + Dev/Test) |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY sla==_ANY usage==Production` | cloud host + hypervisor/guests |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rhel-for-x86-els-unconverted x-rh-identity:$ORG_1_IDENTITY sla==Standard usage==_ANY` | physical host |

### Org Isolation

| httpie command | Expected |
|---|---|
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_2_IDENTITY` | `rosa-other-org-host` only |
| `http :8000/api/rhsm-subscriptions/v1/instances/products/rosa x-rh-identity:$ORG_2_IDENTITY sla==_ANY` | `rosa-other-org-host` only |

## Testing Via The Export Service

Start the export service from the root of your checkout
```
podman-compose -f config/export-service/docker-compose.yml up -d
```

Export the instances that were created from the above steps. The following will test the _ANY cases for sla, usage, billing_provider, and billing_account_id, however, you can add them as filters in the query below, Update the org_id in the request to test the other org as well. The username doesn't really matter because RBAC is stubbed in dev mode.
```
curl -sS -X POST http://localhost:8002/api/export/v1/exports \
    -H "x-rh-identity: $(echo -n '{"identity":{"account_number":"12345","type":"User","user":{"username":"testuser","is_org_admin":true},"internal":{"org_id":"12345678"}}}' | base64 -w0)" \
    -H "Content-Type: application/json" \
    -d '{
      "name": "Test Export Request",
      "format": "json",
      "expires_at": "2027-01-01T00:00:00Z",
      "sources": [
          {
              "application": "subscriptions",
              "resource": "instances",
              "filters": {
                  "product_id": "rosa"
              }
          }
      ]
  }'
```

The uploaded reports are stored in minio (s3). You can verify that this report has been uploaded by checking the folder 'config/export-service/tmp/minio/exports-bucket' where should be a file at `<BUCKET ID>.json/xl.meta`. The `xl.meta` file is binary, but if you open the txt plain editor.
```
ls config/export-service/tmp/minio/exports-bucket/12345678
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable primary-row searching for instance data.
  * Improved data selection based on product type and report criteria.
  * Added feature configuration to enable or disable primary-row searches.
  * Excluded unsupported primary-row searches for hypervisor measurements.

* **Bug Fixes**
  * Prevented duplicate hypervisor results when guest data overlaps.

* **Tests**
  * Expanded coverage for PAYG and traditional product filtering.
  * Added validation for both primary-row search modes and hypervisor deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->