### PR TITLE
SWATCH-5297: Add optional licenseId to getAwsUsageContext

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -386,6 +386,30 @@ Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageCo
   - HTTP 404  
   - Error code `CONTRACTS1006` (`SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID`)
 
+**aws-usage-context-TC005** - **Get AWS usage context filtered by licenseId**  
+- **Description:** When `licenseId` is provided, `getAwsUsageContext` returns the usage context for the contract/subscription matching that license.  
+- **Setup:** Create an AWS ROSA contract with a Partner Gateway `licenseArn` persisted as `licenseId`.  
+- **Action:** GET awsUsageContext with matching `awsAccountId` and `licenseId`.  
+- **Verification:** Parse response as `AwsUsageContext`.  
+- **Expected Result:**  
+  - HTTP 200  
+  - Marketplace fields match the contract (`productCode`, `customerId`, `awsSellerAccountId`, `customerAwsAccountId`)  
+  - `licenseId` and `rhSubscriptionId` match the selected contract
+
+**aws-usage-context-TC006** - **AWS usage context returns 404 for unknown licenseId**  
+- **Description:** A non-existent `licenseId` must not match any subscription (including contracts with null `licenseId`).  
+- **Setup:** Create an AWS ROSA contract with a known `licenseId`.  
+- **Action:** GET awsUsageContext with matching `awsAccountId` and a different `licenseId`.  
+- **Expected Result:** HTTP 404 with empty body
+
+**aws-usage-context-TC007** - **Multiple contracts with different licenseIds queried independently**  
+- **Description:** Two AWS contracts sharing `billingAccountId` / `billingProviderId` but different `licenseId`s can each be looked up independently.  
+- **Setup:** Create two AWS ROSA contracts (same billing account, different `subscriptionNumber` and `licenseId`).  
+- **Action:** GET awsUsageContext twice, once per `licenseId`.  
+- **Expected Result:**  
+  - HTTP 200 for each request  
+  - Each response `licenseId` and `rhSubscriptionId` match the contract selected by that filter
+
 ## Azure Usage Context
 
 Component tests for GET `/api/swatch-contracts/internal/subscriptions/azureUsageContext`. Test class: `AzureUsageContextComponentTest`.

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -484,6 +484,17 @@ public class ContractsSwatchService extends SwatchService {
       ServiceLevelType sla,
       UsageType usage,
       String awsAccountId) {
+    return getAwsUsageContext(orgId, product, date, sla, usage, awsAccountId, null);
+  }
+
+  public Response getAwsUsageContext(
+      String orgId,
+      Product product,
+      OffsetDateTime date,
+      ServiceLevelType sla,
+      UsageType usage,
+      String awsAccountId,
+      String licenseId) {
     Objects.requireNonNull(product, "product must not be null");
     Objects.requireNonNull(date, "date must not be null");
 
@@ -503,6 +514,9 @@ public class ContractsSwatchService extends SwatchService {
     }
     if (awsAccountId != null) {
       request.queryParam("awsAccountId", awsAccountId);
+    }
+    if (licenseId != null) {
+      request.queryParam("licenseId", licenseId);
     }
     return request.when().get(AWS_USAGE_CONTEXT_ENDPOINT);
   }

--- a/swatch-contracts/ct/java/domain/AwsLicenseArns.java
+++ b/swatch-contracts/ct/java/domain/AwsLicenseArns.java
@@ -18,28 +18,14 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.contract.repository;
+package domain;
 
-import com.redhat.swatch.common.model.ServiceLevel;
-import com.redhat.swatch.common.model.Usage;
-import java.time.OffsetDateTime;
-import lombok.Builder;
-import lombok.Data;
+/** Test helpers for AWS Partner Gateway licenseArn / contract licenseId values. */
+public final class AwsLicenseArns {
 
-/** Common criteria that can be used to filter instances, subscriptions, and tally snapshots */
-@Data
-@Builder(toBuilder = true)
-public class DbReportCriteria {
-  private String orgId;
-  private String productTag;
-  private ServiceLevel serviceLevel;
-  private Usage usage;
-  private BillingProvider billingProvider;
-  private String billingAccountId;
-  private String licenseId;
-  private boolean payg;
-  private OffsetDateTime beginning;
-  private OffsetDateTime ending;
-  private String metricId;
-  private HypervisorReportCategory hypervisorReportCategory;
+  private AwsLicenseArns() {}
+
+  public static String awsLicenseArn(String subscriptionNumber) {
+    return "arn:aws:license-manager:us-east-1:000000000000:license:" + subscriptionNumber;
+  }
 }

--- a/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
+++ b/swatch-contracts/ct/java/tests/AwsUsageContextComponentTest.java
@@ -20,12 +20,14 @@
  */
 package tests;
 
+import static domain.AwsLicenseArns.awsLicenseArn;
 import static domain.ErrorCodes.SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE;
 import static domain.ErrorCodes.SUBSCRIPTION_RECENTLY_TERMINATED_CODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.AwsUsageContext;
 import com.redhat.swatch.contract.test.model.ServiceLevelType;
 import com.redhat.swatch.contract.test.model.UsageType;
@@ -52,22 +54,7 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
             .extract()
             .as(AwsUsageContext.class);
 
-    assertEquals(
-        contract.getProductCode(),
-        usageContext.getProductCode(),
-        "productCode should match billing_provider_id");
-    assertEquals(
-        contract.getCustomerId(),
-        usageContext.getCustomerId(),
-        "customerId should match billing_provider_id");
-    assertEquals(
-        contract.getSellerAccountId(),
-        usageContext.getAwsSellerAccountId(),
-        "awsSellerAccountId should match billing_provider_id");
-    assertEquals(
-        contract.getBillingAccountId(),
-        usageContext.getCustomerAwsAccountId(),
-        "customerAwsAccountId should match billing_account_id");
+    thenAwsUsageContextMatchesContract(contract, usageContext);
   }
 
   @TestPlanName("aws-usage-context-TC002")
@@ -119,6 +106,85 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
         "Missing billingAccountId should return " + SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID_CODE);
   }
 
+  @TestPlanName("aws-usage-context-TC005")
+  @Test
+  void shouldReturnAwsUsageContextWhenLicenseIdProvided() {
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0)).toBuilder()
+            .licenseId(awsLicenseArn(RandomUtils.generateRandom()))
+            .build();
+    givenContractIsCreated(contract);
+
+    AwsUsageContext usageContext =
+        whenGetAwsMarketplaceContext(contract.getBillingAccountId(), contract.getLicenseId())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(AwsUsageContext.class);
+
+    thenAwsUsageContextMatchesContract(contract, usageContext);
+  }
+
+  @TestPlanName("aws-usage-context-TC006")
+  @Test
+  void shouldReturn404WhenLicenseIdDoesNotMatch() {
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0)).toBuilder()
+            .licenseId(awsLicenseArn(RandomUtils.generateRandom()))
+            .build();
+    givenContractIsCreated(contract);
+
+    Response response =
+        whenGetAwsMarketplaceContext(
+            contract.getBillingAccountId(), awsLicenseArn("unknown-license"));
+
+    assertEquals(
+        HttpStatus.SC_NOT_FOUND, response.statusCode(), "Unknown licenseId should return 404");
+    assertTrue(
+        response.body().asString().isBlank(),
+        "Unknown licenseId should return 404 without an error body");
+  }
+
+  @TestPlanName("aws-usage-context-TC007")
+  @Test
+  void shouldReturnUsageContextPerLicenseWhenMultipleContracts() {
+    Contract baseContract =
+        Contract.buildRosaContract(
+            orgId, BillingProvider.AWS, Map.of(CORES, 10.0), RandomUtils.generateRandom());
+    String subscriptionA = baseContract.getSubscriptionNumber();
+    String subscriptionB = RandomUtils.generateRandom();
+    Contract contractA =
+        baseContract.toBuilder()
+            .subscriptionNumber(subscriptionA)
+            .subscriptionId(subscriptionA)
+            .licenseId(awsLicenseArn(subscriptionA))
+            .build();
+    Contract contractB =
+        baseContract.toBuilder()
+            .subscriptionNumber(subscriptionB)
+            .subscriptionId(subscriptionB)
+            .licenseId(awsLicenseArn(subscriptionB))
+            .build();
+    givenContractIsCreated(contractA);
+    givenContractIsCreated(contractB);
+
+    AwsUsageContext contextA =
+        whenGetAwsMarketplaceContext(contractA.getBillingAccountId(), contractA.getLicenseId())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(AwsUsageContext.class);
+    AwsUsageContext contextB =
+        whenGetAwsMarketplaceContext(contractB.getBillingAccountId(), contractB.getLicenseId())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .extract()
+            .as(AwsUsageContext.class);
+
+    thenAwsUsageContextMatchesContract(contractA, contextA);
+    thenAwsUsageContextMatchesContract(contractB, contextB);
+  }
+
   private Contract givenRosaContractIsTerminated() {
     Contract contract = givenRosaContractIsCreated(10.0);
     OffsetDateTime terminationDate = OffsetDateTime.now().minusMinutes(30);
@@ -146,12 +212,44 @@ public class AwsUsageContextComponentTest extends BaseContractComponentTest {
   }
 
   private Response whenGetAwsMarketplaceContext(String billingAccountId) {
+    return whenGetAwsMarketplaceContext(billingAccountId, null);
+  }
+
+  private Response whenGetAwsMarketplaceContext(String billingAccountId, String licenseId) {
     return service.getAwsUsageContext(
         orgId,
         Product.ROSA,
         OffsetDateTime.now(),
         ServiceLevelType.PREMIUM,
         UsageType.PRODUCTION,
-        billingAccountId);
+        billingAccountId,
+        licenseId);
+  }
+
+  private void thenAwsUsageContextMatchesContract(Contract contract, AwsUsageContext usageContext) {
+    assertEquals(
+        contract.getProductCode(),
+        usageContext.getProductCode(),
+        "productCode should match billing_provider_id");
+    assertEquals(
+        contract.getCustomerId(),
+        usageContext.getCustomerId(),
+        "customerId should match billing_provider_id");
+    assertEquals(
+        contract.getSellerAccountId(),
+        usageContext.getAwsSellerAccountId(),
+        "awsSellerAccountId should match billing_provider_id");
+    assertEquals(
+        contract.getBillingAccountId(),
+        usageContext.getCustomerAwsAccountId(),
+        "customerAwsAccountId should match billing_account_id");
+    assertEquals(
+        contract.getLicenseId(),
+        usageContext.getLicenseId(),
+        "licenseId should match the selected contract");
+    assertEquals(
+        contract.getSubscriptionId(),
+        usageContext.getRhSubscriptionId(),
+        "rhSubscriptionId should match the selected contract");
   }
 }

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -22,6 +22,7 @@ package tests;
 
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContractsInOrgId;
 import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
+import static domain.AwsLicenseArns.awsLicenseArn;
 import static java.util.Collections.disjoint;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -1091,10 +1092,6 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     stubPartnerAndSearch(contracts.toArray(new Contract[0]));
     Response sync = service.syncOffering(sku);
     assertEquals(HttpStatus.SC_OK, sync.statusCode(), "Sync offering should succeed");
-  }
-
-  private static String awsLicenseArn(String subscriptionNumber) {
-    return "arn:aws:license-manager:us-east-1:000000000000:license:" + subscriptionNumber;
   }
 
   private void stubContractsForOrgSync(Contract... contracts) {

--- a/swatch-contracts/ct/java/utils/AwsContractRequestMapper.java
+++ b/swatch-contracts/ct/java/utils/AwsContractRequestMapper.java
@@ -37,10 +37,15 @@ public class AwsContractRequestMapper extends ContractRequestMapper {
 
   @Override
   protected PartnerIdentityV1 buildPartnerIdentities(Contract contract) {
-    return new PartnerIdentityV1()
-        .awsCustomerId(contract.getCustomerId())
-        .sellerAccountId(contract.getSellerAccountId())
-        .customerAwsAccountId(contract.getBillingAccountId());
+    PartnerIdentityV1 partnerIdentities =
+        new PartnerIdentityV1()
+            .awsCustomerId(contract.getCustomerId())
+            .sellerAccountId(contract.getSellerAccountId())
+            .customerAwsAccountId(contract.getBillingAccountId());
+    if (contract.getLicenseId() != null) {
+      partnerIdentities.licenseArn(contract.getLicenseId());
+    }
+    return partnerIdentities;
   }
 
   @Override

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/SubscriptionEntity.java
@@ -314,6 +314,28 @@ public class SubscriptionEntity extends ModificationTrackedEntity {
         builder.like(root.get(SubscriptionEntity_.billingAccountId), billingAccountId + "%");
   }
 
+  private static Specification<SubscriptionEntity> hasLicenseId(String licenseId) {
+    return (root, query, builder) -> {
+      var subquery = query.subquery(Integer.class);
+      var contractRoot = subquery.from(ContractEntity.class);
+      subquery
+          .select(builder.literal(1))
+          .where(
+              builder.and(
+                  builder.equal(contractRoot.get(ContractEntity_.licenseId), licenseId),
+                  builder.equal(
+                      contractRoot.get(ContractEntity_.subscriptionNumber),
+                      root.get(SubscriptionEntity_.subscriptionNumber)),
+                  builder.equal(
+                      contractRoot.get(ContractEntity_.startDate),
+                      root.get(SubscriptionEntity_.startDate)),
+                  builder.equal(
+                      contractRoot.get(ContractEntity_.orgId),
+                      root.get(SubscriptionEntity_.orgId))));
+      return builder.exists(subquery);
+    };
+  }
+
   private static Specification<SubscriptionEntity> metricsCriteria(
       HypervisorReportCategory hypervisorReportCategory, String metricId) {
     return (root, query, builder) -> {
@@ -393,6 +415,10 @@ public class SubscriptionEntity extends ModificationTrackedEntity {
         && !dbReportCriteria.getBillingAccountId().equals("_ANY")) {
       searchCriteria =
           searchCriteria.and(billingAccountIdLike(dbReportCriteria.getBillingAccountId()));
+    }
+    if (Objects.nonNull(dbReportCriteria.getLicenseId())
+        && !dbReportCriteria.getLicenseId().isBlank()) {
+      searchCriteria = searchCriteria.and(hasLicenseId(dbReportCriteria.getLicenseId()));
     }
     if (Objects.nonNull(dbReportCriteria.getMetricId())
         || Objects.nonNull(dbReportCriteria.getHypervisorReportCategory())) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -231,10 +231,11 @@ public class ContractsResource implements DefaultApi {
       String orgId,
       String sla,
       String usage,
-      String awsAccountId)
+      String awsAccountId,
+      String licenseId)
       throws ProcessingException {
-    return getPaygSubscription(date, productId, orgId, BillingProvider.AWS, awsAccountId)
-        .map(this::buildAwsUsageContext)
+    return getPaygSubscription(date, productId, orgId, BillingProvider.AWS, awsAccountId, licenseId)
+        .map(s -> buildAwsUsageContext(s, licenseId))
         .orElseThrow();
   }
 
@@ -244,6 +245,16 @@ public class ContractsResource implements DefaultApi {
       String orgId,
       BillingProvider billingProvider,
       String awsAccountId) {
+    return getPaygSubscription(date, productId, orgId, billingProvider, awsAccountId, null);
+  }
+
+  private Optional<SubscriptionEntity> getPaygSubscription(
+      OffsetDateTime date,
+      String productId,
+      String orgId,
+      BillingProvider billingProvider,
+      String awsAccountId,
+      String licenseId) {
     DbReportCriteria criteria =
         DbReportCriteria.builder()
             .orgId(orgId)
@@ -255,11 +266,12 @@ public class ContractsResource implements DefaultApi {
             // Set start date one hour in past to pickup recently terminated subscriptions
             .beginning(date.minusHours(1))
             .ending(date)
+            .licenseId(licenseId)
             .build();
     return usageContextSubscriptionProvider.getSubscription(criteria);
   }
 
-  private AwsUsageContext buildAwsUsageContext(SubscriptionEntity subscription) {
+  private AwsUsageContext buildAwsUsageContext(SubscriptionEntity subscription, String licenseId) {
     String billingAccountId = subscription.getBillingAccountId();
     if (StringUtils.isBlank(billingAccountId)) {
       throw new ServiceException(
@@ -278,7 +290,8 @@ public class ContractsResource implements DefaultApi {
         .productCode(productCode)
         .customerId(customerId)
         .awsSellerAccountId(sellerAccount)
-        .customerAwsAccountId(billingAccountId);
+        .customerAwsAccountId(billingAccountId)
+        .licenseId(licenseId);
   }
 
   @Override

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -529,6 +529,11 @@ paths:
         schema:
           type: string
           default: _ANY
+      - name: licenseId
+        in: query
+        required: false
+        schema:
+          type: string
 
     get:
       summary: "Lookup necessary info to submit a usage record to AWS"
@@ -1532,6 +1537,9 @@ components:
           type: string
         customerAwsAccountId:
           description: AWS customer account ID
+          type: string
+        licenseId:
+          description: AWS license ARN.
           type: string
         subscriptionStartDate:
           type: string

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/repository/SubscriptionRepositoryTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/repository/SubscriptionRepositoryTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.candlepin.clock.ApplicationClock;
 import org.hamcrest.Matchers;
@@ -67,6 +68,7 @@ class SubscriptionRepositoryTest {
 
   @Inject SubscriptionRepository subscriptionRepo;
   @Inject OfferingRepository offeringRepo;
+  @Inject ContractRepository contractRepo;
   @Inject ApplicationClock clock;
 
   @BeforeEach
@@ -339,6 +341,54 @@ class SubscriptionRepositoryTest {
 
     var result = resultList.get(0);
     assertEquals("testSku1", result.getOffering().getSku());
+  }
+
+  @TestTransaction
+  @Test
+  void filtersByLicenseIdViaContract() {
+    OfferingEntity offering = persistRosaOffering("licenseSku");
+    var matching = persistAwsSubscription(offering, "subA", "license-a");
+    persistAwsSubscription(offering, "subB", "license-b");
+
+    var results = findByLicenseId("license-a");
+
+    assertEquals(1, results.size());
+    assertEquals(matching.getSubscriptionId(), results.get(0).getSubscriptionId());
+  }
+
+  @TestTransaction
+  @Test
+  void licenseIdFilterDoesNotMatchNullLicenseOnContract() {
+    OfferingEntity offering = persistRosaOffering("nullLicenseSku");
+    persistAwsSubscription(offering, "subNull", null);
+
+    assertTrue(findByLicenseId("missing-license").isEmpty());
+  }
+
+  @TestTransaction
+  @Test
+  void licenseIdFilterRequiresMatchingStartDate() {
+    OfferingEntity offering = persistRosaOffering("startDateSku");
+    SubscriptionEntity subscription = createSubscription("org123", "subStart", BILLING_ACCOUNT_ID);
+    subscription.setOffering(offering);
+    subscription.setBillingProvider(BillingProvider.AWS);
+    subscriptionRepo.persist(subscription);
+    contractRepo.persistAndFlush(
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .orgId(subscription.getOrgId())
+            .subscriptionNumber(subscription.getSubscriptionNumber())
+            .startDate(subscription.getStartDate().minusDays(1))
+            .endDate(subscription.getEndDate())
+            .lastUpdated(now)
+            .offering(offering)
+            .billingProvider("aws")
+            .billingAccountId(BILLING_ACCOUNT_ID)
+            .vendorProductCode("product-code")
+            .licenseId("license-start")
+            .build());
+
+    assertTrue(findByLicenseId("license-start").isEmpty());
   }
 
   @TestTransaction
@@ -868,6 +918,49 @@ class SubscriptionRepositoryTest {
     var resultBillingAccountIds =
         result.stream().map(BillingAccountInfoDTO::billingAccountId).collect(Collectors.toSet());
     assertTrue(resultBillingAccountIds.containsAll(expectedBillingAccountIds));
+  }
+
+  private OfferingEntity persistRosaOffering(String sku) {
+    OfferingEntity offering =
+        createOffering(sku, PRODUCT_TAG, 1, ServiceLevel.PREMIUM, Usage.PRODUCTION, "ocp");
+    offeringRepo.persist(offering);
+    return offering;
+  }
+
+  private SubscriptionEntity persistAwsSubscription(
+      OfferingEntity offering, String subId, String licenseId) {
+    SubscriptionEntity subscription = createSubscription("org123", subId, BILLING_ACCOUNT_ID);
+    subscription.setOffering(offering);
+    subscription.setBillingProvider(BillingProvider.AWS);
+    subscriptionRepo.persist(subscription);
+    contractRepo.persistAndFlush(
+        ContractEntity.builder()
+            .uuid(UUID.randomUUID())
+            .orgId(subscription.getOrgId())
+            .subscriptionNumber(subscription.getSubscriptionNumber())
+            .startDate(subscription.getStartDate())
+            .endDate(subscription.getEndDate())
+            .lastUpdated(now)
+            .offering(offering)
+            .billingProvider("aws")
+            .billingAccountId(BILLING_ACCOUNT_ID)
+            .vendorProductCode("product-code")
+            .licenseId(licenseId)
+            .build());
+    return subscription;
+  }
+
+  private List<SubscriptionEntity> findByLicenseId(String licenseId) {
+    return subscriptionRepo.findByCriteria(
+        DbReportCriteria.builder()
+            .orgId("org123")
+            .productTag(PRODUCT_TAG)
+            .billingProvider(BillingProvider.AWS)
+            .billingAccountId(BILLING_ACCOUNT_ID)
+            .licenseId(licenseId)
+            .beginning(now)
+            .ending(now)
+            .build());
   }
 
   private OfferingEntity createOffering(String sku, int productId) {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/resource/ContractsResourceTest.java
@@ -52,6 +52,7 @@ import com.redhat.swatch.contract.openapi.model.ServiceLevelType;
 import com.redhat.swatch.contract.openapi.model.StatusResponse;
 import com.redhat.swatch.contract.openapi.model.Subscription;
 import com.redhat.swatch.contract.openapi.model.UsageType;
+import com.redhat.swatch.contract.repository.DbReportCriteria;
 import com.redhat.swatch.contract.repository.SubscriptionEntity;
 import com.redhat.swatch.contract.repository.SubscriptionRepository;
 import com.redhat.swatch.contract.service.ContractService;
@@ -80,6 +81,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @QuarkusTest
@@ -375,6 +377,42 @@ class ContractsResourceTest {
     assertEquals("foo2", awsUsageContext.getCustomerId());
     assertEquals("foo3", awsUsageContext.getAwsSellerAccountId());
     assertEquals("123", awsUsageContext.getCustomerAwsAccountId());
+  }
+
+  @Test
+  void passesLicenseIdWhenProvidedOnAwsUsageContextLookup() {
+    SubscriptionEntity sub = new SubscriptionEntity();
+    sub.setBillingProviderId("foo1;foo2;foo3");
+    sub.setBillingAccountId("123");
+    sub.setEndDate(defaultEndDate);
+    when(subscriptionRepository.findByCriteria(any(), any())).thenReturn(List.of(sub));
+
+    String licenseId = "arn:aws:license-manager:us-east-1:1:license:abc";
+    given()
+        .queryParams(
+            "orgId",
+            ORG_ID,
+            "date",
+            defaultLookUpDate.withOffsetSameInstant(ZoneOffset.UTC).toString(),
+            "productId",
+            ROSA,
+            "sla",
+            ServiceLevelType.PREMIUM.toString(),
+            "usage",
+            UsageType.PRODUCTION.toString(),
+            "awsAccountId",
+            "123",
+            "licenseId",
+            licenseId)
+        .header(RH_IDENTITY_HEADER, CUSTOMER_IDENTITY_HEADER)
+        .get("/api/swatch-contracts/internal/subscriptions/awsUsageContext")
+        .then()
+        .statusCode(200);
+
+    ArgumentCaptor<DbReportCriteria> criteriaCaptor =
+        ArgumentCaptor.forClass(DbReportCriteria.class);
+    verify(subscriptionRepository).findByCriteria(criteriaCaptor.capture(), any());
+    assertEquals(licenseId, criteriaCaptor.getValue().getLicenseId());
   }
 
   @Test

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -211,7 +211,9 @@ public class AwsBillableUsageAggregateConsumer {
           billableUsageAggregate.getAggregateKey().getOrgId(),
           billableUsageAggregate.getAggregateKey().getSla(),
           billableUsageAggregate.getAggregateKey().getUsage(),
-          billableUsageAggregate.getAggregateKey().getBillingAccountId());
+          billableUsageAggregate.getAggregateKey().getBillingAccountId(),
+          // LicenseId will be propagated as part of SWATCH-5301.
+          null);
     } catch (DefaultApiException e) {
       if (ofNullable(e.getError())
           .map(error -> "CONTRACTS1005".equals(error.getCode()))

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -201,10 +202,10 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void shouldLookupAwsContextOnApplicableSnapshot() throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(new AwsUsageContext());
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
-    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any());
+    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull());
   }
 
   @Test
@@ -225,7 +226,7 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void shouldSendUsageForApplicableSnapshot() throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -234,7 +235,7 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void whenThrottlingExceptionThenSetRateLimitErrorCode() throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     ThrottlingException throttlingException =
@@ -259,7 +260,7 @@ class AwsBillableUsageAggregateConsumerTest {
             MetricIdUtils.getInstanceHours().toUpperCaseFormatted(),
             OffsetDateTime.now(),
             42.0);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(AwsUsageContextLookupException.class);
     consumer.process(aggregate);
     verifyNoInteractions(meteringClient);
@@ -279,16 +280,16 @@ class AwsBillableUsageAggregateConsumerTest {
 
   @Test
   void shouldFindStorageAwsDimension() throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(new AwsUsageContext());
     consumer.process(ROSA_STORAGE_CORES_RECORD);
-    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any());
+    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull());
   }
 
   @Test
   void shouldIncrementAcceptedAndSuccessCounters() throws ApiException {
     var priorSuccess = successCounter.count();
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -305,7 +306,7 @@ class AwsBillableUsageAggregateConsumerTest {
   void shouldIncrementFailureCounterIfUnprocessed() throws ApiException {
     double priorFailed = failedCounter.count();
     double current = rejectedCounter.count();
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -326,7 +327,7 @@ class AwsBillableUsageAggregateConsumerTest {
   @Test
   void shouldIncrementFailureCounterOnError() throws ApiException {
     double current = rejectedCounter.count();
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -345,7 +346,7 @@ class AwsBillableUsageAggregateConsumerTest {
             Optional.of(true),
             Duration.of(1, ChronoUnit.HOURS),
             billableUsageStatusProducer);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     processor.process(ROSA_INSTANCE_HOURS_RECORD);
     verifyNoInteractions(clientFactory, meteringClient);
@@ -357,7 +358,7 @@ class AwsBillableUsageAggregateConsumerTest {
     error.setCode("CONTRACTS1005");
     var response = Response.serverError().entity(error).build();
     var exception = new DefaultApiException(response, error);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(exception);
 
     assertThrows(
@@ -373,7 +374,7 @@ class AwsBillableUsageAggregateConsumerTest {
     error.setCode("CONTRACTS1005");
     var response = Response.serverError().entity(error).build();
     var exception = new DefaultApiException(response, error);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(exception);
 
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -386,7 +387,7 @@ class AwsBillableUsageAggregateConsumerTest {
     error.setCode("CONTRACTS1006");
     var response = Response.status(Response.Status.NOT_FOUND).entity(error).build();
     var exception = new DefaultApiException(response, error);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(exception);
 
     assertThrows(
@@ -400,7 +401,7 @@ class AwsBillableUsageAggregateConsumerTest {
     error.setCode("CONTRACTS1006");
     var response = Response.status(Response.Status.NOT_FOUND).entity(error).build();
     var exception = new DefaultApiException(response, error);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(exception);
 
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -417,7 +418,7 @@ class AwsBillableUsageAggregateConsumerTest {
   @Test
   void shouldSkipMessageProcessingIfUsageIsOutsideTheUsageWindow() throws Exception {
     double currentIgnored = ignoredCounter.count();
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     BillableUsageAggregate aggregate =
         createAggregate(
@@ -446,7 +447,7 @@ class AwsBillableUsageAggregateConsumerTest {
             42.0);
 
     // verify failure
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenThrow(new SubscriptionCanNotBeDeterminedException(null));
     consumer.process(aggregate);
     verify(billableUsageStatusProducer)
@@ -459,7 +460,7 @@ class AwsBillableUsageAggregateConsumerTest {
 
     // verify success
     reset(contractsApi, billableUsageStatusProducer);
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -506,7 +507,7 @@ class AwsBillableUsageAggregateConsumerTest {
   }
 
   private UsageRecord processUsageAndCaptureRecord(AwsUsageContext context) throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any()))
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(context);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))


### PR DESCRIPTION
Jira issue: SWATCH-5297

## Description
- Add optional `licenseId` query param to `getAwsUsageContext` and filter subscriptions via matching contract `license_id`.
- Echo request `licenseId` on `AwsUsageContext` (null when omitted).
- Update contracts client callers (`swatch-producer-aws` passes null until follow-up).

## Performance

Optional `licenseId` adds an `EXISTS` against `contracts` only when the query param is present; omitting it leaves the previous plan unchanged (current `producer-aws` still passes null).

On stage/prod we ran `EXPLAIN (ANALYZE, BUFFERS)` for the `getAwsUsageContext` lookup shape (org + AWS billing account + product tag + most-recent subscription). With `licenseId`, Postgres correlates
via `contracts_logicalk` (`subscription_number`, `start_date`) — same keys as `SubscriptionEntity.forContract` — then filters `license_id`. Warm-cache overhead on prod was ~1 ms (sub-millisecond vs the baseline
lookup). `contracts` is small (~3k stage / ~19k prod), so no new `license_id` index is needed at current scale.

## Testing
- Unit: `ContractsResourceTest`, `SubscriptionRepositoryTest` (licenseId filter / null license)
- Unit: `AwsBillableUsageAggregateConsumerTest` (7-arg client)
- Component: `AwsUsageContextComponentTest` (TC005–TC007)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AWS usage-context lookups now support an optional license ID.
  - Results can include the matched AWS license ARN.
  - Contracts are selected accurately when multiple contracts share billing details but have different license IDs.
  - Unknown or mismatched license IDs return no matching contract.

- **Documentation**
  - Updated API documentation to describe the optional license ID parameter and response field.

- **Tests**
  - Added coverage for license-based matching, missing licenses, and multiple contracts sharing billing identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->