### PR TITLE
SWATCH-5296: Expose licenseId on getContracts Contract API

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -343,6 +343,13 @@ Test cases should be testable locally and in an ephemeral environment.
   - HTTP 200 with empty array  
   - No errors
 
+**contracts-retrieval-TC007** - **Mixed `license_id` values for the same org**  
+- **Description:** An org can have multiple AWS contracts where only some have a `license_id`; retrieval returns each contract with its own `license_id` value (set or null).  
+- **Setup:** Create two AWS ROSA contracts for the same org and billing account; only one has a `license_id`.  
+- **Action:** GET contracts by `org_id`.  
+- **Verification:** Both contracts returned; `license_id` is set only on the licensed contract.  
+- **Expected Result:** HTTP 200 with both contracts and correct `license_id` values.
+
 ## AWS Usage Context
 
 Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext`. Test class: `AwsUsageContextComponentTest`.

--- a/swatch-contracts/ct/java/tests/ContractsRetrievalComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsRetrievalComponentTest.java
@@ -20,7 +20,9 @@
  */
 package tests;
 
+import static domain.AwsLicenseArns.awsLicenseArn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
@@ -140,6 +142,53 @@ public class ContractsRetrievalComponentTest extends BaseContractComponentTest {
   void shouldGetEmptyContractsWhenThereAreNoContractsForOrgId() {
     var contracts = service.getContractsByOrgId(orgId);
     assertTrue(contracts.isEmpty());
+  }
+
+  @TestPlanName("contracts-retrieval-TC007")
+  @Test
+  void shouldReturnMixedLicenseIdsForSameOrg() {
+    // Given: two AWS contracts for the same org; only one has licenseId
+    String subscriptionWithLicense = RandomUtils.generateRandom();
+    String subscriptionWithoutLicense = RandomUtils.generateRandom();
+    Contract shared =
+        Contract.buildRosaContract(
+            orgId, BillingProvider.AWS, Map.of(CORES, 10.0), RandomUtils.generateRandom());
+    Contract withLicense =
+        shared.toBuilder()
+            .subscriptionNumber(subscriptionWithLicense)
+            .subscriptionId(subscriptionWithLicense)
+            .licenseId(awsLicenseArn(subscriptionWithLicense))
+            .build();
+    Contract withoutLicense =
+        shared.toBuilder()
+            .subscriptionNumber(subscriptionWithoutLicense)
+            .subscriptionId(subscriptionWithoutLicense)
+            .licenseId(null)
+            .build();
+    givenContractIsCreated(withLicense);
+    givenContractIsCreated(withoutLicense);
+
+    // When
+    var contracts = service.getContractsByOrgId(orgId);
+
+    // Then
+    assertEquals(2, contracts.size());
+    var withLicenseContract =
+        contracts.stream()
+            .filter(c -> subscriptionWithLicense.equals(c.getSubscriptionNumber()))
+            .findFirst()
+            .orElseThrow();
+    var withoutLicenseContract =
+        contracts.stream()
+            .filter(c -> subscriptionWithoutLicense.equals(c.getSubscriptionNumber()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(
+        withLicense.getLicenseId(),
+        withLicenseContract.getLicenseId(),
+        "Contract with licenseId must expose it");
+    assertNull(
+        withoutLicenseContract.getLicenseId(), "Contract without licenseId must expose null");
   }
 
   private Contract givenExistingContractForBillingProvider(BillingProvider billingProvider) {

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -809,6 +809,8 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
         service.syncContractsByOrg(orgId).statusCode(),
         is(HttpStatus.SC_OK));
     thenAssertContractsPresentBySubscriptionNumber(contractA, contractB);
+    verifyContractFields(contractA, getPersistedContract(contractA));
+    verifyContractFields(contractB, getPersistedContract(contractB));
     String uuidA = getPersistedContract(contractA).getUuid();
     String uuidB = getPersistedContract(contractB).getUuid();
 
@@ -899,6 +901,9 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertThat("Sync should succeed", syncResponse.statusCode(), is(HttpStatus.SC_OK));
     syncResponse.then().body("status", equalTo(STATUS_SUCCESS));
     thenContractsSizeAre(1);
+    assertNull(
+        getPersistedContract(contract).getLicenseId(),
+        "Persisted contract licenseId must be null when not set");
   }
 
   protected String getContractUuidByProvider(String orgId, BillingProvider provider) {
@@ -938,6 +943,7 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
         expected.getSubscriptionNumber(),
         actual.getSubscriptionNumber(),
         "contracts.subscription_number must match upstream");
+    assertEquals(expected.getLicenseId(), actual.getLicenseId(), "contracts.license_id must match");
     assertFalse(actual.getProductTags().isEmpty(), "contracts.product_tags must not be empty");
     assertNotNull(actual.getMetrics(), "contract_metrics must not be null");
   }

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1366,6 +1366,9 @@ components:
           description: ""
           type: string
           example: "6n58d3s3qpvk22dgew2gal7w3"
+        license_id:
+          description: ""
+          type: string
         metrics:
           description: ""
           type: array

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -95,6 +95,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -166,6 +167,24 @@ class ContractServiceTest extends BaseUnitTest {
         contractService.getContracts(ORG_ID, PRODUCT_TAG, null, null, null, null);
     assertEquals(1, contractList.size());
     assertEquals(2, contractList.get(0).getMetrics().size());
+  }
+
+  @Test
+  void testGetContractsReturnsMixedLicenseIds() {
+    String licenseId = "arn:aws:license-manager:us-east-1:000000000000:license:swatch-test-license";
+    var withLicenseRequest = givenContractRequest("with-license-sub");
+    withLicenseRequest.getPartnerEntitlement().getPartnerIdentities().setLicenseArn(licenseId);
+    givenExistingContract(withLicenseRequest);
+    givenExistingContract(givenContractRequest("without-license-sub"));
+
+    List<Contract> contracts =
+        contractService.getContracts(ORG_ID, PRODUCT_TAG, null, null, null, null);
+
+    assertEquals(2, contracts.size());
+    var bySubscription =
+        contracts.stream().collect(Collectors.toMap(Contract::getSubscriptionNumber, c -> c));
+    assertEquals(licenseId, bySubscription.get("with-license-sub").getLicenseId());
+    assertNull(bySubscription.get("without-license-sub").getLicenseId());
   }
 
   @Test


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5296

Add optional `license_id` to the `Contract` OpenAPI schema so `getContract` returns the `licenseId` already stored on `ContractEntity` (MapStruct maps it). Persistence remains `SWATCH-5295`.

### Verification

Unit:
```bash
./mvnw test -pl swatch-contracts -am -Dtest=ContractServiceTest#testGetContractsReturnsMixedLicenseIds
```

Component:
```bash
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am  -Dtest=ContractsSyncComponentTest,ContractsRetrievalComponentTest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract responses now include an optional AWS license ID.
  * Multiple contracts for the same organization can be retrieved with their individual license IDs preserved.
  * Contracts without an AWS license ID are clearly represented with a null value.

* **Bug Fixes**
  * Improved contract retrieval and synchronization to preserve mixed license-ID states accurately.

* **Tests**
  * Added coverage for retrieving and persisting contracts with and without license IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->