### PR TITLE
SWATCH-5376: Fix optimistic/stale delete races during contract sync

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -307,7 +307,7 @@ public class ContractService {
       if (matchingUpdatedContract == null) {
         log.info(
             "Deleting contract that does not align to IT partner gateway: {}", existingContract);
-        contractRepository.delete(existingContract);
+        detachAndDeleteContract(existingContract);
         hasDeletedContracts = true;
       } else {
         if (!matchingUpdatedContract.equals(existingContract)) {
@@ -677,9 +677,11 @@ public class ContractService {
    * @return existing contract record, or null
    */
   private List<ContractEntity> findExistingContractRecords(ContractEntity contract) {
-    Specification<ContractEntity> specification;
+    Specification<ContractEntity> specification = ContractEntity.orgIdEquals(contract.getOrgId());
     if (contract.getBillingProvider().startsWith("aws")) {
-      specification = ContractEntity.billingProviderIdEquals(contract.getBillingProviderId());
+      specification =
+          specification.and(
+              ContractEntity.billingProviderIdEquals(contract.getBillingProviderId()));
       // AWS contracts can share billingProviderId with different subscriptionNumbers. Scope by
       // subscription number when present so syncing one does not delete the other. Null
       // subscription number keeps legacy billingProviderId-only lookup.
@@ -689,12 +691,23 @@ public class ContractService {
                 ContractEntity.subscriptionNumberEquals(contract.getSubscriptionNumber()));
       }
     } else if (contract.getBillingProvider().startsWith("azure")) {
-      specification = ContractEntity.azureResourceIdEquals(contract.getAzureResourceId());
+      specification =
+          specification.and(ContractEntity.azureResourceIdEquals(contract.getAzureResourceId()));
     } else {
       throw new UnsupportedOperationException(
           String.format("Billing provider %s not implemented", contract.getBillingProvider()));
     }
     return contractRepository.findContracts(specification).toList();
+  }
+
+  private void detachAndDeleteContract(ContractEntity existingContract) {
+    UUID uuid = existingContract.getUuid();
+    var entityManager = contractRepository.getEntityManager();
+    if (entityManager.contains(existingContract)) {
+      entityManager.detach(existingContract);
+    }
+
+    contractRepository.delete("uuid", uuid);
   }
 
   private List<ContractEntity> mapUpstreamContractToContractEntities(

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractSyncService.java
@@ -25,6 +25,7 @@ import static com.redhat.swatch.contract.config.Channels.CONTRACT_SYNC;
 import com.redhat.swatch.contract.model.ContractSyncTask;
 import com.redhat.swatch.contract.repository.ContractRepository;
 import io.smallrye.reactive.messaging.MutinyEmitter;
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -32,6 +33,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Message;
 
 /**
  * Enqueues per-org contract sync tasks onto the Kafka topic. Analogous to {@code
@@ -66,7 +68,9 @@ public class ContractSyncService {
     try (Stream<String> orgIds = contractRepository.getDistinctOrgIds()) {
       orgIds.forEach(
           orgId -> {
-            contractSyncTaskEmitter.sendAndAwait(new ContractSyncTask(orgId));
+            contractSyncTaskEmitter.sendMessageAndAwait(
+                Message.of(new ContractSyncTask(orgId))
+                    .addMetadata(OutgoingKafkaRecordMetadata.builder().withKey(orgId).build()));
             count.incrementAndGet();
           });
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -28,12 +28,15 @@ import static com.redhat.swatch.contract.model.MeasurementMetricIdTransformer.ME
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -74,10 +77,12 @@ import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.test.resources.InjectWireMock;
 import com.redhat.swatch.contract.test.resources.WireMockResource;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -123,6 +128,7 @@ class ContractServiceTest extends BaseUnitTest {
   @Inject OfferingRepository offeringRepository;
   @InjectSpy SubscriptionRepository subscriptionRepository;
   @InjectSpy SubscriptionService subscriptionService;
+  @Inject EntityManager entityManager;
   @InjectWireMock WireMockServer wireMockServer;
   @InjectSpy MeasurementMetricIdTransformer measurementMetricIdTransformer;
 
@@ -216,8 +222,28 @@ class ContractServiceTest extends BaseUnitTest {
     StatusResponse statusResponse = contractService.createPartnerContract(contract);
 
     assertNotEquals("Redundant message ignored", statusResponse.getMessage());
-    verify(contractRepository).delete(argThat(c -> c.getUuid().equals(orphanContract.getUuid())));
+    verify(contractRepository).delete(eq("uuid"), aryEq(new Object[] {orphanContract.getUuid()}));
     verify(subscriptionService, never()).save(any(SubscriptionEntity.class));
+  }
+
+  @Test
+  void syncContractsByOrgIdContinuesWhenConcurrentHardDeleteAlreadyRemovedRow() throws Exception {
+    mockPartnerApi();
+    UUID contractUuid = givenMisalignedAzureContract().getUuid();
+
+    doAnswer(
+            invocation -> {
+              hardDeleteContractInNewTransaction(contractUuid);
+              return invocation.callRealMethod();
+            })
+        .when(contractRepository)
+        .delete(eq("uuid"), aryEq(new Object[] {contractUuid}));
+
+    StatusResponse statusResponse = contractService.syncContractsByOrgId(AZURE_PARTNER_ORG_ID);
+
+    assertEquals("Contracts Synced for " + AZURE_PARTNER_ORG_ID, statusResponse.getMessage());
+    assertEquals("SUCCESS", statusResponse.getStatus());
+    assertNull(contractRepository.findById(contractUuid));
   }
 
   @Test
@@ -249,16 +275,34 @@ class ContractServiceTest extends BaseUnitTest {
 
   @Test
   void createPartnerContractUpdateContract() {
-    ContractEntity existingContract = givenExistingContractWithExistingMetrics();
+    ContractEntity existingContract =
+        givenExistingContract(givenContractRequest(PARTNER_API_AWS_SUBSCRIPTION_NUMBER));
     givenExistingSubscriptionWithBillingProviderId("1234:agb1:1fa");
+    UUID deletedContractUuid = existingContract.getUuid();
+    assertTrue(
+        existingContract.getMetrics().size() > 0,
+        "precondition: contract under test must have metrics");
 
     var request = givenPartnerEntitlementContractRequest();
 
     StatusResponse statusResponse = contractService.createPartnerContract(request);
     verify(subscriptionService, times(2)).save(any(SubscriptionEntity.class));
     verify(contractRepository, times(2)).persist(any(ContractEntity.class));
-    verify(contractRepository).delete(existingContract);
+    verify(contractRepository).delete(eq("uuid"), aryEq(new Object[] {deletedContractUuid}));
     assertEquals("New contract created", statusResponse.getMessage());
+    entityManager.clear();
+    assertEquals(
+        0,
+        countContractMetrics(deletedContractUuid),
+        "DB ON DELETE CASCADE must remove contract_metrics with the contract");
+  }
+
+  private long countContractMetrics(UUID contractUuid) {
+    return (long)
+        entityManager
+            .createQuery("SELECT COUNT(m) FROM ContractMetricEntity m WHERE m.contractUuid = :uuid")
+            .setParameter("uuid", contractUuid)
+            .getSingleResult();
   }
 
   @Test
@@ -894,22 +938,6 @@ class ContractServiceTest extends BaseUnitTest {
     return givenExistingContract(givenContractRequest());
   }
 
-  private ContractEntity givenExistingContractWithExistingMetrics() {
-    var request = givenContractRequest(PARTNER_API_AWS_SUBSCRIPTION_NUMBER);
-    var contract = request.getPartnerEntitlement().getPurchase().getContracts().get(0);
-
-    // existing metrics are coming from WireMockResource.stubForRhPartnerApi() method
-    var metric1 = new DimensionV1();
-    metric1.setName("Instance-hours");
-    metric1.setValue("1000000");
-
-    var metric2 = new DimensionV1();
-    metric2.setName("Cores");
-    metric2.setValue("1000000");
-    contract.setDimensions(List.of(metric1, metric2));
-    return givenExistingContract(request);
-  }
-
   private ContractEntity givenExistingContract(ContractRequest request) {
     ContractResponse created = contractService.createContract(request);
     var entity = contractRepository.findById(UUID.fromString(created.getContract().getUuid()));
@@ -917,6 +945,29 @@ class ContractServiceTest extends BaseUnitTest {
     reset(contractRepository);
     clearInvocations(subscriptionService);
     return entity;
+  }
+
+  @Transactional
+  ContractEntity givenMisalignedAzureContract() {
+    var contract =
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .subscriptionNumber(SUBSCRIPTION_NUMBER)
+            .startDate(ORPHAN_SEGMENT_START_DATE)
+            .endDate(DEFAULT_END_DATE)
+            .orgId(AZURE_PARTNER_ORG_ID)
+            .offering(offeringRepository.findById(SKU))
+            .billingProvider("azure")
+            .billingProviderId(
+                "a69ff71c-aa8b-43d9-dea8-822fab4bbb86;rh-rhel-sub-1yr;azureProductCode;"
+                    + "eadf26ee-6fbc-4295-9a9e-25d4fea8951d_2019-05-31;")
+            .billingAccountId("fa650050-dedd-4958-b901-d8e5118c0a5f")
+            .vendorProductCode("azureProductCode")
+            .lastUpdated(OffsetDateTime.now(ZoneOffset.UTC))
+            .build();
+    contractRepository.persist(contract);
+    reset(contractRepository);
+    return contract;
   }
 
   @Transactional
@@ -1174,5 +1225,16 @@ class ContractServiceTest extends BaseUnitTest {
                 aResponse()
                     .withHeader("Content-Type", "application/json")
                     .withBody(objectMapper.writeValueAsString(response))));
+  }
+
+  /** Necessary to simulate a concurrent transaction that deletes one contract. */
+  private void hardDeleteContractInNewTransaction(UUID uuid) {
+    QuarkusTransaction.requiringNew()
+        .run(
+            () ->
+                entityManager
+                    .createNativeQuery("DELETE FROM contracts WHERE uuid = :uuid")
+                    .setParameter("uuid", uuid)
+                    .executeUpdate());
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-5376

## Description
Changes:
- Fixed optimistic/stale delete exception by removing the entity by uuid instead of using the panache delete operation (which use the optimistic strategy). Also, removing the entity from the entity manager context since the delete by uuid won't do this anylonger vs the panache delete operation. 
- Filtering the existing contracts by org_id in addition to the billing context (this is about correctness).
- Consuming the contracts sync task by org_id, so the tasks for the same org_id will be consumed by the same consumers sequantially. 

## Testing
Added new test to reproduce the optimistic/stale delete exception.
Plus, regression testing for the rest of the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract synchronization when contracts are removed concurrently, allowing processing to continue without interruption.
  * Corrected existing-contract matching so records are consistently associated with the appropriate organization and provider details.
  * Improved cleanup of related contract metrics when contracts are deleted.

* **Reliability Improvements**
  * Enhanced synchronization event handling to preserve organization context and support more consistent processing across systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->