### PR TITLE
SWATCH-5185: swatch-contracts - Add component test coverage for subscription_type & update test plan

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -1440,6 +1440,40 @@ This section verifies the automatic contract termination behavior when contracts
   - Capacity values indicate unlimited status appropriately.
   - Subscription correctly linked to unlimited offering in response.
 
+## Subscription Type (SKU capacity report meta)
+
+**subscription-type-TC001: Report On-demand subscription type on V1 for PAYG products**
+- **Description:** Verify that the v1 SKU capacity report returns On-demand subscription type for PAYG products.
+- **Setup:** Create a PAYG ROSA contract for the organization.
+- **Action:** Query the v1 SKU capacity report for the PAYG product.
+- **Verification:** Inspect the subscription type in the report metadata.
+- **Expected Result:**
+  - Report metadata indicates On-demand subscription type.
+
+**subscription-type-TC002: Report On-demand subscription type on V2 for PAYG products**
+- **Description:** Verify that the v2 SKU capacity report returns On-demand subscription type for PAYG products.
+- **Setup:** Create a PAYG ROSA contract for the organization.
+- **Action:** Query the v2 SKU capacity report for the PAYG product.
+- **Verification:** Inspect the subscription type in the report metadata.
+- **Expected Result:**
+  - Report metadata indicates On-demand subscription type.
+
+**subscription-type-TC003: Report Annual subscription type on V1 for non-PAYG products**
+- **Description:** Verify that the v1 SKU capacity report returns Annual subscription type for non-PAYG products.
+- **Setup:** Create a non-PAYG (annual) RHEL subscription for the organization.
+- **Action:** Query the v1 SKU capacity report for the non-PAYG product.
+- **Verification:** Inspect the subscription type in the report metadata.
+- **Expected Result:**
+  - Report metadata indicates Annual subscription type.
+
+**subscription-type-TC004: Report Annual subscription type on V2 for non-PAYG products**
+- **Description:** Verify that the v2 SKU capacity report returns Annual subscription type for non-PAYG products.
+- **Setup:** Create a non-PAYG (annual) RHEL subscription for the organization.
+- **Action:** Query the v2 SKU capacity report for the non-PAYG product.
+- **Verification:** Inspect the subscription type in the report metadata.
+- **Expected Result:**
+  - Report metadata indicates Annual subscription type.
+
 ## Offering Update
 
 **offering-update-TC001: Process product update event**

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -36,6 +36,7 @@ import com.redhat.swatch.contract.test.model.ContractRequest;
 import com.redhat.swatch.contract.test.model.GranularityType;
 import com.redhat.swatch.contract.test.model.ReportCategory;
 import com.redhat.swatch.contract.test.model.ServiceLevelType;
+import com.redhat.swatch.contract.test.model.SkuCapacityReportV1;
 import com.redhat.swatch.contract.test.model.SkuCapacityReportV2;
 import com.redhat.swatch.contract.test.model.SkuCapacityV2;
 import com.redhat.swatch.contract.test.model.SubscriptionResponse;
@@ -65,7 +66,9 @@ public class ContractsSwatchService extends SwatchService {
   private static final String RESET_DATA_ENDPOINT = ENDPOINT_PREFIX + "/rpc/reset/%s";
   private static final String CONTRACTS_ENDPOINT = ENDPOINT_PREFIX + "/contracts";
   private static final String SUBSCRIPTIONS_ENDPOINT = ENDPOINT_PREFIX + "/subscriptions";
-  private static final String GET_SKU_ENDPOINT =
+  private static final String GET_SKU_CAPACITY_REPORT_V1_ENDPOINT =
+      "/api/rhsm-subscriptions/v1/subscriptions/products/{product_id}";
+  private static final String GET_SKU_CAPACITY_REPORT_V2_ENDPOINT =
       "/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}";
   private static final String CAPACITY_REPORT_ENDPOINT =
       "/api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}";
@@ -221,6 +224,25 @@ public class ContractsSwatchService extends SwatchService {
     return getSkuCapacityByProductIdForOrg(subscription.getProduct(), subscription.getOrgId());
   }
 
+  public SkuCapacityReportV1 getSkuCapacityReportV1(Product product, String orgId) {
+    Objects.requireNonNull(product, "product id must not be null");
+    Objects.requireNonNull(orgId, "org id must not be null");
+
+    return given()
+        .headers(securityHeadersWithServiceRole(orgId))
+        .accept("application/vnd.api+json")
+        .pathParam("product_id", product.getName())
+        .get(GET_SKU_CAPACITY_REPORT_V1_ENDPOINT)
+        .then()
+        .statusCode(SC_OK)
+        .extract()
+        .as(SkuCapacityReportV1.class);
+  }
+
+  public SkuCapacityReportV2 getSkuCapacityReportV2(Product product, String orgId) {
+    return getSkuCapacityByProductIdForOrg(product, orgId);
+  }
+
   public SkuCapacityReportV2 getSkuCapacityByProductIdForOrg(Product product, String orgId) {
     return getSkuCapacityByProductIdForOrg(product, orgId, null, null);
   }
@@ -241,7 +263,12 @@ public class ContractsSwatchService extends SwatchService {
     if (ending != null) {
       request = request.queryParam("ending", ending.toString());
     }
-    return request.get(GET_SKU_ENDPOINT).then().extract().as(SkuCapacityReportV2.class);
+    return request
+        .get(GET_SKU_CAPACITY_REPORT_V2_ENDPOINT)
+        .then()
+        .statusCode(SC_OK)
+        .extract()
+        .as(SkuCapacityReportV2.class);
   }
 
   public CapacityReportByMetricId getCapacityReportByMetricId(

--- a/swatch-contracts/ct/java/tests/SubscriptionTypeComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionTypeComponentTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.SkuCapacityReportV1;
+import com.redhat.swatch.contract.test.model.SkuCapacityReportV2;
+import com.redhat.swatch.contract.test.model.SubscriptionType;
+import domain.Product;
+import org.junit.jupiter.api.Test;
+
+public class SubscriptionTypeComponentTest extends BaseContractComponentTest {
+
+  private static final double CORES_CAPACITY = 8.0;
+  private static final double SOCKETS_CAPACITY = 2.0;
+
+  @TestPlanName("subscription-type-TC001")
+  @Test
+  void shouldReportOnDemandSubscriptionTypeOnV1() {
+    // Given: A PAYG ROSA contract for the org
+    givenPaygContractIsCreated();
+
+    // When: Querying the v1 SKU capacity report
+    SkuCapacityReportV1 report = whenGetSkuCapacityReportV1(Product.ROSA);
+
+    // Then: Meta reports On-demand subscription type
+    thenSubscriptionTypeIs(report, SubscriptionType.ON_DEMAND);
+  }
+
+  @TestPlanName("subscription-type-TC002")
+  @Test
+  void shouldReportOnDemandSubscriptionTypeOnV2() {
+    // Given: A PAYG ROSA contract for the org
+    givenPaygContractIsCreated();
+
+    // When: Querying the v2 SKU capacity report
+    SkuCapacityReportV2 report = whenGetSkuCapacityReportV2(Product.ROSA);
+
+    // Then: Meta reports On-demand subscription type
+    thenSubscriptionTypeIs(report, SubscriptionType.ON_DEMAND);
+  }
+
+  @TestPlanName("subscription-type-TC003")
+  @Test
+  void shouldReportAnnualSubscriptionTypeOnV1() {
+    // Given: A non-PAYG (annual) RHEL subscription for the org
+    givenAnnualSubscriptionIsCreated();
+
+    // When: Querying the v1 SKU capacity report
+    SkuCapacityReportV1 report = whenGetSkuCapacityReportV1(Product.RHEL);
+
+    // Then: Meta reports Annual subscription type
+    thenSubscriptionTypeIs(report, SubscriptionType.ANNUAL);
+  }
+
+  @TestPlanName("subscription-type-TC004")
+  @Test
+  void shouldReportAnnualSubscriptionTypeOnV2() {
+    // Given: A non-PAYG (annual) RHEL subscription for the org
+    givenAnnualSubscriptionIsCreated();
+
+    // When: Querying the v2 SKU capacity report
+    SkuCapacityReportV2 report = whenGetSkuCapacityReportV2(Product.RHEL);
+
+    // Then: Meta reports Annual subscription type
+    thenSubscriptionTypeIs(report, SubscriptionType.ANNUAL);
+  }
+
+  private void givenPaygContractIsCreated() {
+    givenRosaContractIsCreated(CORES_CAPACITY);
+  }
+
+  private void givenAnnualSubscriptionIsCreated() {
+    givenPhysicalSubscriptionIsCreated(
+        RandomUtils.generateRandom(), CORES_CAPACITY, SOCKETS_CAPACITY);
+  }
+
+  private SkuCapacityReportV1 whenGetSkuCapacityReportV1(Product product) {
+    return service.getSkuCapacityReportV1(product, orgId);
+  }
+
+  private SkuCapacityReportV2 whenGetSkuCapacityReportV2(Product product) {
+    return service.getSkuCapacityReportV2(product, orgId);
+  }
+
+  private void thenSubscriptionTypeIs(SkuCapacityReportV1 report, SubscriptionType expected) {
+    assertNotNull(report, "v1 SKU capacity report should not be null");
+    assertNotNull(report.getMeta(), "v1 report meta should not be null");
+    thenSubscriptionTypeIs(report.getMeta().getSubscriptionType(), expected);
+  }
+
+  private void thenSubscriptionTypeIs(SkuCapacityReportV2 report, SubscriptionType expected) {
+    assertNotNull(report, "v2 SKU capacity report should not be null");
+    assertNotNull(report.getMeta(), "v2 report meta should not be null");
+    thenSubscriptionTypeIs(report.getMeta().getSubscriptionType(), expected);
+  }
+
+  private void thenSubscriptionTypeIs(SubscriptionType actual, SubscriptionType expected) {
+    assertNotNull(actual, "meta.subscriptionType should not be null");
+    assertEquals(expected, actual, "meta.subscriptionType should be " + expected.getValue());
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5185

## Description
- Add `SubscriptionTypeComponentTest` covering `meta.subscription_type` on the v1 and v2 SKU capacity report APIs (`subscription-type-TC001`–`TC004`).
- Document those cases in `SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md`.
- Extend `ContractsSwatchService` with `getSkuCapacityReportV1` / `getSkuCapacityReportV2` helpers (and assert HTTP 200 on the v2 client path).
## Coverage
| Case | API | Product setup | Expected `subscription_type` |
| --- | --- | --- | --- |
| TC001 | v1 | PAYG ROSA contract | On-demand |
| TC002 | v2 | PAYG ROSA contract | On-demand |
| TC003 | v1 | Annual RHEL subscription | Annual |
| TC004 | v2 | Annual RHEL subscription | Annual |
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.
