### PR TITLE
SWATCH-5299: Pick the most recent licenseId for billing

### DIFF
--- a/swatch-billable-usage/TEST_PLAN.md
+++ b/swatch-billable-usage/TEST_PLAN.md
@@ -268,6 +268,93 @@ Java component tests in `ContractCoverageComponentTest` (`swatch-billable-usage/
 - **Expected Result:**  
   - Contract lookup failure prevents billable remittance and billing
 
+**billable-usage-contract-coverage-TC009 - Multi-contract coverage fully covers usage**
+
+- **Description:** Verify summed capacities across contracts with `licenseId` still suppress remittance when usage is within total coverage.  
+- **Setup:**  
+  - Two ROSA contracts with licenseIds; combined coverage = 6 Instance-hours  
+  - Tally `current_total` = 5
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - Account remittance `remittedValue` = 0  
+  - No Kafka message emitted (blocked by known bug: SWATCH-5443 — zero remitted still produces BillableUsage; assertion commented in CT until fixed)
+- **Expected Result:**  
+  - Prepaid coverage math unchanged (sum of capacities)
+
+**billable-usage-contract-coverage-TC010 - Overage remittance stamps newest licenseId**
+
+- **Description:** Verify PAYG overage selects the newest agreement licenseId and stamps remittance + BillableUsage.  
+- **Setup:**  
+  - Two ROSA contracts (coverage 2+2), different start dates and licenseIds  
+  - Tally `current_total` = 5 (overage 1)
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - One remittance with `remitted_pending_value` = 1 and selected (newest) `licenseId`  
+  - One Kafka BillableUsage with same `licenseId` and value 1
+- **Expected Result:**  
+  - Single overage remittance allocated to newest agreement
+
+**billable-usage-contract-coverage-TC011 - Mixed licensed and unlicensed contracts**
+
+- **Description:** Verify coverage sums all contracts; overage licenseId comes only from licensed set.  
+- **Setup:**  
+  - Older licensed contract (coverage 2) + newer unlicensed contract (coverage 2)  
+  - Tally `current_total` = 5 (overage 1)
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - Remittance pending value = 1 with licensed agreement's `licenseId`  
+  - Kafka BillableUsage carries the same `licenseId`
+- **Expected Result:**  
+  - Mixed set: coverage includes both; selection ignores null licenseId
+
+**billable-usage-contract-coverage-TC012 - Mixed gratis-eligible and established agreements**
+
+- **Description:** Verify multiple contracts with `licenseId` still require every active agreement to be gratis-eligible; if any established (non-gratis) agreement exists, overage is billed to the newest `licenseId`.  
+- **Setup:**  
+  - Product: `ansible-aap-managed` (gratis-enabled metric)  
+  - Established agreement at month start (00:00 UTC) + mid-month agreement (newer `licenseId`); combined coverage = 2  
+  - Tally `current_total` = 3 (overage 1) in start month
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - Remittance status = `pending`, value = 1, `licenseId` = mid-month agreement  
+  - Kafka BillableUsage emitted with same `licenseId`
+- **Expected Result:**  
+  - Newest agreement does not make the period gratis by itself; one established agreement disqualifies gratis
+
+**billable-usage-contract-coverage-TC013 - All agreements gratis-eligible**
+
+- **Description:** Verify when every active agreement starts after month start, overage remittance is `gratis` and stamps the newest `licenseId` (no Kafka emission).  
+- **Setup:**  
+  - Product: `ansible-aap-managed`  
+  - Two mid-month agreements with different start dates/licenseIds; combined coverage = 2  
+  - Tally `current_total` = 3 (overage 1) in start month
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - Remittance status = `gratis`, value = 1, `licenseId` = newest agreement  
+  - No message on `billable-usage` topic
+- **Expected Result:**  
+  - All-agreements gratis rule unchanged; selected overage `licenseId` still recorded on remittance
+
+**billable-usage-contract-coverage-TC014 - Same startDate uses lexicographic licenseId tie-break**
+
+- **Description:** Verify when two licensed agreements share the same `startDate`, overage uses the lexicographically smaller `licenseId` regardless of contracts API order.  
+- **Setup:**  
+  - Two ROSA contracts with identical start/end dates (coverage 2+2)  
+  - Larger `licenseId` listed first, smaller second  
+  - Tally `current_total` = 5 (overage 1)
+- **Action:**  
+  - Publish tally summary
+- **Verification:**  
+  - One remittance with `remitted_pending_value` = 1 and smaller `licenseId`  
+  - One Kafka BillableUsage with the same smaller `licenseId` and value 1
+- **Expected Result:**  
+  - Deterministic overage allocation when start dates tie (lexicographically smaller wins)
+
 ---
 
 ## Contract Adjustment Remittance

--- a/swatch-billable-usage/ct/java/api/ContractsWiremockService.java
+++ b/swatch-billable-usage/ct/java/api/ContractsWiremockService.java
@@ -21,7 +21,9 @@
 package api;
 
 import com.redhat.swatch.component.tests.api.WiremockService;
+import domain.ContractStub;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,57 +77,22 @@ public class ContractsWiremockService extends WiremockService {
     registerContractStub(orgId, productId, startDate, endDate, metrics);
   }
 
-  /**
-   * Setup multiple contracts, each with the same set of AWS dimension coverages. Use to simulate
-   * adding a contract mid-month (c1 + c2) while keeping c1 active.
-   *
-   * @param orgId Organization ID
-   * @param productId Product ID
-   * @param contractsCoverage Per-contract map of AWS dimension to billable-unit coverage
-   */
-  public void setupMultipleMultiMetricContracts(
-      String orgId, String productId, List<Map<String, Double>> contractsCoverage) {
-    OffsetDateTime startDate = OffsetDateTime.now().minusMonths(1);
-    OffsetDateTime endDate = OffsetDateTime.now().plusYears(1);
-    List<Map<String, Object>> contracts =
-        contractsCoverage.stream()
+  public void setupContracts(String orgId, String productId, List<ContractStub> contracts) {
+    List<Map<String, Object>> payloads =
+        contracts.stream()
             .map(
-                coverage ->
+                contract ->
                     contractPayload(
                         orgId,
                         productId,
-                        startDate,
-                        endDate,
-                        coverage.entrySet().stream()
+                        contract.startDate(),
+                        contract.endDate(),
+                        contract.metricCoverage().entrySet().stream()
                             .map(entry -> contractMetric(entry.getKey(), entry.getValue()))
-                            .toList()))
+                            .toList(),
+                        contract.licenseId()))
             .toList();
-    registerContractsStub(orgId, productId, contracts);
-  }
-
-  /**
-   * Setup the contracts API to return contract coverage with a custom date range.
-   *
-   * @param orgId Organization ID
-   * @param productId Product ID
-   * @param metricId Contract metric ID (e.g., "redhat.com:storage_gibibytes_months")
-   * @param coverageValue The amount of coverage provided by the contract
-   * @param startDate Contract start date (inclusive)
-   * @param endDate Contract end date (exclusive for usage comparison)
-   */
-  public void setupContractCoverage(
-      String orgId,
-      String productId,
-      String metricId,
-      double coverageValue,
-      OffsetDateTime startDate,
-      OffsetDateTime endDate) {
-    registerContractStub(
-        orgId,
-        productId,
-        startDate,
-        endDate,
-        List.of(Map.of("metric_id", metricId, "value", coverageValue)));
+    registerContractsStub(orgId, productId, payloads);
   }
 
   /**
@@ -162,7 +129,9 @@ public class ContractsWiremockService extends WiremockService {
       OffsetDateTime endDate,
       List<?> metrics) {
     registerContractsStub(
-        orgId, productId, List.of(contractPayload(orgId, productId, startDate, endDate, metrics)));
+        orgId,
+        productId,
+        List.of(contractPayload(orgId, productId, startDate, endDate, metrics, null)));
   }
 
   private static Map<String, Object> contractPayload(
@@ -170,18 +139,18 @@ public class ContractsWiremockService extends WiremockService {
       String productId,
       OffsetDateTime startDate,
       OffsetDateTime endDate,
-      List<?> metrics) {
-    return Map.of(
-        "org_id",
-        orgId,
-        "product_id",
-        productId,
-        "start_date",
-        startDate.toString(),
-        "end_date",
-        endDate.toString(),
-        "metrics",
-        metrics);
+      List<?> metrics,
+      String licenseId) {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("org_id", orgId);
+    payload.put("product_id", productId);
+    payload.put("start_date", startDate.toString());
+    payload.put("end_date", endDate.toString());
+    payload.put("metrics", metrics);
+    if (licenseId != null) {
+      payload.put("license_id", licenseId);
+    }
+    return payload;
   }
 
   private static Map<String, Object> contractMetric(String metricId, double coverageValue) {

--- a/swatch-billable-usage/ct/java/domain/ContractStub.java
+++ b/swatch-billable-usage/ct/java/domain/ContractStub.java
@@ -18,23 +18,14 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.swatch.billable.usage.services.model;
+package domain;
 
-import lombok.Builder;
-import lombok.Getter;
+import java.time.OffsetDateTime;
+import java.util.Map;
 
-@Getter
-@Builder
-public class ContractCoverage {
-  private final String metricId;
-  private final boolean gratis;
-  private final double total;
-  private final String licenseId;
-
-  @Override
-  public String toString() {
-    return String.format(
-        "Coverage for metric '%s': %s%s licenseId=%s",
-        metricId, total, gratis ? "(Gratis)" : "", licenseId);
-  }
-}
+/** WireMock stub fields for one contracts-API agreement. */
+public record ContractStub(
+    OffsetDateTime startDate,
+    OffsetDateTime endDate,
+    Map<String, Double> metricCoverage,
+    String licenseId) {}

--- a/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
@@ -31,7 +31,9 @@ import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import domain.BillingProvider;
+import domain.ContractStub;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,12 +186,22 @@ public class ContractAdjustmentComponentTest extends BaseBillableUsageComponentT
   /** Stub two active contracts; billable-usage aggregates coverage across both. */
   private void givenMultipleRosaContractsWithEqualMetricCoverage(
       double firstContractBillableUnits, double secondContractBillableUnits) {
-    contractsWiremock.setupMultipleMultiMetricContracts(
+    OffsetDateTime startDate = OffsetDateTime.now().minusMonths(1);
+    OffsetDateTime endDate = OffsetDateTime.now().plusYears(1);
+    contractsWiremock.setupContracts(
         orgId,
         ROSA.getName(),
         List.of(
-            equalCoverageForAllRosaMetrics(firstContractBillableUnits),
-            equalCoverageForAllRosaMetrics(secondContractBillableUnits)));
+            new ContractStub(
+                startDate,
+                endDate,
+                equalCoverageForAllRosaMetrics(firstContractBillableUnits),
+                null),
+            new ContractStub(
+                startDate,
+                endDate,
+                equalCoverageForAllRosaMetrics(secondContractBillableUnits),
+                null)));
   }
 
   /** Stub contracts API so no contract exists for the org/product. */

--- a/swatch-billable-usage/ct/java/tests/ContractCoverageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/ContractCoverageComponentTest.java
@@ -26,31 +26,29 @@ import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import api.MessageValidators;
 import com.redhat.swatch.billable.usage.openapi.model.MonthlyRemittance;
 import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import domain.BillingProvider;
+import domain.ContractStub;
 import domain.RemittanceStatus;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import org.awaitility.Awaitility;
+import java.util.Map;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.TallySummary;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * Component tests for contract coverage integration with swatch-contracts (mocked via Wiremock).
- *
- * <p>See {@code swatch-billable-usage/TEST_PLAN.md} — Contract Coverage (TC001–TC008).
- */
 public class ContractCoverageComponentTest extends BaseBillableUsageComponentTest {
 
   private static final MetricId INSTANCE_HOURS = MetricIdUtils.getInstanceHours();
@@ -75,8 +73,8 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
     whenRosaTallyIsPublished(CORES.toString(), 20.0, OffsetDateTime.now(ZoneOffset.UTC));
 
-    thenEventuallyAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
-    thenEventuallyNoBillableUsageKafkaMessage(ROSA.getName());
+    thenAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
+    thenNoBillableUsageKafkaMessage(ROSA.getName());
   }
 
   @Test
@@ -89,7 +87,7 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     whenRosaTallyIsPublished(
         INSTANCE_HOURS.toString(), currentTotal, OffsetDateTime.now(ZoneOffset.UTC));
 
-    thenEventuallyAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 0.0);
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 0.0);
   }
 
   @Test
@@ -102,9 +100,9 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     TallySummary tallySummary =
         whenRosaTallyIsPublished(
             INSTANCE_HOURS.toString(), currentTotal, OffsetDateTime.now(ZoneOffset.UTC));
-    String tallyId = tallySummary.getTallySnapshots().get(0).getId().toString();
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
-    thenEventuallyTallyRemittancePendingValueEquals(tallyId, 1.0);
+    thenTallyRemittancePendingValueEquals(tallyId, 1.0);
   }
 
   @Test
@@ -116,9 +114,9 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     TallySummary tallySummary =
         whenRosaTallyIsPublished(
             INSTANCE_HOURS.toString(), currentTotal, OffsetDateTime.now(ZoneOffset.UTC));
-    String tallyId = tallySummary.getTallySnapshots().get(0).getId().toString();
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
-    thenEventuallyTallyRemittancePendingValueEquals(tallyId, currentTotal);
+    thenTallyRemittancePendingValueEquals(tallyId, currentTotal);
   }
 
   @Test
@@ -129,10 +127,10 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
     TallySummary tallySummary =
         whenAnsibleTallyIsPublished(usageValue, ANSIBLE_GRATIS_SNAPSHOT_DATE);
-    String tallyId = tallySummary.getTallySnapshots().get(0).getId().toString();
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
-    thenEventuallyTallyRemittanceStatusEquals(tallyId, RemittanceStatus.GRATIS);
-    thenEventuallyNoBillableUsageKafkaMessage(ANSIBLE_AAP_MANAGED.getName());
+    thenTallyRemittanceStatusEquals(tallyId, RemittanceStatus.GRATIS);
+    thenNoBillableUsageKafkaMessage(ANSIBLE_AAP_MANAGED.getName());
   }
 
   @Test
@@ -143,10 +141,10 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
     TallySummary tallySummary =
         whenAnsibleTallyIsPublished(usageValue, ANSIBLE_NEXT_MONTH_SNAPSHOT_DATE);
-    String tallyId = tallySummary.getTallySnapshots().get(0).getId().toString();
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
-    thenEventuallyTallyRemittanceStatusEquals(tallyId, RemittanceStatus.PENDING);
-    thenEventuallyBillableUsageKafkaMessageEmitted(ANSIBLE_AAP_MANAGED.getName(), usageValue);
+    thenTallyRemittanceStatusEquals(tallyId, RemittanceStatus.PENDING);
+    thenBillableUsageKafkaMessageEmitted(ANSIBLE_AAP_MANAGED.getName(), usageValue);
   }
 
   @Test
@@ -159,7 +157,7 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
     whenRosaTallyIsPublished(CORES.toString(), currentTotal, OffsetDateTime.now(ZoneOffset.UTC));
 
-    thenEventuallyAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
+    thenAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
   }
 
   @Test
@@ -169,12 +167,182 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
     whenRosaTallyIsPublished(CORES.toString(), 8.0, OffsetDateTime.now(ZoneOffset.UTC));
 
-    thenEventuallyAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
-    thenEventuallyNoBillableUsageKafkaMessage(ROSA.getName());
+    thenAccountRemittanceEquals(ROSA.getName(), CORES.toString(), 0.0);
+    thenNoBillableUsageKafkaMessage(ROSA.getName());
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC009")
+  void shouldSkipRemittanceWhenUsageWithinMultiContractCoverage() {
+    String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusMonths(2),
+                end,
+                Map.of(awsDimension, 3.0),
+                "arn:aws:license-manager:1:license:a"),
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1),
+                end,
+                Map.of(awsDimension, 3.0),
+                "arn:aws:license-manager:1:license:b")));
+
+    whenRosaTallyIsPublished(INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
+
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 0.0);
+    // TODO(SWATCH-5443): restore once zero remitted value no longer emits BillableUsage to Kafka
+    // thenNoBillableUsageKafkaMessage(ROSA.getName());
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC010")
+  void shouldStampNewestLicenseIdWhenUsageExceedsCoverage() {
+    String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+    String newerLicense = "arn:aws:license-manager:1:license:newer";
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusMonths(2),
+                end,
+                Map.of(awsDimension, 2.0),
+                "arn:aws:license-manager:1:license:older"),
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1),
+                end,
+                Map.of(awsDimension, 2.0),
+                newerLicense)));
+
+    TallySummary tallySummary =
+        whenRosaTallyIsPublished(
+            INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+
+    thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, newerLicense);
+    thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, newerLicense);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC011")
+  void shouldSelectLicensedAgreementWhenMixedWithUnlicensed() {
+    String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+    String licensedId = "arn:aws:license-manager:1:license:only";
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusMonths(2),
+                end,
+                Map.of(awsDimension, 2.0),
+                licensedId),
+            new ContractStub(
+                OffsetDateTime.now(ZoneOffset.UTC).minusDays(10),
+                end,
+                Map.of(awsDimension, 2.0),
+                null)));
+
+    TallySummary tallySummary =
+        whenRosaTallyIsPublished(
+            INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+
+    thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, licensedId);
+    thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, licensedId);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC012")
+  void shouldBillWhenMixedGratisAndEstablishedAgreements() {
+    // Gratis requires EVERY active agreement to start after month start — not only the newest.
+    String awsDimension = ANSIBLE_AAP_MANAGED.getMetric(MANAGED_NODES).getAwsDimension();
+    OffsetDateTime monthStart = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = ANSIBLE_GRATIS_SNAPSHOT_DATE.plusYears(1);
+    String newestLicense = "arn:aws:license-manager:1:license:jan-15";
+    givenContracts(
+        ANSIBLE_AAP_MANAGED.getName(),
+        List.of(
+            new ContractStub(
+                monthStart,
+                end,
+                Map.of(awsDimension, 1.0),
+                "arn:aws:license-manager:1:license:jan-1"),
+            new ContractStub(
+                ANSIBLE_GRATIS_SNAPSHOT_DATE.withDayOfMonth(15),
+                end,
+                Map.of(awsDimension, 1.0),
+                newestLicense)));
+
+    TallySummary tallySummary = whenAnsibleTallyIsPublished(3.0, ANSIBLE_GRATIS_SNAPSHOT_DATE);
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+
+    thenTallyRemittanceStatusLicenseAndValueEquals(
+        tallyId, RemittanceStatus.PENDING, newestLicense, 1.0);
+    thenBillableUsageKafkaMessageWithLicense(ANSIBLE_AAP_MANAGED.getName(), 1.0, newestLicense);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC013")
+  void shouldMarkGratisWhenAllAgreementsAreGratisEligible() {
+    String awsDimension = ANSIBLE_AAP_MANAGED.getMetric(MANAGED_NODES).getAwsDimension();
+    OffsetDateTime snapshotDate = OffsetDateTime.of(2026, 1, 25, 12, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime end = snapshotDate.plusYears(1);
+    String newestLicense = "arn:aws:license-manager:1:license:jan-20";
+    givenContracts(
+        ANSIBLE_AAP_MANAGED.getName(),
+        List.of(
+            new ContractStub(
+                OffsetDateTime.of(2026, 1, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                end,
+                Map.of(awsDimension, 1.0),
+                "arn:aws:license-manager:1:license:jan-10"),
+            new ContractStub(
+                OffsetDateTime.of(2026, 1, 20, 12, 0, 0, 0, ZoneOffset.UTC),
+                end,
+                Map.of(awsDimension, 1.0),
+                newestLicense)));
+
+    TallySummary tallySummary = whenAnsibleTallyIsPublished(3.0, snapshotDate);
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+
+    thenTallyRemittanceStatusLicenseAndValueEquals(
+        tallyId, RemittanceStatus.GRATIS, newestLicense, 1.0);
+    thenNoBillableUsageKafkaMessage(ANSIBLE_AAP_MANAGED.getName());
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC014")
+  void shouldSelectLexicographicallySmallerLicenseOnTie() {
+    String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+    String smallerLicense = "arn:aws:license-manager:1:license:a";
+    String largerLicense = "arn:aws:license-manager:1:license:z";
+    OffsetDateTime sameStart = OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1);
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(sameStart, end, Map.of(awsDimension, 2.0), largerLicense),
+            new ContractStub(sameStart, end, Map.of(awsDimension, 2.0), smallerLicense)));
+
+    TallySummary tallySummary =
+        whenRosaTallyIsPublished(
+            INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+
+    thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, smallerLicense);
+    thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, smallerLicense);
   }
 
   private void givenNoContractExistsForRosa() {
     contractsWiremock.setupContractNotFound(orgId, ROSA.getName());
+  }
+
+  private void givenContracts(String productId, List<ContractStub> contracts) {
+    contractsWiremock.setupContracts(orgId, productId, contracts);
   }
 
   private void givenRosaContractWithEmptyMetrics() {
@@ -233,101 +401,131 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     return tallySummary;
   }
 
-  private void thenEventuallyAccountRemittanceEquals(
+  private void thenAccountRemittanceEquals(
       String productId, String metricId, double expectedRemittedValue) {
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(2))
-        .untilAsserted(
-            () -> {
-              List<MonthlyRemittance> remittances =
-                  service.getRemittances(
-                      productId,
-                      orgId,
-                      metricId,
-                      BillingProvider.AWS.toTallyApiModel().value(),
-                      billingAccountId);
-              assertFalse(remittances.isEmpty(), "Expected account remittance response");
-              assertEquals(
-                  expectedRemittedValue,
-                  remittances.get(0).getRemittedValue(),
-                  0.001,
-                  "Account remittance value mismatch");
-            });
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<MonthlyRemittance> remittances =
+              service.getRemittances(
+                  productId,
+                  orgId,
+                  metricId,
+                  BillingProvider.AWS.toTallyApiModel().value(),
+                  billingAccountId);
+          assertFalse(remittances.isEmpty(), "Expected account remittance response");
+          assertEquals(
+              expectedRemittedValue,
+              remittances.get(0).getRemittedValue(),
+              0.001,
+              "Account remittance value mismatch");
+        });
   }
 
-  private void thenEventuallyTallyRemittancePendingValueEquals(
+  private void thenTallyRemittancePendingValueEquals(
       String tallyId, double expectedRemittedPendingValue) {
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(2))
-        .untilAsserted(
-            () -> {
-              List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
-              assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
-              assertEquals(1, remittances.size(), "Expected one remittance for tally " + tallyId);
-              assertEquals(
-                  expectedRemittedPendingValue,
-                  remittances.get(0).getRemittedPendingValue(),
-                  0.001,
-                  "Remitted pending value mismatch");
-            });
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+          assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
+          assertEquals(1, remittances.size(), "Expected one remittance for tally " + tallyId);
+          assertEquals(
+              expectedRemittedPendingValue,
+              remittances.get(0).getRemittedPendingValue(),
+              0.001,
+              "Remitted pending value mismatch");
+        });
   }
 
-  private void thenEventuallyTallyRemittanceStatusEquals(
-      String tallyId, RemittanceStatus expectedStatus) {
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(2))
-        .untilAsserted(
-            () -> {
-              List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
-              assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
-              assertEquals(1, remittances.size(), "Expected one remittance for tally " + tallyId);
-              assertEquals(
-                  expectedStatus.name(),
-                  remittances.get(0).getStatus(),
-                  "Remittance status mismatch for tally " + tallyId);
-            });
+  private void thenTallyRemittanceStatusEquals(String tallyId, RemittanceStatus expectedStatus) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+          assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
+          assertEquals(1, remittances.size(), "Expected one remittance for tally " + tallyId);
+          assertEquals(
+              expectedStatus.name(),
+              remittances.get(0).getStatus(),
+              "Remittance status mismatch for tally " + tallyId);
+        });
   }
 
-  private void thenEventuallyNoBillableUsageKafkaMessage(String productId) {
-    Awaitility.await()
-        .during(Duration.ofSeconds(8))
-        .atMost(Duration.ofSeconds(15))
-        .pollInterval(Duration.ofSeconds(2))
-        .untilAsserted(
-            () ->
-                assertEquals(
-                    0,
-                    kafkaBridge
-                        .waitForKafkaMessage(
-                            BILLABLE_USAGE,
-                            MessageValidators.billableUsageMatches(orgId, productId),
-                            0,
-                            AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(2)))
-                        .size(),
-                    "Expected no billable-usage Kafka message for org/product"));
+  private void thenNoBillableUsageKafkaMessage(String productId) {
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                0,
+                kafkaBridge
+                    .waitForKafkaMessage(
+                        BILLABLE_USAGE,
+                        MessageValidators.billableUsageMatches(orgId, productId),
+                        0,
+                        AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(2)))
+                    .size(),
+                "Expected no billable-usage Kafka message for org/product"),
+        AwaitilitySettings.usingTimeout(Duration.ofSeconds(15)));
   }
 
-  private void thenEventuallyBillableUsageKafkaMessageEmitted(
-      String productId, double expectedValue) {
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(60))
-        .pollInterval(Duration.ofSeconds(2))
-        .untilAsserted(
-            () -> {
-              List<BillableUsage> messages =
-                  kafkaBridge.waitForKafkaMessage(
-                      BILLABLE_USAGE,
-                      MessageValidators.billableUsageMatchesWithValue(
-                          orgId, productId, expectedValue),
-                      1,
-                      AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(5)));
-              assertEquals(
+  private void thenBillableUsageKafkaMessageEmitted(String productId, double expectedValue) {
+    thenBillableUsageKafkaMessageWithLicense(productId, expectedValue, null);
+  }
+
+  private void thenTallyRemittancePendingValueAndLicenseEquals(
+      String tallyId, double expectedRemittedPendingValue, String expectedLicenseId) {
+    thenTallyRemittanceStatusLicenseAndValueEquals(
+        tallyId, null, expectedLicenseId, expectedRemittedPendingValue);
+  }
+
+  private void thenTallyRemittanceStatusLicenseAndValueEquals(
+      String tallyId,
+      RemittanceStatus expectedStatus,
+      String expectedLicenseId,
+      double expectedRemittedPendingValue) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+          assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
+          assertEquals(1, remittances.size(), "Expected one remittance for tally " + tallyId);
+          assertEquals(
+              expectedRemittedPendingValue,
+              remittances.get(0).getRemittedPendingValue(),
+              0.001,
+              "Remitted pending value mismatch");
+          if (expectedStatus != null) {
+            assertEquals(
+                expectedStatus.name(),
+                remittances.getFirst().getStatus(),
+                "Remittance status mismatch for tally " + tallyId);
+          }
+          String actualLicenseId = remittances.getFirst().getLicenseId();
+          if (expectedLicenseId == null) {
+            assertNull(actualLicenseId, "Expected null licenseId");
+          } else {
+            assertEquals(expectedLicenseId, actualLicenseId, "Remittance licenseId mismatch");
+          }
+        });
+  }
+
+  private void thenBillableUsageKafkaMessageWithLicense(
+      String productId, double expectedValue, String expectedLicenseId) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<BillableUsage> messages =
+              kafkaBridge.waitForKafkaMessage(
+                  BILLABLE_USAGE,
+                  MessageValidators.billableUsageMatchesWithValue(orgId, productId, expectedValue),
                   1,
-                  messages.size(),
-                  "Expected one billable-usage Kafka message for org/product/value");
-            });
+                  AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(5)));
+          assertEquals(
+              1,
+              messages.size(),
+              "Expected one billable-usage Kafka message for org/product/value");
+          String actualLicenseId = messages.getFirst().getLicenseId();
+          if (expectedLicenseId == null) {
+            assertNull(actualLicenseId, "Expected null licenseId on usage");
+          } else {
+            assertEquals(expectedLicenseId, actualLicenseId, "BillableUsage licenseId mismatch");
+          }
+        },
+        AwaitilitySettings.usingTimeout(Duration.ofSeconds(60)));
   }
 }

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageService.java
@@ -61,7 +61,7 @@ public class BillableUsageService {
   private final ApplicationClock clock;
   private final BillingProducer billingProducer;
   private final BillableUsageRemittanceRepository billableUsageRemittanceRepository;
-  private final ContractsController contractsController;
+  private final ContractCoverageService contractCoverageService;
   private final MeterProvider<Counter> coveredUsageCounter;
   private final MeterProvider<Counter> billableUsageCounter;
 
@@ -69,12 +69,12 @@ public class BillableUsageService {
       ApplicationClock clock,
       BillingProducer billingProducer,
       BillableUsageRemittanceRepository billableUsageRemittanceRepository,
-      ContractsController contractsController,
+      ContractCoverageService contractCoverageService,
       MeterRegistry meterRegistry) {
     this.clock = clock;
     this.billingProducer = billingProducer;
     this.billableUsageRemittanceRepository = billableUsageRemittanceRepository;
-    this.contractsController = contractsController;
+    this.contractCoverageService = contractCoverageService;
     this.coveredUsageCounter = Counter.builder(COVERED_USAGE_METRIC).withRegistry(meterRegistry);
     this.billableUsageCounter = Counter.builder(BILLABLE_USAGE_METRIC).withRegistry(meterRegistry);
   }
@@ -161,7 +161,7 @@ public class BillableUsageService {
   private ContractCoverage getContractCoverage(BillableUsage usage)
       throws ContractCoverageException {
     try {
-      return contractsController.getContractCoverage(usage);
+      return contractCoverageService.getContractCoverage(usage);
     } catch (ContractMissingException ex) {
       if (usage.getSnapshotDate().isAfter(OffsetDateTime.now().minus(30, ChronoUnit.MINUTES))) {
         log.warn(
@@ -250,6 +250,7 @@ public class BillableUsageService {
             .usage(usage.getUsage().value())
             .remittancePendingDate(clock.now())
             .tallyId(usage.getTallyId())
+            .licenseId(contractCoverage.getLicenseId())
             .status(
                 contractCoverage.isGratis() ? RemittanceStatus.GRATIS : RemittanceStatus.PENDING)
             .build();
@@ -263,6 +264,7 @@ public class BillableUsageService {
     usage.setStatus(
         contractCoverage.isGratis() ? BillableUsage.Status.GRATIS : BillableUsage.Status.PENDING);
     usage.setUuid(newRemittance.getUuid());
+    usage.setLicenseId(contractCoverage.getLicenseId());
   }
 
   private void updateBillableUsageMeter(BillableUsage usage, BillableUsageCalculation usageCalc) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractCoverageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractCoverageService.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import com.redhat.swatch.billable.usage.exceptions.ContractMissingException;
+import com.redhat.swatch.billable.usage.services.model.ContractCoverage;
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import com.redhat.swatch.clients.contracts.api.model.Metric;
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.clock.ApplicationClock;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+
+@Slf4j
+@ApplicationScoped
+public class ContractCoverageService {
+
+  private final ContractsController contractsController;
+  private final ApplicationClock clock;
+
+  public ContractCoverageService(ContractsController contractsController, ApplicationClock clock) {
+    this.contractsController = contractsController;
+    this.clock = clock;
+  }
+
+  public ContractCoverage getContractCoverage(BillableUsage usage) throws ContractMissingException {
+    String contractMetricId = getContractMetricId(usage);
+    boolean isGratis = isGratisContract(usage);
+    double total = 0.0;
+    String licenseId = null;
+    OffsetDateTime newestStartDate = null;
+
+    List<Contract> contracts = contractsController.getValidContracts(usage);
+    for (Contract contract : contracts) {
+      total += getValueByContractMetricId(contract, contractMetricId);
+      isGratis &= isContractCompatibleWithGratis(contract, usage);
+      if (isNewerOverageLicense(contract, newestStartDate, licenseId)) {
+        newestStartDate = contract.getStartDate();
+        licenseId = contract.getLicenseId();
+      }
+    }
+
+    ContractCoverage coverage =
+        ContractCoverage.builder()
+            .metricId(contractMetricId)
+            .gratis(isGratis)
+            .total(total)
+            .licenseId(licenseId)
+            .build();
+    log.debug("Total contract coverage is {} for usage {} ", coverage, usage);
+    return coverage;
+  }
+
+  private static boolean isGratisContract(BillableUsage usage) {
+    MetricId metricId = MetricId.fromString(usage.getMetricId());
+    return SubscriptionDefinition.isMetricGratis(usage.getProductId(), metricId);
+  }
+
+  private static double getValueByContractMetricId(Contract contract, String contractMetricId) {
+    return contract.getMetrics().stream()
+        .filter(metric -> metric.getMetricId().equals(contractMetricId))
+        .map(Metric::getValue)
+        .reduce(0, Integer::sum);
+  }
+
+  private static String getContractMetricId(BillableUsage usage) {
+    BillableUsage.BillingProvider billingProvider = usage.getBillingProvider();
+    String productId = usage.getProductId();
+    MetricId metricId = MetricId.fromString(usage.getMetricId());
+
+    String contractMetricId = null;
+    String measurementMetricId = metricId.toString();
+    if (BillableUsage.BillingProvider.AWS.equals(billingProvider)) {
+      contractMetricId = SubscriptionDefinition.getAwsDimension(productId, measurementMetricId);
+    } else if (BillableUsage.BillingProvider.RED_HAT.equals(billingProvider)) {
+      contractMetricId = SubscriptionDefinition.getRhmMetricId(productId, measurementMetricId);
+    } else if (BillableUsage.BillingProvider.AZURE.equals(billingProvider)) {
+      contractMetricId = SubscriptionDefinition.getAzureDimension(productId, measurementMetricId);
+    }
+
+    if (contractMetricId == null || contractMetricId.isEmpty()) {
+      throw new IllegalStateException(
+          String.format(
+              "Contract metric ID is not configured for billingProvider=%s product=%s metric=%s",
+              usage.getBillingProvider(), usage.getProductId(), usage.getMetricId()));
+    }
+
+    return contractMetricId;
+  }
+
+  /**
+   * Check whether contract start date applies the condition for a gratis usage: contract starts on
+   * the current month. See more in <a
+   * href="https://issues.redhat.com/browse/SWATCH-2571">SWATCH-2571</a>. contract starting in Jan
+   * First part billable usage in Jan -> gratis 'jan 2' != null && 'jan 2'.isAfter(startOfMonth('jan
+   * 4')) -> true && 'jan 2'.isAfter('jan 1') = true. Second part billable usage in Feb -> not 'jan
+   * 2' != null && 'jan 2'.isAfter(startOfMonth('feb 4')) -> true && 'jan 2'.isAfter('feb 1') =
+   * false
+   */
+  private boolean isContractCompatibleWithGratis(Contract contract, BillableUsage usage) {
+    OffsetDateTime startDate = contract.getStartDate();
+    return startDate != null && startDate.isAfter(clock.startOfMonth(usage.getSnapshotDate()));
+  }
+
+  /**
+   * Overage license selection: newest startDate wins; equal startDate → lexicographically smaller
+   * licenseId (deterministic fallback). Contracts without licenseId are ignored for selection
+   * (legacy); coverage still sums all valid contracts.
+   */
+  private static boolean isNewerOverageLicense(
+      Contract contract, OffsetDateTime newestStartDate, String selectedLicenseId) {
+    String licenseId = contract.getLicenseId();
+    if (licenseId == null || licenseId.isBlank()) {
+      return false;
+    }
+    // Use the candidate licenseId if and only if:
+    // - candidate agreement is newer
+    if (newestStartDate == null || newestStartDate.isBefore(contract.getStartDate())) {
+      return true;
+    }
+    // - or candidate has the same start date, then choose it by lexicographical order
+    if (newestStartDate.isEqual(contract.getStartDate())) {
+      return licenseId.compareTo(selectedLicenseId) < 0;
+    }
+    return false;
+  }
+}

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractsController.java
@@ -23,21 +23,15 @@ package com.redhat.swatch.billable.usage.services;
 import com.redhat.swatch.billable.usage.exceptions.ContractMissingException;
 import com.redhat.swatch.billable.usage.exceptions.ErrorCode;
 import com.redhat.swatch.billable.usage.exceptions.ExternalServiceException;
-import com.redhat.swatch.billable.usage.services.model.ContractCoverage;
 import com.redhat.swatch.clients.contracts.api.model.Contract;
-import com.redhat.swatch.clients.contracts.api.model.Metric;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
 import com.redhat.swatch.clients.contracts.api.resources.DefaultApi;
-import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import com.redhat.swatch.faulttolerance.api.RetryWithExponentialBackoff;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.candlepin.clock.ApplicationClock;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -45,30 +39,16 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 @ApplicationScoped
 public class ContractsController {
   @RestClient DefaultApi contractsApi;
-  @Inject ApplicationClock clock;
 
   @RetryWithExponentialBackoff(
       maxRetries = "${CONTRACT_CLIENT_MAX_ATTEMPTS:1}",
       delay = "${CONTRACT_CLIENT_BACK_OFF_INITIAL_INTERVAL_MILLIS:1000ms}",
       maxDelay = "${CONTRACT_CLIENT_BACK_OFF_MAX_INTERVAL_MILLIS:64s}",
       factor = "${CONTRACT_CLIENT_BACK_OFF_MULTIPLIER:2}")
-  public ContractCoverage getContractCoverage(BillableUsage usage) throws ContractMissingException {
+  public List<Contract> getValidContracts(BillableUsage usage) throws ContractMissingException {
     if (!SubscriptionDefinition.isContractEnabled(usage.getProductId())) {
       throw new IllegalStateException(
           String.format("Product %s is not contract enabled.", usage.getProductId()));
-    }
-
-    String contractMetricId =
-        getContractMetricId(
-            usage.getBillingProvider(),
-            usage.getProductId(),
-            MetricId.fromString(usage.getMetricId()));
-
-    if (contractMetricId == null || contractMetricId.isEmpty()) {
-      throw new IllegalStateException(
-          String.format(
-              "Contract metric ID is not configured for billingProvider=%s product=%s metric=%s",
-              usage.getBillingProvider(), usage.getProductId(), usage.getMetricId()));
     }
 
     log.debug("Looking up contract information for usage {}", usage);
@@ -94,42 +74,7 @@ public class ContractsController {
           String.format("No contract info found for usage! %s", usage));
     }
 
-    MetricId metricId = MetricId.fromString(usage.getMetricId());
-    boolean isGratisContract =
-        SubscriptionDefinition.isMetricGratis(usage.getProductId(), metricId);
-    double total = 0;
-    for (Contract contract : contracts) {
-      if (isValidContract(contract, usage)) {
-        var value =
-            contract.getMetrics().stream()
-                .filter(metric -> metric.getMetricId().equals(contractMetricId))
-                .map(Metric::getValue)
-                .reduce(0, Integer::sum);
-        isGratisContract &= isContractCompatibleWithGratis(contract, usage);
-        total += value;
-      }
-    }
-
-    log.debug("Total contract coverage is {} for usage {} ", total, usage);
-    return ContractCoverage.builder()
-        .metricId(contractMetricId)
-        .gratis(isGratisContract)
-        .total(total)
-        .build();
-  }
-
-  /**
-   * Check whether contract start date applies the condition for a gratis usage: contract starts on
-   * the current month. See more in <a
-   * href="https://issues.redhat.com/browse/SWATCH-2571">SWATCH-2571</a>. contract starting in Jan
-   * First part billable usage in Jan -> gratis 'jan 2' != null && 'jan 2'.isAfter(startOfMonth('jan
-   * 4')) -> true && 'jan 2'.isAfter('jan 1') = true. Second part billable usage in Feb -> not 'jan
-   * 2' != null && 'jan 2'.isAfter(startOfMonth('feb 4')) -> true && 'jan 2'.isAfter('feb 1') =
-   * false
-   */
-  private boolean isContractCompatibleWithGratis(Contract contract, BillableUsage usage) {
-    OffsetDateTime startDate = contract.getStartDate();
-    return startDate != null && startDate.isAfter(clock.startOfMonth(usage.getSnapshotDate()));
+    return contracts.stream().filter(contract -> isValidContract(contract, usage)).toList();
   }
 
   private boolean isValidContract(Contract contract, BillableUsage usage) {
@@ -138,18 +83,5 @@ public class ContractsController {
         Objects.isNull(contract.getEndDate())
             || usage.getSnapshotDate().isBefore(contract.getEndDate());
     return isWithinStart && isWithinEnd;
-  }
-
-  private String getContractMetricId(
-      BillableUsage.BillingProvider billingProvider, String productId, MetricId metricId) {
-    String measurementMetricId = metricId.toString();
-    if (BillableUsage.BillingProvider.AWS.equals(billingProvider)) {
-      return SubscriptionDefinition.getAwsDimension(productId, measurementMetricId);
-    } else if (BillableUsage.BillingProvider.RED_HAT.equals(billingProvider)) {
-      return SubscriptionDefinition.getRhmMetricId(productId, measurementMetricId);
-    } else if (BillableUsage.BillingProvider.AZURE.equals(billingProvider)) {
-      return SubscriptionDefinition.getAzureDimension(productId, measurementMetricId);
-    }
-    return null;
   }
 }

--- a/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
@@ -283,6 +283,9 @@ components:
           nullable: true
         tallyId:
           type: string
+        licenseId:
+          type: string
+          nullable: true
     Error:
       required:
         - status

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageServiceTest.java
@@ -98,7 +98,6 @@ class BillableUsageServiceTest {
 
   @Inject ApplicationClock clock;
   @Inject BillableUsageService service;
-  @Inject BillableUsageService billableUsageService;
   @Inject MeterRegistry meterRegistry;
 
   private final SubscriptionDefinitionRegistry mockSubscriptionDefinitionRegistry =
@@ -136,6 +135,35 @@ class BillableUsageServiceTest {
     thenRemittanceIsUpdated(usage, 1.0);
     thenUsageIsSent(usage, 1.0);
     thenBillableMeterMatches(usage, 1.0);
+  }
+
+  @Test
+  void monthlyWindowStampsSelectedLicenseIdOnRemittanceAndUsage() throws ApiException {
+    BillableUsage usage = givenInstanceHoursUsageForRosa(0.0003);
+    Contract older = contractWithCoverage(usage, 0);
+    older.setStartDate(usage.getSnapshotDate().minusMonths(2));
+    older.setLicenseId("arn:aws:license-manager:us-east-1:1:license:older");
+    Contract newer = contractWithCoverage(usage, 0);
+    newer.setStartDate(usage.getSnapshotDate().minusDays(5));
+    newer.setLicenseId("arn:aws:license-manager:us-east-1:1:license:newer");
+    givenContractApiReturnsContracts(older, newer);
+
+    service.submitBillableUsage(usage);
+
+    thenRemittanceIsUpdated(usage, 1.0, newer.getLicenseId());
+    thenUsageIsSent(usage, 1.0, newer.getLicenseId());
+    thenBillableMeterMatches(usage, 1.0);
+  }
+
+  @Test
+  void monthlyWindowKeepsNullLicenseIdWhenContractsHaveNone() {
+    BillableUsage usage = givenInstanceHoursUsageForRosa(0.0003);
+    givenExistingContractForUsage(usage);
+
+    service.submitBillableUsage(usage);
+
+    thenRemittanceIsUpdated(usage, 1.0, null);
+    thenUsageIsSent(usage, 1.0, null);
   }
 
   @Test
@@ -819,6 +847,11 @@ class BillableUsageServiceTest {
   }
 
   private void thenUsageIsSent(BillableUsage usage, double expectedValue) {
+    thenUsageIsSent(usage, expectedValue, null);
+  }
+
+  private void thenUsageIsSent(
+      BillableUsage usage, double expectedValue, String expectedLicenseId) {
     verify(producer)
         .produce(
             argThat(
@@ -827,6 +860,7 @@ class BillableUsageServiceTest {
                   assertEquals(usage.getTallyId(), output.getTallyId());
                   assertEquals(expectedValue, output.getValue());
                   assertEquals(usage.getCurrentTotal(), output.getCurrentTotal());
+                  assertEquals(expectedLicenseId, output.getLicenseId());
                   return true;
                 }));
   }
@@ -867,13 +901,19 @@ class BillableUsageServiceTest {
   }
 
   private void thenRemittanceIsUpdated(BillableUsage usage, double expectedRemittedPendingValue) {
-    thenRemittanceIsUpdated(usage, CLOCK.now(), expectedRemittedPendingValue, null);
+    thenRemittanceIsUpdated(usage, CLOCK.now(), expectedRemittedPendingValue, null, null);
+  }
+
+  private void thenRemittanceIsUpdated(
+      BillableUsage usage, double expectedRemittedPendingValue, String expectedLicenseId) {
+    thenRemittanceIsUpdated(
+        usage, CLOCK.now(), expectedRemittedPendingValue, null, expectedLicenseId);
   }
 
   private void thenRemittanceIsUpdatedWithStatusGratis(
       BillableUsage usage, double expectedRemittedPendingValue) {
     thenRemittanceIsUpdated(
-        usage, clock.now(), expectedRemittedPendingValue, RemittanceStatus.GRATIS);
+        usage, clock.now(), expectedRemittedPendingValue, RemittanceStatus.GRATIS, null);
   }
 
   private void thenRemittanceIsUpdated(
@@ -881,6 +921,16 @@ class BillableUsageServiceTest {
       OffsetDateTime expectedAccumulationPeriodDate,
       double expectedRemittedPendingValue,
       RemittanceStatus expectedStatus) {
+    thenRemittanceIsUpdated(
+        usage, expectedAccumulationPeriodDate, expectedRemittedPendingValue, expectedStatus, null);
+  }
+
+  private void thenRemittanceIsUpdated(
+      BillableUsage usage,
+      OffsetDateTime expectedAccumulationPeriodDate,
+      double expectedRemittedPendingValue,
+      RemittanceStatus expectedStatus,
+      String expectedLicenseId) {
     verify(remittanceRepo)
         .persistAndFlush(
             argThat(
@@ -898,6 +948,7 @@ class BillableUsageServiceTest {
                   if (expectedStatus != null) {
                     assertEquals(expectedStatus, remittance.getStatus());
                   }
+                  assertEquals(expectedLicenseId, remittance.getLicenseId());
                   return true;
                 }));
   }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractCoverageServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractCoverageServiceTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.billable.usage.services.model.ContractCoverage;
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import com.redhat.swatch.clients.contracts.api.model.Metric;
+import com.redhat.swatch.clients.contracts.api.resources.DefaultApi;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
+import com.redhat.swatch.configuration.registry.SubscriptionDefinitionRegistry;
+import com.redhat.swatch.configuration.registry.Variant;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import org.candlepin.clock.ApplicationClock;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ContractCoverageServiceTest {
+  private static final String CONTRACT_METRIC_ID = "four_vcpu_0";
+  private static final String CONTRACT_CONTROL_PLANE_METRIC_ID = "control_plane_0";
+  private static final String CORES = "Cores";
+
+  private static SubscriptionDefinitionRegistry originalReference;
+
+  @InjectMock @RestClient DefaultApi contractsApi;
+  @Inject ApplicationClock clock;
+  @Inject ContractCoverageService contractCoverageService;
+  private SubscriptionDefinitionRegistry subscriptionDefinitionRegistry;
+
+  @BeforeAll
+  static void setupClass() {
+    originalReference = SubscriptionDefinitionRegistry.getInstance();
+  }
+
+  @AfterAll
+  static void tearDownClass() throws Exception {
+    Field instance = SubscriptionDefinitionRegistry.class.getDeclaredField("instance");
+    instance.setAccessible(true);
+    instance.set(instance, originalReference);
+  }
+
+  @BeforeEach
+  void setupTest() {
+    subscriptionDefinitionRegistry = mock(SubscriptionDefinitionRegistry.class);
+    setMock(subscriptionDefinitionRegistry);
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Reset so stubbed SubscriptionDefinitions do not pollute the tag cache for later tests.
+    SubscriptionDefinitionRegistry.reset();
+  }
+
+  private void setMock(SubscriptionDefinitionRegistry mock) {
+    try {
+      Field instance = SubscriptionDefinitionRegistry.class.getDeclaredField("instance");
+      instance.setAccessible(true);
+      instance.set(instance, mock);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testIllegalStateExceptionThrownWhenMetricIdIsNotFoundForBillingProvider() {
+    BillableUsage usage = defaultUsage();
+
+    var variant = Variant.builder().tag(usage.getProductId()).build();
+    var metric = new com.redhat.swatch.configuration.registry.Metric();
+    metric.setId(usage.getMetricId());
+    var subscriptionDefinition =
+        SubscriptionDefinition.builder()
+            .contractEnabled(true)
+            .variants(Set.of(variant))
+            .metrics(Set.of(metric))
+            .build();
+    variant.setSubscription(subscriptionDefinition);
+    when(subscriptionDefinitionRegistry.getSubscriptions())
+        .thenReturn(List.of(subscriptionDefinition));
+
+    assertThrows(
+        IllegalStateException.class, () -> contractCoverageService.getContractCoverage(usage));
+  }
+
+  @Test
+  void testIllegalStateExceptionThrownWhenMetricIdIsConfiguredAsEmptyForBillingProvider() {
+    BillableUsage usage = defaultUsage();
+    createSubscriptionDefinition(usage.getProductId(), usage.getMetricId(), null, "", true, false);
+
+    assertThrows(
+        IllegalStateException.class, () -> contractCoverageService.getContractCoverage(usage));
+  }
+
+  @Test
+  void testGetContractCoverageIncludesMetricValuesFromAllContracts() throws Exception {
+    BillableUsage usage = defaultUsage();
+    Contract contract1 = contractFromUsage(usage);
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
+
+    Contract contract2 = contractFromUsage(usage);
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(40));
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
+
+    givenContractHasMetricWithContractEnabled(usage);
+    stubContracts(usage, List.of(contract1, contract2));
+
+    ContractCoverage contractCoverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(140, contractCoverage.getTotal());
+  }
+
+  @Test
+  void testOverageLicenseIdSelectsNewestStartDate() throws Exception {
+    BillableUsage usage = defaultUsage();
+    givenContractHasMetricWithContractEnabled(usage);
+
+    Contract older = contractFromUsage(usage);
+    older.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
+    older.setLicenseId("arn:aws:license-manager:us-east-1:1:license:older");
+    older.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    Contract newer = contractFromUsage(usage);
+    newer.setStartDate(clock.startOfCurrentMonth().minusMonths(1));
+    newer.setLicenseId("arn:aws:license-manager:us-east-1:1:license:newer");
+    newer.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    stubContracts(usage, List.of(older, newer));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(100, coverage.getTotal());
+    assertEquals(newer.getLicenseId(), coverage.getLicenseId());
+  }
+
+  @Test
+  void testOverageLicenseIdNullWhenNoContractHasLicenseId() throws Exception {
+    BillableUsage usage = defaultUsage();
+    givenContractHasMetricWithContractEnabled(usage);
+
+    Contract contract = contractFromUsage(usage);
+    contract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+
+    stubContracts(usage, List.of(contract));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(100, coverage.getTotal());
+    assertNull(coverage.getLicenseId());
+  }
+
+  @Test
+  void testOverageLicenseIdIgnoresBlankLicenseId() throws Exception {
+    BillableUsage usage = defaultUsage();
+    givenContractHasMetricWithContractEnabled(usage);
+
+    Contract blankLicense = contractFromUsage(usage);
+    blankLicense.setStartDate(clock.startOfCurrentMonth().minusDays(5));
+    blankLicense.setLicenseId(" ");
+    blankLicense.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(40));
+
+    Contract licensed = contractFromUsage(usage);
+    licensed.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
+    licensed.setLicenseId("arn:aws:license-manager:us-east-1:1:license:real");
+    licensed.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(60));
+
+    stubContracts(usage, List.of(blankLicense, licensed));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(100, coverage.getTotal());
+    assertEquals(licensed.getLicenseId(), coverage.getLicenseId());
+  }
+
+  @Test
+  void testOverageLicenseIdLexicographicTieBreakWhenSameStartDate() throws Exception {
+    BillableUsage usage = defaultUsage();
+    givenContractHasMetricWithContractEnabled(usage);
+    OffsetDateTime sameStart = clock.startOfCurrentMonth().minusMonths(1);
+    String smallerLicense = "arn:aws:license-manager:us-east-1:1:license:a";
+    String largerLicense = "arn:aws:license-manager:us-east-1:1:license:z";
+
+    Contract largerFirst = contractFromUsage(usage);
+    largerFirst.setStartDate(sameStart);
+    largerFirst.setLicenseId(largerLicense);
+    largerFirst.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    Contract smallerSecond = contractFromUsage(usage);
+    smallerSecond.setStartDate(sameStart);
+    smallerSecond.setLicenseId(smallerLicense);
+    smallerSecond.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    // Larger licenseId first in list; smaller must still win.
+    stubContracts(usage, List.of(largerFirst, smallerSecond));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(100, coverage.getTotal());
+    assertEquals(smallerLicense, coverage.getLicenseId());
+  }
+
+  @Test
+  void testOverageLicenseIdFromLicensedSetOnlyWhileCoverageSumsMixed() throws Exception {
+    BillableUsage usage = defaultUsage();
+    givenContractHasMetricWithContractEnabled(usage);
+
+    Contract unlicensed = contractFromUsage(usage);
+    unlicensed.setStartDate(clock.startOfCurrentMonth().minusDays(5));
+    unlicensed.setLicenseId(null);
+    unlicensed.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(30));
+
+    Contract licensed = contractFromUsage(usage);
+    licensed.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
+    licensed.setLicenseId("arn:aws:license-manager:us-east-1:1:license:only");
+    licensed.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(70));
+
+    stubContracts(usage, List.of(unlicensed, licensed));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(100, coverage.getTotal());
+    assertEquals(licensed.getLicenseId(), coverage.getLicenseId());
+  }
+
+  @Test
+  void testGetContractCoverageIncludesMetricValuesFromAllMetricsOfAContract() throws Exception {
+    BillableUsage usage = defaultUsage();
+    Contract contract1 = contractFromUsage(usage);
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    Contract contract2 = contractFromUsage(usage);
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
+
+    stubContracts(usage, List.of(contract1, contract2));
+    givenContractHasMetricWithContractEnabled(usage);
+
+    ContractCoverage contractCoverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(200, contractCoverage.getTotal());
+  }
+
+  @Test
+  void testSingleGratisEligibleAgreementIsGratisWithItsLicenseId() throws Exception {
+    BillableUsage usage = defaultUsage();
+    usage.setSnapshotDate(clock.startOfCurrentMonth().plusDays(24));
+    givenContractHasMetricWithGratisEnabled(usage);
+
+    String licenseId = "arn:aws:license-manager:us-east-1:1:license:gratis-only";
+    Contract agreement = contractFromUsage(usage);
+    agreement.setStartDate(clock.startOfCurrentMonth().plusDays(14));
+    agreement.setEndDate(null);
+    agreement.setLicenseId(licenseId);
+    agreement.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    stubContracts(usage, List.of(agreement));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertTrue(coverage.isGratis());
+    assertEquals(50, coverage.getTotal());
+    assertEquals(licenseId, coverage.getLicenseId());
+  }
+
+  @Test
+  void testMixedGratisAndEstablishedAgreementsIsNotGratisAndSelectsNewestLicenseId()
+      throws Exception {
+    BillableUsage usage = defaultUsage();
+    usage.setSnapshotDate(clock.startOfCurrentMonth().plusDays(24));
+    givenContractHasMetricWithGratisEnabled(usage);
+
+    Contract establishedEarlyMonth = contractFromUsage(usage);
+    establishedEarlyMonth.setStartDate(clock.startOfCurrentMonth());
+    establishedEarlyMonth.setEndDate(null);
+    establishedEarlyMonth.setLicenseId("arn:aws:license-manager:us-east-1:1:license:apr-1");
+    establishedEarlyMonth.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
+
+    Contract establishedPriorMonth = contractFromUsage(usage);
+    establishedPriorMonth.setStartDate(clock.startOfCurrentMonth().minusMonths(1));
+    establishedPriorMonth.setEndDate(null);
+    establishedPriorMonth.setLicenseId("arn:aws:license-manager:us-east-1:1:license:mar-1");
+    establishedPriorMonth.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+
+    Contract midMonth = contractFromUsage(usage);
+    midMonth.setStartDate(clock.startOfCurrentMonth().plusDays(14));
+    midMonth.setEndDate(null);
+    midMonth.setLicenseId("arn:aws:license-manager:us-east-1:1:license:apr-15");
+    midMonth.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+
+    stubContracts(usage, List.of(establishedEarlyMonth, establishedPriorMonth, midMonth));
+
+    ContractCoverage coverage = contractCoverageService.getContractCoverage(usage);
+    assertFalse(coverage.isGratis());
+    assertEquals(250, coverage.getTotal());
+    assertEquals(midMonth.getLicenseId(), coverage.getLicenseId());
+  }
+
+  @Test
+  void testAllGratisEligibleAgreementsIsGratisAndSelectsNewestLicenseId() throws Exception {
+    BillableUsage usage = defaultUsage();
+    Contract gratisContract = contractFromUsage(usage);
+    gratisContract.setStartDate(clock.startOfCurrentMonth().plusHours(1));
+    gratisContract.setLicenseId("arn:aws:license-manager:us-east-1:1:license:a");
+    gratisContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+
+    Contract anotherGratisContract = contractFromUsage(usage);
+    anotherGratisContract.setStartDate(clock.startOfCurrentMonth().plusHours(2));
+    anotherGratisContract.setLicenseId("arn:aws:license-manager:us-east-1:1:license:b");
+    anotherGratisContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
+
+    stubContracts(usage, List.of(gratisContract, anotherGratisContract));
+    givenContractHasMetricWithGratisEnabled(usage);
+
+    ContractCoverage contractCoverage = contractCoverageService.getContractCoverage(usage);
+    assertTrue(contractCoverage.isGratis());
+    assertEquals(125, contractCoverage.getTotal());
+    assertEquals(anotherGratisContract.getLicenseId(), contractCoverage.getLicenseId());
+  }
+
+  @Test
+  void testContractsFilteredByDateWhenGettingCoverage() throws Exception {
+    BillableUsage usage = defaultUsage();
+
+    Contract contract1 = contractFromUsage(usage);
+    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+
+    Contract contract2 = contractFromUsage(usage);
+    contract2.setEndDate(clock.endOfMonth(contract2.getStartDate()));
+    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
+
+    Contract contract3 = contractFromUsage(usage);
+    contract3.setStartDate(clock.startOfCurrentMonth().plusMonths(1));
+    contract3.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(5));
+
+    Contract contract4 = contractFromUsage(usage);
+    contract4.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
+    contract4.setEndDate(clock.endOfMonth(contract4.getStartDate().plusMonths(1)));
+    contract4.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(10));
+
+    givenContractHasMetricWithContractEnabled(usage);
+    stubContracts(usage, List.of(contract1, contract2, contract3, contract4));
+
+    ContractCoverage contractCoverage = contractCoverageService.getContractCoverage(usage);
+    assertEquals(125, contractCoverage.getTotal());
+  }
+
+  private void stubContracts(BillableUsage usage, List<Contract> contracts) throws Exception {
+    when(contractsApi.getContract(
+            usage.getOrgId(),
+            usage.getProductId(),
+            usage.getVendorProductCode(),
+            usage.getBillingProvider().value(),
+            usage.getBillingAccountId(),
+            usage.getSnapshotDate()))
+        .thenReturn(contracts);
+  }
+
+  private BillableUsage defaultUsage() {
+    return new BillableUsage()
+        .withOrgId("org123")
+        .withProductId("RHEL Server")
+        .withValue(24.5)
+        .withUsage(BillableUsage.Usage.PRODUCTION)
+        .withBillingAccountId("ba123")
+        .withSla(BillableUsage.Sla.PREMIUM)
+        .withBillingProvider(BillableUsage.BillingProvider.AWS)
+        .withMetricId(CORES.toUpperCase())
+        .withVendorProductCode("vendor_product_code")
+        .withSnapshotDate(clock.now());
+  }
+
+  private Contract contractFromUsage(BillableUsage usage) {
+    return new Contract()
+        .orgId(usage.getOrgId())
+        .productTags(List.of(usage.getProductId()))
+        .endDate(null)
+        .billingAccountId(usage.getBillingAccountId())
+        .billingProvider(usage.getBillingProvider().value())
+        .startDate(clock.startOfMonth(usage.getSnapshotDate()));
+  }
+
+  private void givenContractHasMetricWithGratisEnabled(BillableUsage usage) {
+    createSubscriptionDefinition(usage.getProductId(), CORES, CONTRACT_METRIC_ID, null, true, true);
+  }
+
+  private void givenContractHasMetricWithContractEnabled(BillableUsage usage) {
+    createSubscriptionDefinition(
+        usage.getProductId(), CORES, CONTRACT_METRIC_ID, null, true, false);
+  }
+
+  private void createSubscriptionDefinition(
+      String tag,
+      String metricId,
+      String awsDimension,
+      String rhmDimension,
+      boolean contractEnabled,
+      boolean gratisEnabled) {
+    var variant = Variant.builder().tag(tag).build();
+    var awsMetric =
+        com.redhat.swatch.configuration.registry.Metric.builder()
+            .awsDimension(awsDimension)
+            .rhmMetricId(rhmDimension)
+            .enableGratisUsage(gratisEnabled)
+            .id(metricId)
+            .build();
+    var subscriptionDefinition =
+        SubscriptionDefinition.builder()
+            .contractEnabled(contractEnabled)
+            .variants(Set.of(variant))
+            .metrics(Set.of(awsMetric))
+            .build();
+    variant.setSubscription(subscriptionDefinition);
+    when(subscriptionDefinitionRegistry.getSubscriptions())
+        .thenReturn(List.of(subscriptionDefinition));
+  }
+}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractsControllerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractsControllerTest.java
@@ -21,9 +21,7 @@
 package com.redhat.swatch.billable.usage.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -33,7 +31,6 @@ import static org.mockito.Mockito.when;
 import com.redhat.swatch.billable.usage.exceptions.ContractMissingException;
 import com.redhat.swatch.billable.usage.exceptions.ErrorCode;
 import com.redhat.swatch.billable.usage.exceptions.ExternalServiceException;
-import com.redhat.swatch.billable.usage.services.model.ContractCoverage;
 import com.redhat.swatch.clients.contracts.api.model.Contract;
 import com.redhat.swatch.clients.contracts.api.model.Metric;
 import com.redhat.swatch.clients.contracts.api.resources.ApiException;
@@ -61,7 +58,6 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 class ContractsControllerTest {
   private static final String CONTRACT_METRIC_ID = "four_vcpu_0";
-  private static final String CONTRACT_CONTROL_PLANE_METRIC_ID = "control_plane_0";
   private static final String CORES = "Cores";
 
   private static SubscriptionDefinitionRegistry originalReference;
@@ -124,23 +120,19 @@ class ContractsControllerTest {
   void testThrowsIllegalStateExceptionWhenProductIsNotContractEnabled() {
     BillableUsage usage = defaultUsage();
     createSubscriptionDefinition(
-        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, false, false);
+        usage.getProductId(), usage.getMetricId(), CONTRACT_METRIC_ID, null, false);
     IllegalStateException e =
-        assertThrows(IllegalStateException.class, () -> controller.getContractCoverage(usage));
+        assertThrows(IllegalStateException.class, () -> controller.getValidContracts(usage));
     assertEquals(
         String.format("Product %s is not contract enabled.", usage.getProductId()), e.getMessage());
   }
 
   @Test
-  void testContractApiCallMadeWithConfiguredAwsDimensionAsMetricIdWhenBillingProviderIsAws()
-      throws Exception {
+  void testContractApiCalledWithUsageParameters() throws Exception {
     BillableUsage usage = defaultUsage();
-
-    Contract contract1 = contractFromUsage(usage);
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithContractEnabled(usage);
+    Contract contract = contractFromUsage(usage);
+    contract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+    givenContractEnabled(usage);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -149,9 +141,10 @@ class ContractsControllerTest {
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
             usage.getSnapshotDate()))
-        .thenReturn(List.of(contract1));
+        .thenReturn(List.of(contract));
 
-    controller.getContractCoverage(usage);
+    List<Contract> contracts = controller.getValidContracts(usage);
+    assertEquals(1, contracts.size());
 
     verify(contractsApi)
         .getContract(
@@ -164,16 +157,28 @@ class ContractsControllerTest {
   }
 
   @Test
-  void testContractApiMadeWithConfiguredRhmMetricsAsMetricId() throws Exception {
+  void testContractsFilteredByDate() throws Exception {
     BillableUsage usage = defaultUsage();
-    usage.setBillingProvider(BillableUsage.BillingProvider.RED_HAT);
 
-    Contract contract1 = contractFromUsage(usage);
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
+    Contract validOpenEnded = contractFromUsage(usage);
+    validOpenEnded.setEndDate(null);
+    validOpenEnded.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
 
-    // Make sure product is contract enabled.
-    createSubscriptionDefinition(
-        usage.getProductId(), usage.getMetricId(), null, CONTRACT_METRIC_ID, true, false);
+    Contract validEndingThisMonth = contractFromUsage(usage);
+    validEndingThisMonth.setEndDate(clock.endOfMonth(validEndingThisMonth.getStartDate()));
+    validEndingThisMonth.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
+
+    Contract future = contractFromUsage(usage);
+    future.setStartDate(clock.startOfCurrentMonth().plusMonths(1));
+    future.setEndDate(null);
+    future.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(5));
+
+    Contract expired = contractFromUsage(usage);
+    expired.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
+    expired.setEndDate(clock.endOfMonth(expired.getStartDate().plusMonths(1)));
+    expired.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(10));
+
+    givenContractEnabled(usage);
 
     when(contractsApi.getContract(
             usage.getOrgId(),
@@ -182,231 +187,22 @@ class ContractsControllerTest {
             usage.getBillingProvider().value(),
             usage.getBillingAccountId(),
             usage.getSnapshotDate()))
-        .thenReturn(List.of(contract1));
+        .thenReturn(List.of(validOpenEnded, validEndingThisMonth, future, expired));
 
-    controller.getContractCoverage(usage);
-
-    verify(contractsApi)
-        .getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().toString(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate());
-  }
-
-  @Test
-  void testIllegalStateExceptionThrownWhenMetricIdIsNotFoundForBillingProvider() {
-    BillableUsage usage = defaultUsage();
-
-    // Make sure product is contract enabled.
-    var variant = Variant.builder().tag(usage.getProductId()).build();
-    var metric = new com.redhat.swatch.configuration.registry.Metric();
-    metric.setId(usage.getMetricId());
-    var subscriptionDefinition =
-        SubscriptionDefinition.builder()
-            .contractEnabled(true)
-            .variants(Set.of(variant))
-            .metrics(Set.of(metric))
-            .build();
-    variant.setSubscription(subscriptionDefinition);
-    when(subscriptionDefinitionRegistry.getSubscriptions())
-        .thenReturn(List.of(subscriptionDefinition));
-
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          controller.getContractCoverage(usage);
-        });
-  }
-
-  @Test
-  void testIllegalStateExceptionThrownWhenMetricIdIsConfiguredAsEmptyForBillingProvider() {
-    BillableUsage usage = defaultUsage();
-    createSubscriptionDefinition(usage.getProductId(), usage.getMetricId(), null, "", true, false);
-
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          controller.getContractCoverage(usage);
-        });
-  }
-
-  @Test
-  void testGetContractCoverageIncludesMetricValuesFromAllContracts() throws Exception {
-    BillableUsage usage = defaultUsage();
-    // Set up the mocked contract data
-    Contract contract1 = contractFromUsage(usage);
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
-
-    Contract contract2 = contractFromUsage(usage);
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(40));
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithContractEnabled(usage);
-
-    when(contractsApi.getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().value(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate()))
-        .thenReturn(List.of(contract1, contract2));
-
-    // Contract coverage should be the sum of all matching Cores metrics in the contracts.
-    ContractCoverage contractCoverage = controller.getContractCoverage(usage);
-    assertEquals(140, contractCoverage.getTotal());
-  }
-
-  @Test
-  void testGetContractCoverageIncludesMetricValuesFromAllMetricsOfAContract() throws Exception {
-    BillableUsage usage = defaultUsage();
-    // Set up the mocked contract data
-    Contract contract1 = contractFromUsage(usage);
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(50));
-
-    Contract contract2 = contractFromUsage(usage);
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_CONTROL_PLANE_METRIC_ID).value(20));
-
-    when(contractsApi.getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().value(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate()))
-        .thenReturn(List.of(contract1, contract2));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithContractEnabled(usage);
-
-    // Contract coverage should be the sum of all matching Cores metrics in the contracts.
-    ContractCoverage contractCoverage = controller.getContractCoverage(usage);
-    assertEquals(200, contractCoverage.getTotal());
-  }
-
-  @Test
-  void testGetContractCoverageWhenThereAreContractsGratisAndPendingThenIsNotGratis()
-      throws Exception {
-    BillableUsage usage = defaultUsage();
-    // Set up the mocked contract data
-    Contract gratisContract = contractFromUsage(usage);
-    gratisContract.setStartDate(clock.startOfCurrentMonth().plusHours(1));
-    gratisContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-
-    Contract regularContract = contractFromUsage(usage);
-    regularContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
-
-    when(contractsApi.getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().value(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate()))
-        .thenReturn(List.of(gratisContract, regularContract));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithGratisEnabled(usage);
-
-    // Contract coverage should return that is gratis because there is an existing contract with
-    // gratis for the usage.
-    ContractCoverage contractCoverage = controller.getContractCoverage(usage);
-    assertFalse(contractCoverage.isGratis());
-  }
-
-  @Test
-  void testGetContractCoverageWhenAllTheContractsAreThenIsGratis() throws Exception {
-    BillableUsage usage = defaultUsage();
-    // Set up the mocked contract data
-    Contract gratisContract = contractFromUsage(usage);
-    gratisContract.setStartDate(clock.startOfCurrentMonth().plusHours(1));
-    gratisContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-
-    Contract anotherGratisContract = contractFromUsage(usage);
-    anotherGratisContract.setStartDate(clock.startOfCurrentMonth().plusHours(1));
-    anotherGratisContract.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
-
-    when(contractsApi.getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().value(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate()))
-        .thenReturn(List.of(gratisContract, anotherGratisContract));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithGratisEnabled(usage);
-
-    // Contract coverage should return that is gratis because there is an existing contract with
-    // gratis for the usage.
-    ContractCoverage contractCoverage = controller.getContractCoverage(usage);
-    assertTrue(contractCoverage.isGratis());
-  }
-
-  @Test
-  void testContractsFilteredByDateWhenGettingCoverage() throws Exception {
-    BillableUsage usage = defaultUsage();
-
-    // Start of the month, with no end date (VALID)
-    Contract contract1 = contractFromUsage(usage);
-    contract1.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(100));
-
-    // Start of the month, ending at the end of the month (VALID)
-    Contract contract2 = contractFromUsage(usage);
-    contract2.setEndDate(clock.endOfMonth(contract2.getStartDate()));
-    contract2.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(25));
-
-    // Future contract, no end date (INVALID - not in usage range)
-    Contract contract3 = contractFromUsage(usage);
-    contract3.setStartDate(clock.startOfCurrentMonth().plusMonths(1));
-    contract3.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(5));
-
-    // Expired contract (INVALID - contract ended before usage date).
-    Contract contract4 = contractFromUsage(usage);
-    contract4.setStartDate(clock.startOfCurrentMonth().minusMonths(2));
-    contract4.setEndDate(clock.endOfMonth(contract4.getStartDate().plusMonths(1)));
-    contract4.addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value(10));
-
-    // Make sure product is contract enabled.
-    givenContractHasMetricWithContractEnabled(usage);
-
-    when(contractsApi.getContract(
-            usage.getOrgId(),
-            usage.getProductId(),
-            usage.getVendorProductCode(),
-            usage.getBillingProvider().value(),
-            usage.getBillingAccountId(),
-            usage.getSnapshotDate()))
-        .thenReturn(List.of(contract1, contract2));
-
-    // Contract coverage should be the sum of all matching Cores metrics in the contracts.
-    ContractCoverage contractCoverage = controller.getContractCoverage(usage);
-    assertEquals(125, contractCoverage.getTotal());
+    List<Contract> contracts = controller.getValidContracts(usage);
+    assertEquals(2, contracts.size());
+    assertEquals(List.of(validOpenEnded, validEndingThisMonth), contracts);
   }
 
   @Test
   void throwsExternalServiceExceptionWhenApiCallFails() throws Exception {
     BillableUsage usage = defaultUsage();
-    givenContractHasMetricWithContractEnabled(usage);
+    givenContractEnabled(usage);
     doThrow(ApiException.class)
         .when(contractsApi)
         .getContract(any(), any(), any(), any(), any(), any());
     ExternalServiceException e =
-        assertThrows(
-            ExternalServiceException.class,
-            () -> {
-              controller.getContractCoverage(usage);
-            });
+        assertThrows(ExternalServiceException.class, () -> controller.getValidContracts(usage));
     assertEquals(ErrorCode.CONTRACTS_SERVICE_ERROR, e.getCode());
     assertEquals(
         String.format("Could not look up contract info for usage! %s", usage), e.getMessage());
@@ -415,15 +211,11 @@ class ContractsControllerTest {
   @Test
   void throwsContractMissingExceptionWhenNoContractsFound() throws Exception {
     BillableUsage usage = defaultUsage();
-    givenContractHasMetricWithContractEnabled(usage);
+    givenContractEnabled(usage);
     when(contractsApi.getContract(any(), any(), any(), any(), any(), any()))
         .thenReturn(new ArrayList<>());
     ContractMissingException e =
-        assertThrows(
-            ContractMissingException.class,
-            () -> {
-              controller.getContractCoverage(usage);
-            });
+        assertThrows(ContractMissingException.class, () -> controller.getValidContracts(usage));
     assertEquals(String.format("No contract info found for usage! %s", usage), e.getMessage());
   }
 
@@ -451,13 +243,8 @@ class ContractsControllerTest {
         .startDate(clock.startOfMonth(usage.getSnapshotDate()));
   }
 
-  private void givenContractHasMetricWithGratisEnabled(BillableUsage usage) {
-    createSubscriptionDefinition(usage.getProductId(), CORES, CONTRACT_METRIC_ID, null, true, true);
-  }
-
-  private void givenContractHasMetricWithContractEnabled(BillableUsage usage) {
-    createSubscriptionDefinition(
-        usage.getProductId(), CORES, CONTRACT_METRIC_ID, null, true, false);
+  private void givenContractEnabled(BillableUsage usage) {
+    createSubscriptionDefinition(usage.getProductId(), CORES, CONTRACT_METRIC_ID, null, true);
   }
 
   private void createSubscriptionDefinition(
@@ -465,14 +252,13 @@ class ContractsControllerTest {
       String metricId,
       String awsDimension,
       String rhmDimension,
-      boolean contractEnabled,
-      boolean gratisEnabled) {
+      boolean contractEnabled) {
     var variant = Variant.builder().tag(tag).build();
     var awsMetric =
         com.redhat.swatch.configuration.registry.Metric.builder()
             .awsDimension(awsDimension)
             .rhmMetricId(rhmDimension)
-            .enableGratisUsage(gratisEnabled)
+            .enableGratisUsage(false)
             .id(metricId)
             .build();
     var subscriptionDefinition =

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -82,3 +82,7 @@ properties:
   currentTotal:
     description: Sum of all measurements between the start of the month to the snapshot date.
     type: number
+  license_id:
+    description: License ID to use for billing
+    type: string
+    nullable: true


### PR DESCRIPTION
Jira issue: SWATCH-5299

## Description
Changes:
- Select the overage licenseId for contract-enabled PAYG remittance: newest agreement startDate, lexicographically smaller licenseId on ties; ignore null/blank (legacy).
- Stamp that licenseId on the remittance row and emitted BillableUsage; coverage sum and gratis rules unchanged.
- Refactor coverage logic into ContractCoverageService because (1) separation of concerns, (2) ContractController only to deal with ContractsApi (and retry when the API fails only); and (3) keep the contract coverage into a single service. 
- Refactor wiremock for the creating of contracts to use a new record ContractStub instead of a set of arguments (collections of collections)

## Testing
- Unit: ContractCoverageServiceTest / BillableUsageServiceTest (selection, blank licenseId, gratis, mixed)
- Component: ContractCoverageComponentTest TC009–TC014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for evaluating usage across multiple active contracts.
  - Overage calculations now select and preserve the applicable license identifier.
  - Added support for mixed licensed/unlicensed and gratis contract scenarios.
  - Billable usage and remittance records now expose an optional license ID.

- **Bug Fixes**
  - Improved deterministic license selection when multiple contracts qualify.
  - Contract coverage now respects contract validity dates and configured metric mappings.

- **Tests**
  - Expanded coverage for multi-contract, licensing, overage, and gratis eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->