### PR TITLE
SWATCH-5119: Validate AwsUsageContext always return the customer aws account ID

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -377,6 +377,15 @@ Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageCo
   - HTTP 404  
   - Error code `CONTRACTS1005` (`SUBSCRIPTION_RECENTLY_TERMINATED`)
 
+**aws-usage-context-TC004** - **AWS usage context returns CONTRACTS1006 when billingAccountId is missing**  
+- **Description:** `customerAwsAccountId` is required on `AwsUsageContext`. When a matched subscription has a null/blank `billing_account_id`, contracts returns a controlled error instead of a 200 with a null field.
+- **Setup:** Persist an AWS ROSA subscription via `saveSubscriptions` with marketplace fields (`productCode;customerId;sellerAccount`) but without `billing_account_id`.  
+- **Action:** GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext`.  
+- **Verification:** Check HTTP status and error body.  
+- **Expected Result:**  
+  - HTTP 404  
+  - Error code `CONTRACTS1006` (`SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID`)
+
 ## Azure Usage Context
 
 Component tests for GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext`. Test class: `AzureUsageContextComponentTest`.

--- a/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
+++ b/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
@@ -20,6 +20,7 @@
  */
 package tests;
 
+import static domain.ErrorCodes.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE;
 import static domain.ErrorCodes.SUBSCRIPTION_RECENTLY_TERMINATED_CODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,10 +29,12 @@ import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.contract.test.model.AwsUsageContext;
 import com.redhat.swatch.contract.test.model.ServiceLevelType;
 import com.redhat.swatch.contract.test.model.UsageType;
+import domain.BillingProvider;
 import domain.Contract;
 import domain.Product;
 import io.restassured.response.Response;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
@@ -98,6 +101,24 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
         "Inactive subscription should return " + SUBSCRIPTION_RECENTLY_TERMINATED_CODE);
   }
 
+  @TestPlanName("aws-usage-context-TC004")
+  @Test
+  void shouldFailWhenCustomerAwsAccountIdMissing() {
+    givenRosaSubscriptionWithoutBillingAccount();
+
+    // awsAccountId defaults to _ANY so lookup is not filtered by billing_account_id
+    Response response = whenGetAwsMarketplaceContext(null);
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND,
+        response.statusCode(),
+        "Missing billingAccountId should return CONTRACTS1006");
+    assertEquals(
+        SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE,
+        response.jsonPath().getString("code"),
+        "Missing billingAccountId should return " + SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE);
+  }
+
   private Contract givenRosaContractIsTerminated() {
     Contract contract = givenRosaContractIsCreated(10.0);
     OffsetDateTime terminationDate = OffsetDateTime.now().minusMinutes(30);
@@ -106,6 +127,22 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
         service.terminateSubscription(contract, terminationDate).statusCode(),
         "Contract termination should succeed");
     return contract;
+  }
+
+  private void givenRosaSubscriptionWithoutBillingAccount() {
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0)).toBuilder()
+            .billingAccountId(null)
+            .build();
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.syncOffering(contract.getOffering().getSku()).statusCode(),
+        "Sync offering should succeed");
+    assertEquals(
+        HttpStatus.SC_OK,
+        service.saveSubscriptions(true, contract).statusCode(),
+        "Saving subscription without billingAccountId should succeed");
   }
 
   private Response whenGetAwsMarketplaceContext(String billingAccountId) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ErrorCode.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   CONTRACT_DOES_NOT_EXIST(1002, "Contract does not exist"),
   SUBSCRIPTION_RECENTLY_TERMINATED(
       1005, "Subscription recently terminated. No active subscriptions."),
+  SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID(1006, "Subscription missing billingAccountId"),
   SUBSCRIPTION_SERVICE_REQUEST_ERROR(3000, "Subscription Service Error"),
   OFFERING_MISSING_ERROR(3003, "Sku not present in Offering"),
   BAD_UPDATE(4000, "Bad update request"),

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.redhat.swatch.clients.product.api.resources.ApiException;
 import com.redhat.swatch.configuration.registry.Variant;
 import com.redhat.swatch.contract.config.ApplicationConfiguration;
+import com.redhat.swatch.contract.exception.ErrorCode;
+import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
 import com.redhat.swatch.contract.model.SyncResult;
 import com.redhat.swatch.contract.openapi.model.AwsUsageContext;
@@ -57,6 +59,7 @@ import com.redhat.swatch.contract.service.OfferingSyncService;
 import com.redhat.swatch.contract.service.SubscriptionListService;
 import com.redhat.swatch.contract.service.SubscriptionSyncService;
 import com.redhat.swatch.contract.service.UsageContextSubscriptionProvider;
+import io.micrometer.common.util.StringUtils;
 import io.quarkus.runtime.LaunchMode;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -257,6 +260,14 @@ public class ContractsResource implements DefaultApi {
   }
 
   private AwsUsageContext buildAwsUsageContext(SubscriptionEntity subscription) {
+    String billingAccountId = subscription.getBillingAccountId();
+    if (StringUtils.isBlank(billingAccountId)) {
+      throw new ServiceException(
+          ErrorCode.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID,
+          Response.Status.NOT_FOUND,
+          ErrorCode.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID.getDescription(),
+          subscription.getSubscriptionId());
+    }
     String[] parts = subscription.getBillingProviderId().split(";");
     String productCode = parts[0];
     String customerId = parts[1];
@@ -267,7 +278,7 @@ public class ContractsResource implements DefaultApi {
         .productCode(productCode)
         .customerId(customerId)
         .awsSellerAccountId(sellerAccount)
-        .customerAwsAccountId(subscription.getBillingAccountId());
+        .customerAwsAccountId(billingAccountId);
   }
 
   @Override

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1519,6 +1519,8 @@ components:
           type: string
     AwsUsageContext:
       description: Encapsulates all data needed to map tally snapshot usage to AWS UsageRecords.
+      required:
+        - customerAwsAccountId
       properties:
         rhSubscriptionId:
           type: string

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -77,6 +77,9 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 @QuarkusTest
@@ -442,6 +445,39 @@ class ContractsResourceTest {
     assertEquals("bar2", awsUsageContext.getCustomerId());
     assertEquals("bar3", awsUsageContext.getAwsSellerAccountId());
     assertEquals("123", awsUsageContext.getCustomerAwsAccountId());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void shouldFailWhenAwsUsageContextHasBlankBillingAccountId(String billingAccountId) {
+    SubscriptionEntity sub = new SubscriptionEntity();
+    sub.setSubscriptionId("sub-blank-billing-account");
+    sub.setBillingProviderId("foo1;foo2;foo3");
+    sub.setBillingAccountId(billingAccountId);
+    sub.setEndDate(defaultEndDate);
+    when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(List.of(sub));
+
+    given()
+        .queryParams(
+            "orgId",
+            ORG_ID,
+            "date",
+            defaultLookUpDate.withOffsetSameInstant(ZoneOffset.UTC).toString(),
+            "productId",
+            ROSA,
+            "sla",
+            ServiceLevelType.PREMIUM.toString(),
+            "usage",
+            UsageType.PRODUCTION.toString(),
+            "awsAccountId",
+            "123")
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .get("/api/swatch-contracts/internal/subscriptions/awsUsageContext")
+        .then()
+        .statusCode(HttpStatus.SC_NOT_FOUND)
+        .body("code", equalTo(ErrorCode.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID.getCode()))
+        .body("title", equalTo(ErrorCode.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID.getDescription()));
   }
 
   @Test

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
   SUBSCRIPTION_CANNOT_BE_DETERMINED(
       1010,
       "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId."),
+  SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID(
+      1012, "Subscription missing billingAccountId required for customerAwsAccountId"),
   AWS_THROTTLING_ERROR(1011, "AWS throttling error");
 
   private static final String CODE_PREFIX = "SWATCHAWS";

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/SubscriptionMissingBillingAccountIdException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/SubscriptionMissingBillingAccountIdException.java
@@ -18,12 +18,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package domain;
+package com.redhat.swatch.aws.exception;
 
-public final class ErrorCodes {
+public class SubscriptionMissingBillingAccountIdException extends AwsProducerException {
 
-  public static final String SUBSCRIPTION_RECENTLY_TERMINATED_CODE = "CONTRACTS1005";
-  public static final String SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE = "CONTRACTS1006";
-
-  private ErrorCodes() {}
+  public SubscriptionMissingBillingAccountIdException(Exception e) {
+    super(ErrorCode.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID, e);
+  }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -30,6 +30,7 @@ import com.redhat.swatch.aws.exception.AwsUnprocessedRecordsException;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
+import com.redhat.swatch.aws.exception.SubscriptionMissingBillingAccountIdException;
 import com.redhat.swatch.aws.exception.SubscriptionRecentlyTerminatedException;
 import com.redhat.swatch.aws.exception.UsageTimestampOutOfBoundsException;
 import com.redhat.swatch.clients.contracts.api.model.AwsUsageContext;
@@ -156,6 +157,10 @@ public class AwsBillableUsageAggregateConsumer {
           billableUsageAggregate, BillableUsage.ErrorCode.SUBSCRIPTION_TERMINATED);
       log.info("Subscription recently terminated for aggregate={}", billableUsageAggregate, e);
       return;
+    } catch (SubscriptionMissingBillingAccountIdException e) {
+      emitErrorStatusOnUsage(billableUsageAggregate, BillableUsage.ErrorCode.USAGE_CONTEXT_LOOKUP);
+      log.warn("Subscription missing billingAccountId for aggregate={}", billableUsageAggregate, e);
+      return;
     } catch (AwsUsageContextLookupException e) {
       emitErrorStatusOnUsage(billableUsageAggregate, BillableUsage.ErrorCode.USAGE_CONTEXT_LOOKUP);
       log.error("Error looking up aws usage context for aggregate={}", billableUsageAggregate, e);
@@ -216,6 +221,11 @@ public class AwsBillableUsageAggregateConsumer {
           .map(error -> "CONTRACTS1005".equals(error.getCode()))
           .orElse(false)) {
         throw new SubscriptionRecentlyTerminatedException(e);
+      }
+      if (ofNullable(e.getError())
+          .map(error -> "CONTRACTS1006".equals(error.getCode()))
+          .orElse(false)) {
+        throw new SubscriptionMissingBillingAccountIdException(e);
       }
       if (Response.Status.NOT_FOUND.getStatusCode() == e.getResponse().getStatus()) {
         throw new SubscriptionCanNotBeDeterminedException(e);

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -35,6 +35,7 @@ import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
+import com.redhat.swatch.aws.exception.SubscriptionMissingBillingAccountIdException;
 import com.redhat.swatch.aws.exception.SubscriptionRecentlyTerminatedException;
 import com.redhat.swatch.clients.contracts.api.model.AwsUsageContext;
 import com.redhat.swatch.clients.contracts.api.model.Error;
@@ -105,6 +106,7 @@ class AwsBillableUsageAggregateConsumerTest {
       new AwsUsageContext()
           .rhSubscriptionId("id")
           .customerId("customer")
+          .customerAwsAccountId("123456789012")
           .productCode("product")
           .subscriptionStartDate(OffsetDateTime.MIN);
   public static final BatchMeterUsageResponse BATCH_METER_USAGE_SUCCESS_RESPONSE =
@@ -411,6 +413,40 @@ class AwsBillableUsageAggregateConsumerTest {
 
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
     verifyNoInteractions(meteringClient);
+  }
+
+  @Test
+  void shouldThrowSubscriptionMissingBillingAccountIdException() throws ApiException {
+    Error error = new Error();
+    error.setCode("CONTRACTS1006");
+    var response = Response.status(Response.Status.NOT_FOUND).entity(error).build();
+    var exception = new DefaultApiException(response, error);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+        .thenThrow(exception);
+
+    assertThrows(
+        SubscriptionMissingBillingAccountIdException.class,
+        () -> consumer.lookupAwsUsageContext(ROSA_INSTANCE_HOURS_RECORD));
+  }
+
+  @Test
+  void shouldSkipMessageIfSubscriptionMissingBillingAccountId() throws ApiException {
+    Error error = new Error();
+    error.setCode("CONTRACTS1006");
+    var response = Response.status(Response.Status.NOT_FOUND).entity(error).build();
+    var exception = new DefaultApiException(response, error);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+        .thenThrow(exception);
+
+    consumer.process(ROSA_INSTANCE_HOURS_RECORD);
+    verifyNoInteractions(meteringClient);
+    verify(billableUsageStatusProducer)
+        .emitStatus(
+            argThat(
+                usage ->
+                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                        && BillableUsage.ErrorCode.USAGE_CONTEXT_LOOKUP.equals(
+                            usage.getErrorCode())));
   }
 
   @Test


### PR DESCRIPTION
Jira issue: SWATCH-5119

## Description
Changes:
- Make customerAwsAccountId required on AwsUsageContext (OpenAPI).
- Contracts returns 404 / CONTRACTS1006 when the matched subscription has no billing_account_id.
- Producer maps CONTRACTS1006 to a non-retryable failure (usage_context_lookup) and does not call AWS.

Note that I will be creating a sumo alert to spot these issues in production after the changes are merged.

## Testing
New component tests / unit tests to verify the above changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AWS usage context requests now return a controlled HTTP 404 with a clear error code when the subscription billing account ID is missing/blank.
  * AWS usage processing now treats this case as a lookup failure, marks the aggregate as FAILED, and stops to avoid incomplete account data.
  * AWS usage context responses now require `customerAwsAccountId`.

* **Tests**
  * Added new component and resource coverage for the missing billing account scenario (including TC004) and updated AWS usage processing tests to validate the new error handling path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->