### PR TITLE
SWATCH-5184: Assert terminated subscription leaves active capacity search

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -1329,13 +1329,19 @@ This section verifies the automatic contract termination behavior when contracts
 
 **subscriptions-termination-TC001** - **Terminate subscription with timestamp**  
 - **Description:** Verify manual subscription termination.  
-- **Setup:** Create an active subscription.  
-- **Action:** POST `/api/swatch-contracts/internal/subscriptions/terminate/{subscription_id}?timestamp=2024-01-01T00:00:00Z`.  
-- **Verification:** Check subscription end date.  
+- **Setup:**
+  - Create an active subscription
+  - Confirm it appears in the active subscription search (SKU capacity report)
+- **Action:** POST `/api/swatch-contracts/internal/subscriptions/terminate/{subscription_id}?timestamp=<past>`.  
+- **Verification:**
+  - Check subscription `end_date` via internal GET subscriptions
+  - Re-query the v2 SKU capacity report (active subscription search) for the org/product
+  - Confirm the report shows zero active capacity (`meta.count` is 0)
 - **Expected Result:**  
   - TerminationRequest with message  
   - Subscription `end_date` set to timestamp  
-  - Subscription effectively terminated
+  - Subscription no longer appears in the active subscription search for the org/product/SKU  
+  - v2 SKU capacity report returns zero active capacity (`meta.count` is 0)
 
 ## Offering Synchronization
 

--- a/swatch-contracts/ct/java/tests/SubscriptionsTerminationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsTerminationComponentTest.java
@@ -22,6 +22,7 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import domain.Subscription;
@@ -37,15 +38,24 @@ public class SubscriptionsTerminationComponentTest extends BaseContractComponent
   @Test
   void shouldTerminateSubscriptionWithTimestamp() {
     Subscription subscription = givenActiveSubscription();
-    OffsetDateTime terminationDate =
-        OffsetDateTime.now().plusDays(1).withHour(23).withMinute(59).withSecond(59).withNano(0);
+    int initialCapacity = givenCapacityIsIncreased(subscription);
+
+    OffsetDateTime terminationDate = OffsetDateTime.now().withNano(0).minusHours(1);
 
     Response response = service.terminateSubscription(subscription, terminationDate);
     assertEquals(HttpStatus.SC_OK, response.statusCode());
 
-    service
-        .getSubscriptionsByOrgId(orgId)
-        .forEach(s -> assertDatesAreEqual(terminationDate, s.getEndDate()));
+    var terminatedSubscription =
+        service.getSubscriptionsByOrgId(orgId).stream()
+            .filter(s -> subscription.getSubscriptionId().equals(s.getSubscriptionId()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(
+        terminatedSubscription, "Terminated subscription should remain in subscription table");
+    assertDatesAreEqual(terminationDate, terminatedSubscription.getEndDate());
+
+    int remainingCapacity = thenCapacityIsDecreased(subscription, initialCapacity);
+    assertEquals(0, remainingCapacity, "Active subscription capacity should drop to zero");
   }
 
   private Subscription givenActiveSubscription() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5184

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Extend `subscriptions-termination-TC001` to verify the v2 SKU capacity report drops to zero after terminate, matching the removed IQE coverage.

## Testing
Component test:
```bash
./mvnw -Pcomponent-tests -pl swatch-contracts/ct test -Dtest=SubscriptionsTerminationComponentTest
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced subscription termination coverage to verify the termination end date is persisted.
  * Confirmed terminated subscriptions no longer appear in active capacity searches.
  * Added validation that active capacity reaches zero for the organization, product, and SKU.
  * Updated termination timing checks to use a timestamp one hour in the past.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->