### PR TITLE
Removed the mapstruct-processor from <dependencies> in swatch-tally/pom.xml

### DIFF
--- a/swatch-tally/pom.xml
+++ b/swatch-tally/pom.xml
@@ -173,10 +173,6 @@
       <artifactId>mapstruct</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct-processor</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>


### PR DESCRIPTION

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

I found this while trying to run unit tests in Intellij while building. It was blocking the tests from running. This only occurs when you have deselected 'Delegate IDE build/run actions to Maven' at Settings > Build, Execution, Deployment > Build Tools > Maven > Runner

mapstruct-processor was declared both as a regular dependency (classpath) and in
 <annotationProcessorPaths> (compiler plugin). Maven ignores classpath
 processors when annotationProcessorPaths is set, but IntelliJ's JPS
 builder discovers the processor from both paths, causing MapStruct to
 run twice and collide on the generated file.

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. Run a unit test from the command line
```./mvnw test -pl swatch-tally -Dtest=TallyResourceTest```
3. Run it from Intellij also (with the arrow icon)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing a redundant dependency.
  * Existing annotation processing remains available through the project’s compiler configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->