### PR TITLE
SWATCH-5375: Do not mark contract sync FAILED when Partner Gateway returns no contracts for an org

### DIFF
--- a/swatch-contracts/TEST_PLAN.md
+++ b/swatch-contracts/TEST_PLAN.md
@@ -754,7 +754,7 @@ This section verifies the automatic contract termination behavior when contracts
 - **Expected Result**:
   - HTTP 200 with StatusResponse
   - StatusResponse message: "No contracts found in upstream for the org org123"
-  - StatusResponse status: "FAILED"
+  - StatusResponse status: "SUCCESS"
   - Contract still exists in database (not hard deleted)
   - Contract `end_date` is set to current timestamp (within 5 seconds of sync time)
   - Associated subscription also has `end_date` set to same timestamp

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -485,7 +485,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertThat("Sync should return OK", syncResponse.statusCode(), is(HttpStatus.SC_OK));
     syncResponse
         .then()
-        .body("status", equalTo("FAILED"))
+        .body("status", equalTo(STATUS_SUCCESS))
         .body("message", equalTo("No contracts found in upstream for the org " + orgId));
 
     // Verify contract still exists in database (soft delete, not hard delete)
@@ -600,7 +600,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertThat("Sync should return OK", syncResponse.statusCode(), is(HttpStatus.SC_OK));
     syncResponse
         .then()
-        .body("status", equalTo("FAILED"))
+        .body("status", equalTo(STATUS_SUCCESS))
         .body("message", equalTo("No contracts found in upstream for the org " + orgId));
 
     var contractsAfterSecondSync = service.getContractsByOrgId(orgId);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ContractService.java
@@ -473,11 +473,10 @@ public class ContractService {
 
       if (!upstreamContracts.isEmpty()) {
         statusResponse.setMessage("Contracts Synced for " + contractOrgSync);
-        statusResponse.setStatus(SUCCESS_MESSAGE);
       } else {
         statusResponse.setMessage("No contracts found in upstream for the org " + contractOrgSync);
-        statusResponse.setStatus(FAILURE_MESSAGE);
       }
+      statusResponse.setStatus(SUCCESS_MESSAGE);
     } catch (NumberFormatException e) {
       log.error(e.getMessage());
       statusResponse.setStatus(FAILURE_MESSAGE);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -311,6 +311,7 @@ class ContractServiceTest extends BaseUnitTest {
 
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
 
+    assertEquals(ContractService.SUCCESS_MESSAGE, statusResponse.getStatus());
     assertEquals(
         "No contracts found in upstream for the org " + ORG_ID, statusResponse.getMessage());
 
@@ -333,6 +334,7 @@ class ContractServiceTest extends BaseUnitTest {
 
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
 
+    assertEquals(ContractService.SUCCESS_MESSAGE, statusResponse.getStatus());
     assertEquals(
         "No contracts found in upstream for the org " + ORG_ID, statusResponse.getMessage());
 
@@ -575,6 +577,7 @@ class ContractServiceTest extends BaseUnitTest {
 
     StatusResponse statusResponse = contractService.syncContractsByOrgId(ORG_ID);
 
+    assertEquals(ContractService.SUCCESS_MESSAGE, statusResponse.getStatus());
     assertEquals(
         "No contracts found in upstream for the org " + ORG_ID, statusResponse.getMessage());
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -266,7 +266,7 @@ public class AwsBillableUsageAggregateConsumer {
               result -> {
                 if (result.status() == UsageRecordResultStatus.CUSTOMER_NOT_SUBSCRIBED) {
                   log.warn(
-                      "No subscription found for aggregate={}, result={}",
+                      "AWS BatchMeterUsage CUSTOMER_NOT_SUBSCRIBED (No subscription found) for aggregate={}, result={}",
                       billableUsageAggregate,
                       result);
                 } else if (result.status() != UsageRecordResultStatus.SUCCESS) {


### PR DESCRIPTION
Jira issue: SWATCH-5375

## Description
After these changes, when doing the per-org contract sync and there are no contracts found in upstream. this is no longer reported as FAILED (and thus not Sumo-alerted).

## Testing
Regression testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract synchronization now reports a successful status when no upstream contracts are found, while retaining the existing informational message.
  * Updated handling for missing, fully removed, and already-terminated contracts.

* **Improvements**
  * AWS usage warnings now include the API operation and clearly indicate when no subscription is found.

* **Tests**
  * Updated synchronization test expectations to reflect successful handling of missing upstream contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->