### PR TITLE
SWATCH-5335: Update billable usage status consumer to update the licenseId to the remittance records

### DIFF
--- a/swatch-billable-usage/TEST_PLAN.md
+++ b/swatch-billable-usage/TEST_PLAN.md
@@ -440,6 +440,63 @@ Java component tests in `ContractAdjustmentComponentTest` (`swatch-billable-usag
 
 ---
 
+## Status Consumer (marketplace feedback)
+
+**billable-usage-status-TC001 - Align remittance licenses to status aggregate licenseId**
+
+- **Description:** Verify when a status aggregate carries a non-null `licenseId`, all referenced remittance rows are updated to that final metering license (even if they previously had a different or null license).  
+- **Setup:**  
+  - Create two pending remittances for the **same** org/billingAccountId (same hourly aggregate key)  
+  - Stamp them with licenseIds A then B via successive tallies as contracts change  
+- **Action:**  
+  - Publish `billable-usage.status` aggregate referencing both remittance UUIDs with `status=SUCCEEDED` and `licenseId=B`  
+- **Verification:**  
+  - Both remittances reach `SUCCEEDED`  
+  - Both remittances have `licenseId=B`  
+- **Expected Result:**  
+  - Remittance ledger matches the license actually used for AWS metering
+
+**billable-usage-status-TC002 - Null status licenseId clears remittance license**
+
+- **Description:** Verify a status update with null `licenseId` updates status/billedOn and sets remittance `license_id` to null (same value as the metering status payload).  
+- **Setup:**  
+  - Create a pending remittance stamped with licenseId A  
+- **Action:**  
+  - Publish status aggregate with `status=SUCCEEDED` and null `licenseId`  
+- **Verification:**  
+  - Remittance status = `SUCCEEDED`  
+  - Remittance `licenseId` is null  
+- **Expected Result:**  
+  - Remittance license always mirrors the status aggregate licenseId
+
+**billable-usage-status-TC003 - Update remittance with SUCCEEDED status**
+
+- **Description:** Verify status consumer marks remittance SUCCEEDED and sets billedOn.  
+- **Setup:**  
+  - Create a pending remittance (no contract coverage)  
+- **Action:**  
+  - Publish status aggregate with `status=SUCCEEDED` and billedOn  
+- **Verification:**  
+  - Remittance status = `SUCCEEDED`  
+  - `billedOn` is set near the published timestamp  
+- **Expected Result:**  
+  - Successful marketplace feedback updates remittance lifecycle fields
+
+**billable-usage-status-TC004 - Update remittance with FAILED status**
+
+- **Description:** Verify status consumer marks remittance FAILED and sets errorCode.  
+- **Setup:**  
+  - Create a pending remittance (no contract coverage)  
+- **Action:**  
+  - Publish status aggregate with `status=FAILED` and `errorCode=SUBSCRIPTION_NOT_FOUND`  
+- **Verification:**  
+  - Remittance status = `FAILED`  
+  - `errorCode` = `SUBSCRIPTION_NOT_FOUND`  
+- **Expected Result:**  
+  - Failed marketplace feedback updates remittance lifecycle fields
+
+---
+
 ## Negative and Resilience
 
 **billable-usage-negative-TC001 - Service survives null tally message**

--- a/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BaseBillableUsageComponentTest.java
@@ -246,12 +246,13 @@ public class BaseBillableUsageComponentTest {
             status,
             errorCode,
             billedOn,
-            List.of(billableUsage.getUuid().toString())));
+            List.of(billableUsage.getUuid().toString()),
+            null));
     waitForRemittanceStatus(billableUsage.getTallyId().toString(), expectedRemittanceStatus);
     return billableUsage;
   }
 
-  private BillableUsageAggregate buildBillableUsageAggregate(
+  protected BillableUsageAggregate buildBillableUsageAggregate(
       String orgId,
       String productId,
       String metricId,
@@ -259,7 +260,8 @@ public class BaseBillableUsageComponentTest {
       BillableUsage.Status status,
       BillableUsage.ErrorCode errorCode,
       OffsetDateTime billedOn,
-      List<String> remittanceUuids) {
+      List<String> remittanceUuids,
+      String licenseId) {
     var aggregateKey = new BillableUsageAggregateKey();
     aggregateKey.setOrgId(orgId);
     aggregateKey.setProductId(productId);
@@ -279,6 +281,7 @@ public class BaseBillableUsageComponentTest {
     Set<OffsetDateTime> snapshotDateSet = new HashSet<>();
     snapshotDateSet.add(OffsetDateTime.now(ZoneOffset.UTC).minusDays(3));
     aggregate.setSnapshotDates(snapshotDateSet);
+    aggregate.setLicenseId(licenseId);
     if (errorCode != null) {
       aggregate.setErrorCode(errorCode);
     }

--- a/swatch-billable-usage/ct/java/tests/BillableUsageStatusComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/BillableUsageStatusComponentTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageTestHelper.createTallySummary;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import api.MessageValidators;
+import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
+import com.redhat.swatch.component.tests.api.DefaultMessageValidator;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import domain.BillingProvider;
+import domain.ContractStub;
+import domain.RemittanceErrorCode;
+import domain.RemittanceStatus;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.TallySummary;
+import org.junit.jupiter.api.Test;
+
+public class BillableUsageStatusComponentTest extends BaseBillableUsageComponentTest {
+
+  private static final double VALUE = 8.0;
+  private static final double BILLING_FACTOR = ROSA.getBillingFactor(CORES);
+  private static final String LICENSE_A = "arn:aws:license-manager:1:license:a";
+  private static final String LICENSE_B = "arn:aws:license-manager:1:license:b";
+
+  @Test
+  @TestPlanName("billable-usage-status-TC001")
+  void shouldAlignRemittanceLicensesWhenStatusHasLicenseId() {
+    // Given: two pending remittances for the same billing account (same hourly
+    // aggregate key), stamped with different licenses as contracts change
+    BillableUsage usageA = givenPendingRemittanceWithLicense(LICENSE_A, VALUE);
+    BillableUsage usageB = givenPendingRemittanceWithLicense(LICENSE_B, VALUE * 2);
+
+    // When: status arrives with the final metering license
+    whenStatusUpdateIsSent(
+        BillableUsage.Status.SUCCEEDED,
+        null,
+        OffsetDateTime.now(ZoneOffset.UTC),
+        List.of(usageA.getUuid().toString(), usageB.getUuid().toString()),
+        LICENSE_B);
+
+    // Then: both remittances succeed and share that license
+    thenRemittanceStatusIs(usageA.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
+    thenRemittanceStatusIs(usageB.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
+    assertEquals(LICENSE_B, remittanceLicenseForTally(usageA.getTallyId().toString()));
+    assertEquals(LICENSE_B, remittanceLicenseForTally(usageB.getTallyId().toString()));
+  }
+
+  @Test
+  @TestPlanName("billable-usage-status-TC002")
+  void shouldClearRemittanceLicenseWhenStatusLicenseIsNull() {
+    // Given: a pending remittance stamped with a license
+    BillableUsage usage = givenPendingRemittanceWithLicense(LICENSE_A, VALUE);
+
+    // When: status arrives without a licenseId
+    whenStatusUpdateIsSent(
+        BillableUsage.Status.SUCCEEDED,
+        null,
+        OffsetDateTime.now(ZoneOffset.UTC),
+        List.of(usage.getUuid().toString()),
+        null);
+
+    // Then: status updates and remittance license mirrors the status payload
+    thenRemittanceStatusIs(usage.getTallyId().toString(), RemittanceStatus.SUCCEEDED);
+    assertNull(remittanceLicenseForTally(usage.getTallyId().toString()));
+  }
+
+  @Test
+  @TestPlanName("billable-usage-status-TC003")
+  void shouldUpdateRemittanceWithSucceededStatus() {
+    // Given: a pending remittance exists
+    BillableUsage billableUsage = givenPendingRemittanceExists();
+    String tallyId = billableUsage.getTallyId().toString();
+    OffsetDateTime expectedBilledOnTime = OffsetDateTime.now(ZoneOffset.UTC);
+
+    // When: status update with SUCCEEDED is published
+    whenStatusUpdateIsSent(
+        BillableUsage.Status.SUCCEEDED,
+        null,
+        expectedBilledOnTime,
+        List.of(billableUsage.getUuid().toString()),
+        null);
+
+    // Then: remittance is SUCCEEDED with billedOn populated
+    thenRemittanceStatusIs(tallyId, RemittanceStatus.SUCCEEDED);
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+    assertNotNull(remittances, "Remittances should exist");
+    assertFalse(remittances.isEmpty(), "Should have at least one remittance");
+    thenBilledOnIsNear(remittances.getFirst(), expectedBilledOnTime);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-status-TC004")
+  void shouldUpdateRemittanceWithFailedStatus() {
+    // Given: a pending remittance exists
+    BillableUsage billableUsage = givenPendingRemittanceExists();
+    String tallyId = billableUsage.getTallyId().toString();
+
+    // When: status update with FAILED is published
+    whenStatusUpdateIsSent(
+        BillableUsage.Status.FAILED,
+        BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND,
+        null,
+        List.of(billableUsage.getUuid().toString()),
+        null);
+
+    // Then: remittance is FAILED with the expected error code
+    thenRemittanceStatusIs(tallyId, RemittanceStatus.FAILED);
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+    assertNotNull(remittances, "Remittances should exist");
+    assertFalse(remittances.isEmpty(), "Should have at least one remittance");
+    thenErrorCodeIs(remittances.getFirst(), RemittanceErrorCode.SUBSCRIPTION_NOT_FOUND.name());
+  }
+
+  private BillableUsage givenPendingRemittanceExists() {
+    contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
+    whenRosaTallyIsSent(VALUE);
+
+    double expectedValue = VALUE * BILLING_FACTOR;
+    List<BillableUsage> billableUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            MessageValidators.billableUsageMatchesWithValue(orgId, ROSA.getName(), expectedValue),
+            1);
+    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage message");
+    BillableUsage usage = billableUsages.getFirst();
+    waitForRemittanceStatus(usage.getTallyId().toString(), RemittanceStatus.PENDING);
+    return usage;
+  }
+
+  private BillableUsage givenPendingRemittanceWithLicense(String licenseId, double tallyValue) {
+    OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1);
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    contractsWiremock.setupContracts(
+        orgId, ROSA.getName(), List.of(new ContractStub(start, end, Map.of(), licenseId)));
+
+    TallySummary tallySummary = whenRosaTallyIsSent(tallyValue);
+    String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
+    waitForRemittanceStatus(tallyId, RemittanceStatus.PENDING);
+    assertEquals(licenseId, remittanceLicenseForTally(tallyId), "Remittance license mismatch");
+
+    List<BillableUsage> billableUsages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE,
+            new DefaultMessageValidator<>(
+                usage ->
+                    orgId.equals(usage.getOrgId())
+                        && ROSA.getName().equals(usage.getProductId())
+                        && usage.getTallyId() != null
+                        && tallyId.equals(usage.getTallyId().toString()),
+                BillableUsage.class),
+            1);
+    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage for tally");
+    return billableUsages.getFirst();
+  }
+
+  private TallySummary whenRosaTallyIsSent(double tallyValue) {
+    TallySummary tallySummary =
+        createTallySummary(
+            orgId,
+            ROSA.getName(),
+            CORES.toString(),
+            tallyValue,
+            BillingProvider.AWS,
+            billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+    return tallySummary;
+  }
+
+  private void whenStatusUpdateIsSent(
+      BillableUsage.Status status,
+      BillableUsage.ErrorCode errorCode,
+      OffsetDateTime billedOn,
+      List<String> remittanceUuids,
+      String licenseId) {
+    kafkaBridge.produceKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        buildBillableUsageAggregate(
+            orgId,
+            ROSA.getName(),
+            CORES.toString(),
+            billingAccountId,
+            status,
+            errorCode,
+            billedOn,
+            remittanceUuids,
+            licenseId));
+  }
+
+  private String remittanceLicenseForTally(String tallyId) {
+    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+    assertNotNull(remittances, "Remittances should exist for tally " + tallyId);
+    assertFalse(remittances.isEmpty(), "Should have at least one remittance");
+    return remittances.getFirst().getLicenseId();
+  }
+
+  private void thenBilledOnIsNear(TallyRemittance remittance, OffsetDateTime expectedTime) {
+    assertNotNull(remittance.getBilledOn(), "billedOn field should be present");
+    Duration timeDiff = Duration.between(expectedTime, remittance.getBilledOn()).abs();
+    assertTrue(
+        timeDiff.toSeconds() <= 1,
+        String.format(
+            "billedOn timestamp %s should be within 1 second of expected time %s",
+            remittance.getBilledOn(), expectedTime));
+  }
+
+  private void thenErrorCodeIs(TallyRemittance remittance, String expectedErrorCode) {
+    assertNotNull(remittance.getErrorCode(), "errorCode field should be present");
+    assertEquals(
+        expectedErrorCode,
+        remittance.getErrorCode(),
+        String.format(
+            "Expected error code '%s' but got '%s'", expectedErrorCode, remittance.getErrorCode()));
+  }
+}

--- a/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/TallySummaryConsumerComponentTest.java
@@ -25,12 +25,10 @@ import static api.BillableUsageTestHelper.createTallySummaryWithDefaults;
 import static api.BillableUsageTestHelper.createTallySummaryWithGranularity;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOURLY_AGGREGATE;
-import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
 import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import api.MessageValidators;
 import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
@@ -39,20 +37,15 @@ import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import domain.BillingProvider;
-import domain.RemittanceErrorCode;
 import domain.RemittanceStatus;
-import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
-import org.candlepin.subscriptions.billable.usage.BillableUsageAggregateKey;
 import org.candlepin.subscriptions.billable.usage.TallySnapshot;
 import org.candlepin.subscriptions.billable.usage.TallySummary;
 import org.junit.jupiter.api.Test;
@@ -223,75 +216,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
         hourlySnapshotId,
         messages.get(0).getTallyId(),
         "Billable usage should be generated from HOURLY tally snapshot");
-  }
-
-  /** Verify that status consumer updates remittance with succeeded status. */
-  @Test
-  public void testStatusConsumerUpdatesRemittanceWithSucceededStatus() {
-    // Given a pending remittance exists
-    BillableUsage billableUsage = givenPendingRemittanceExists();
-
-    // Verify initial PENDING status via API (remittance created automatically)
-    String tallyId = billableUsage.getTallyId().toString();
-    waitForRemittanceStatus(tallyId, RemittanceStatus.PENDING);
-
-    // Capture expected billed_on time before creating status update
-    OffsetDateTime expectedBilledOnTime = OffsetDateTime.now(ZoneOffset.UTC);
-
-    // Create and send status update message with SUCCEEDED status
-    BillableUsageAggregate statusUpdate =
-        givenBillableUsageAggregate(
-            orgId,
-            ROSA.getName(),
-            billableUsage.getBillingAccountId(),
-            BillableUsage.Status.SUCCEEDED,
-            null,
-            expectedBilledOnTime, // Use the captured time
-            List.of(billableUsage.getUuid().toString()));
-
-    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_STATUS, statusUpdate);
-
-    // Verify final SUCCEEDED status via API (polling waits for consumer processing)
-    waitForRemittanceStatus(tallyId, RemittanceStatus.SUCCEEDED);
-
-    // Verify billed_on field was populated with proper timestamp
-    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
-    assertNotNull(remittances, "Remittances should exist");
-    assertFalse(remittances.isEmpty(), "Should have at least one remittance");
-    verifyBilledOnTimestamp(remittances.get(0), expectedBilledOnTime);
-  }
-
-  /** Verify that status consumer updates remittance with failed status. */
-  @Test
-  public void testStatusConsumerUpdatesRemittanceWithFailedStatus() {
-    // Given a pending remittance exists
-    BillableUsage billableUsage = givenPendingRemittanceExists();
-
-    // Verify initial PENDING status via API (remittance created automatically)
-    String tallyId = billableUsage.getTallyId().toString();
-    waitForRemittanceStatus(tallyId, RemittanceStatus.PENDING);
-
-    // Create and send status update message with FAILED status
-    BillableUsageAggregate statusUpdate =
-        givenBillableUsageAggregate(
-            orgId,
-            ROSA.getName(),
-            billableUsage.getBillingAccountId(),
-            BillableUsage.Status.FAILED,
-            BillableUsage.ErrorCode.SUBSCRIPTION_NOT_FOUND,
-            null,
-            List.of(billableUsage.getUuid().toString()));
-
-    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_STATUS, statusUpdate);
-
-    // Verify final FAILED status via API (polling waits for consumer processing)
-    waitForRemittanceStatus(tallyId, RemittanceStatus.FAILED);
-
-    // Verify error code was populated properly
-    List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
-    assertNotNull(remittances, "Remittances should exist");
-    assertFalse(remittances.isEmpty(), "Should have at least one remittance");
-    verifyErrorCode(remittances.get(0), RemittanceErrorCode.SUBSCRIPTION_NOT_FOUND.name());
   }
 
   /**
@@ -518,91 +442,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
     contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
   }
 
-  /**
-   * Sets up test preconditions: creates tally summary, waits for billable usage with pending
-   * remittance
-   *
-   * @return The generated BillableUsage that has an associated pending remittance
-   */
-  private BillableUsage givenPendingRemittanceExists() {
-    // Setup wiremock endpoints
-    contractsWiremock.setupNoContractCoverage(orgId, ROSA.getName());
-
-    // Create and send tally summary to generate billable usage with remittance
-    whenSendTallySummaryWithValue(VALUE);
-
-    // Wait for billable usage to be produced
-    double expectedValue = VALUE * BILLING_FACTOR;
-    List<BillableUsage> billableUsages =
-        kafkaBridge.waitForKafkaMessage(
-            BILLABLE_USAGE,
-            MessageValidators.billableUsageMatchesWithValue(orgId, ROSA.getName(), expectedValue),
-            1);
-
-    assertEquals(1, billableUsages.size(), "Expected exactly 1 billable usage message");
-    return billableUsages.get(0);
-  }
-
-  /** Builds a billable usage aggregate (status update) for use in status consumer tests. */
-  private BillableUsageAggregate givenBillableUsageAggregate(
-      String orgId,
-      String productId,
-      String billingAccountId,
-      BillableUsage.Status status,
-      BillableUsage.ErrorCode errorCode,
-      OffsetDateTime billedOn,
-      List<String> remittanceUuids) {
-    return givenBillableUsageAggregate(
-        orgId,
-        productId,
-        CORES.toString(),
-        billingAccountId,
-        status,
-        errorCode,
-        billedOn,
-        remittanceUuids);
-  }
-
-  private BillableUsageAggregate givenBillableUsageAggregate(
-      String orgId,
-      String productId,
-      String metricId,
-      String billingAccountId,
-      BillableUsage.Status status,
-      BillableUsage.ErrorCode errorCode,
-      OffsetDateTime billedOn,
-      List<String> remittanceUuids) {
-
-    var aggregateKey = new BillableUsageAggregateKey();
-    aggregateKey.setOrgId(orgId);
-    aggregateKey.setProductId(productId);
-    aggregateKey.setMetricId(metricId);
-    aggregateKey.setSla("Premium");
-    aggregateKey.setUsage("Production");
-    aggregateKey.setBillingProvider(BillingProvider.AWS.name());
-    aggregateKey.setBillingAccountId(billingAccountId);
-
-    var aggregate = new BillableUsageAggregate();
-    aggregate.setAggregateKey(aggregateKey);
-    aggregate.setStatus(status);
-    aggregate.setRemittanceUuids(remittanceUuids);
-    aggregate.setTotalValue(BigDecimal.valueOf(5.0));
-    aggregate.setWindowTimestamp(OffsetDateTime.now(ZoneOffset.UTC).minusDays(3));
-    aggregate.setAggregateId(UUID.randomUUID());
-    Set<OffsetDateTime> snapshotDateSet = new HashSet<>();
-    snapshotDateSet.add(OffsetDateTime.now(ZoneOffset.UTC).minusDays(3));
-    aggregate.setSnapshotDates(snapshotDateSet);
-
-    if (errorCode != null) {
-      aggregate.setErrorCode(errorCode);
-    }
-    if (billedOn != null) {
-      aggregate.setBilledOn(billedOn);
-    }
-
-    return aggregate;
-  }
-
   private List<BillableUsageAggregate> whenHourlyAggregatesAreReceived(
       Set<String> orgIds, int expectedCount) {
     return kafkaBridge.waitForKafkaMessage(
@@ -724,30 +563,6 @@ public class TallySummaryConsumerComponentTest extends BaseBillableUsageComponen
             billingAccountId);
     kafkaBridge.produceKafkaMessage(TALLY, tallySummaryRosa);
     kafkaBridge.produceKafkaMessage(TALLY, tallySummaryRhelAddon);
-  }
-
-  /** Verify that billed_on timestamp is populated and within expected range */
-  private void verifyBilledOnTimestamp(TallyRemittance remittance, OffsetDateTime expectedTime) {
-    assertNotNull(remittance.getBilledOn(), "billedOn field should be present");
-
-    OffsetDateTime actualBilledOn = remittance.getBilledOn();
-    Duration timeDiff = Duration.between(expectedTime, actualBilledOn).abs();
-
-    assertTrue(
-        timeDiff.toSeconds() <= 1,
-        String.format(
-            "billedOn timestamp %s should be within 1 second of expected time %s",
-            actualBilledOn, expectedTime));
-  }
-
-  /** Verify that error code matches expected value */
-  private void verifyErrorCode(TallyRemittance remittance, String expectedErrorCode) {
-    assertNotNull(remittance.getErrorCode(), "errorCode field should be present");
-    assertEquals(
-        expectedErrorCode,
-        remittance.getErrorCode(),
-        String.format(
-            "Expected error code '%s' but got '%s'", expectedErrorCode, remittance.getErrorCode()));
   }
 
   private BillableUsageAggregate thenBillableUsageAggregateIsFound(

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -107,14 +107,16 @@ public class BillableUsageRemittanceRepository
       List<String> uuids,
       RemittanceStatus status,
       OffsetDateTime billedOn,
-      RemittanceErrorCode errorCode) {
+      RemittanceErrorCode errorCode,
+      String licenseId) {
     List<UUID> uuidList = uuids.stream().map(UUID::fromString).toList();
     update(
-        "status = ?1, billedOn=?2, errorCode=?3, updatedAt=?4 where uuid in (?5)",
+        "status = ?1, billedOn=?2, errorCode=?3, updatedAt=?4, licenseId=?5 where uuid in (?6)",
         status,
         billedOn,
         errorCode,
         OffsetDateTime.now(ZoneOffset.UTC),
+        licenseId,
         uuidList);
   }
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumer.java
@@ -85,6 +85,10 @@ public class BillableUsageStatusConsumer {
     }
 
     remittanceRepository.updateStatusByIdIn(
-        remittanceUuidsToUpdate, status, billableUsageAggregate.getBilledOn(), errorCode);
+        remittanceUuidsToUpdate,
+        status,
+        billableUsageAggregate.getBilledOn(),
+        errorCode,
+        billableUsageAggregate.getLicenseId());
   }
 }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
@@ -63,6 +63,8 @@ import org.junit.jupiter.api.Test;
 class BillableUsageStatusConsumerTest {
 
   private static final String ORG_ID = "org123";
+  private static final String LICENSE_A = "arn:aws:license-manager:1:license:a";
+  private static final String LICENSE_B = "arn:aws:license-manager:1:license:b";
   private static final OffsetDateTime BILLED_ON =
       OffsetDateTime.of(2024, 5, 10, 10, 20, 5, 0, ZoneOffset.UTC);
 
@@ -204,9 +206,55 @@ class BillableUsageStatusConsumerTest {
     Awaitility.await().untilAsserted(this::verifyUpdateForSuccess);
   }
 
+  @Test
+  void testWhenStatusHasLicenseIdThenRemittancesUpdatedToThatLicense() {
+    var remittanceA = givenExistingRemittanceWithLicense(LICENSE_A);
+    var remittanceB = givenExistingRemittanceWithLicense(LICENSE_B);
+    var remittanceNull = givenExistingRemittanceWithLicense(null);
+
+    var successMessage =
+        createBillableUsageAggregate(
+            Status.SUCCEEDED, null, BILLED_ON, LICENSE_B, remittanceA, remittanceB, remittanceNull);
+
+    whenSendResponse(successMessage);
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                verifyRemittancesHaveLicense(
+                    List.of(
+                        remittanceA.getUuid().toString(),
+                        remittanceB.getUuid().toString(),
+                        remittanceNull.getUuid().toString()),
+                    LICENSE_B));
+  }
+
+  @Test
+  void testWhenStatusHasNullLicenseIdThenRemittanceLicenseCleared() {
+    var remittanceA = givenExistingRemittanceWithLicense(LICENSE_A);
+    var remittanceNull = givenExistingRemittanceWithLicense(null);
+
+    var successMessage =
+        createBillableUsageAggregate(
+            Status.SUCCEEDED, null, BILLED_ON, (String) null, remittanceA, remittanceNull);
+
+    whenSendResponse(successMessage);
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                verifyRemittancesHaveLicense(
+                    List.of(remittanceA.getUuid().toString(), remittanceNull.getUuid().toString()),
+                    null));
+  }
+
   @Transactional
   BillableUsageRemittanceEntity givenExistingRemittance() {
+    return givenExistingRemittanceWithLicense(null);
+  }
+
+  @Transactional
+  BillableUsageRemittanceEntity givenExistingRemittanceWithLicense(String licenseId) {
     var remittance = buildBillableUsageRemittanceEntity();
+    remittance.setLicenseId(licenseId);
     remittanceRepository.persist(remittance);
     return remittance;
   }
@@ -295,10 +343,33 @@ class BillableUsageStatusConsumerTest {
         .forEach(assertion);
   }
 
+  @Transactional
+  void verifyRemittancesHaveLicense(List<String> uuids, String expectedLicenseId) {
+    verifyUpdateForSuccess();
+    verifyRemittances(
+        uuids,
+        result -> {
+          if (expectedLicenseId == null) {
+            assertNull(result.getLicenseId());
+          } else {
+            assertEquals(expectedLicenseId, result.getLicenseId());
+          }
+        });
+  }
+
   private BillableUsageAggregate createBillableUsageAggregate(
       Status status,
       ErrorCode errorCode,
       OffsetDateTime billedOn,
+      BillableUsageRemittanceEntity... remittances) {
+    return createBillableUsageAggregate(status, errorCode, billedOn, null, remittances);
+  }
+
+  private BillableUsageAggregate createBillableUsageAggregate(
+      Status status,
+      ErrorCode errorCode,
+      OffsetDateTime billedOn,
+      String licenseId,
       BillableUsageRemittanceEntity... remittances) {
     var aggregate = new BillableUsageAggregate();
     aggregate.setStatus(status);
@@ -308,6 +379,7 @@ class BillableUsageStatusConsumerTest {
     if (billedOn != null) {
       aggregate.setBilledOn(billedOn);
     }
+    aggregate.setLicenseId(licenseId);
     aggregate.setRemittanceUuids(
         Stream.of(remittances)
             .map(BillableUsageRemittanceEntity::getUuid)


### PR DESCRIPTION
Jira issue: SWATCH-5335

## Description
When processing billable-usage status aggregates, always set remittance license_id to the aggregate licenseId (including null), so remittances match the license used for metering.

## Testing
Added unit coverage and move status consumer component tests into BillableUsageStatusComponentTest with TEST_PLAN cases TC001–TC004.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remittance status processing now synchronizes associated license information.
  * License details are set or cleared appropriately during successful and failed status updates.

* **Tests**
  * Added coverage for license synchronization, billing timestamps, error codes, and remittance lifecycle transitions.
  * Expanded marketplace feedback test documentation for succeeded and failed status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->