### PR TITLE
SWATCH-5397: Upgrade to Java 25 and OpenJDK 25 container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
       - name: Install GitHub CLI
         run: |
@@ -112,7 +112,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
 
       - name: Run Spotless & Checkstyle
@@ -144,7 +144,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
 
       - name: Setup JBang
@@ -196,7 +196,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
 
       - name: Run Build
@@ -228,7 +228,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
 
       - name: Run Tests
@@ -272,7 +272,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'maven'
 
       - name: Build

--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -696,7 +696,7 @@ spec:
               # Persist kubeconfig for the next step
               oc config view --minify --raw > "$(workspaces.output.path)/kubeconfig"
           - name: tests
-            image: registry.access.redhat.com/ubi9/openjdk-21
+            image: registry.access.redhat.com/ubi10/openjdk-25:1784351724
             workingDir: $(workspaces.output.path)/source
             env:
               - name: KUBECONFIG

--- a/.tekton/bonfire-component-tests-pipeline.yaml
+++ b/.tekton/bonfire-component-tests-pipeline.yaml
@@ -698,6 +698,13 @@ spec:
           - name: tests
             image: registry.access.redhat.com/ubi10/openjdk-25:1784351724
             workingDir: $(workspaces.output.path)/source
+            computeResources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                cpu: "2"
+                memory: 4Gi
             env:
               - name: KUBECONFIG
                 value: "$(workspaces.output.path)/kubeconfig"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -6,8 +6,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -24,21 +24,21 @@ RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl 
 RUN (cd /stage/swatch-tally && exec jar -xf ./target/*.jar)
 RUN ls -al /stage/swatch-tally
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 
 # Required labels for Enterprise Contract
 LABEL name="rhsm-subscriptions"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="rhsm-subscriptions"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="RHSM Subscriptions service based on UBI9 OpenJDK 21."
-LABEL description="RHSM Subscriptions service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="RHSM Subscriptions service based on UBI10 OpenJDK 25."
+LABEL description="RHSM Subscriptions service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -46,12 +46,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # TODO: Investigate layertools? See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#container-images.efficient-images.layering

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 USER root
 WORKDIR /tmp/src
 ADD . /tmp/src

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <!-- configuration -->
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/swatch-billable-usage/pom.xml
+++ b/swatch-billable-usage/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-billable-usage/src/main/docker/Dockerfile.jvm
+++ b/swatch-billable-usage/src/main/docker/Dockerfile.jvm
@@ -74,7 +74,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -82,8 +82,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -98,7 +98,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-billable-usage'
@@ -106,14 +106,14 @@ ARG PROJECT_NAME='swatch-billable-usage'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Billable Usage service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Billable Usage service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Billable Usage service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Billable Usage service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -121,12 +121,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-common-clock/pom.xml
+++ b/swatch-common-clock/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Clock</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-config-workaround/pom.xml
+++ b/swatch-common-config-workaround/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Config Workaround for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-export/pom.xml
+++ b/swatch-common-export/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Export</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-health/pom.xml
+++ b/swatch-common-health/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Health for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-info/pom.xml
+++ b/swatch-common-info/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Info for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-kafka/pom.xml
+++ b/swatch-common-kafka/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Kafka for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-logging/pom.xml
+++ b/swatch-common-logging/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Logging for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-models/pom.xml
+++ b/swatch-common-models/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Models</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-panache/pom.xml
+++ b/swatch-common-panache/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Panache for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-resteasy-client/pom.xml
+++ b/swatch-common-resteasy-client/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - RESTEasy Client for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-resteasy/pom.xml
+++ b/swatch-common-resteasy/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - RESTEasy</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-security/pom.xml
+++ b/swatch-common-security/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Security</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-smallrye-fault-tolerance/pom.xml
+++ b/swatch-common-smallrye-fault-tolerance/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Smallrye Fault Tolerance for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-splunk/pom.xml
+++ b/swatch-common-splunk/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Splunk for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-testcontainers/pom.xml
+++ b/swatch-common-testcontainers/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Testcontainers</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-common-trace-response/pom.xml
+++ b/swatch-common-trace-response/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Common - Trace Response</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-contracts/src/main/docker/Dockerfile.jvm
+++ b/swatch-contracts/src/main/docker/Dockerfile.jvm
@@ -73,7 +73,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -81,8 +81,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -97,7 +97,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-contracts'
@@ -105,14 +105,14 @@ ARG PROJECT_NAME='swatch-contracts'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Contracts service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Contracts service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Contracts service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Contracts service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -120,12 +120,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-core-test/pom.xml
+++ b/swatch-core-test/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Core Test</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-core/pom.xml
+++ b/swatch-core/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Core</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-metrics-hbi/pom.xml
+++ b/swatch-metrics-hbi/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics-hbi/src/main/docker/Dockerfile.jvm
@@ -73,7 +73,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -81,8 +81,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -97,7 +97,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-metrics-hbi'
@@ -105,14 +105,14 @@ ARG PROJECT_NAME='swatch-metrics-hbi'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Metrics HBI service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Metrics HBI service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Metrics HBI service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Metrics HBI service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -120,12 +120,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-metrics/pom.xml
+++ b/swatch-metrics/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-metrics/src/main/docker/Dockerfile.jvm
+++ b/swatch-metrics/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -83,8 +83,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -99,7 +99,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-metrics'
@@ -107,14 +107,14 @@ ARG PROJECT_NAME='swatch-metrics'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Metrics service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Metrics service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Metrics service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Metrics service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -122,12 +122,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-model-billable-usage/pom.xml
+++ b/swatch-model-billable-usage/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Model - Billable Usage for Quarkus</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-model-events/pom.xml
+++ b/swatch-model-events/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Model - Events</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-model-metrics-hbi/pom.xml
+++ b/swatch-model-metrics-hbi/pom.xml
@@ -15,7 +15,7 @@
   <description>Lightweight shared models and DTOs for metrics HBI component tests</description>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-producer-aws/pom.xml
+++ b/swatch-producer-aws/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-producer-aws/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-aws/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -83,8 +83,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -99,7 +99,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-producer-aws'
@@ -107,14 +107,14 @@ ARG PROJECT_NAME='swatch-producer-aws'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Producer AWS service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Producer AWS service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Producer AWS service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Producer AWS service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -122,12 +122,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-producer-azure/pom.xml
+++ b/swatch-producer-azure/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-producer-azure/src/main/docker/Dockerfile.jvm
+++ b/swatch-producer-azure/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -83,8 +83,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -99,7 +99,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-producer-azure'
@@ -107,14 +107,14 @@ ARG PROJECT_NAME='swatch-producer-azure'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Producer Azure service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Producer Azure service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Producer Azure service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Producer Azure service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -122,12 +122,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode

--- a/swatch-product-configuration/pom.xml
+++ b/swatch-product-configuration/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Product Configuration</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-system-conduit/Dockerfile
+++ b/swatch-system-conduit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -6,8 +6,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -25,21 +25,21 @@ RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl 
 RUN (cd /stage/swatch-system-conduit && exec jar -xf ./target/*.jar)
 RUN ls -al /stage/swatch-system-conduit
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 
 # Required labels for Enterprise Contract
 LABEL name="swatch-system-conduit"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="swatch-system-conduit"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH System Conduit service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH System Conduit service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH System Conduit service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH System Conduit service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -47,7 +47,7 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 
 COPY --from=0 /stage/swatch-system-conduit/BOOT-INF/lib /deployments/lib

--- a/swatch-system-conduit/pom.xml
+++ b/swatch-system-conduit/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Services - System Conduit</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <openapi.spec.folder>src/main/spec</openapi.spec.folder>
     <openapi.spec.api>internal-organizations-sync-api-spec.yaml</openapi.spec.api>

--- a/swatch-tally/pom.xml
+++ b/swatch-tally/pom.xml
@@ -14,7 +14,7 @@
   <name>SWATCH - Services - Tally</name>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <tally_api_spec_file>${maven.multiModuleProjectDirectory}/src/main/spec/internal-tally-api-spec.yaml</tally_api_spec_file>
   </properties>

--- a/swatch-utilization/pom.xml
+++ b/swatch-utilization/pom.xml
@@ -15,7 +15,7 @@
   <packaging>quarkus</packaging>
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 

--- a/swatch-utilization/src/main/docker/Dockerfile.jvm
+++ b/swatch-utilization/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.24-2.1782292637
+FROM registry.access.redhat.com/ubi10/openjdk-25:1784351724
 
 USER root
 # Add git, so that the build can determine the git hash
@@ -83,8 +83,8 @@ USER root
 # this makes the container buildable without needing RHEL repos.
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   install -y \
   git
 WORKDIR /stage
@@ -99,7 +99,7 @@ ARG MAVEN_BUILD_ARGS='-DskipTests'
 ARG MAVEN_TASKS='clean package'
 RUN mvn --no-transfer-progress -U -s /tmp/maven-settings.xml ${MAVEN_TASKS} -pl ${PROJECT_NAME} -am ${MAVEN_BUILD_ARGS}
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24-2.1782293370
+FROM registry.access.redhat.com/ubi10/openjdk-25-runtime:1784364635
 
 ARG VERSION=1.0.0
 ARG PROJECT_NAME='swatch-utilization'
@@ -107,14 +107,14 @@ ARG PROJECT_NAME='swatch-utilization'
 # Required labels for Enterprise Contract
 LABEL name="${PROJECT_NAME}"
 LABEL maintainer="Red Hat, Inc."
-LABEL version="ubi9"
+LABEL version="ubi10"
 LABEL release="${VERSION}"
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://github.com/RedHatInsights/rhsm-subscriptions"
 LABEL com.redhat.component="${PROJECT_NAME}"
 LABEL distribution-scope="public"
-LABEL io.k8s.description="SWATCH Utilization service based on UBI9 OpenJDK 21."
-LABEL description="SWATCH Utilization service based on UBI9 OpenJDK 21."
+LABEL io.k8s.description="SWATCH Utilization service based on UBI10 OpenJDK 25."
+LABEL description="SWATCH Utilization service based on UBI10 OpenJDK 25."
 
 #label for EULA
 LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
@@ -122,12 +122,12 @@ LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user
 USER root
 RUN microdnf \
     --disablerepo=* \
-    --enablerepo=ubi-9-baseos-rpms \
+    --enablerepo=ubi-10-baseos-rpms \
     install -y tar rsync
 RUN microdnf \
   --disablerepo=* \
-  --enablerepo=ubi-9-appstream-rpms \
-  --enablerepo=ubi-9-baseos-rpms \
+  --enablerepo=ubi-10-appstream-rpms \
+  --enablerepo=ubi-10-baseos-rpms \
   update -y
 
 # Used by Quarkus dev mode


### PR DESCRIPTION
## Summary
- Update `java.version` from 21 to 25 across all 32 pom.xml files
- Switch Dockerfiles from `ubi9/openjdk-21` to `ubi10/openjdk-25:1784351724` (builder) and `ubi10/openjdk-25-runtime:1784364635` (runtime)
- Update GitHub Actions CI workflow to use `java-version: 25`
- Update tekton pipeline to use `ubi10/openjdk-25` image

## Test plan
- [ ] CI builds and tests pass with Java 25
- [ ] Container images build successfully
- [ ] Component tests pass against OpenShift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the project build and runtime environments from Java 21 to Java 25.
  * Updated container images to Red Hat UBI 10 with OpenJDK 25.
  * Updated automated CI and component test pipelines to use Java 25.
  * Added explicit CPU and memory resources for component test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->