### PR TITLE
SWATCH-5187: Add get_contracts billing_account_id component test

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -350,6 +350,15 @@ Test cases should be testable locally and in an ephemeral environment.
 - **Verification:** Both contracts returned; `license_id` is set only on the licensed contract.  
 - **Expected Result:** HTTP 200 with both contracts and correct `license_id` values.
 
+**contracts-retrieval-TC008** - **Get contracts by `billing_account_id`**  
+- **Description:** Verify filtering by billing account ID returns only the matching contract.  
+- **Setup:** Create two AWS ROSA contracts for the same org with different `billing_account_id` values.  
+- **Action:** GET `/api/swatch-contracts/internal/contracts?org_id={org_id}&billing_account_id={billing_account_id}` for each billing account.  
+- **Verification:** Check the returned contract list.  
+- **Expected Result:**  
+  - Only the contract with the matching `billing_account_id` is returned  
+  - Response includes the correct contract `uuid` and `billing_account_id`
+
 ## AWS Usage Context
 
 Component tests for GET `/api/swatch-contracts/internal/subscriptions/awsUsageContext`. Test class: `AwsUsageContextComponentTest`.

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -136,6 +136,13 @@ public class ContractsSwatchService extends SwatchService {
   }
 
   public List<com.redhat.swatch.contract.test.model.Contract>
+      getContractsByOrgIdAndBillingAccountId(String orgId, String billingAccountId) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(billingAccountId, "billingAccountId must not be null");
+    return getContracts(Map.of("org_id", orgId, "billing_account_id", billingAccountId));
+  }
+
+  public List<com.redhat.swatch.contract.test.model.Contract>
       getContractsByOrgIdAndBillingProviderAndTimestamp(
           String orgId, BillingProvider billingProvider, OffsetDateTime timestamp) {
     Objects.requireNonNull(orgId, "orgId must not be null");

--- a/swatch-contracts/ct/java/tests/ContractsRetrievalComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsRetrievalComponentTest.java
@@ -191,8 +191,35 @@ public class ContractsRetrievalComponentTest extends BaseContractComponentTest {
         withoutLicenseContract.getLicenseId(), "Contract without licenseId must expose null");
   }
 
+  @TestPlanName("contracts-retrieval-TC008")
+  @Test
+  void shouldGetContractsByBillingAccountId() {
+    final String firstBillingAccountId = "billing-" + RandomUtils.generateRandom();
+    final String secondBillingAccountId = "billing-" + RandomUtils.generateRandom();
+    var firstContract = givenExistingContractForBillingAccountId(firstBillingAccountId);
+    var secondContract = givenExistingContractForBillingAccountId(secondBillingAccountId);
+    final String firstUuid = service.getContracts(firstContract).get(0).getUuid();
+    final String secondUuid = service.getContracts(secondContract).get(0).getUuid();
+
+    var contracts = service.getContractsByOrgIdAndBillingAccountId(orgId, firstBillingAccountId);
+    assertEquals(1, contracts.size());
+    assertEquals(firstUuid, contracts.get(0).getUuid());
+    assertEquals(firstBillingAccountId, contracts.get(0).getBillingAccountId());
+
+    contracts = service.getContractsByOrgIdAndBillingAccountId(orgId, secondBillingAccountId);
+    assertEquals(1, contracts.size());
+    assertEquals(secondUuid, contracts.get(0).getUuid());
+    assertEquals(secondBillingAccountId, contracts.get(0).getBillingAccountId());
+  }
+
   private Contract givenExistingContractForBillingProvider(BillingProvider billingProvider) {
     Contract contract = (Contract) contractBuilder().billingProvider(billingProvider).build();
+    givenContractIsCreated(contract);
+    return contract;
+  }
+
+  private Contract givenExistingContractForBillingAccountId(String billingAccountId) {
+    Contract contract = (Contract) contractBuilder().billingAccountId(billingAccountId).build();
     givenContractIsCreated(contract);
     return contract;
   }


### PR DESCRIPTION
Filter contracts by billing_account_id in retrieval CT coverage, replacing IQE test_contracts_api_get_contract_filter.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
SWATCH-5187

## Testing
```
./mvnw test -Pcomponent-tests -pl swatch-contracts/ct -Dtest=ContractsRetrievalComponentTest#shouldGetContractsByBillingAccountId
```
MR to delete test: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1574