### PR TITLE
SWATCH-5120: Always send CustomerAWSAccountId from swatch-producer-aws

### DIFF
--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -37,36 +37,17 @@ Test cases should be testable locally and in deployed environments.
 - Billable-usage aggregates can be published directly to the Kafka `billable-usage-hourly-aggregate` topic
 - Contracts `awsUsageContext` and AWS `BatchMeterUsage` can be stubbed via Wiremock (`AwsWiremockService`)
 - Outcomes can be verified on the `billable-usage.status` topic and, where relevant, on captured AWS request bodies
-- Unleash toggles can be exercised through the component-test harness (`AwsUnleashService`) when feature-flag behavior is under test
 
 # Test Cases
 
 ## Customer identification on BatchMeterUsage
 
-When the feature flag is enabled, usage records may use `CustomerAWSAccountId` from `AwsUsageContext.customerAwsAccountId` instead of `CustomerIdentifier`. Covered by component tests in `CustomerAwsAccountIdComponentTest`.
-**Feature flag covered:** `swatch.swatch-producer-aws.use-customer-aws-account-id` (default off)
+Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAwsAccountId`. Covered by component tests in `CustomerAwsAccountIdComponentTest`.
 
-**producer-aws-customer-id-TC001 - Use CustomerIdentifier when feature flag is off**
+**producer-aws-customer-id-TC001 - Use CustomerAWSAccountId on BatchMeterUsage**
 
-- **Description**: Verify that with the toggle disabled (default), usage records sent to AWS use `CustomerIdentifier` from `AwsUsageContext.customerId`.
+- **Description**: Verify that usage records sent to AWS use `CustomerAWSAccountId` from `AwsUsageContext.customerAwsAccountId`.
 - **Setup**:
-  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is off
-  - Wiremock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
-  - Kafka topics for billable-usage hourly aggregate and status are available
-- **Action**:
-  - Produce a valid AWS billable-usage aggregate to Kafka
-- **Verification**:
-  - Wait for `SUCCEEDED` on `billable-usage.status`
-  - Inspect captured `BatchMeterUsage` request in Wiremock
-- **Expected Result**:
-  - `UsageRecords[0].CustomerIdentifier` equals `customerId`
-  - `CustomerAWSAccountId` is absent from the usage record
-
-**producer-aws-customer-id-TC002 - Use CustomerAWSAccountId when feature flag is on**
-
-- **Description**: Verify that with the toggle enabled and `customerAwsAccountId` present, usage records use `CustomerAWSAccountId`.
-- **Setup**:
-  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is enabled
   - Wiremock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
   - Kafka topics for billable-usage hourly aggregate and status are available
 - **Action**:
@@ -78,24 +59,6 @@ When the feature flag is enabled, usage records may use `CustomerAWSAccountId` f
   - `UsageRecords[0].CustomerAWSAccountId` matches `customerAwsAccountId` from context
   - `CustomerIdentifier` is absent from the usage record
   - `ProductCode` is still sent on the request
-
-**producer-aws-customer-id-TC003 - Fall back to CustomerIdentifier when account id is missing**
-
-- **Description**: Verify that with the toggle enabled but `customerAwsAccountId` absent from context, the producer logs a warning and falls back to `CustomerIdentifier`.
-- **Setup**:
-  - Unleash toggle `swatch.swatch-producer-aws.use-customer-aws-account-id` is enabled
-  - Wiremock returns `awsUsageContext` without `customerAwsAccountId`
-  - Kafka topics for billable-usage hourly aggregate and status are available
-- **Action**:
-  - Produce a valid AWS billable-usage aggregate to Kafka
-- **Verification**:
-  - Wait for `SUCCEEDED` on `billable-usage.status`
-  - Inspect captured `BatchMeterUsage` request in Wiremock
-- **Expected Result**:
-  - Remittance status is `SUCCEEDED`
-  - `UsageRecords[0].CustomerIdentifier` equals `customerId`
-  - Warning logged about missing `customerAwsAccountId`
-
 
 ## LicenseArn on BatchMeterUsage (SWATCH-5050 / SWATCH-5303)
 
@@ -155,9 +118,9 @@ When the feature flag is enabled, usage records may use `CustomerAWSAccountId` f
 
 **producer-aws-license-TC004 - LicenseArn combined with CustomerAWSAccountId**
 
-- **Description**: Verify the two SWATCH-5050 toggles are orthogonal: both can be on so the usage record has `CustomerAWSAccountId` **and** `LicenseArn`.
+- **Description**: Verify `CustomerAWSAccountId` (always set) and `LicenseArn` (when `use-license` is on) can appear together on the usage record.
 - **Setup**:
-  - `use-customer-aws-account-id` enabled; `use-license` enabled
+  - `use-license` enabled
   - Aggregate includes `licenseId`
   - Wiremock `awsUsageContext` includes `customerAwsAccountId`
 - **Action**:
@@ -185,7 +148,7 @@ When the feature flag is enabled, usage records may use `CustomerAWSAccountId` f
 - **Expected Result**:
   - Contracts lookup includes the aggregate `licenseId` (when the API contract requires/accepts it)
   - Successful remittance uses that context
-  - If no contract matches the licenseId, behavior matches contracts error handling (404 / existing classification — see usage-context section)
+  - If no contract matches the licenseId, behavior matches contracts error handling (404 / existing classification - see usage-context section)
 
 **producer-aws-license-TC006 - Status emission includes licenseId on success path**
 

--- a/swatch-producer-aws/ct/java/api/AwsUnleashService.java
+++ b/swatch-producer-aws/ct/java/api/AwsUnleashService.java
@@ -22,16 +22,4 @@ package api;
 
 import com.redhat.swatch.component.tests.api.UnleashService;
 
-public class AwsUnleashService extends UnleashService {
-
-  public static final String USE_CUSTOMER_AWS_ACCOUNT_ID =
-      "swatch.swatch-producer-aws.use-customer-aws-account-id";
-
-  public void enableUseCustomerAwsAccountId() {
-    enableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
-  }
-
-  public void disableUseCustomerAwsAccountId() {
-    disableFlag(USE_CUSTOMER_AWS_ACCOUNT_ID);
-  }
-}
+public class AwsUnleashService extends UnleashService {}

--- a/swatch-producer-aws/ct/java/tests/CustomerAwsAccountIdComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/CustomerAwsAccountIdComponentTest.java
@@ -25,11 +25,10 @@ import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOUR
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
 
 import api.MessageValidators;
+import com.redhat.swatch.component.tests.api.TestPlanName;
 import domain.Product;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CustomerAwsAccountIdComponentTest extends BaseAwsComponentTest {
@@ -37,18 +36,9 @@ public class CustomerAwsAccountIdComponentTest extends BaseAwsComponentTest {
   private static final double TOTAL_VALUE = 2.0;
   private static final String CUSTOMER_AWS_ACCOUNT_ID = "123456789012";
 
-  @BeforeEach
-  void setUpFlagDisabled() {
-    unleash.disableUseCustomerAwsAccountId();
-  }
-
-  @AfterEach
-  void tearDown() {
-    unleash.disableUseCustomerAwsAccountId();
-  }
-
+  @TestPlanName("producer-aws-customer-id-TC001")
   @Test
-  void testUsesCustomerIdentifierWhenFlagOff() {
+  void shouldUseCustomerAwsAccountIdOnBatchMeterUsage() {
     String metricId = Product.ROSA.getFirstMetric().getId();
 
     wiremock.setupAwsUsageContext(
@@ -59,43 +49,6 @@ public class CustomerAwsAccountIdComponentTest extends BaseAwsComponentTest {
         productCode,
         CUSTOMER_AWS_ACCOUNT_ID);
 
-    produceAggregateAndWaitForSuccess(metricId);
-
-    wiremock.verifyBatchMeterUsageCustomerIdentifier(customerId);
-  }
-
-  @Test
-  void testUsesCustomerAwsAccountIdWhenFlagOn() {
-    String metricId = Product.ROSA.getFirstMetric().getId();
-
-    unleash.enableUseCustomerAwsAccountId();
-    wiremock.setupAwsUsageContext(
-        awsAccountId,
-        awsSellerAccountId,
-        rhSubscriptionId,
-        customerId,
-        productCode,
-        CUSTOMER_AWS_ACCOUNT_ID);
-
-    produceAggregateAndWaitForSuccess(metricId);
-
-    wiremock.verifyBatchMeterUsageCustomerAwsAccountId(CUSTOMER_AWS_ACCOUNT_ID);
-  }
-
-  @Test
-  void testFallsBackToCustomerIdentifierWhenFlagOnAndAccountIdMissing() {
-    String metricId = Product.ROSA.getFirstMetric().getId();
-
-    unleash.enableUseCustomerAwsAccountId();
-    wiremock.setupAwsUsageContext(
-        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode);
-
-    produceAggregateAndWaitForSuccess(metricId);
-
-    wiremock.verifyBatchMeterUsageCustomerIdentifier(customerId);
-  }
-
-  private void produceAggregateAndWaitForSuccess(String metricId) {
     BillableUsageAggregate aggregateData =
         createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
     kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
@@ -104,5 +57,7 @@ public class CustomerAwsAccountIdComponentTest extends BaseAwsComponentTest {
         BILLABLE_USAGE_STATUS,
         MessageValidators.aggregateMatches(awsAccountId, BillableUsage.Status.SUCCEEDED),
         1);
+
+    wiremock.verifyBatchMeterUsageCustomerAwsAccountId(CUSTOMER_AWS_ACCOUNT_ID);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
@@ -28,8 +28,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class FeatureFlags implements InfoFeatureFlagContributor {
-  public static final String USE_CUSTOMER_AWS_ACCOUNT_ID =
-      "swatch.swatch-producer-aws.use-customer-aws-account-id";
 
   private final Unleash unleash;
 
@@ -37,12 +35,8 @@ public class FeatureFlags implements InfoFeatureFlagContributor {
     this.unleash = unleash;
   }
 
-  public boolean useCustomerAwsAccountId() {
-    return unleash.isEnabled(USE_CUSTOMER_AWS_ACCOUNT_ID);
-  }
-
   @Override
   public InfoFeatureFlags getFeatureFlags() {
-    return UnleashInfoFeatureFlags.snapshot(unleash, USE_CUSTOMER_AWS_ACCOUNT_ID);
+    return UnleashInfoFeatureFlags.snapshot(unleash);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -23,7 +23,6 @@ package com.redhat.swatch.aws.service;
 import static com.redhat.swatch.configuration.registry.SubscriptionDefinition.getBillingFactor;
 import static java.util.Optional.ofNullable;
 
-import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
 import com.redhat.swatch.aws.exception.AwsThrottlingException;
 import com.redhat.swatch.aws.exception.AwsUnprocessedRecordsException;
@@ -83,7 +82,6 @@ public class AwsBillableUsageAggregateConsumer {
   private final Duration awsUsageWindow;
   private final BillableUsageStatusProducer billableUsageStatusProducer;
   private final MeterProvider<Counter> meteredTotalCounter;
-  private final FeatureFlags featureFlags;
 
   public AwsBillableUsageAggregateConsumer(
       MeterRegistry meterRegistry,
@@ -91,8 +89,7 @@ public class AwsBillableUsageAggregateConsumer {
       AwsMarketplaceMeteringClientFactory awsMarketplaceMeteringClientFactory,
       @ConfigProperty(name = "ENABLE_AWS_DRY_RUN") Optional<Boolean> isDryRun,
       @ConfigProperty(name = "AWS_MARKETPLACE_USAGE_WINDOW") Duration awsUsageWindow,
-      BillableUsageStatusProducer billableUsageStatusProducer,
-      FeatureFlags featureFlags) {
+      BillableUsageStatusProducer billableUsageStatusProducer) {
     acceptedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_accepted_total");
     rejectedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_rejected_total");
     ignoreCounter = meterRegistry.counter("swatch_aws_marketplace_batch_ignored_total");
@@ -102,7 +99,6 @@ public class AwsBillableUsageAggregateConsumer {
     this.isDryRun = isDryRun;
     this.awsUsageWindow = awsUsageWindow;
     this.billableUsageStatusProducer = billableUsageStatusProducer;
-    this.featureFlags = featureFlags;
   }
 
   @Incoming("billable-usage-hourly-aggregate-in")
@@ -321,35 +317,12 @@ public class AwsBillableUsageAggregateConsumer {
           "Unable to send usage since it is outside of the AWS processing window");
     }
 
-    UsageRecord.Builder recordBuilder =
-        UsageRecord.builder()
-            .dimension(metric.getAwsDimension())
-            .quantity(billableUsageAggregate.getTotalValue().intValueExact())
-            .timestamp(effectiveTimestamp.toInstant());
-
-    applyCustomerIdentification(recordBuilder, context);
-
-    return recordBuilder.build();
-  }
-
-  private void applyCustomerIdentification(
-      UsageRecord.Builder recordBuilder, AwsUsageContext context) {
-    if (!featureFlags.useCustomerAwsAccountId()) {
-      recordBuilder.customerIdentifier(context.getCustomerId());
-      return;
-    }
-
-    String customerAwsAccountId = context.getCustomerAwsAccountId();
-    if (customerAwsAccountId != null) {
-      recordBuilder.customerAWSAccountId(customerAwsAccountId);
-      return;
-    }
-
-    log.warn(
-        "customerAwsAccountId missing; falling back to customerIdentifier rhSubscriptionId={} awsCustomerId={}",
-        context.getRhSubscriptionId(),
-        context.getCustomerId());
-    recordBuilder.customerIdentifier(context.getCustomerId());
+    return UsageRecord.builder()
+        .customerAWSAccountId(context.getCustomerAwsAccountId())
+        .dimension(metric.getAwsDimension())
+        .quantity(billableUsageAggregate.getTotalValue().intValueExact())
+        .timestamp(effectiveTimestamp.toInstant())
+        .build();
   }
 
   private boolean isForAws(BillableUsageAggregateKey aggregationKey) {

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
@@ -126,7 +125,6 @@ class AwsBillableUsageAggregateConsumerTest {
   @InjectMock AwsMarketplaceMeteringClientFactory clientFactory;
   MarketplaceMeteringClient meteringClient;
   @InjectMock BillableUsageStatusProducer billableUsageStatusProducer;
-  @InjectMock FeatureFlags featureFlags;
 
   @Inject MeterRegistry meterRegistry;
   Counter acceptedCounter;
@@ -177,7 +175,6 @@ class AwsBillableUsageAggregateConsumerTest {
             "status", BillableUsage.Status.SUCCEEDED.toString(), "error_code", "");
 
     meteringClient = mock(MarketplaceMeteringClient.class);
-    when(featureFlags.useCustomerAwsAccountId()).thenReturn(false);
   }
 
   @Test
@@ -211,7 +208,7 @@ class AwsBillableUsageAggregateConsumerTest {
   }
 
   @Test
-  void shouldUseCustomerIdentifierWhenFlagOff() throws ApiException {
+  void shouldUseCustomerAwsAccountId() throws ApiException {
     AwsUsageContext context =
         new AwsUsageContext()
             .rhSubscriptionId("id")
@@ -220,41 +217,10 @@ class AwsBillableUsageAggregateConsumerTest {
             .productCode("product")
             .subscriptionStartDate(OffsetDateTime.MIN);
 
-    UsageRecord record = processUsageAndCaptureRecord(context, false);
-
-    assertEquals("marketplace-customer", record.customerIdentifier());
-    assertTrue(record.customerAWSAccountId() == null || record.customerAWSAccountId().isBlank());
-  }
-
-  @Test
-  void shouldUseCustomerAwsAccountIdWhenFlagOn() throws ApiException {
-    AwsUsageContext context =
-        new AwsUsageContext()
-            .rhSubscriptionId("id")
-            .customerId("marketplace-customer")
-            .customerAwsAccountId("123456789012")
-            .productCode("product")
-            .subscriptionStartDate(OffsetDateTime.MIN);
-
-    UsageRecord record = processUsageAndCaptureRecord(context, true);
+    UsageRecord record = processUsageAndCaptureRecord(context);
 
     assertEquals("123456789012", record.customerAWSAccountId());
     assertTrue(record.customerIdentifier() == null || record.customerIdentifier().isBlank());
-  }
-
-  @Test
-  void shouldFallbackToCustomerIdentifierWhenFlagOnAndAccountIdNull() throws ApiException {
-    AwsUsageContext context =
-        new AwsUsageContext()
-            .rhSubscriptionId("id")
-            .customerId("marketplace-customer")
-            .productCode("product")
-            .subscriptionStartDate(OffsetDateTime.MIN);
-
-    UsageRecord record = processUsageAndCaptureRecord(context, true);
-
-    assertEquals("marketplace-customer", record.customerIdentifier());
-    assertTrue(record.customerAWSAccountId() == null || record.customerAWSAccountId().isBlank());
   }
 
   @Test
@@ -378,8 +344,7 @@ class AwsBillableUsageAggregateConsumerTest {
             clientFactory,
             Optional.of(true),
             Duration.of(1, ChronoUnit.HOURS),
-            billableUsageStatusProducer,
-            featureFlags);
+            billableUsageStatusProducer);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     processor.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -493,8 +458,7 @@ class AwsBillableUsageAggregateConsumerTest {
                             usage.getErrorCode())));
 
     // verify success
-    reset(contractsApi, billableUsageStatusProducer, featureFlags);
-    when(featureFlags.useCustomerAwsAccountId()).thenReturn(false);
+    reset(contractsApi, billableUsageStatusProducer);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
@@ -541,9 +505,7 @@ class AwsBillableUsageAggregateConsumerTest {
     assertEquals(isValid, consumer.isUsageDateValid(clock, aggregate));
   }
 
-  private UsageRecord processUsageAndCaptureRecord(
-      AwsUsageContext context, boolean useCustomerAwsAccountId) throws ApiException {
-    when(featureFlags.useCustomerAwsAccountId()).thenReturn(useCustomerAwsAccountId);
+  private UsageRecord processUsageAndCaptureRecord(AwsUsageContext context) throws ApiException {
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
         .thenReturn(context);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);


### PR DESCRIPTION
Jira issue: SWATCH-5120
## Description
Changes:
- Remove the `swatch.swatch-producer-aws.use-customer-aws-account-id` Unleash toggle and `FeatureFlags` wiring from `swatch-producer-aws`.
- Always set `CustomerAWSAccountId` on `BatchMeterUsage` UsageRecords (no legacy `CustomerIdentifier` path).
- Drop Unleash from producer deploy config / application properties / CT harness, and collapse CT / TEST_PLAN coverage to the single CustomerAWSAccountId path.


## Testing
Unit tests:
```bash
./mvnw test -pl swatch-producer-aws -am
```
Component tests:
```bash
./mvnw clean install -Pcomponent-tests -pl swatch-producer-aws/ct -am
```

IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1567

/use-iqe-image-tag=rhsm-subscriptions-1567-ed62e729


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Updates**
  * AWS usage records now consistently identify customers using their AWS account ID.
  * Customer account identification no longer depends on feature-flag settings or fallback behavior.
* **Reliability**
  * Simplified customer identification provides more predictable AWS usage metering.
  * Updated validation ensures customer account IDs are used consistently across batch usage processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->