### PR TITLE
swatch-3913: Remove billable-usage retry_after column

### DIFF
--- a/swatch-billable-usage/src/main/resources/db/202608051100-drop-retry-after-from-billable-usage-remittance.xml
+++ b/swatch-billable-usage/src/main/resources/db/202608051100-drop-retry-after-from-billable-usage-remittance.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet id="202608051100-001" author="vbusch">
+    <preConditions onFail="MARK_RAN">
+      <indexExists tableName="billable_usage_remittance" indexName="billable_usage_retry_after_idx"/>
+    </preConditions>
+    <comment>Drop index on retry_after column before removing the column</comment>
+    <dropIndex tableName="billable_usage_remittance" indexName="billable_usage_retry_after_idx"/>
+
+    <rollback>
+      <createIndex tableName="billable_usage_remittance" indexName="billable_usage_retry_after_idx">
+        <column name="retry_after"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="202608051100-002" author="vbusch">
+    <preConditions onFail="MARK_RAN">
+      <columnExists tableName="billable_usage_remittance" columnName="retry_after"/>
+    </preConditions>
+    <comment>Drop retry_after column from billable_usage_remittance; retry logic was removed and all code references were cleaned up</comment>
+    <dropColumn tableName="billable_usage_remittance" columnName="retry_after"/>
+
+    <rollback>
+      <addColumn tableName="billable_usage_remittance">
+        <column name="retry_after" type="TIMESTAMP WITH TIME ZONE">
+          <constraints nullable="true"/>
+        </column>
+      </addColumn>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/swatch-billable-usage/src/main/resources/db/changelog.xml
+++ b/swatch-billable-usage/src/main/resources/db/changelog.xml
@@ -9,5 +9,6 @@
   <include file="/db/202510051200-create-billable-usage-remittance-table.xml"/>
   <include file="/db/202604021015-add-primary-key-to-changelog-table.xml"/>
   <include file="/db/202607231000-add-license-id-to-billable-usage-remittance.xml"/>
+  <include file="/db/202608051100-drop-retry-after-from-billable-usage-remittance.xml"/>
 
 </databaseChangeLog>

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -560,10 +560,11 @@ class BillableUsageServiceTest {
     BillableUsage usage = givenInstanceHoursUsageForRosa(0.0);
     givenExistingRemittanceForUsage(usage, startOfUsage, 1.0, RemittanceStatus.SUCCEEDED);
     givenExistingRemittanceForUsage(usage, startOfUsage.plusDays(2), 5.0, RemittanceStatus.PENDING);
-    // failures be included
+
+    // failed remittances should be excluded
     givenExistingRemittanceForUsage(usage, startOfUsage.plusDays(4), 10.0, RemittanceStatus.FAILED);
-    // failures with retry after null should be filtered out
     givenExistingRemittanceForUsage(usage, startOfUsage.plusDays(4), 30.0, RemittanceStatus.FAILED);
+    // null status should be included
     givenExistingRemittanceForUsage(usage, startOfUsage.plusDays(4), 20.0, null);
 
     var result = service.getTotalRemitted(usage);


### PR DESCRIPTION
Jira issue: SWATCH-3913

## Description
Drop the db column `swatch_billable_usage_remittance.retry_after`.  All uses of it have already been removed.
Also corrected test comment about retry.

 
## Testing

- All existing tests should continue to work.
- restart the service and verify the column is removed.
- restart the service a 2nd time and verify the migration is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated billable usage remittance handling to exclude failed remittances from totals while still counting entries without a status.
  * Removed the `retry_after` field from billable usage remittance storage, with support for restoring it if needed.

* **Tests**
  * Adjusted coverage to verify total remitted calculations across successful, failed, and unset-status remittances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->