### PR TITLE
SWATCH-5188: Add component test for tag-metrics endpoint

### DIFF
--- a/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
+++ b/swatch-contracts/SWATCH-CONTRACTS-COMPONENT-TEST-PLAN.md
@@ -1433,6 +1433,15 @@ This section verifies the automatic contract termination behavior when contracts
   - Operation completes without causing system errors.
   - API response properly handles non-existent SKU (appropriate error code or message).
 
+**offering-tags-TC004: Retrieve tag metrics for product tag**
+- **Description:** Verify that tag metrics can be retrieved for a configured product tag such as `rosa`.
+- **Setup:** None (reads from product configuration registry).
+- **Action:** Call internal GET `/api/swatch-contracts/internal/tags/{tag}/metrics` for `rosa`.
+- **Verification:** Assert HTTP 200 and each returned entry has non-null `metric_id` and `aws_dimension` matching the product configuration.
+- **Expected Result:**
+  - API returns all metrics configured for the tag.
+  - Each metric includes `metric_id` and `aws_dimension` values from product configuration.
+
 ## Capacity Management
 
 **offering-capacity-TC001: Verify capacity calculation for metered offerings**

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -88,6 +88,7 @@ public class ContractsSwatchService extends SwatchService {
       ENDPOINT_PREFIX + "/rpc/sync/contracts/%s/subscriptions";
   private static final String SKU_PRODUCT_TAGS_ENDPOINT =
       ENDPOINT_PREFIX + "/offerings/%s/product_tags";
+  private static final String TAG_METRICS_ENDPOINT = ENDPOINT_PREFIX + "/tags/%s/metrics";
   private static final String FORCE_RECONCILE_OFFERING_ENDPOINT =
       ENDPOINT_PREFIX + "/rpc/offerings/reconcile/%s";
 
@@ -536,6 +537,13 @@ public class ContractsSwatchService extends SwatchService {
     Objects.requireNonNull(sku, "sku must not be null");
 
     String endpoint = String.format(SKU_PRODUCT_TAGS_ENDPOINT, sku);
+    return given().headers(SECURITY_HEADERS).accept("application/json").when().get(endpoint);
+  }
+
+  public Response getTagMetrics(String tag) {
+    Objects.requireNonNull(tag, "tag must not be null");
+
+    String endpoint = String.format(TAG_METRICS_ENDPOINT, tag);
     return given().headers(SECURITY_HEADERS).accept("application/json").when().get(endpoint);
   }
 

--- a/swatch-contracts/ct/java/tests/OfferingTagsComponentTest.java
+++ b/swatch-contracts/ct/java/tests/OfferingTagsComponentTest.java
@@ -36,10 +36,14 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.configuration.registry.Metric;
+import com.redhat.swatch.contract.test.model.MetricResponse;
 import com.redhat.swatch.contract.test.model.OfferingProductTags;
 import domain.Offering;
 import domain.Product;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.Response;
+import java.util.List;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
@@ -113,6 +117,16 @@ public class OfferingTagsComponentTest extends BaseContractComponentTest {
         "Response should return 404 Not Found for non-existent SKU");
   }
 
+  @TestPlanName("offering-tags-TC004")
+  @Test
+  void shouldReturnTagMetricsForRosa() {
+    // When: Retrieving tag metrics for rosa
+    List<MetricResponse> metrics = whenGetTagMetrics(ROSA.getName());
+
+    // Then: Each metric has aws_dimension and metric_id from product configuration
+    thenTagMetricsMatchProductConfiguration(metrics, ROSA);
+  }
+
   private Offering givenRosaOfferingExists() {
     return givenOfferingExists(buildRosaOffering(generateRandom()));
   }
@@ -142,6 +156,36 @@ public class OfferingTagsComponentTest extends BaseContractComponentTest {
         .statusCode(SC_OK)
         .extract()
         .as(OfferingProductTags.class);
+  }
+
+  private List<MetricResponse> whenGetTagMetrics(String tag) {
+    return service.getTagMetrics(tag).then().statusCode(SC_OK).extract().as(new TypeRef<>() {});
+  }
+
+  private void thenTagMetricsMatchProductConfiguration(
+      List<MetricResponse> metrics, Product product) {
+    assertNotNull(metrics, "Tag metrics should not be null");
+    assertFalse(metrics.isEmpty(), "Tag metrics should not be empty");
+    assertEquals(
+        product.getMetrics().size(),
+        metrics.size(),
+        "Should return all configured metrics for " + product.getName());
+
+    for (Metric expected : product.getMetrics().values()) {
+      MetricResponse actual =
+          metrics.stream()
+              .filter(metric -> expected.getId().equals(metric.getMetricId()))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new AssertionError("Missing metric_id " + expected.getId() + " in response"));
+      assertNotNull(actual.getAwsDimension(), "aws_dimension must not be null");
+      assertFalse(actual.getAwsDimension().isBlank(), "aws_dimension must not be blank");
+      assertEquals(
+          expected.getAwsDimension(),
+          actual.getAwsDimension(),
+          "aws_dimension should match product configuration for " + expected.getId());
+    }
   }
 
   private void thenProductTagsShouldMatch(OfferingProductTags tags, Product productName) {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5188

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
Add offering-tags-TC004 to assert rosa tag metrics return metric_id and aws_dimension from product configuration. IQE removal tracked [here](https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1576).
## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

```
./mvnw -Pcomponent-tests -pl swatch-contracts/ct -Dtest=OfferingTagsComponentTest#shouldReturnTagMetricsForRosa test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving configured metrics by product tag.
  * Responses now include metric identifiers and their mapped AWS dimensions.

* **Tests**
  * Added coverage validating successful metric retrieval for the ROSA product tag.
  * Tests verify that all configured metrics are returned with populated, correctly mapped fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->