### PR TITLE
SWATCH-5077: Create the IT Product Service Kafka Consumer

### DIFF
--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -121,6 +121,10 @@ parameters:
     value: '3'
   - name: KAFKA_IT_SUBSCRIPTION_PARTITIONS
     value: '3'
+  - name: KAFKA_IT_PRODUCT_REPLICAS
+    value: '3'
+  - name: KAFKA_IT_PRODUCT_PARTITIONS
+    value: '3'
   - name: CURL_CRON_IMAGE
     value: registry.access.redhat.com/ubi8/ubi-minimal
   - name: CURL_CRON_IMAGE_TAG
@@ -274,6 +278,9 @@ objects:
         - replicas: ${{KAFKA_IT_SUBSCRIPTION_REPLICAS}}
           partitions: ${{KAFKA_IT_SUBSCRIPTION_PARTITIONS}}
           topicName: subscription.subscriptions.private
+        - replicas: ${{KAFKA_IT_PRODUCT_REPLICAS}}
+          partitions: ${{KAFKA_IT_PRODUCT_PARTITIONS}}
+          topicName: product-service.operationalproduct.protected
 
       deployments:
         - name: service

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/Channels.java
@@ -34,6 +34,7 @@ public final class Channels {
   public static final String OFFERING_SYNC = "offering-sync";
   public static final String OFFERING_SYNC_TASK_TOPIC = "offering-sync-task";
   public static final String OFFERING_SYNC_TASK_SERVICE_UMB = "offering-sync-service-umb";
+  public static final String IT_OFFERING_SYNC = "it-offering-sync";
   public static final String EXPORT_REQUESTS_TOPIC = "export-requests";
   public static final String TALLY_IN = "tally-in";
   public static final String UTILIZATION_OUT = "utilization-out";

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static com.redhat.swatch.contract.config.Channels.IT_OFFERING_SYNC;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+@Slf4j
+public class ProductStatusKafkaMessageConsumer {
+
+  @Inject ObjectMapper mapper;
+
+  @Blocking
+  @Incoming(IT_OFFERING_SYNC)
+  public void consumeMessage(String message) throws JsonProcessingException {
+    log.debug("IT Product Kafka consumer was called");
+    if (message == null) {
+      return;
+    }
+    consumeProduct(message);
+  }
+
+  public void consumeProduct(String message) throws JsonProcessingException {
+    OperationalProductEvent productEvent;
+    try {
+      productEvent = mapper.readValue(message, OperationalProductEvent.class);
+    } catch (JsonProcessingException e) {
+      log.warn("Unable to read IT Product Kafka message from JSON.", e);
+      throw e;
+    }
+
+    log.info(
+        "IT Product message consumed: source=kafka, productCode={}, eventType={}, "
+            + "productCategory={}, childSku={}",
+        productEvent.getProductCode(),
+        productEvent.getEventType(),
+        productEvent.getProductCategory(),
+        isChildSku(productEvent.getProductCode()));
+  }
+
+  private static boolean isChildSku(String productCode) {
+    return productCode != null && productCode.startsWith("SVC");
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
@@ -67,14 +67,19 @@ public class ProductStatusUMBMessageConsumer {
 
       log.info(
           "IT Product message consumed: source=umb, productCode={}, eventType={}, "
-              + "productCategory={}",
+              + "productCategory={}, childSku={}",
           productEvent.getProductCode(),
           productEvent.getEventType(),
-          productEvent.getProductCategory());
+          productEvent.getProductCategory(),
+          isChildSku(productEvent.getProductCode()));
 
       service.syncUmbProductFromEvent(productEvent);
     } catch (Exception e) {
       log.error("Unable to read UMB product message for JSON: {}", message, e);
     }
+  }
+
+  private static boolean isChildSku(String productCode) {
+    return productCode != null && productCode.startsWith("SVC");
   }
 }

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -212,6 +212,9 @@ IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitleme
 %stage.IT_PARTNER_KAFKA_TOPIC=stage.partner-integration.entitlement-gateway.partner-entitlement.protected
 %prod.IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitlement.protected
 
+IT_PRODUCT_KAFKA_TOPIC=product-service.operationalproduct.protected
+%stage.IT_PRODUCT_KAFKA_TOPIC=stage.product-service.operationalproduct.protected
+
 IT_SUBSCRIPTION_KAFKA_TOPIC=subscription.subscriptions.private
 %stage.IT_SUBSCRIPTION_KAFKA_TOPIC=stage.subscription.subscriptions.private
 %prod.IT_SUBSCRIPTION_KAFKA_TOPIC=subscription.subscriptions.private
@@ -318,6 +321,20 @@ mp.messaging.incoming.offering-sync-service-umb.address=${OFFERING_UMB_SERVICE_Q
 mp.messaging.incoming.offering-sync-service-umb.client-options-name=umb
 mp.messaging.incoming.offering-sync-service-umb.enabled=${UMB_ENABLED}
 mp.messaging.incoming.offering-sync-service-umb.failure-strategy=accept
+
+mp.messaging.incoming.it-offering-sync.connector=smallrye-kafka
+%test.mp.messaging.incoming.it-offering-sync.connector=smallrye-in-memory
+mp.messaging.incoming.it-offering-sync.topic=${IT_PRODUCT_KAFKA_TOPIC}
+%stage,prod.mp.messaging.incoming.it-offering-sync.bootstrap.servers=${IT_MANAGED_KAFKA_SERVERS}
+%stage,prod.mp.messaging.incoming.it-offering-sync.security.protocol=SASL_SSL
+%stage,prod.mp.messaging.incoming.it-offering-sync.sasl.mechanism=SCRAM-SHA-512
+%stage,prod.mp.messaging.incoming.it-offering-sync.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+    username="${IT_MANAGED_KAFKA_USERNAME}" \
+    password="${IT_MANAGED_KAFKA_PASSWORD}";
+mp.messaging.incoming.it-offering-sync.group.id=it-product-kafka-worker
+mp.messaging.incoming.it-offering-sync.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.it-offering-sync.failure-strategy=ignore
+mp.messaging.incoming.it-offering-sync.health-enabled=false
 
 mp.messaging.incoming.subscription-sync-umb.connector=smallrye-amqp
 %test.mp.messaging.incoming.subscription-sync-umb.connector=smallrye-in-memory

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -210,14 +210,12 @@ SUBSCRIPTION_UMB_QUEUE=VirtualTopic.canonical.subscription
 
 IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitlement.protected
 %stage.IT_PARTNER_KAFKA_TOPIC=stage.partner-integration.entitlement-gateway.partner-entitlement.protected
-%prod.IT_PARTNER_KAFKA_TOPIC=partner-integration.entitlement-gateway.partner-entitlement.protected
 
 IT_PRODUCT_KAFKA_TOPIC=product-service.operationalproduct.protected
 %stage.IT_PRODUCT_KAFKA_TOPIC=stage.product-service.operationalproduct.protected
 
 IT_SUBSCRIPTION_KAFKA_TOPIC=subscription.subscriptions.private
 %stage.IT_SUBSCRIPTION_KAFKA_TOPIC=stage.subscription.subscriptions.private
-%prod.IT_SUBSCRIPTION_KAFKA_TOPIC=subscription.subscriptions.private
 
 %ephemeral.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm-ephemeral
 %stage.UMB_SERVICE_ACCOUNT_NAME=nonprod-insightsrhsm

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static com.redhat.swatch.contract.config.Channels.IT_OFFERING_SYNC;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.redhat.swatch.contract.test.LoggerCaptor;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class ProductStatusKafkaMessageConsumerTest {
+
+  private static final String VALID_JSON_MESSAGE =
+      """
+        {
+          "occurredOn": "2023-05-29T16:00:54.279Z",
+          "productCode": "RH0180191",
+          "productCategory": "Parent SKU",
+          "eventType": "Create"
+        }
+        """;
+
+  private static final String CHILD_SKU_JSON_MESSAGE =
+      """
+        {
+          "occurredOn": "2023-05-29T16:00:54.279Z",
+          "productCode": "SVCRH01",
+          "productCategory": "Child SKU",
+          "eventType": "Update"
+        }
+        """;
+
+  @Inject @Any InMemoryConnector connector;
+  @InjectSpy ProductStatusKafkaMessageConsumer consumer;
+
+  private InMemorySource<Object> productKafkaChannel;
+
+  @BeforeAll
+  static void configureLogging() {
+    LoggerCaptor.registerHandler(ProductStatusKafkaMessageConsumer.class);
+  }
+
+  @BeforeEach
+  void setUp() {
+    productKafkaChannel = connector.source(IT_OFFERING_SYNC);
+    LoggerCaptor.clearRecords();
+  }
+
+  @Test
+  void shouldDeserializeAndLogParentSkuMessage() {
+    whenSendMessage(VALID_JSON_MESSAGE);
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeProduct(VALID_JSON_MESSAGE);
+              LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=kafka");
+            });
+  }
+
+  @Test
+  void shouldDeserializeAndLogChildSkuMessage() {
+    whenSendMessage(CHILD_SKU_JSON_MESSAGE);
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeProduct(CHILD_SKU_JSON_MESSAGE);
+              LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=kafka");
+            });
+  }
+
+  @Test
+  void shouldNotLogSuccessWhenMessageIsInvalidJson() {
+    whenSendMessage("not-valid-json");
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeProduct("not-valid-json");
+              LoggerCaptor.thenWarnLogWithMessage("Unable to read IT Product Kafka message");
+            });
+  }
+
+  @Test
+  void shouldIgnoreNullMessage() throws Exception {
+    consumer.consumeMessage(null);
+
+    LoggerCaptor.thenLogNothing();
+    verify(consumer, never()).consumeProduct(anyString());
+  }
+
+  private void whenSendMessage(String message) {
+    productKafkaChannel.send(message);
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_SERVICE_UMB;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.LoggerCaptor;
+import com.redhat.swatch.contract.test.resources.EnableUmbResource;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySource;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(EnableUmbResource.class)
+class ProductStatusUMBMessageConsumerTest {
+
+  private static final String VALID_JSON_MESSAGE =
+      """
+        {
+          "occurredOn": "2023-05-29T16:00:54.279Z",
+          "productCode": "RH0180191",
+          "productCategory": "Parent SKU",
+          "eventType": "Create"
+        }
+        """;
+
+  @InjectMock OfferingSyncService offeringSyncService;
+  @Inject @Any InMemoryConnector connector;
+  @InjectSpy ProductStatusUMBMessageConsumer consumer;
+
+  private InMemorySource<Object> productUmbChannel;
+
+  @BeforeAll
+  static void configureLogging() {
+    LoggerCaptor.registerHandler(ProductStatusUMBMessageConsumer.class);
+  }
+
+  @BeforeEach
+  void setUp() {
+    productUmbChannel = connector.source(OFFERING_SYNC_TASK_SERVICE_UMB);
+    LoggerCaptor.clearRecords();
+  }
+
+  @Test
+  void shouldDeserializeLogAndSyncProduct() {
+    whenSendMessage(VALID_JSON_MESSAGE);
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              verify(consumer).consumeProduct(VALID_JSON_MESSAGE);
+              LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=umb");
+              verify(offeringSyncService)
+                  .syncUmbProductFromEvent(any(OperationalProductEvent.class));
+            });
+  }
+
+  private void whenSendMessage(String message) {
+    productUmbChannel.send(message);
+  }
+}


### PR DESCRIPTION
Jira issue: SWATCH-5077

## Description
This PR creates a new Kafka consumer for the IT Product (offerings) Service, consuming from the IT Managed Kafka instance. Topics:
- stage: stage.product-service.operationalproduct.protected
- prod: product-service.operationalproduct.protected

## Testing
Unit tests included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka-based product offering synchronization through the IT offering event stream.
  * Added support for product-service event topics across deployment environments.
  * Enhanced product consumption logs with product category and child SKU details.
  * Added handling for malformed or empty messages without disrupting processing.

* **Tests**
  * Added coverage for Kafka message processing, deserialization, logging, validation, and synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->