### PR TITLE
Fix local export service dev setup

### DIFF
--- a/config/export-service/docker-compose.yml
+++ b/config/export-service/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   export:
     container_name: export-server
-    image: quay.io/cloudservices/export-service:f6c95f2
+    image: quay.io/redhat-services-prod/hcc-integrations-tenant/export-service:f5f5016
     environment:
       - PGSQL_PORT=5432
       - PGSQL_HOSTNAME=db
@@ -17,9 +17,11 @@ services:
       - AWS_SECRET_ACCESS_KEY=minioadmin
       - PUBLIC_PORT=8000
       - METRICS_PORT=9090
+      - AWS_REGION=us-east-1
       - MINIO_HOST=s3
       - MINIO_PORT=9099
       - PRIVATE_PORT=10010
+      - EXPORT_ENABLE_APPS={"subscriptions":["instances","subscriptions"]}
     ports:
       - 8002:8000
       - 10000:10010
@@ -45,9 +47,9 @@ services:
     restart: on-failure
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc config host add myminio http://s3:9099 ${AWS_ACCESS_KEY-minio} ${AWS_SECRET_ACCESS_KEY-minioadmin} || exit 1;
+      until /usr/bin/mc alias set myminio http://s3:9099 ${AWS_ACCESS_KEY-minio} ${AWS_SECRET_ACCESS_KEY-minioadmin}; do echo 'Waiting for MinIO...'; sleep 2; done;
       /usr/bin/mc mb --ignore-existing myminio/exports-bucket;
-      /usr/bin/mc policy set public myminio/exports-bucket;
+      /usr/bin/mc anonymous set public myminio/exports-bucket;
       "
 networks:
   swatch-network:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,5 +4,12 @@ SERVER_PORT: 8010
 METRICS_SERVER_PORT: 9010
 ENABLE_SYNCHRONOUS_OPERATIONS: true
 DEV_MODE: true
+
+# Stub RBAC to avoid requiring a running RBAC service in dev mode
+rhsm-subscriptions:
+  rbac-service:
+    use-stub: true
+    stub-permissions:
+      - subscriptions:*:*
 # Fetch interval is defined in seconds
 UNLEASH_FETCH_TOGGLES_INTERVAL: 1S


### PR DESCRIPTION
Relates to Jira issue: SWATCH-4862

## Description
Fixes export service deployment for a local development environment.

Update export-service docker-compose:
* update the container image reference.
* compatibility with newer minio/mc image (config→alias, policy→anonymous)
* add retry loop for MinIO readiness
* configure AWS_REGION and EXPORT_ENABLE_APPS for the subscriptions application

Stub RBAC for tally service in DEV_MODE so the export handler does not require a running RBAC service when started via `make swatch-tally`.

## Testing

Ensure all other supporting containers are deployed and start swatch-tally.
```
make swatch-tally
```

Start the export service from the root of your checkout
```
podman-compose -f config/export-service/docker-compose.yml up -d
```

Send an export instances request.
```
curl -sS -X POST http://localhost:8002/api/export/v1/exports \
    -H "x-rh-identity: $(echo -n '{"identity":{"account_number":"12345","type":"User","user":{"username":"testuser","is_org_admin":true},"internal":{"org_id":"12345678"}}}' | base64 -w0)" \
    -H "Content-Type: application/json" \
    -d '{
      "name": "Test Export Request",
      "format": "json",
      "expires_at": "2027-01-01T00:00:00Z",
      "sources": [
          {
              "application": "subscriptions",
              "resource": "instances",
              "filters": {
                  "product_id": "rosa"
              }
          }
      ]
  }'
```

The uploaded reports are stored in minio (s3). You can verify that this report has been uploaded by checking the folder 'config/export-service/tmp/minio/exports-bucket' where should be a file at `<BUCKET ID>.json/xl.meta`. The `xl.meta` file is binary, but if you open the txt plain editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export processing now supports configurable AWS region settings and application export options.
  * Export storage is automatically prepared and made accessible during service setup.
* **Development Improvements**
  * Development environments can run with built-in subscription permissions, reducing the need for a separate authorization service.
  * Updated export service deployment configuration improves setup consistency and readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->