### PR TITLE
SWATCH-5246: Port remaining IQE hourly tally component tests

### DIFF
--- a/swatch-tally/ct/java/tests/TallyFilterProductConfigTest.java
+++ b/swatch-tally/ct/java/tests/TallyFilterProductConfigTest.java
@@ -445,6 +445,71 @@ public class TallyFilterProductConfigTest extends BaseTallyComponentTest {
         "RHEL instance should NOT be created - role=moa should only map to rosa, not RHEL");
   }
 
+  @Test
+  @TestPlanName("tally-product-filter-TC008")
+  public void testMetricsFilteringDropsUnknownMetrics() {
+    // Given: A ROSA PAYG event with valid metrics plus an invalid metric
+    String validMetricCores = "Cores";
+    String validMetricInstanceHours = "Instance-hours";
+    String invalidMetric = "INVALID_METRIC_NOT_IN_CONFIG";
+    float validValue = 10.0f;
+    float invalidValue = 99.0f;
+
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            setup.instanceId,
+            setup.start.toString(),
+            UUID.randomUUID().toString(),
+            validMetricCores,
+            validValue,
+            ROSA.productId(),
+            ROSA.productTag());
+
+    List<Measurement> measurements = new ArrayList<>();
+    Measurement cores = new Measurement();
+    cores.setMetricId(validMetricCores);
+    cores.setValue((double) validValue);
+    measurements.add(cores);
+
+    Measurement instanceHours = new Measurement();
+    instanceHours.setMetricId(validMetricInstanceHours);
+    instanceHours.setValue((double) validValue);
+    measurements.add(instanceHours);
+
+    Measurement invalid = new Measurement();
+    invalid.setMetricId(invalidMetric);
+    invalid.setValue((double) invalidValue);
+    measurements.add(invalid);
+
+    event.setMeasurements(measurements);
+    event.setDisplayName(Optional.of(setup.instanceId));
+    event.setProductTag(Set.of(ROSA.productTag()));
+
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+
+    // When: Performing hourly tally
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    // Then: Valid metrics should be tallied
+    awaitHourlyTallySum(
+        setup.orgId,
+        ROSA.productTag(),
+        validMetricCores,
+        setup.start,
+        setup.start.plusHours(1),
+        validValue);
+
+    // And: Instance should contain only valid metrics, not the invalid one
+    assertInstanceMeasurements(
+        setup.orgId,
+        setup.instanceId,
+        ROSA.productTag(),
+        setup.start,
+        setup.start.plusHours(1),
+        Map.of("Cores", (double) validValue, "Instance-hours", (double) validValue));
+  }
+
   // --- Given helper methods ---
 
   private TestSetup setupTest() {

--- a/swatch-tally/ct/java/tests/TallyHandlingConflictsTest.java
+++ b/swatch-tally/ct/java/tests/TallyHandlingConflictsTest.java
@@ -22,6 +22,8 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static utils.TallyTestProducts.ANSIBLE_AAP_MANAGED;
+import static utils.TallyTestProducts.OPENSHIFT_DEDICATED;
 import static utils.TallyTestProducts.RHACM;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 import static utils.TallyTestProducts.ROSA;
@@ -192,6 +194,99 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
     }
   }
 
+  @Test
+  @TestPlanName("tally-conflicts-TC005")
+  public void testCounterBackfillAmendsHourlyTotals() {
+    // Given: 5 events spanning consecutive hours for OpenShift-dedicated-metrics
+    String billingAccountId = UUID.randomUUID().toString();
+    OffsetDateTime ending = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+    OffsetDateTime beginning = ending.minusHours(7);
+    int eventCount = 5;
+    float firstValue = 15.0f;
+    float secondValue = 150.0f;
+
+    for (String metricId : OPENSHIFT_DEDICATED.metricIds()) {
+      double initialSum =
+          getHourlyTallySum(
+              setup.orgId, OPENSHIFT_DEDICATED.productTag(), metricId, beginning, ending);
+
+      for (int i = 0; i < eventCount; i++) {
+        createEventForProductWithBilling(
+            beginning.plusHours(i), OPENSHIFT_DEDICATED, metricId, firstValue, billingAccountId);
+      }
+      service.performHourlyTallyForOrg(setup.orgId);
+
+      double afterFirstBatch =
+          awaitHourlyTallySum(
+              setup.orgId,
+              OPENSHIFT_DEDICATED.productTag(),
+              metricId,
+              beginning,
+              ending,
+              initialSum + (firstValue * eventCount));
+
+      // When: Two backfill events amend two distinct hours within the original range
+      createEventForProductWithBilling(
+          beginning.plusHours(1), OPENSHIFT_DEDICATED, metricId, secondValue, billingAccountId);
+      createEventForProductWithBilling(
+          beginning.plusHours(3), OPENSHIFT_DEDICATED, metricId, secondValue, billingAccountId);
+      service.performHourlyTallyForOrg(setup.orgId);
+
+      // Then: Total increases by the two backfill values
+      awaitHourlyTallySum(
+          setup.orgId,
+          OPENSHIFT_DEDICATED.productTag(),
+          metricId,
+          beginning,
+          ending,
+          afterFirstBatch + (secondValue * 2));
+    }
+  }
+
+  @Test
+  @TestPlanName("tally-conflicts-TC006")
+  public void testAnsibleDualEventCounterBackfill() {
+    // Given: An initial Ansible event for each metric
+    String billingAccountId = UUID.randomUUID().toString();
+    OffsetDateTime ending = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+    OffsetDateTime beginning = ending.minusHours(7);
+
+    for (String metricId : ANSIBLE_AAP_MANAGED.metricIds()) {
+      double initialSum =
+          getHourlyTallySum(
+              setup.orgId, ANSIBLE_AAP_MANAGED.productTag(), metricId, beginning, ending);
+
+      float firstValue = 15.0f;
+      createAnsibleEvent(beginning, metricId, firstValue, billingAccountId);
+      service.performHourlyTallyForOrg(setup.orgId);
+
+      double afterFirst =
+          awaitHourlyTallySum(
+              setup.orgId,
+              ANSIBLE_AAP_MANAGED.productTag(),
+              metricId,
+              beginning,
+              ending,
+              initialSum + firstValue);
+
+      // When: Two backfill events at different hours
+      float secondValue = 3.0f;
+      OffsetDateTime pastDate = beginning.plusHours(2);
+      createAnsibleEvent(pastDate, metricId, secondValue, billingAccountId);
+      createAnsibleEvent(ending.minusHours(1), metricId, secondValue, billingAccountId);
+      service.performHourlyTallyForOrg(setup.orgId);
+
+      // Then: Total increases by secondValue for each of the two backfill events
+      awaitHourlyTallySum(
+          setup.orgId,
+          ANSIBLE_AAP_MANAGED.productTag(),
+          metricId,
+          beginning,
+          ending,
+          afterFirst + (secondValue * 2));
+    }
+  }
+
   // --- Given helper methods ---
 
   private TestSetup setupTest() {
@@ -220,6 +315,54 @@ public class TallyHandlingConflictsTest extends BaseTallyComponentTest {
 
     event.setDisplayName(Optional.of(setup.instanceId));
 
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+  }
+
+  private void createEventForProductWithBilling(
+      OffsetDateTime timestamp,
+      TallyTestProducts product,
+      String metricId,
+      float value,
+      String billingAccountId) {
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            UUID.randomUUID().toString(),
+            timestamp.toString(),
+            UUID.randomUUID().toString(),
+            metricId,
+            value,
+            Event.Sla.PREMIUM,
+            Event.Usage.PRODUCTION,
+            Event.BillingProvider.AWS,
+            billingAccountId,
+            Event.HardwareType.CLOUD,
+            product.productId(),
+            product.productTag());
+    event.setServiceType(product.serviceType());
+    event.setRole(Event.Role.OSD);
+    kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+  }
+
+  private void createAnsibleEvent(
+      OffsetDateTime timestamp, String metricId, float value, String billingAccountId) {
+    Event event =
+        helpers.createPaygEventWithTimestamp(
+            setup.orgId,
+            UUID.randomUUID().toString(),
+            timestamp.toString(),
+            UUID.randomUUID().toString(),
+            metricId,
+            value,
+            Event.Sla.PREMIUM,
+            Event.Usage.PRODUCTION,
+            Event.BillingProvider.AWS,
+            billingAccountId,
+            Event.HardwareType.CLOUD,
+            ANSIBLE_AAP_MANAGED.productId(),
+            ANSIBLE_AAP_MANAGED.productTag());
+    event.setServiceType(ANSIBLE_AAP_MANAGED.serviceType());
+    event.setRole(null);
     kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
   }
 

--- a/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static utils.TallyTestProducts.ANSIBLE_AAP_MANAGED;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
@@ -867,6 +868,113 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
       assertTrue(
           sumMeteredValues(response) > 0.0,
           "Metered total should be positive for the SLA filter fixture rows in the current month");
+    }
+
+    @Test
+    @TestPlanName("tally-instances-payg-TC013")
+    public void testAnsibleClusterProducesTwoInstanceRows() {
+      // Given: Ansible events are published and tallied
+      String ansibleOrgId = RandomUtils.generateRandom();
+      String ansibleClusterUuid = UUID.randomUUID().toString();
+      String billingAccountId = UUID.randomUUID().toString();
+      OffsetDateTime eventTime =
+          OffsetDateTime.now(ZoneOffset.UTC).minusHours(2).truncatedTo(ChronoUnit.HOURS);
+      OffsetDateTime ansibleBeginning = eventTime;
+      OffsetDateTime ansibleEnding = eventTime.plusHours(3);
+
+      stubRbacAccessForOrg(ansibleOrgId);
+
+      Event controlNodeEvent =
+          helpers.createPaygEventWithTimestamp(
+              ansibleOrgId,
+              ansibleClusterUuid + "/control-host",
+              eventTime.toString(),
+              UUID.randomUUID().toString(),
+              "Managed-nodes",
+              1.0f,
+              Event.Sla.PREMIUM,
+              Event.Usage.PRODUCTION,
+              Event.BillingProvider.AWS,
+              billingAccountId,
+              Event.HardwareType.CLOUD,
+              ANSIBLE_AAP_MANAGED.productId(),
+              ANSIBLE_AAP_MANAGED.productTag());
+      controlNodeEvent.setServiceType("Ansible Managed Node");
+      controlNodeEvent.setRole(null);
+
+      Event managedNodeEvent =
+          helpers.createPaygEventWithTimestamp(
+              ansibleOrgId,
+              ansibleClusterUuid + "/managed-host",
+              eventTime.toString(),
+              UUID.randomUUID().toString(),
+              "Instance-hours",
+              1.0f,
+              Event.Sla.PREMIUM,
+              Event.Usage.PRODUCTION,
+              Event.BillingProvider.AWS,
+              billingAccountId,
+              Event.HardwareType.CLOUD,
+              ANSIBLE_AAP_MANAGED.productId(),
+              ANSIBLE_AAP_MANAGED.productTag());
+      managedNodeEvent.setServiceType("Ansible Managed Node");
+      managedNodeEvent.setRole(null);
+
+      helpers.ingestPaygEventsAndSyncOnceForOrg(
+          service,
+          kafkaBridge,
+          ansibleOrgId,
+          () -> {
+            InstanceResponse r =
+                service.getInstancesByProduct(
+                    ansibleOrgId,
+                    ANSIBLE_AAP_MANAGED.productTag(),
+                    ansibleBeginning,
+                    ansibleEnding);
+            return r.getData() != null && r.getData().size() >= 2;
+          },
+          controlNodeEvent,
+          managedNodeEvent);
+
+      // Then: Instances report should contain 2 rows (control node + managed node)
+      InstanceResponse response =
+          service.getInstancesByProduct(
+              ansibleOrgId, ANSIBLE_AAP_MANAGED.productTag(), ansibleBeginning, ansibleEnding);
+      assertNotNull(response.getData(), "Instance data should not be null");
+      assertEquals(
+          2,
+          response.getData().size(),
+          "Ansible cluster should produce 2 instance rows (control + managed)");
+
+      List<String> metricIds = response.getMeta().getMeasurements();
+      Map<String, Map<String, Double>> byId = new HashMap<>();
+      for (InstanceData instance : response.getData()) {
+        assertNotNull(instance.getMeasurements(), "Instance measurements should not be null");
+        Map<String, Double> measurements = new HashMap<>();
+        for (int i = 0; i < metricIds.size(); i++) {
+          measurements.put(metricIds.get(i), instance.getMeasurements().get(i));
+        }
+        byId.put(instance.getInstanceId(), measurements);
+      }
+
+      String controlId = ansibleClusterUuid + "/control-host";
+      String managedId = ansibleClusterUuid + "/managed-host";
+      assertEquals(
+          Set.of(controlId, managedId),
+          byId.keySet(),
+          "Expected exactly the control-host and managed-host instance IDs");
+      assertEquals(
+          1.0,
+          byId.get(controlId).get("Managed-nodes"),
+          0.0001,
+          "Control host should have Managed-nodes=1.0");
+      assertEquals(0.0, byId.get(controlId).get("Instance-hours"), 0.0001);
+      assertEquals(
+          1.0,
+          byId.get(managedId).get("Instance-hours"),
+          0.0001,
+          "Managed host should have Instance-hours=1.0");
+      assertEquals(0.0, byId.get(managedId).get("Managed-nodes"), 0.0001);
     }
   }
 

--- a/swatch-tally/ct/java/tests/TallyPersistenceTest.java
+++ b/swatch-tally/ct/java/tests/TallyPersistenceTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
  *
  * <p><a href="https://issues.redhat.com/browse/ENT-3713">...</a>
  */
-@Disabled(value = "Tests disabled due to timing flakiness to be fixed in SWATCH-4567.")
 public class TallyPersistenceTest extends BaseTallyComponentTest {
 
   private static final String TEST_PRODUCT_TAG = OPENSHIFT_DEDICATED.productTag();
@@ -62,6 +61,7 @@ public class TallyPersistenceTest extends BaseTallyComponentTest {
 
   @Test
   @TestPlanName("tally-persistence-TC001")
+  @Disabled(value = "Tests disabled due to timing flakiness to be fixed in SWATCH-4567.")
   public void testTallyReportPersistsWithDateTimeRangeVariations() {
     // Given: Initial tally reports for today and yesterday
     service.performHourlyTallyForOrg(setup.orgId);
@@ -106,6 +106,64 @@ public class TallyPersistenceTest extends BaseTallyComponentTest {
         "Yesterday's instances report should not change after re-tally");
   }
 
+  @Test
+  @TestPlanName("tally-persistence-TC003")
+  public void testPreviousMonthBackfillLeavesCurrentMonthUnchanged() {
+    // Given: Time ranges for previous month and current month
+    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    OffsetDateTime startOfCurrentMonth = now.truncatedTo(ChronoUnit.DAYS).withDayOfMonth(1);
+    OffsetDateTime endOfCurrentMonth = startOfCurrentMonth.plusMonths(1);
+    OffsetDateTime startOfPreviousMonth = startOfCurrentMonth.minusMonths(1);
+
+    OffsetDateTime prevMonthDay1 = startOfPreviousMonth.withDayOfMonth(1).withHour(0);
+    OffsetDateTime prevMonthDay2 = startOfPreviousMonth.withDayOfMonth(2).withHour(0);
+    OffsetDateTime prevMonthDay3 = startOfPreviousMonth.withDayOfMonth(3).withHour(0);
+
+    service.performHourlyTallyForOrg(setup.orgId);
+
+    for (String metricId : OPENSHIFT_DEDICATED.metricIds()) {
+      double initialCurrentMonthSum =
+          getHourlyTallySum(
+              setup.orgId, TEST_PRODUCT_TAG, metricId, startOfCurrentMonth, endOfCurrentMonth);
+
+      double initialPreviousMonthSum =
+          getHourlyTallySum(
+              setup.orgId,
+              TEST_PRODUCT_TAG,
+              metricId,
+              startOfPreviousMonth,
+              prevMonthDay3.plusHours(1));
+
+      // When: Creating 3 events in the previous month and tallying
+      createEvent(setup.orgId, prevMonthDay1, 1.0f, metricId);
+      createEvent(setup.orgId, prevMonthDay2, 1.0f, metricId);
+      createEvent(setup.orgId, prevMonthDay3, 1.0f, metricId);
+
+      service.performHourlyTallyForOrg(setup.orgId);
+
+      // Then: Previous month tally should increase by 3
+      awaitHourlyTallySum(
+          setup.orgId,
+          TEST_PRODUCT_TAG,
+          metricId,
+          startOfPreviousMonth,
+          prevMonthDay3.plusHours(1),
+          initialPreviousMonthSum + 3.0);
+
+      // And: Current month tally should remain unchanged
+      double finalCurrentMonthSum =
+          getHourlyTallySum(
+              setup.orgId, TEST_PRODUCT_TAG, metricId, startOfCurrentMonth, endOfCurrentMonth);
+      assertEquals(
+          initialCurrentMonthSum,
+          finalCurrentMonthSum,
+          0.0001,
+          String.format(
+              "Current month tally for %s should not change after previous month backfill",
+              metricId));
+    }
+  }
+
   // --- Given helper methods ---
 
   private TestSetup setupTest() {
@@ -134,13 +192,17 @@ public class TallyPersistenceTest extends BaseTallyComponentTest {
   }
 
   private void createEvent(String orgId, OffsetDateTime timestamp, float value) {
+    createEvent(orgId, timestamp, value, TEST_METRIC_ID);
+  }
+
+  private void createEvent(String orgId, OffsetDateTime timestamp, float value, String metricId) {
     Event event =
         helpers.createPaygEventWithTimestamp(
             orgId,
             UUID.randomUUID().toString(),
             timestamp.toString(),
             UUID.randomUUID().toString(),
-            TEST_METRIC_ID,
+            metricId,
             value,
             TEST_PRODUCT_ID,
             TEST_PRODUCT_TAG);

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
@@ -22,11 +22,15 @@ package tests;
 
 import static com.redhat.swatch.component.tests.utils.Topics.SWATCH_SERVICE_INSTANCE_INGRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.tally.test.model.BillingProviderType;
 import com.redhat.swatch.tally.test.model.GranularityType;
 import com.redhat.swatch.tally.test.model.ServiceLevelType;
@@ -35,6 +39,7 @@ import com.redhat.swatch.tally.test.model.TallyReportDataMeta;
 import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
 import com.redhat.swatch.tally.test.model.UsageType;
 import io.restassured.response.Response;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -771,5 +776,123 @@ public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
         HttpStatus.SC_BAD_REQUEST,
         response.getStatusCode(),
         "Invalid granularity should return 400 Bad Request");
+  }
+
+  @TestPlanName("tally-report-filters-payg-TC025")
+  @Test
+  void shouldMatchDailyTotalToSumOfHourlyValues() {
+    // Given: ROSA events are published and tallied
+    String rosaOrgId = String.valueOf(10000 + (int) (Math.random() * 90000));
+    service.createOptInConfig(rosaOrgId);
+    stubRbacAccessForOrg(rosaOrgId);
+
+    String rosaProductTag = "rosa";
+    String rosaProductId = "rosa";
+    String rosaBillingAccountId = UUID.randomUUID().toString();
+
+    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    OffsetDateTime yesterday = now.minusDays(1);
+    OffsetDateTime yesterdayHour7 = yesterday.withHour(7).withMinute(0).withSecond(0).withNano(0);
+    OffsetDateTime yesterdayHour10 = yesterday.withHour(10).withMinute(0).withSecond(0).withNano(0);
+    OffsetDateTime todayHour = now.truncatedTo(ChronoUnit.HOURS);
+
+    OffsetDateTime rosaYesterdayBeginning = yesterday.truncatedTo(ChronoUnit.DAYS);
+    OffsetDateTime rosaYesterdayEnding = rosaYesterdayBeginning.plusDays(1).minusNanos(1);
+
+    float rosaCoresValue1 = 42.0f;
+    float rosaCoresValue2 = 58.0f;
+    float rosaCoresValue3 = 33.0f;
+    float rosaInstanceHoursValue1 = 100.0f;
+    float rosaInstanceHoursValue2 = 200.0f;
+    float rosaInstanceHoursValue3 = 150.0f;
+
+    for (Object[] eventData :
+        new Object[][] {
+          {yesterdayHour7, "Cores", rosaCoresValue1, "fake_cluster_7"},
+          {yesterdayHour7, "Instance-hours", rosaInstanceHoursValue1, "fake_cluster_7"},
+          {yesterdayHour10, "Cores", rosaCoresValue2, "fake_cluster_10"},
+          {yesterdayHour10, "Instance-hours", rosaInstanceHoursValue2, "fake_cluster_10"},
+          {todayHour, "Cores", rosaCoresValue3, "fake_cluster_now"},
+          {todayHour, "Instance-hours", rosaInstanceHoursValue3, "fake_cluster_now"},
+        }) {
+      Event event =
+          helpers.createPaygEventWithTimestamp(
+              rosaOrgId,
+              (String) eventData[3],
+              ((OffsetDateTime) eventData[0]).toString(),
+              UUID.randomUUID().toString(),
+              (String) eventData[1],
+              (float) eventData[2],
+              Event.Sla.PREMIUM,
+              Event.Usage.PRODUCTION,
+              Event.BillingProvider.AWS,
+              rosaBillingAccountId,
+              Event.HardwareType.CLOUD,
+              rosaProductId,
+              rosaProductTag);
+      kafkaBridge.produceKafkaMessage(SWATCH_SERVICE_INSTANCE_INGRESS, event);
+    }
+    // Then: For each ROSA metric, daily total for yesterday == sum of hourly hasData points
+    AwaitilitySettings settings =
+        AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(30))
+            .withService(service)
+            .timeoutMessage(
+                "Timed out waiting for ROSA daily total to match hourly sum for org %s", rosaOrgId);
+
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          service.performHourlyTallyForOrg(rosaOrgId);
+
+          for (String metricId : List.of("Cores", "Instance-hours")) {
+            TallyReportData hourlyReport =
+                service.getTallyReportData(
+                    rosaOrgId,
+                    rosaProductTag,
+                    metricId,
+                    Map.of(
+                        "granularity", "Hourly",
+                        "beginning", rosaYesterdayBeginning.toString(),
+                        "ending", rosaYesterdayEnding.toString()));
+
+            assertNotNull(
+                hourlyReport.getData(), "Hourly report data should not be null for " + metricId);
+            assertFalse(
+                hourlyReport.getData().isEmpty(),
+                "Hourly report should contain data for " + metricId);
+
+            double hourlySum =
+                hourlyReport.getData().stream()
+                    .filter(dp -> Boolean.TRUE.equals(dp.getHasData()))
+                    .mapToInt(TallyReportDataPoint::getValue)
+                    .sum();
+            assertTrue(hourlySum > 0, "Hourly sum should be positive for " + metricId);
+
+            TallyReportData dailyReport =
+                service.getTallyReportData(
+                    rosaOrgId,
+                    rosaProductTag,
+                    metricId,
+                    Map.of(
+                        "granularity", "Daily",
+                        "beginning", rosaYesterdayBeginning.toString(),
+                        "ending", rosaYesterdayEnding.toString()));
+
+            assertNotNull(
+                dailyReport.getData(), "Daily report data should not be null for " + metricId);
+            assertFalse(
+                dailyReport.getData().isEmpty(),
+                "Daily report should contain data for " + metricId);
+
+            double dailyTotal = dailyReport.getData().get(0).getValue();
+
+            assertEquals(
+                hourlySum,
+                dailyTotal,
+                0.0001,
+                String.format(
+                    "Daily total for %s should equal the sum of hourly hasData values", metricId));
+          }
+        },
+        settings);
   }
 }

--- a/swatch-tally/ct/java/utils/TallyTestHelpers.java
+++ b/swatch-tally/ct/java/utils/TallyTestHelpers.java
@@ -238,7 +238,12 @@ public class TallyTestHelpers {
     event.setProductTag(Set.of(productTag));
 
     event.setRole(Event.Role.RED_HAT_ENTERPRISE_LINUX_SERVER);
-    event.setServiceType("RHEL System");
+    String resolvedServiceType =
+        TallyTestProducts.byProductTag(productTag)
+            .map(TallyTestProducts::serviceType)
+            .filter(java.util.Objects::nonNull)
+            .orElse("RHEL System");
+    event.setServiceType(resolvedServiceType);
 
     if (hardwareType == Event.HardwareType.CLOUD) {
       event.setCloudProvider(Event.CloudProvider.AWS);

--- a/swatch-tally/ct/java/utils/TallyTestProducts.java
+++ b/swatch-tally/ct/java/utils/TallyTestProducts.java
@@ -26,23 +26,36 @@ import java.util.Optional;
 
 /** Test-only productTag + metricId definitions used by swatch-tally component tests. */
 public enum TallyTestProducts {
-  RHEL_FOR_X86("rhel-for-x86", "RHEL for x86", "Sockets", "SOCKETS"),
-  RHEL_FOR_X86_ELS_PAYG("204", "rhel-for-x86-els-payg", "vCPUs", "VCPUS"),
-  RHEL_FOR_X86_ELS_PAYG_ADDON("204", "rhel-for-x86-els-payg-addon", "vCPUs", "VCPUS"),
+  RHEL_FOR_X86("rhel-for-x86", "RHEL for x86", null, "Sockets", "SOCKETS"),
+  RHEL_FOR_X86_ELS_PAYG("204", "rhel-for-x86-els-payg", "RHEL System", "vCPUs", "VCPUS"),
+  RHEL_FOR_X86_ELS_PAYG_ADDON(
+      "204", "rhel-for-x86-els-payg-addon", "RHEL System", "vCPUs", "VCPUS"),
   RHEL_FOR_X86_ELS_UNCONVERTED(
-      "rhel-for-x86-els-unconverted", "rhel-for-x86-els-unconverted", "Sockets", "SOCKETS"),
-  RHACM("rhacm", "rhacm", "vCPUs"),
-  ROSA("rosa", "rosa", "Cores", "Instance-hours"),
+      "rhel-for-x86-els-unconverted", "rhel-for-x86-els-unconverted", null, "Sockets", "SOCKETS"),
+  RHACM("rhacm", "rhacm", "rhacm Instance", "vCPUs"),
+  ROSA("rosa", "rosa", "rosa Instance", "Cores", "Instance-hours"),
   OPENSHIFT_DEDICATED(
-      "openshift-dedicated-metrics", "OpenShift-dedicated-metrics", "Cores", "Instance-hours");
+      "openshift-dedicated-metrics",
+      "OpenShift-dedicated-metrics",
+      "OpenShift Cluster",
+      "Cores",
+      "Instance-hours"),
+  ANSIBLE_AAP_MANAGED(
+      "ansible-aap-managed",
+      "ansible-aap-managed",
+      "Ansible Managed Node",
+      "Managed-nodes",
+      "Instance-hours");
 
   private final String productId;
   private final String productTag;
+  private final String serviceType;
   private final List<String> metricIds;
 
-  TallyTestProducts(String productId, String productTag, String... metricIds) {
+  TallyTestProducts(String productId, String productTag, String serviceType, String... metricIds) {
     this.productId = productId;
     this.productTag = productTag;
+    this.serviceType = serviceType;
     this.metricIds = List.copyOf(Arrays.asList(metricIds));
   }
 
@@ -52,6 +65,10 @@ public enum TallyTestProducts {
 
   public String productTag() {
     return productTag;
+  }
+
+  public String serviceType() {
+    return serviceType;
   }
 
   public List<String> metricIds() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. The issue will be auto-linked -->
Jira issue: SWATCH-5246

## Linked IQE MR
https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1573

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The tests listed in the card were ported from IQE. After analysis, the following updates were made to ensure test determination:


### TallyHandlingConflictsTest

  TC005 — Backfill timestamps fixed (testCounterBackfillAmendsHourlyTotals): The second backfill event was placed at ending.minusHours(1) (beginning+6h), which fell outside the 5-event range (beginning through beginning+4h), creating a new bucket instead of amending an existing one. Changed both backfill timestamps to beginning.plusHours(1) and beginning.plusHours(3) so both genuinely amend existing hourly buckets.

### TallyInstancesReportFiltersPaygTest

  TC013 — Weak OR assertion replaced with exact ID-keyed checks (testAnsibleClusterProducesTwoInstanceRows): The original loop asserted each row had Managed-nodes=1.0 OR Instance-hours=1.0, which couldn't distinguish which instance carried which metric. Replaced with a map keyed by instance ID, then asserted exactly the two expected IDs are present (clusterUuid + "/control-host" and clusterUuid + "/managed-host") and that each has its specific metric value.

### TallyPersistenceTest

  TC003 — Missing initial tally added (testPreviousMonthBackfillLeavesCurrentMonthUnchanged): The setupTest() method creates events via Kafka, but TC003 reads baseline sums without tallying first — unlike TC001 and TC002, which both call performHourlyTallyForOrg before their baselines. Added that call before the baseline loop so the setupTest events are processed before baselines are recorded, preventing the current-month-unchanged assertion from failing when the tally processes all events at once.

### TallyReportFiltersPaygTest

  Yesterday ending bound tightened (shouldMatchDailyTotalToSumOfHourlyValues): Changed yesterdayEnding from plusDays(1) (midnight today) to plusDays(1).minusNanos(1) (23:59:59.999999999 yesterday), preventing the query window from potentially including today's tally bucket. This aligns with the pattern used in TallyPersistenceTest.

  Empty-report false-pass eliminated (same test): Both hourlySum and dailyTotal previously fell back to 0.0 on null/empty data, allowing assertEquals(0.0, 0.0) to pass silently. Added assertNotNull/assertFalse(isEmpty) guards on both reports and assertTrue(hourlySum > 0), so empty reports now fail fast with descriptive messages instead of producing a vacuous pass.


### Verification

The successful execution of each ported test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Added coverage confirming unknown metrics are excluded from instance measurements.
- Added validation for hourly tally backfills, including OpenShift Dedicated and Ansible events.
- Added PAYG reporting coverage for Ansible clusters and multiple instance rows.
- Added checks ensuring daily totals match eligible hourly data.
- Added coverage for preserving monthly tally boundaries during backfills.
- Added support for testing Ansible managed-node metrics and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->