### PR TITLE
SWATCH-5078: Add feature flag to the IT Product Service Kafka/UMB consumers

### DIFF
--- a/swatch-contracts/pom.xml
+++ b/swatch-contracts/pom.xml
@@ -348,6 +348,7 @@
                 <sourcePath>subscriptions_export_json_measurement.yaml</sourcePath>
                 <sourcePath>enable_partner_gateway_contracts_variant_payload.yaml</sourcePath>
                 <sourcePath>it_subscription_service_feature_flag_variant_payload.yaml</sourcePath>
+                <sourcePath>product_service_consumer_feature_flag_variant_payload.yaml</sourcePath>
               </sourcePaths>
             </configuration>
           </execution>

--- a/swatch-contracts/schemas/product_service_consumer_feature_flag_variant_payload.yaml
+++ b/swatch-contracts/schemas/product_service_consumer_feature_flag_variant_payload.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: ProductServiceConsumerFeatureFlagVariantPayload
+description: JSON payload for the enable-product-service-consumer feature toggle variant.
+type: object
+properties:
+  kafka_consumer_enabled:
+    description: If the kafka consumer is enabled.
+    type: boolean
+    default: false
+  umb_consumer_enabled:
+    description: If the UMB consumer is enabled.
+    type: boolean
+    default: true

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/config/FeatureFlags.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.contract.model.ItSubscriptionServiceFeatureFlagVariantPayload;
 import com.redhat.swatch.contract.model.PartnerGatewayContractsFeatureFlagVariantPayload;
+import com.redhat.swatch.contract.model.ProductServiceConsumerFeatureFlagVariantPayload;
 import com.redhat.swatch.info.InfoFeatureFlagContributor;
 import com.redhat.swatch.info.UnleashInfoFeatureFlags;
 import com.redhat.swatch.info.model.InfoFeatureFlags;
@@ -43,6 +44,8 @@ public class FeatureFlags implements InfoFeatureFlagContributor {
       "swatch.swatch-contracts.enable-partner-gateway-contracts";
   public static final String IT_SUBSCRIPTION_SERVICE =
       "swatch.swatch-contracts.enable-it-subscription-service";
+  public static final String PRODUCT_SERVICE_CONSUMER =
+      "swatch.swatch-contracts.enable-product-service-consumer";
   public static final String CONFIG_VARIANT = "config";
 
   protected static final boolean DEFAULT_IS_ENABLED = true;
@@ -80,6 +83,22 @@ public class FeatureFlags implements InfoFeatureFlagContributor {
         IT_SUBSCRIPTION_SERVICE,
         this::mapToItSubscriptionServicePayload,
         ItSubscriptionServiceFeatureFlagVariantPayload::getUmbConsumerEnabled);
+  }
+
+  /** Whether the Kafka consumer for Product Service is allowed. */
+  public boolean isProductServiceKafkaConsumerEnabled() {
+    return isFeatureFlagEnabled(
+        PRODUCT_SERVICE_CONSUMER,
+        this::mapToProductServiceConsumerPayload,
+        ProductServiceConsumerFeatureFlagVariantPayload::getKafkaConsumerEnabled);
+  }
+
+  /** Whether the UMB consumer for Product Service is allowed. */
+  public boolean isProductServiceUmbConsumerEnabled() {
+    return isFeatureFlagEnabled(
+        PRODUCT_SERVICE_CONSUMER,
+        this::mapToProductServiceConsumerPayload,
+        ProductServiceConsumerFeatureFlagVariantPayload::getUmbConsumerEnabled);
   }
 
   /**
@@ -130,6 +149,12 @@ public class FeatureFlags implements InfoFeatureFlagContributor {
         variant, ItSubscriptionServiceFeatureFlagVariantPayload.class, IT_SUBSCRIPTION_SERVICE);
   }
 
+  private Optional<ProductServiceConsumerFeatureFlagVariantPayload>
+      mapToProductServiceConsumerPayload(Variant variant) {
+    return mapToPayload(
+        variant, ProductServiceConsumerFeatureFlagVariantPayload.class, PRODUCT_SERVICE_CONSUMER);
+  }
+
   private <T> Optional<T> mapToPayload(
       Variant variant, Class<T> payloadClass, String featureFlagName) {
     var payload = variant.getPayload();
@@ -153,6 +178,10 @@ public class FeatureFlags implements InfoFeatureFlagContributor {
   @Override
   public InfoFeatureFlags getFeatureFlags() {
     return UnleashInfoFeatureFlags.snapshot(
-        unleash, DEFAULT_IS_ENABLED, PARTNER_GATEWAY_CONTRACTS, IT_SUBSCRIPTION_SERVICE);
+        unleash,
+        DEFAULT_IS_ENABLED,
+        PARTNER_GATEWAY_CONTRACTS,
+        IT_SUBSCRIPTION_SERVICE,
+        PRODUCT_SERVICE_CONSUMER);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.contract.config.Channels.IT_OFFERING_SYNC;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -35,6 +36,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 @Slf4j
 public class ProductStatusKafkaMessageConsumer {
 
+  @Inject FeatureFlags featureFlags;
   @Inject ObjectMapper mapper;
 
   @Blocking
@@ -42,6 +44,10 @@ public class ProductStatusKafkaMessageConsumer {
   public void consumeMessage(String message) throws JsonProcessingException {
     log.debug("IT Product Kafka consumer was called");
     if (message == null) {
+      return;
+    }
+    if (!featureFlags.isProductServiceKafkaConsumerEnabled()) {
+      log.debug("IT Product Kafka consumer is disabled by feature flag.");
       return;
     }
     consumeProduct(message);

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_SERV
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.contract.config.Channels;
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
 import com.redhat.swatch.contract.product.UpstreamProductData;
 import io.smallrye.common.annotation.Blocking;
@@ -40,6 +41,7 @@ public class ProductStatusUMBMessageConsumer {
 
   @Inject ObjectMapper mapper;
   @Inject OfferingSyncService service;
+  @Inject FeatureFlags featureFlags;
 
   @ConfigProperty(name = "UMB_ENABLED")
   boolean umbEnabled;
@@ -48,15 +50,19 @@ public class ProductStatusUMBMessageConsumer {
   @Incoming(OFFERING_SYNC_TASK_SERVICE_UMB)
   public void consumeMessage(String message) {
     log.info("Received message from UMB offering sync service.  product {}", message);
-    if (umbEnabled) {
-      try {
-        MDC.put(UpstreamProductData.REQUEST_SOURCE, Channels.OFFERING_SYNC_TASK_SERVICE_UMB);
-        consumeProduct(message);
-      } finally {
-        MDC.remove(UpstreamProductData.REQUEST_SOURCE);
-      }
-    } else {
+    if (!umbEnabled) {
       log.debug("UMB processing is not enabled");
+      return;
+    }
+    if (!featureFlags.isProductServiceUmbConsumerEnabled()) {
+      log.debug("IT Product UMB consumer is disabled by feature flag.");
+      return;
+    }
+    try {
+      MDC.put(UpstreamProductData.REQUEST_SOURCE, Channels.OFFERING_SYNC_TASK_SERVICE_UMB);
+      consumeProduct(message);
+    } finally {
+      MDC.remove(UpstreamProductData.REQUEST_SOURCE);
     }
   }
 

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/config/FeatureFlagsTest.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.contract.config.FeatureFlags.CONFIG_VARIANT;
 import static com.redhat.swatch.contract.config.FeatureFlags.DEFAULT_IS_ENABLED;
 import static com.redhat.swatch.contract.config.FeatureFlags.IT_SUBSCRIPTION_SERVICE;
 import static com.redhat.swatch.contract.config.FeatureFlags.PARTNER_GATEWAY_CONTRACTS;
+import static com.redhat.swatch.contract.config.FeatureFlags.PRODUCT_SERVICE_CONSUMER;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -228,5 +229,46 @@ class FeatureFlagsTest {
   private void givenItSubscriptionServiceEnabledWithVariant(Variant variant) {
     when(unleash.isEnabled(IT_SUBSCRIPTION_SERVICE, DEFAULT_IS_ENABLED)).thenReturn(true);
     when(unleash.getVariant(IT_SUBSCRIPTION_SERVICE)).thenReturn(variant);
+  }
+
+  @Test
+  void shouldReturnFalse_whenProductServiceConsumerDisabled() {
+    when(unleash.isEnabled(PRODUCT_SERVICE_CONSUMER, DEFAULT_IS_ENABLED)).thenReturn(false);
+
+    assertFalse(featureFlags.isProductServiceKafkaConsumerEnabled());
+    assertFalse(featureFlags.isProductServiceUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldRespectProductServiceKafkaConsumerFlag() {
+    givenProductServiceConsumerEnabledWithConfigPayload("{\"kafka_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isProductServiceKafkaConsumerEnabled());
+  }
+
+  @Test
+  void shouldRespectProductServiceUmbConsumerFlag() {
+    givenProductServiceConsumerEnabledWithConfigPayload("{\"umb_consumer_enabled\":false}");
+
+    assertFalse(featureFlags.isProductServiceUmbConsumerEnabled());
+  }
+
+  @Test
+  void shouldDecoupleKafkaAndUmbForProductServiceConsumer() {
+    givenProductServiceConsumerEnabledWithConfigPayload(
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
+
+    assertFalse(featureFlags.isProductServiceKafkaConsumerEnabled());
+    assertTrue(featureFlags.isProductServiceUmbConsumerEnabled());
+  }
+
+  private void givenProductServiceConsumerEnabledWithConfigPayload(String json) {
+    givenProductServiceConsumerEnabledWithVariant(
+        new Variant(CONFIG_VARIANT, new Payload("json", json), true, "any", true));
+  }
+
+  private void givenProductServiceConsumerEnabledWithVariant(Variant variant) {
+    when(unleash.isEnabled(PRODUCT_SERVICE_CONSUMER, DEFAULT_IS_ENABLED)).thenReturn(true);
+    when(unleash.getVariant(PRODUCT_SERVICE_CONSUMER)).thenReturn(variant);
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
@@ -23,10 +23,14 @@ package com.redhat.swatch.contract.service;
 import static com.redhat.swatch.contract.config.Channels.IT_OFFERING_SYNC;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.test.LoggerCaptor;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
@@ -61,6 +65,7 @@ class ProductStatusKafkaMessageConsumerTest {
         }
         """;
 
+  @InjectMock FeatureFlags featureFlags;
   @Inject @Any InMemoryConnector connector;
   @InjectSpy ProductStatusKafkaMessageConsumer consumer;
 
@@ -75,6 +80,7 @@ class ProductStatusKafkaMessageConsumerTest {
   void setUp() {
     productKafkaChannel = connector.source(IT_OFFERING_SYNC);
     LoggerCaptor.clearRecords();
+    when(featureFlags.isProductServiceKafkaConsumerEnabled()).thenReturn(true);
   }
 
   @Test
@@ -119,6 +125,13 @@ class ProductStatusKafkaMessageConsumerTest {
 
     LoggerCaptor.thenLogNothing();
     verify(consumer, never()).consumeProduct(anyString());
+  }
+
+  @Test
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() throws Exception {
+    when(featureFlags.isProductServiceKafkaConsumerEnabled()).thenReturn(false);
+    whenSendMessage(VALID_JSON_MESSAGE);
+    verify(consumer, after(500).never()).consumeProduct(VALID_JSON_MESSAGE);
   }
 
   private void whenSendMessage(String message) {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
@@ -23,8 +23,11 @@ package com.redhat.swatch.contract.service;
 import static com.redhat.swatch.contract.config.Channels.OFFERING_SYNC_TASK_SERVICE_UMB;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.redhat.swatch.contract.config.FeatureFlags;
 import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
 import com.redhat.swatch.contract.test.LoggerCaptor;
 import com.redhat.swatch.contract.test.resources.EnableUmbResource;
@@ -56,6 +59,7 @@ class ProductStatusUMBMessageConsumerTest {
         """;
 
   @InjectMock OfferingSyncService offeringSyncService;
+  @InjectMock FeatureFlags featureFlags;
   @Inject @Any InMemoryConnector connector;
   @InjectSpy ProductStatusUMBMessageConsumer consumer;
 
@@ -70,6 +74,7 @@ class ProductStatusUMBMessageConsumerTest {
   void setUp() {
     productUmbChannel = connector.source(OFFERING_SYNC_TASK_SERVICE_UMB);
     LoggerCaptor.clearRecords();
+    when(featureFlags.isProductServiceUmbConsumerEnabled()).thenReturn(true);
   }
 
   @Test
@@ -84,6 +89,15 @@ class ProductStatusUMBMessageConsumerTest {
               verify(offeringSyncService)
                   .syncUmbProductFromEvent(any(OperationalProductEvent.class));
             });
+  }
+
+  @Test
+  void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() {
+    when(featureFlags.isProductServiceUmbConsumerEnabled()).thenReturn(false);
+    consumer.consumeMessage(VALID_JSON_MESSAGE);
+    verify(consumer, never()).consumeProduct(VALID_JSON_MESSAGE);
+    verify(offeringSyncService, never())
+        .syncUmbProductFromEvent(any(OperationalProductEvent.class));
   }
 
   private void whenSendMessage(String message) {


### PR DESCRIPTION
Jira issue: SWATCH-5078

## Description
Gate the Product Service Kafka and UMB consumers (to sync offerings) behind Unleash (feature flags), with optional structured config variant payload to turn each consumer on or off independently.

A separate MR in app-interface has registered the "swatch.swatch-contracts.enable-product-service-consumer" feature flag in the insights-default and insights-stage-default Unleash projects. To control consumers independently, add a config variant whose string payload is JSON, for example:

{"kafka_consumer_enabled": true, "umb_consumer_enabled": false}

## Testing
Added unit tests to cover these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature-flag controls for enabling or disabling Product Service Kafka and UMB message consumers independently.
  * Added configuration schema support for consumer settings, including default enabled states.

* **Bug Fixes**
  * Prevented message processing when the corresponding consumer feature flag or required configuration is disabled.

* **Tests**
  * Added coverage for consumer enablement, disablement, and independent flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->