### PR TITLE
ci: disable hotfix Konflux updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["main", "hotfix"],
+  "baseBranchPatterns": ["main"],
   "tekton": {
     "enabled": true,
     "automerge": true,
     "schedule": ["* * * * *"]
-  },
-  "packageRules": [
-    {
-      "description": "Disable dependency updates (Maven/Dockerfile) on hotfix branch",
-      "matchBaseBranches": ["hotfix"],
-      "matchManagers": ["maven", "dockerfile"],
-      "enabled": false
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Description
Disable the Konflux PRs on the `hotfix` branch for now, since this branch is no longer in use. 