### PR TITLE
SWATCH-5303: Use the LicenseId to invoke AWS billing API

### DIFF
--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -16,9 +16,9 @@ This document outlines the test plan for swatch-producer-aws.
 **Assumptions:**
 
 * The swatch-producer-aws service is deployed in a stable and functional environment
-* **swatch-contracts** provides accurate `AwsUsageContext` for subscribed orgs (including `customerAwsAccountId` and, when applicable, license-scoped context per SWATCH-5297)
+* **swatch-contracts** provides accurate `AwsUsageContext` for subscribed orgs (including `customerAwsAccountId` and, when applicable, license-scoped context)
 * Kafka is available for billable-usage input and status output topics
-* Billable-usage hourly aggregates may carry `licenseId` on the aggregate body (SWATCH-5301)
+* Billable-usage hourly aggregates may carry `licenseId` on the aggregate body
 * AWS Marketplace and contracts APIs are stubbed via Wiremock in component tests
 
 **Constraints:**
@@ -48,7 +48,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 
 - **Description**: Verify that usage records sent to AWS use `CustomerAWSAccountId` from `AwsUsageContext.customerAwsAccountId`.
 - **Setup**:
-  - Wiremock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
+  - WireMock returns `awsUsageContext` with distinct `customerId` and `customerAwsAccountId`
   - Kafka topics for billable-usage hourly aggregate and status are available
 - **Action**:
   - Produce a valid AWS billable-usage aggregate to Kafka
@@ -60,7 +60,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
   - `CustomerIdentifier` is absent from the usage record
   - `ProductCode` is still sent on the request
 
-## LicenseArn on BatchMeterUsage (SWATCH-5050 / SWATCH-5303)
+## LicenseArn on BatchMeterUsage
 
 **producer-aws-license-TC001 - Omit LicenseArn when feature flag is off**
 
@@ -68,7 +68,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Setup**:
   - Unleash toggle `swatch.swatch-producer-aws.use-license` is off
   - Produce an AWS billable-usage aggregate **with** `licenseId` set on the aggregate body
-  - Wiremock returns a valid `awsUsageContext`
+  - WireMock returns a valid `awsUsageContext`
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -77,6 +77,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Expected Result**:
   - `UsageRecords[0].LicenseArn` is absent / null
   - `ProductCode` is still present on the request
+  - Contracts `awsUsageContext` lookup does **not** include `licenseId`
   - Remittance status is `SUCCEEDED`
 
 **producer-aws-license-TC002 - Set LicenseArn when feature flag is on and licenseId is present**
@@ -85,7 +86,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Setup**:
   - Unleash toggle `swatch.swatch-producer-aws.use-license` is enabled
   - Aggregate body includes `licenseId` (e.g. `arn:aws:license-manager:...:license:swatch-test-license`)
-  - Wiremock stubs `getAwsUsageContext` successfully (with optional `licenseId` query param per SWATCH-5297 when implemented)
+  - WireMock stubs `getAwsUsageContext` successfully (with optional `licenseId` query param)
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -103,7 +104,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Setup**:
   - Unleash toggle `swatch.swatch-producer-aws.use-license` is enabled
   - Aggregate has **no** `licenseId`
-  - Wiremock returns a valid `awsUsageContext`
+  - WireMock returns a valid `awsUsageContext`
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -122,7 +123,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Setup**:
   - `use-license` enabled
   - Aggregate includes `licenseId`
-  - Wiremock `awsUsageContext` includes `customerAwsAccountId`
+  - WireMock `awsUsageContext` includes `customerAwsAccountId`
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -140,11 +141,11 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 - **Setup**:
   - `use-license` enabled
   - Aggregate includes `licenseId`
-  - Wiremock can match `getAwsUsageContext` with optional `licenseId` parameter
+  - WireMock can match `getAwsUsageContext` with optional `licenseId` parameter
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
-  - Inspect contracts Wiremock recorded request for `awsUsageContext`
+  - Inspect contracts WireMock recorded request for `awsUsageContext`
 - **Expected Result**:
   - Contracts lookup includes the aggregate `licenseId` (when the API contract requires/accepts it)
   - Successful remittance uses that context
@@ -152,11 +153,11 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 
 **producer-aws-license-TC006 - Status emission includes licenseId on success path**
 
-- **Description**: Verify remittance status messages carry the `licenseId` used for metering after a successful AWS remittance (`emitStatus` success path; remittance correlation per SWATCH-5303 / SWATCH-5335).
+- **Description**: Verify remittance status messages carry the `licenseId` used for metering after a successful AWS remittance (`emitStatus` success path).
 - **Setup**:
   - `use-license` enabled
   - Aggregate includes `licenseId`
-  - Wiremock stubs successful `getAwsUsageContext` and successful AWS `BatchMeterUsage`
+  - WireMock stubs successful `getAwsUsageContext` and successful AWS `BatchMeterUsage`
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -166,11 +167,11 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
 
 **producer-aws-license-TC007 - Status emission includes licenseId on failure path**
 
-- **Description**: Verify remittance status messages still carry `licenseId` when remittance fails after `licenseId` was known (`emitStatus` failure path; remittance correlation per SWATCH-5303 / SWATCH-5335).
+- **Description**: Verify remittance status messages still carry `licenseId` when remittance fails after `licenseId` was known (`emitStatus` failure path).
 - **Setup**:
   - `use-license` enabled
   - Aggregate includes `licenseId`
-  - Wiremock stubs a contracts or AWS failure that still emits status (e.g. contracts `awsUsageContext` 404)
+  - WireMock stubs a contracts or AWS failure that still emits status (e.g. contracts `awsUsageContext` 404)
 - **Action**:
   - Produce the aggregate to Kafka
 - **Verification**:
@@ -187,7 +188,7 @@ Contracts `awsUsageContext` lookup failures and remittance error classification.
 
 - **Description**: Verify that when swatch-contracts returns 404 with `CONTRACTS1005`, remittance status is `SUBSCRIPTION_TERMINATED` (not `SUBSCRIPTION_NOT_FOUND`).
 - **Setup**:
-  - Wiremock returns `awsUsageContext` 404 with an `Error` body containing `CONTRACTS1005`
+  - WireMock returns `awsUsageContext` 404 with an `Error` body containing `CONTRACTS1005`
   - Kafka topics for billable-usage hourly aggregate and status are available
 - **Action**:
   - Produce a valid AWS billable-usage aggregate to Kafka

--- a/swatch-producer-aws/ct/java/api/AwsTestHelper.java
+++ b/swatch-producer-aws/ct/java/api/AwsTestHelper.java
@@ -37,6 +37,16 @@ public final class AwsTestHelper {
 
   public static BillableUsageAggregate createUsageAggregate(
       String productId, String billingAccountId, String metricId, double totalValue, String orgId) {
+    return createUsageAggregate(productId, billingAccountId, metricId, totalValue, orgId, null);
+  }
+
+  public static BillableUsageAggregate createUsageAggregate(
+      String productId,
+      String billingAccountId,
+      String metricId,
+      double totalValue,
+      String orgId,
+      String licenseId) {
     OffsetDateTime snapshotDate =
         OffsetDateTime.now().minusHours(1).withOffsetSameInstant(ZoneOffset.UTC);
 
@@ -45,6 +55,7 @@ public final class AwsTestHelper {
     aggregate.setWindowTimestamp(
         OffsetDateTime.now().truncatedTo(ChronoUnit.HOURS).withOffsetSameInstant(ZoneOffset.UTC));
     aggregate.setAggregateId(UUID.randomUUID());
+    aggregate.setLicenseId(licenseId);
 
     var key = new BillableUsageAggregateKey();
     key.setOrgId(orgId);

--- a/swatch-producer-aws/ct/java/api/AwsUnleashService.java
+++ b/swatch-producer-aws/ct/java/api/AwsUnleashService.java
@@ -22,4 +22,15 @@ package api;
 
 import com.redhat.swatch.component.tests.api.UnleashService;
 
-public class AwsUnleashService extends UnleashService {}
+public class AwsUnleashService extends UnleashService {
+
+  public static final String USE_LICENSE = "swatch.swatch-producer-aws.use-license";
+
+  public void enableUseLicense() {
+    enableFlag(USE_LICENSE);
+  }
+
+  public void disableUseLicense() {
+    disableFlag(USE_LICENSE);
+  }
+}

--- a/swatch-producer-aws/ct/java/api/AwsWiremockService.java
+++ b/swatch-producer-aws/ct/java/api/AwsWiremockService.java
@@ -21,11 +21,14 @@
 package api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.component.tests.api.WiremockService;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,15 +145,6 @@ public class AwsWiremockService extends WiremockService {
         "");
   }
 
-  public void verifyBatchMeterUsageCustomerIdentifier(String expectedCustomerIdentifier) {
-    UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
-    assertEquals(
-        expectedCustomerIdentifier,
-        usageRecord.customerIdentifier(),
-        "customerIdentifier mismatch");
-    assertFieldAbsent("customerAWSAccountId", usageRecord.customerAWSAccountId());
-  }
-
   public void verifyBatchMeterUsageCustomerAwsAccountId(String expectedCustomerAwsAccountId) {
     UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
     assertEquals(
@@ -158,6 +152,37 @@ public class AwsWiremockService extends WiremockService {
         usageRecord.customerAWSAccountId(),
         "customerAWSAccountId mismatch");
     assertFieldAbsent("customerIdentifier", usageRecord.customerIdentifier());
+  }
+
+  public void verifyBatchMeterUsageLicenseArn(String expectedLicenseArn) {
+    UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
+    assertEquals(expectedLicenseArn, usageRecord.licenseArn(), "licenseArn mismatch");
+  }
+
+  public void verifyBatchMeterUsageLicenseArnAbsent() {
+    UsageRecord usageRecord = findLatestBatchMeterUsageUsageRecord();
+    assertFieldAbsent("licenseArn", usageRecord.licenseArn());
+  }
+
+  public void verifyBatchMeterUsageProductCode(String expectedProductCode) {
+    BatchMeterUsageRequest batchRequest = findLatestBatchMeterUsageRequest();
+    assertEquals(expectedProductCode, batchRequest.productCode(), "productCode mismatch");
+  }
+
+  public void verifyAwsUsageContextLicenseId(String expectedLicenseId) {
+    String requestUrl = findLatestAwsUsageContextRequestUrl();
+    String decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
+    assertTrue(
+        decodedUrl.contains("licenseId=" + expectedLicenseId),
+        "Expected licenseId query param in awsUsageContext request: " + requestUrl);
+  }
+
+  public void verifyAwsUsageContextLicenseIdAbsent() {
+    String requestUrl = findLatestAwsUsageContextRequestUrl();
+    String decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);
+    assertFalse(
+        decodedUrl.contains("licenseId="),
+        "Expected no licenseId query param in awsUsageContext request: " + requestUrl);
   }
 
   private static void assertFieldAbsent(String fieldName, String value) {
@@ -172,6 +197,51 @@ public class AwsWiremockService extends WiremockService {
       throw new AssertionError("BatchMeterUsage request missing UsageRecords: " + batchRequest);
     }
     return batchRequest.usageRecords().get(0);
+  }
+
+  private String findLatestAwsUsageContextRequestUrl() {
+    var response =
+        given().when().get("/__admin/requests").then().statusCode(200).extract().response();
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode responseJson = objectMapper.readTree(response.getBody().asString());
+      JsonNode requests = responseJson.get("requests");
+
+      if (requests == null || requests.isEmpty()) {
+        throw new AssertionError("No requests found in Wiremock");
+      }
+
+      String matchingUrl = null;
+      for (JsonNode requestNode : requests) {
+        JsonNode request = requestNode.get("request");
+        if (request == null) {
+          continue;
+        }
+
+        JsonNode urlNode = request.get("url");
+        JsonNode methodNode = request.get("method");
+        if (urlNode == null || methodNode == null) {
+          continue;
+        }
+
+        String url = urlNode.asText();
+        String method = methodNode.asText();
+        if (!url.contains("awsUsageContext") || !"GET".equals(method)) {
+          continue;
+        }
+        matchingUrl = url;
+      }
+
+      if (matchingUrl == null) {
+        throw new AssertionError("No awsUsageContext requests found");
+      }
+      return matchingUrl;
+    } catch (AssertionError e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to verify awsUsageContext request: " + e.getMessage(), e);
+    }
   }
 
   private BatchMeterUsageRequest findLatestBatchMeterUsageRequest() {

--- a/swatch-producer-aws/ct/java/api/MessageValidators.java
+++ b/swatch-producer-aws/ct/java/api/MessageValidators.java
@@ -36,6 +36,16 @@ public class MessageValidators {
         BillableUsageAggregate.class);
   }
 
+  public static DefaultMessageValidator<BillableUsageAggregate> aggregateMatches(
+      String billingAccountId, Status status, String licenseId) {
+    return new DefaultMessageValidator<>(
+        aggregate ->
+            billingAccountId.equals(aggregate.getAggregateKey().getBillingAccountId())
+                && status.equals(aggregate.getStatus())
+                && licenseId.equals(aggregate.getLicenseId()),
+        BillableUsageAggregate.class);
+  }
+
   public static DefaultMessageValidator<BillableUsageAggregate> alwaysMatch() {
     return new DefaultMessageValidator<>(agg -> true, BillableUsageAggregate.class);
   }

--- a/swatch-producer-aws/ct/java/tests/LicenseArnComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/LicenseArnComponentTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.AwsTestHelper.createUsageAggregate;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
+
+import api.MessageValidators;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import domain.Product;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class LicenseArnComponentTest extends BaseAwsComponentTest {
+
+  private static final double TOTAL_VALUE = 2.0;
+  private static final String LICENSE_ID =
+      "arn:aws:license-manager:us-east-1:123456789012:license:swatch-test-license";
+  private static final String CUSTOMER_AWS_ACCOUNT_ID = "123456789012";
+
+  @AfterEach
+  void tearDown() {
+    unleash.disableUseLicense();
+  }
+
+  @TestPlanName("producer-aws-license-TC001")
+  @Test
+  void shouldOmitLicenseArnWhenFlagOff() {
+    givenUseLicenseDisabled();
+    givenContractsReturnsAwsUsageContext();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceSucceeds();
+    thenLicenseArnIsAbsent();
+    thenProductCodeIsPresent();
+    wiremock.verifyAwsUsageContextLicenseIdAbsent();
+  }
+
+  @TestPlanName("producer-aws-license-TC002")
+  @Test
+  void shouldSetLicenseArnWhenFlagOn() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsAwsUsageContext();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceSucceedsWithLicense();
+    thenLicenseArnMatchesAggregate();
+    thenProductCodeIsPresent();
+  }
+
+  @TestPlanName("producer-aws-license-TC003")
+  @Test
+  void shouldOmitLicenseArnWhenFlagOnButLicenseMissing() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsAwsUsageContext();
+
+    whenBillableUsageAggregateWithoutLicenseIsProduced();
+
+    thenRemittanceSucceeds();
+    thenLicenseArnIsAbsent();
+    thenProductCodeIsPresent();
+  }
+
+  @TestPlanName("producer-aws-license-TC004")
+  @Test
+  void shouldSetLicenseArnWithCustomerAwsAccountId() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsAwsUsageContextWithCustomerAwsAccountId();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceSucceedsWithLicense();
+    wiremock.verifyBatchMeterUsageCustomerAwsAccountId(CUSTOMER_AWS_ACCOUNT_ID);
+    thenLicenseArnMatchesAggregate();
+    thenProductCodeIsPresent();
+  }
+
+  @TestPlanName("producer-aws-license-TC005")
+  @Test
+  void shouldPassLicenseIdToGetAwsUsageContext() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsAwsUsageContext();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceSucceedsWithLicense();
+    wiremock.verifyAwsUsageContextLicenseId(LICENSE_ID);
+  }
+
+  @TestPlanName("producer-aws-license-TC006")
+  @Test
+  void shouldEmitStatusWithLicenseIdOnSuccess() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsAwsUsageContext();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceSucceedsWithLicense();
+  }
+
+  @TestPlanName("producer-aws-license-TC007")
+  @Test
+  void shouldEmitStatusWithLicenseIdOnFailure() {
+    givenUseLicenseEnabled();
+    givenContractsReturnsSubscriptionNotFound();
+
+    whenBillableUsageAggregateWithLicenseIsProduced();
+
+    thenRemittanceFailsWithLicense();
+    thenNoAwsUsageIsSent();
+  }
+
+  private void givenUseLicenseEnabled() {
+    unleash.enableUseLicense();
+  }
+
+  private void givenUseLicenseDisabled() {
+    unleash.disableUseLicense();
+  }
+
+  private void givenContractsReturnsAwsUsageContext() {
+    wiremock.setupAwsUsageContext(
+        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode);
+  }
+
+  private void givenContractsReturnsAwsUsageContextWithCustomerAwsAccountId() {
+    wiremock.setupAwsUsageContext(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        CUSTOMER_AWS_ACCOUNT_ID);
+  }
+
+  private void givenContractsReturnsSubscriptionNotFound() {
+    wiremock.setupAwsUsageContextToReturnSubscriptionNotFound(awsAccountId);
+  }
+
+  private void whenBillableUsageAggregateWithLicenseIsProduced() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+    BillableUsageAggregate aggregate =
+        createUsageAggregate(
+            Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId, LICENSE_ID);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregate);
+  }
+
+  private void whenBillableUsageAggregateWithoutLicenseIsProduced() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+    BillableUsageAggregate aggregate =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregate);
+  }
+
+  private void thenRemittanceSucceeds() {
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateMatches(awsAccountId, BillableUsage.Status.SUCCEEDED),
+        1);
+  }
+
+  private void thenRemittanceSucceedsWithLicense() {
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateMatches(
+            awsAccountId, BillableUsage.Status.SUCCEEDED, LICENSE_ID),
+        1);
+  }
+
+  private void thenRemittanceFailsWithLicense() {
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateMatches(awsAccountId, BillableUsage.Status.FAILED, LICENSE_ID),
+        1);
+  }
+
+  private void thenLicenseArnMatchesAggregate() {
+    wiremock.verifyBatchMeterUsageLicenseArn(LICENSE_ID);
+  }
+
+  private void thenLicenseArnIsAbsent() {
+    wiremock.verifyBatchMeterUsageLicenseArnAbsent();
+  }
+
+  private void thenProductCodeIsPresent() {
+    wiremock.verifyBatchMeterUsageProductCode(productCode);
+  }
+
+  private void thenNoAwsUsageIsSent() {
+    wiremock.verifyNoAwsUsage();
+  }
+}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/config/FeatureFlags.java
@@ -29,14 +29,21 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class FeatureFlags implements InfoFeatureFlagContributor {
 
+  public static final String USE_LICENSE = "swatch.swatch-producer-aws.use-license";
+
   private final Unleash unleash;
 
   public FeatureFlags(Unleash unleash) {
     this.unleash = unleash;
   }
 
+  /** Whether BatchMeterUsage UsageRecords should include LicenseArn. */
+  public boolean useLicense() {
+    return unleash.isEnabled(USE_LICENSE);
+  }
+
   @Override
   public InfoFeatureFlags getFeatureFlags() {
-    return UnleashInfoFeatureFlags.snapshot(unleash);
+    return UnleashInfoFeatureFlags.snapshot(unleash, USE_LICENSE);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.aws.service;
 import static com.redhat.swatch.configuration.registry.SubscriptionDefinition.getBillingFactor;
 import static java.util.Optional.ofNullable;
 
+import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
 import com.redhat.swatch.aws.exception.AwsThrottlingException;
 import com.redhat.swatch.aws.exception.AwsUnprocessedRecordsException;
@@ -81,6 +82,7 @@ public class AwsBillableUsageAggregateConsumer {
   private final Optional<Boolean> isDryRun;
   private final Duration awsUsageWindow;
   private final BillableUsageStatusProducer billableUsageStatusProducer;
+  private final FeatureFlags featureFlags;
   private final MeterProvider<Counter> meteredTotalCounter;
 
   public AwsBillableUsageAggregateConsumer(
@@ -89,7 +91,8 @@ public class AwsBillableUsageAggregateConsumer {
       AwsMarketplaceMeteringClientFactory awsMarketplaceMeteringClientFactory,
       @ConfigProperty(name = "ENABLE_AWS_DRY_RUN") Optional<Boolean> isDryRun,
       @ConfigProperty(name = "AWS_MARKETPLACE_USAGE_WINDOW") Duration awsUsageWindow,
-      BillableUsageStatusProducer billableUsageStatusProducer) {
+      BillableUsageStatusProducer billableUsageStatusProducer,
+      FeatureFlags featureFlags) {
     acceptedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_accepted_total");
     rejectedCounter = meterRegistry.counter("swatch_aws_marketplace_batch_rejected_total");
     ignoreCounter = meterRegistry.counter("swatch_aws_marketplace_batch_ignored_total");
@@ -99,6 +102,7 @@ public class AwsBillableUsageAggregateConsumer {
     this.isDryRun = isDryRun;
     this.awsUsageWindow = awsUsageWindow;
     this.billableUsageStatusProducer = billableUsageStatusProducer;
+    this.featureFlags = featureFlags;
   }
 
   @Incoming("billable-usage-hourly-aggregate-in")
@@ -205,6 +209,7 @@ public class AwsBillableUsageAggregateConsumer {
   public AwsUsageContext lookupAwsUsageContext(BillableUsageAggregate billableUsageAggregate)
       throws AwsUsageContextLookupException {
     try {
+      String licenseId = featureFlags.useLicense() ? billableUsageAggregate.getLicenseId() : null;
       return contractsApi.getAwsUsageContext(
           billableUsageAggregate.getWindowTimestamp(),
           billableUsageAggregate.getAggregateKey().getProductId(),
@@ -212,8 +217,7 @@ public class AwsBillableUsageAggregateConsumer {
           billableUsageAggregate.getAggregateKey().getSla(),
           billableUsageAggregate.getAggregateKey().getUsage(),
           billableUsageAggregate.getAggregateKey().getBillingAccountId(),
-          // LicenseId will be propagated as part of SWATCH-5301.
-          null);
+          licenseId);
     } catch (DefaultApiException e) {
       if (ofNullable(e.getError())
           .map(error -> "CONTRACTS1005".equals(error.getCode()))
@@ -319,12 +323,37 @@ public class AwsBillableUsageAggregateConsumer {
           "Unable to send usage since it is outside of the AWS processing window");
     }
 
-    return UsageRecord.builder()
-        .customerAWSAccountId(context.getCustomerAwsAccountId())
-        .dimension(metric.getAwsDimension())
-        .quantity(billableUsageAggregate.getTotalValue().intValueExact())
-        .timestamp(effectiveTimestamp.toInstant())
-        .build();
+    UsageRecord.Builder usageRecord =
+        UsageRecord.builder()
+            .customerAWSAccountId(context.getCustomerAwsAccountId())
+            .dimension(metric.getAwsDimension())
+            .quantity(billableUsageAggregate.getTotalValue().intValueExact())
+            .timestamp(effectiveTimestamp.toInstant());
+
+    applyLicenseArnIfEnabled(usageRecord, billableUsageAggregate);
+
+    return usageRecord.build();
+  }
+
+  private void applyLicenseArnIfEnabled(
+      UsageRecord.Builder usageRecord, BillableUsageAggregate billableUsageAggregate) {
+    if (!featureFlags.useLicense()) {
+      log.debug(
+          "use-license flag off; omitting LicenseArn for aggregateId={}",
+          billableUsageAggregate.getAggregateId());
+      return;
+    }
+
+    String licenseId = billableUsageAggregate.getLicenseId();
+    if (licenseId == null || licenseId.isBlank()) {
+      log.warn(
+          "use-license is enabled but licenseId is missing; omitting LicenseArn"
+              + " for aggregateId={}",
+          billableUsageAggregate.getAggregateId());
+      return;
+    }
+
+    usageRecord.licenseArn(licenseId);
   }
 
   private boolean isForAws(BillableUsageAggregateKey aggregationKey) {

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/config/FeatureFlagsTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/config/FeatureFlagsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.redhat.swatch.info.model.InfoFeatureFlag;
+import com.redhat.swatch.info.model.InfoFeatureFlags;
+import io.getunleash.Unleash;
+import io.getunleash.variant.Variant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagsTest {
+
+  @Mock(strictness = Strictness.LENIENT)
+  Unleash unleash;
+
+  @InjectMocks FeatureFlags featureFlags;
+
+  @Test
+  void useLicenseMapsToToggleName() {
+    when(unleash.isEnabled(FeatureFlags.USE_LICENSE)).thenReturn(true);
+    assertTrue(featureFlags.useLicense());
+
+    when(unleash.isEnabled(FeatureFlags.USE_LICENSE)).thenReturn(false);
+    assertFalse(featureFlags.useLicense());
+  }
+
+  @Test
+  void infoContributorExposesUseLicenseFlag() {
+    when(unleash.isEnabled(FeatureFlags.USE_LICENSE)).thenReturn(true);
+    when(unleash.getVariant(FeatureFlags.USE_LICENSE)).thenReturn(Variant.DISABLED_VARIANT);
+
+    InfoFeatureFlags info = featureFlags.getFeatureFlags();
+    InfoFeatureFlag flag =
+        info.getFlags().stream()
+            .filter(entry -> FeatureFlags.USE_LICENSE.equals(entry.getName()))
+            .findFirst()
+            .orElseThrow();
+
+    assertEquals(FeatureFlags.USE_LICENSE, flag.getName());
+    assertTrue(flag.getEnabled());
+  }
+}

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -21,10 +21,12 @@
 package com.redhat.swatch.aws.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.aws.config.FeatureFlags;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
@@ -126,6 +129,7 @@ class AwsBillableUsageAggregateConsumerTest {
   @InjectMock AwsMarketplaceMeteringClientFactory clientFactory;
   MarketplaceMeteringClient meteringClient;
   @InjectMock BillableUsageStatusProducer billableUsageStatusProducer;
+  @InjectMock FeatureFlags featureFlags;
 
   @Inject MeterRegistry meterRegistry;
   Counter acceptedCounter;
@@ -176,6 +180,7 @@ class AwsBillableUsageAggregateConsumerTest {
             "status", BillableUsage.Status.SUCCEEDED.toString(), "error_code", "");
 
     meteringClient = mock(MarketplaceMeteringClient.class);
+    when(featureFlags.useLicense()).thenReturn(false);
   }
 
   @Test
@@ -218,10 +223,117 @@ class AwsBillableUsageAggregateConsumerTest {
             .productCode("product")
             .subscriptionStartDate(OffsetDateTime.MIN);
 
-    UsageRecord record = processUsageAndCaptureRecord(context);
+    UsageRecord record = processUsageAndCaptureRecord(context, ROSA_INSTANCE_HOURS_RECORD);
 
     assertEquals("123456789012", record.customerAWSAccountId());
     assertTrue(record.customerIdentifier() == null || record.customerIdentifier().isBlank());
+  }
+
+  @Test
+  void shouldOmitLicenseArnWhenUseLicenseFlagOff() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(false);
+    BillableUsageAggregate aggregateWithLicense =
+        createAggregateWithLicense("arn:aws:license:test");
+
+    UsageRecord record = processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
+
+    assertNull(record.licenseArn());
+    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull());
+  }
+
+  @Test
+  void shouldSetLicenseArnWhenUseLicenseFlagOn() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(true);
+    String licenseId = "arn:aws:license-manager:us-east-1:123:license:swatch-test";
+    BillableUsageAggregate aggregateWithLicense = createAggregateWithLicense(licenseId);
+
+    UsageRecord record = processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
+
+    assertEquals(licenseId, record.licenseArn());
+  }
+
+  @Test
+  void shouldOmitLicenseArnWhenFlagOnButLicenseIdMissing() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(true);
+
+    UsageRecord record =
+        processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, ROSA_INSTANCE_HOURS_RECORD);
+
+    assertNull(record.licenseArn());
+  }
+
+  @Test
+  void shouldPassLicenseIdToGetAwsUsageContext() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(true);
+    String licenseId = "arn:aws:license-manager:us-east-1:123:license:lookup";
+    BillableUsageAggregate aggregate = createAggregateWithLicense(licenseId);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), eq(licenseId)))
+        .thenReturn(MOCK_AWS_USAGE_CONTEXT);
+    when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
+    when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
+        .thenReturn(BATCH_METER_USAGE_SUCCESS_RESPONSE);
+
+    consumer.process(aggregate);
+
+    verify(contractsApi)
+        .getAwsUsageContext(any(), any(), any(), any(), any(), any(), eq(licenseId));
+  }
+
+  @Test
+  void shouldOmitLicenseIdFromContextLookupWhenFlagOff() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(false);
+    BillableUsageAggregate aggregate =
+        createAggregateWithLicense("arn:aws:license-manager:us-east-1:123:license:legacy");
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
+        .thenReturn(MOCK_AWS_USAGE_CONTEXT);
+    when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
+    when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
+        .thenReturn(BATCH_METER_USAGE_SUCCESS_RESPONSE);
+
+    consumer.process(aggregate);
+
+    verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull());
+  }
+
+  @Test
+  void shouldEmitStatusWithLicenseIdOnSuccess() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(true);
+    String licenseId = "arn:aws:license-manager:us-east-1:123:license:status-ok";
+    BillableUsageAggregate aggregate = createAggregateWithLicense(licenseId);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), eq(licenseId)))
+        .thenReturn(MOCK_AWS_USAGE_CONTEXT);
+    when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
+    when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
+        .thenReturn(BATCH_METER_USAGE_SUCCESS_RESPONSE);
+
+    consumer.process(aggregate);
+
+    verify(billableUsageStatusProducer)
+        .emitStatus(
+            argThat(
+                usage ->
+                    BillableUsage.Status.SUCCEEDED.equals(usage.getStatus())
+                        && licenseId.equals(usage.getLicenseId())));
+  }
+
+  @Test
+  void shouldEmitStatusWithLicenseIdOnFailure() throws ApiException {
+    when(featureFlags.useLicense()).thenReturn(true);
+    String licenseId = "arn:aws:license-manager:us-east-1:123:license:status-fail";
+    BillableUsageAggregate aggregate = createAggregateWithLicense(licenseId);
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), eq(licenseId)))
+        .thenThrow(new SubscriptionCanNotBeDeterminedException(null));
+
+    consumer.process(aggregate);
+
+    verify(billableUsageStatusProducer)
+        .emitStatus(
+            argThat(
+                usage ->
+                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                        && BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND.equals(
+                            usage.getErrorCode())
+                        && licenseId.equals(usage.getLicenseId())));
   }
 
   @Test
@@ -289,13 +401,14 @@ class AwsBillableUsageAggregateConsumerTest {
   @Test
   void shouldIncrementAcceptedAndSuccessCounters() throws ApiException {
     var priorSuccess = successCounter.count();
+    var priorAccepted = acceptedCounter.count();
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
         .thenReturn(BATCH_METER_USAGE_SUCCESS_RESPONSE);
     consumer.process(ROSA_INSTANCE_HOURS_RECORD);
-    assertEquals(1.0, acceptedCounter.count());
+    assertEquals(priorAccepted + 1.0, acceptedCounter.count());
 
     var metric = getMeteredTotalMetricForSucceeded(MetricIdUtils.getInstanceHours().getValue());
     assertTrue(metric.isPresent());
@@ -345,7 +458,8 @@ class AwsBillableUsageAggregateConsumerTest {
             clientFactory,
             Optional.of(true),
             Duration.of(1, ChronoUnit.HOURS),
-            billableUsageStatusProducer);
+            billableUsageStatusProducer,
+            featureFlags);
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
         .thenReturn(MOCK_AWS_USAGE_CONTEXT);
     processor.process(ROSA_INSTANCE_HOURS_RECORD);
@@ -506,8 +620,9 @@ class AwsBillableUsageAggregateConsumerTest {
     assertEquals(isValid, consumer.isUsageDateValid(clock, aggregate));
   }
 
-  private UsageRecord processUsageAndCaptureRecord(AwsUsageContext context) throws ApiException {
-    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
+  private UsageRecord processUsageAndCaptureRecord(
+      AwsUsageContext context, BillableUsageAggregate aggregate) throws ApiException {
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(context);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
     when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
@@ -515,9 +630,21 @@ class AwsBillableUsageAggregateConsumerTest {
 
     ArgumentCaptor<BatchMeterUsageRequest> requestCaptor =
         ArgumentCaptor.forClass(BatchMeterUsageRequest.class);
-    consumer.process(ROSA_INSTANCE_HOURS_RECORD);
+    consumer.process(aggregate);
     verify(meteringClient).batchMeterUsage(requestCaptor.capture());
-    return requestCaptor.getValue().usageRecords().get(0);
+    var captured = requestCaptor.getValue();
+    return captured.usageRecords().getFirst();
+  }
+
+  private static BillableUsageAggregate createAggregateWithLicense(String licenseId) {
+    BillableUsageAggregate aggregate =
+        createAggregate(
+            "rosa",
+            MetricIdUtils.getInstanceHours().toUpperCaseFormatted(),
+            OffsetDateTime.now(Clock.systemUTC()),
+            42.0);
+    aggregate.setLicenseId(licenseId);
+    return aggregate;
   }
 
   private static BillableUsageAggregate createAggregate(


### PR DESCRIPTION
Jira issue: SWATCH-5303

## Description
Changes:
- add licenseArn if use-license feature flag is enabled and the billable usage aggregate has the licenseId field set. 
- configured the use-license feature flag to be exposed into the /info API.

## Testing
Added unit-tests and component tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional license support for AWS usage reporting.
  * License details and identifiers are included when licensing is enabled and valid information is available.
  * Added controls to enable or disable license handling.
* **Bug Fixes**
  * Improved handling of missing or unavailable license information.
  * Enhanced success and failure status reporting for license-related processing.
* **Tests**
  * Added coverage for license ARN, product code, license propagation, and AWS usage-context behavior.
* **Documentation**
  * Clarified test scenarios, setup requirements, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->