### PR TITLE
SWATCH-5116: Add workaround moto patch to support CustomerAWSAccountId

### DIFF
--- a/swatch-producer-aws/deploy/clowdapp.yaml
+++ b/swatch-producer-aws/deploy/clowdapp.yaml
@@ -284,6 +284,35 @@ objects:
         containers:
           - name: moto
             image: 'motoserver/moto:5.1.8'
+            # Workaround until https://github.com/getmoto/moto/pull/10133 is released:
+            # BatchMeterUsage must accept CustomerAWSAccountId. Image is read-only and
+            # PWD=/moto shadows PYTHONPATH, so copy+patch under /tmp then start.
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                set -eu
+                mkdir -p /tmp/moto-src && cp -a /moto/moto /tmp/moto-src/moto
+                python3 <<'PY'
+                from pathlib import Path
+                path = Path("/tmp/moto-src/moto/meteringmarketplace/models.py")
+                text = path.read_text()
+                text = text.replace(
+                    'customer_identifier=kwargs["CustomerIdentifier"],',
+                    'customer_identifier=kwargs.get("CustomerIdentifier") or kwargs.get("CustomerAWSAccountId"),',
+                    1,
+                )
+                needle = 'self["MeteringRecordId"] = self.usage_record.metering_record_id'
+                insert = (
+                    'if kwargs.get("CustomerAWSAccountId") is not None:\n'
+                    '            self.usage_record["CustomerAWSAccountId"] = kwargs["CustomerAWSAccountId"]\n'
+                    '        ' + needle
+                )
+                if needle not in text:
+                    raise SystemExit("CustomerAWSAccountId moto patch failed")
+                path.write_text(text.replace(needle, insert, 1))
+                PY
+                export PYTHONPATH=/tmp/moto-src
+                cd /tmp && exec moto_server -H 0.0.0.0
             env:
               - name: MOTO_PORT
                 value: '5000'


### PR DESCRIPTION
Jira issue: SWATCH-5116

## Description
The IQE tests use Moto to validate the happy path scenarios when submitting AWS usages.
However, moto does not support the CustomerAWSAccountId field (I contributed to moto to support this https://github.com/getmoto/moto/pull/10133). 

In the mean time, this is a workaround / hack to support CustomerAWSAccountId and CustomerIdentifier both fields. 
This is necessary to validate the CustomerAWSAccountId (AWS concurrent agreements epic) in the IQE tests. 
I also reported https://redhat.atlassian.net/browse/SWATCH-5317 to stop using Moto (which does not guarantee the compatibility with AWS SDK) and start using Wiremock as done in the component tests. 

## Testing
IQE MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS Marketplace metering compatibility by correctly handling customer account identifiers during batch usage reporting.
  - Enhanced local service startup reliability and validation for metering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->