### PR TITLE
SWATCH-5272: ServiceAccount Kessel fixes, swatch-api opt-in rbac component tests

### DIFF
--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -25,7 +25,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
 
-/** Represents a normal cloud.redhat.com user authenticated via the x-rh-identity header. */
+/**
+ * Represents a user or service account authenticated via the x-rh-identity header.
+ *
+ * <p>This class handles both "User" and "ServiceAccount" identity types from the x-rh-identity
+ * header, as they share the same org_id structure and authentication flow.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InsightsUserPrincipal implements RhIdentity.Identity {
 
@@ -54,19 +59,6 @@ public class InsightsUserPrincipal implements RhIdentity.Identity {
     }
   }
 
-  @JsonProperty("account_number")
-  private String accountNumber;
-
-  @JsonProperty("org_id")
-  private String orgId;
-
-  @JsonProperty("user_id")
-  private String userId;
-
-  private Internal internal = new Internal();
-
-  private User user = new User();
-
   /** POJO representation of "user" object inside the x-rh-identity object JSON. */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class User {
@@ -82,17 +74,58 @@ public class InsightsUserPrincipal implements RhIdentity.Identity {
     }
   }
 
+  /** POJO representation of "service_account" object inside the x-rh-identity object JSON. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class ServiceAccount {
+    @JsonProperty("client_id")
+    private String clientId;
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public void setClientId(String clientId) {
+      this.clientId = clientId;
+    }
+  }
+
+  @JsonProperty("account_number")
+  private String accountNumber;
+
+  @JsonProperty("org_id")
+  private String orgId;
+
+  @JsonProperty("user_id")
+  private String userId;
+
+  private Internal internal = new Internal();
+
+  private User user = new User();
+
+  @JsonProperty("service_account")
+  private ServiceAccount serviceAccount;
+
   /**
    * Returns the principal identifier used for Kessel authorization checks ({@code redhat/{id}}).
    *
-   * <p>Matches insights-rbac, which checks permissions for user principals, not org IDs.
+   * <p>For users, this returns the user_id. For service accounts, this returns the client_id.
+   *
+   * <p>Matches insights-rbac and swatch-common-security KesselPrincipalIds logic.
    */
   public Optional<String> getKesselPrincipalId() {
+    // Check top-level user_id first (present in both user and service account identities)
     if (userId != null && !userId.isBlank()) {
       return Optional.of(userId);
     }
+    // Check nested user.user_id (for User type)
     if (user != null && user.getUserId() != null && !user.getUserId().isBlank()) {
       return Optional.of(user.getUserId());
+    }
+    // Check service_account.client_id (for ServiceAccount type)
+    if (serviceAccount != null
+        && serviceAccount.getClientId() != null
+        && !serviceAccount.getClientId().isBlank()) {
+      return Optional.of(serviceAccount.getClientId());
     }
     return Optional.empty();
   }

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/RhIdentity.java
@@ -41,6 +41,7 @@ public class RhIdentity {
       defaultImpl = InsightsUserPrincipal.class)
   @JsonSubTypes({
     @JsonSubTypes.Type(value = InsightsUserPrincipal.class, name = "User"),
+    @JsonSubTypes.Type(value = InsightsUserPrincipal.class, name = "ServiceAccount"),
     @JsonSubTypes.Type(value = RhAssociatePrincipal.class, name = "Associate"),
     @JsonSubTypes.Type(value = X509Principal.class, name = "X509")
   })

--- a/swatch-tally/ct/java/api/TallySwatchService.java
+++ b/swatch-tally/ct/java/api/TallySwatchService.java
@@ -77,7 +77,7 @@ public class TallySwatchService extends SwatchService {
     return response.as(VersionInfo.class);
   }
 
-  // --- Configuration methods ---
+  // --- Opt-in configuration methods ---
 
   /**
    * Creates opt-in configuration for an organization.
@@ -103,6 +103,36 @@ public class TallySwatchService extends SwatchService {
             + response.getBody().asString());
 
     Log.info(this, "Opt-in config created successfully for org: %s", orgId);
+  }
+
+  /**
+   * Retrieves opt-in status using caller-supplied request headers (for access control tests).
+   *
+   * @param requestHeaders map containing x-rh-identity and other headers
+   * @return the raw HTTP response
+   */
+  public Response getOptInWithHeaders(Map<String, String> requestHeaders) {
+    return given().headers(requestHeaders).get(API_PATH + "/opt-in").then().extract().response();
+  }
+
+  /**
+   * Creates/updates opt-in using caller-supplied request headers (for access control tests).
+   *
+   * @param requestHeaders map containing x-rh-identity and other headers
+   * @return the raw HTTP response
+   */
+  public Response putOptInWithHeaders(Map<String, String> requestHeaders) {
+    return given().headers(requestHeaders).put(API_PATH + "/opt-in").then().extract().response();
+  }
+
+  /**
+   * Deletes opt-in using caller-supplied request headers (for access control tests).
+   *
+   * @param requestHeaders map containing x-rh-identity and other headers
+   * @return the raw HTTP response
+   */
+  public Response deleteOptInWithHeaders(Map<String, String> requestHeaders) {
+    return given().headers(requestHeaders).delete(API_PATH + "/opt-in").then().extract().response();
   }
 
   // --- Tally operation methods ---

--- a/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
+++ b/swatch-tally/ct/java/tests/BaseTallyComponentTest.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import utils.RbacAccessTestHelper;
 import utils.TallyDbHostSeeder;
 import utils.TallyTestHelpers;
 
@@ -97,11 +98,26 @@ public class BaseTallyComponentTest {
 
   protected final TallyDbHostSeeder seeder = new TallyDbHostSeeder(swatchDatabase);
   protected String orgId;
+  protected RbacAccessTestHelper rbacHelper;
 
   @BeforeEach
   void setUp() {
     orgId = RandomUtils.generateRandom();
+    rbacHelper = new RbacAccessTestHelper(unleash, wiremock, orgId);
     String identityHeader = SwatchUtils.createUserIdentityHeader(orgId);
+    wiremock
+        .forRbacAccessControl()
+        .stubSubscriptionsAccess(identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+  }
+
+  /**
+   * Helper method to stub RBAC access for a custom org ID (for tests that don't use the instance
+   * orgId).
+   *
+   * @param customOrgId the organization ID to stub access for
+   */
+  protected void stubRbacAccessForOrg(String customOrgId) {
+    String identityHeader = SwatchUtils.createUserIdentityHeader(customOrgId);
     wiremock
         .forRbacAccessControl()
         .stubSubscriptionsAccess(identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);

--- a/swatch-tally/ct/java/tests/OptInRbacAccessComponentTest.java
+++ b/swatch-tally/ct/java/tests/OptInRbacAccessComponentTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.X_RH_IDENTITY_HEADER;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.swatch.component.tests.api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.component.tests.utils.SwatchUtils;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class OptInRbacAccessComponentTest extends BaseTallyComponentTest {
+
+  @BeforeEach
+  void setUpAccessControl() {
+    service.createOptInConfig(orgId);
+  }
+
+  @AfterAll
+  static void resetKesselRbacFlag() {
+    unleash.disableKesselRbac();
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC001")
+  void shouldAllowOptInWhenUserHasAdminAccess(AuthorizationModel authorizationModel) {
+    // Given: User with admin permission
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When/Then: All operations succeed
+    assertOptInEndpointsSucceed(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC002")
+  void shouldAllowOptInWhenUserHasReaderAccess(AuthorizationModel authorizationModel) {
+    // Given: User with reader permission
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+
+    // When/Then: All operations succeed
+    assertOptInEndpointsSucceed(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC003")
+  void shouldDenyOptInWhenUserHasNoAccess(AuthorizationModel authorizationModel) {
+    // Given: User with no permissions
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    // When/Then: All operations fail (forbidden)
+    assertOptInEndpointsForbidden(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC004")
+  void shouldAllowOptInWhenServiceAccountHasAdminAccess(AuthorizationModel authorizationModel) {
+    // Given: ServiceAccount with admin permission
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When/Then: All operations succeed
+    assertOptInEndpointsSucceed(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC005")
+  void shouldAllowOptInWhenServiceAccountHasReaderAccess(AuthorizationModel authorizationModel) {
+    // Given: ServiceAccount with reader permission
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+
+    // When/Then: All operations succeed
+    assertOptInEndpointsSucceed(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC006")
+  void shouldDenyOptInWhenServiceAccountHasNoAccess(AuthorizationModel authorizationModel) {
+    // Given: ServiceAccount with no permissions
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    // When/Then: All operations fail (forbidden)
+    assertOptInEndpointsForbidden(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC007")
+  void shouldDenyOptInForAssociateIdentity(AuthorizationModel authorizationModel) {
+    // Given: Associate identity
+    String email = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithAssociate(orgId, email);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenAssociateHasSubscriptionsAccess(
+        authorizationModel, email, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When/Then: All operations fail (forbidden)
+    assertOptInEndpointsForbidden(requestHeaders);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-optin-TC008")
+  void shouldDenyOptInForX509Identity(AuthorizationModel authorizationModel) {
+    // Given: X509 identity
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceRole(orgId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    rbacHelper.givenX509HasSubscriptionsAccess(
+        authorizationModel, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When/Then: All operations fail (forbidden)
+    assertOptInEndpointsForbidden(requestHeaders);
+  }
+
+  private void assertOptInEndpointsSucceed(Map<String, String> requestHeaders) {
+    assertOptInEndpointsReturn(
+        requestHeaders, HttpStatus.SC_OK, HttpStatus.SC_OK, HttpStatus.SC_NO_CONTENT);
+  }
+
+  private void assertOptInEndpointsForbidden(Map<String, String> requestHeaders) {
+    assertOptInEndpointsReturn(
+        requestHeaders, HttpStatus.SC_FORBIDDEN, HttpStatus.SC_FORBIDDEN, HttpStatus.SC_FORBIDDEN);
+  }
+
+  private void assertOptInEndpointsReturn(
+      Map<String, String> requestHeaders, int expectedGet, int expectedPut, int expectedDelete) {
+    Response getResponse = service.getOptInWithHeaders(requestHeaders);
+    Response putResponse = service.putOptInWithHeaders(requestHeaders);
+    Response deleteResponse = service.deleteOptInWithHeaders(requestHeaders);
+
+    assertAll(
+        "opt-in endpoint responses",
+        () -> assertEquals(expectedGet, getResponse.statusCode(), "GET /opt-in"),
+        () -> assertEquals(expectedPut, putResponse.statusCode(), "PUT /opt-in"),
+        () -> assertEquals(expectedDelete, deleteResponse.statusCode(), "DELETE /opt-in"));
+  }
+}

--- a/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesBillingAccountIdsTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
@@ -60,6 +61,11 @@ class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
   private static ThreeBillings three;
   private static SharedByTwoEvents shared;
   private static MixedProviderBillings providers;
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    stubRbacAccessForOrg(testOrgId);
+  }
 
   @BeforeAll
   static void setupEvents() {
@@ -229,6 +235,7 @@ class TallyInstancesBillingAccountIdsTest extends BaseTallyComponentTest {
   @TestPlanName("tally-instances-billing-account-TC001")
   void shouldExcludeBillingAccountsWithLastSeenBeforeCurrentMonth() {
     final String isolatedOrg = RandomUtils.generateRandom();
+    stubRbacAccessForOrg(isolatedOrg);
     final String testInventoryId = UUID.randomUUID().toString();
     final String billingAccountId = UUID.randomUUID().toString();
     final OffsetDateTime lastMonthDate =

--- a/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesReportFiltersPaygTest.java
@@ -49,6 +49,7 @@ import org.apache.http.HttpStatus;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -136,6 +137,11 @@ public class TallyInstancesReportFiltersPaygTest extends BaseTallyComponentTest 
   private CrossMonthPair crossMonth;
 
   private static final int EXPECTED_CURRENT_MONTH_INSTANCE_ROWS = 16;
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    stubRbacAccessForOrg(testOrgId);
+  }
 
   @BeforeAll
   void setupSharedFixture() {

--- a/swatch-tally/ct/java/tests/TallyInstancesReportPaginationAndSortTest.java
+++ b/swatch-tally/ct/java/tests/TallyInstancesReportPaginationAndSortTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TallyInstancesReportPaginationAndSortTest extends BaseTallyComponentTest {
@@ -77,6 +78,11 @@ public class TallyInstancesReportPaginationAndSortTest extends BaseTallyComponen
   private static DisplayNameSortFixture displayName;
   private static MetricSortFixture metric;
   private static CategorySortFixture category;
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    stubRbacAccessForOrg(testOrgId);
+  }
 
   @BeforeAll
   static void setupEvents() {

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportCategoryHasDataPaygTest.java
@@ -27,10 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.TallyTestProducts.RHEL_FOR_X86_ELS_PAYG;
 
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.component.tests.utils.SwatchUtils;
 import com.redhat.swatch.tally.test.model.ServiceLevelType;
 import com.redhat.swatch.tally.test.model.TallyReportData;
 import com.redhat.swatch.tally.test.model.TallyReportDataPoint;
@@ -44,6 +46,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -57,6 +60,25 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
   private static final Duration PIPELINE_POLL_INTERVAL = Duration.ofSeconds(2);
 
   private static String firstOrgId;
+
+  private static void stubRbacForOrg(String orgId) {
+    String identityHeader = SwatchUtils.createUserIdentityHeader(orgId);
+    wiremock
+        .forRbacAccessControl()
+        .stubSubscriptionsAccess(identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+  }
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    // Stub RBAC for test org IDs (wiremock clears mappings before each test)
+    if (firstOrgId != null) {
+      stubRbacForOrg(firstOrgId);
+    }
+    if (dataGapOrgId != null) {
+      stubRbacForOrg(dataGapOrgId);
+    }
+  }
+
   private static OffsetDateTime positiveEventHourStart;
   private static OffsetDateTime positiveEventHourEnd;
   private static OffsetDateTime positiveRangeStart;
@@ -81,6 +103,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     zeroEventHourEnd = zeroEventHourStart.plusHours(1).minusNanos(1);
 
     firstOrgId = RandomUtils.generateRandom();
+    stubRbacForOrg(firstOrgId);
     service.createOptInConfig(firstOrgId);
     givenCloudPaygEventPublished(firstOrgId, positiveEventHourStart, 8.0f);
     AwaitilityUtils.untilAsserted(
@@ -106,6 +129,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     dataGapRangeBeginning = dataGapBaseTime;
     dataGapRangeEnding = dataGapBaseTime.plusHours(4).minusNanos(1);
     dataGapOrgId = RandomUtils.generateRandom();
+    stubRbacForOrg(dataGapOrgId);
     service.createOptInConfig(dataGapOrgId);
     givenCloudPaygEventPublished(dataGapOrgId, dataGapBaseTime, 10.0f);
     givenCloudPaygEventPublished(dataGapOrgId, dataGapBaseTime.plusHours(2), 20.0f);
@@ -155,6 +179,7 @@ public class TallyReportCategoryHasDataPaygTest extends BaseTallyComponentTest {
     // Given: Zero cloud PAYG is published and tallied
     givenFeatureFlagIsConfigured(primaryRowSearches);
     String orgId = RandomUtils.generateRandom();
+    stubRbacForOrg(orgId);
     service.createOptInConfig(orgId);
     givenCloudPaygEventPublished(orgId, zeroEventHourStart, 0.0f);
     givenZeroCloudMeasurementReadyForOrg(orgId);

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersEdgeCaseTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -47,6 +48,12 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 public class TallyReportFiltersEdgeCaseTest extends BaseTallyComponentTest {
   private static String testOrgId;
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    stubRbacAccessForOrg(testOrgId);
+  }
+
   private static final String PRODUCT_ID = RHEL_FOR_X86_ELS_PAYG.productId();
   private static final String PRODUCT_TAG = RHEL_FOR_X86_ELS_PAYG.productTag();
   private static final String METRIC_ID = RHEL_FOR_X86_ELS_PAYG.metricIds().get(0);

--- a/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportTests/TallyReportFiltersPaygTest.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.candlepin.subscriptions.json.Event;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -63,6 +64,12 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 public class TallyReportFiltersPaygTest extends BaseTallyComponentTest {
   private static String testOrgId;
+
+  @BeforeEach
+  void setUpRbacForTestOrg() {
+    stubRbacAccessForOrg(testOrgId);
+  }
+
   private static final String PRODUCT_ID = RHEL_FOR_X86_ELS_PAYG.productId();
   private static final String PRODUCT_TAG = RHEL_FOR_X86_ELS_PAYG.productTag();
   private static final String METRIC_ID = RHEL_FOR_X86_ELS_PAYG.metricIds().get(0); // vCPUs

--- a/swatch-tally/ct/java/utils/RbacAccessTestHelper.java
+++ b/swatch-tally/ct/java/utils/RbacAccessTestHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package utils;
+
+import api.TallyUnleashService;
+import api.TallyWiremockService;
+import com.redhat.swatch.component.tests.api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
+
+/** Helper methods to create security headers for tally/api rbac component tests. */
+public class RbacAccessTestHelper {
+
+  private final TallyUnleashService unleash;
+  private final TallyWiremockService wiremock;
+  private final String orgId;
+
+  public RbacAccessTestHelper(
+      TallyUnleashService unleash, TallyWiremockService wiremock, String orgId) {
+    this.unleash = unleash;
+    this.wiremock = wiremock;
+    this.orgId = orgId;
+  }
+
+  public void givenUserHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String userId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(userId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  public void givenServiceAccountHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String clientId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(clientId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  public void givenAssociateHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String email,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(email, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  public void givenX509HasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(orgId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+}

--- a/swatch-tally/test-plans/rbac-authorization.md
+++ b/swatch-tally/test-plans/rbac-authorization.md
@@ -215,116 +215,6 @@ This test plan validates authorization parity between RBACv1 and RBACv2/Kessel f
   - No export data is produced
 - **Expected Result**: No permissions results in export denial
 
-#### Opt-in
-
-**rbac-v1-optin-TC001 - User with admin permission accesses all opt-in endpoints**
-
-- **Description**: Verify that a User granted `subscriptions:*:*` permission can access all opt-in endpoints (E5, E6, E7) under RBACv1.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
-  - Stub RBACv1 endpoint to return `subscriptions:*:*` for this identity
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: Admin permission grants access to all opt-in endpoints
-
-**rbac-v1-optin-TC002 - User with reader permission accesses opt-in endpoints**
-
-- **Description**: Verify that a User granted `subscriptions:reports:read` permission can access opt-in endpoints (E5, E6, E7) under RBACv1. Despite the annotation name `@SubscriptionWatchAdminOnly`, both admin and reader roles are accepted.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
-  - Stub RBACv1 endpoint to return `subscriptions:reports:read` for this identity
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: Reader permission grants access to all opt-in endpoints
-
-**rbac-v1-optin-TC003 - User with no permissions denied all opt-in endpoints**
-
-- **Description**: Verify that a User with no subscriptions permissions is denied access to all opt-in endpoints (E5, E6, E7) under RBACv1.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
-  - Stub RBACv1 endpoint to return no subscriptions permissions (`{"data": [], "meta": {"count": 0}}`)
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for all three endpoints
-- **Expected Result**: No permissions results in denial for all opt-in endpoints
-
-**rbac-v1-optin-TC004 - ServiceAccount with admin permission accesses all opt-in endpoints**
-
-- **Description**: Verify that a ServiceAccount granted `subscriptions:*:*` permission can access all opt-in endpoints (E5, E6, E7) under RBACv1.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
-  - Stub RBACv1 endpoint to return `subscriptions:*:*` for this identity
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: ServiceAccount with admin permission accesses all opt-in endpoints
-
-**rbac-v1-optin-TC005 - ServiceAccount with reader permission accesses all opt-in endpoints**
-
-- **Description**: Verify that a ServiceAccount granted `subscriptions:reports:read` permission can access all opt-in endpoints (E5, E6, E7) under RBACv1.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
-  - Stub RBACv1 endpoint to return `subscriptions:reports:read` for this identity
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: ServiceAccount with reader permission accesses all opt-in endpoints
-
-**rbac-v1-optin-TC006 - ServiceAccount with no permissions denied all opt-in endpoints**
-
-- **Description**: Verify that a ServiceAccount with no subscriptions permissions is denied access to all opt-in endpoints (E5, E6, E7) under RBACv1.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
-  - Stub RBACv1 endpoint to return no subscriptions permissions (`{"data": [], "meta": {"count": 0}}`)
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
-  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for all three endpoints
-- **Expected Result**: ServiceAccount with no permissions is denied from all opt-in endpoints
-
-**rbac-v1-optin-TC007 - Associate identity denied opt-in endpoint**
-
-- **Description**: Verify that an Associate identity is denied access to opt-in endpoint (E5). `ROLE_INTERNAL` is not accepted by @SubscriptionWatchAdminOnly.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=Associate`, `associate.email`
-  - No RBAC stub needed (Associate bypasses RBAC, gets `ROLE_INTERNAL`)
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for opt-in endpoint
-- **Expected Result**: Associate identity denied opt-in endpoint (INTERNAL role not accepted)
-
-**rbac-v1-optin-TC008 - X509 identity denied opt-in endpoint**
-
-- **Description**: Verify that an X509/Turnpike identity is denied access to opt-in endpoint (E5). `ROLE_INTERNAL` is not accepted by @SubscriptionWatchAdminOnly.
-- **Setup**:
-  - Kessel Unleash flag is OFF
-  - Prepare `x-rh-identity` header with `type=X509`
-  - No RBAC stub needed (X509 bypasses RBAC, gets `ROLE_INTERNAL`)
-- **Action**:
-  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for opt-in endpoint
-- **Expected Result**: X509 identity denied opt-in endpoint (INTERNAL role not accepted)
-
 ### RBACv2 / Kessel (Flag ON)
 
 **rbac-v2-TC001 - User with Kessel permission accesses all reporting endpoints**
@@ -471,90 +361,153 @@ This test plan validates authorization parity between RBACv1 and RBACv2/Kessel f
 
 ### Opt-in
 
-**rbac-v2-optin-TC001 - User with Kessel permission accesses all opt-in endpoints**
+**rbac-optin-TC001 - User with admin permission accesses all opt-in endpoints**
 
-- **Description**: Verify that a User granted Kessel `subscriptions_report_view` relation can access all opt-in endpoints (E5, E6, E7) under RBACv2.
+- **Description**: Verify that a User with admin permissions can access all opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2.
 - **Setup**:
-  - Kessel Unleash flag is ON
-  - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
-  - Stub Kessel workspace endpoint to return default workspace
-  - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=user_id`
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub RBACv1 endpoint to return `subscriptions:*:*` for this identity
+  - RBAC V2:
+    - Kessel Unleash flag is ON
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=user_id`
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: Kessel permission grants access to all opt-in endpoints
+- **Verification**: HTTP 200 for GET and PUT, HTTP 204 for DELETE
+- **Expected Result**: Admin permission grants access to all opt-in endpoints
 
-**rbac-v2-optin-TC002 - User with no permissions denied all opt-in endpoints**
+**rbac-optin-TC002 - User with reader permission accesses opt-in endpoints**
 
-- **Description**: Verify that a User with no Kessel permissions is denied access to all opt-in endpoints (E5, E6, E7) under RBACv2.
+- **Description**: Verify that a User with reader permissions can access opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2. Despite the annotation name `@SubscriptionWatchAdminOnly`, both admin and reader roles are accepted.
 - **Setup**:
-  - Kessel Unleash flag is ON
-  - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
-  - Stub Kessel workspace endpoint to return default workspace
-  - Stub Kessel check endpoint to return `ALLOWED_FALSE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=user_id`
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub RBACv1 endpoint to return `subscriptions:reports:read` for this identity
+  - RBAC V2:
+    - Kessel Unleash flag is  ON
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=user_id`
+- **Action**:
+  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
+- **Verification**: HTTP 200 for GET and PUT, HTTP 204 for DELETE
+- **Expected Result**: Reader permission grants access to all opt-in endpoints
+
+**rbac-optin-TC003 - User with no permissions denied all opt-in endpoints**
+
+- **Description**: Verify that a User with no permissions is denied access to all opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2.
+- **Setup**:
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub RBACv1 endpoint to return no subscriptions permissions (`{"data": [], "meta": {"count": 0}}`)
+  - RBAC V2:
+    - Kessel Unleash flag is ON
+    - Prepare `x-rh-identity` header with `type=User`, `org_id`, `user_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_FALSE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=user_id`
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
 - **Verification**: HTTP 403 for all three endpoints
-- **Expected Result**: No Kessel permissions results in denial for all opt-in endpoints
+- **Expected Result**: No permissions results in denial for all opt-in endpoints
 
-**rbac-v2-optin-TC003 - ServiceAccount with admin permission accesses all opt-in endpoints**
+**rbac-optin-TC004 - ServiceAccount with admin permission accesses all opt-in endpoints**
 
-- **Description**: Verify that a ServiceAccount granted Kessel `subscriptions_report_view` relation can access all opt-in endpoints (E5, E6, E7) under RBACv2.
+- **Description**: Verify that a ServiceAccount with admin permissions can access all opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2.
 - **Setup**:
-  - Kessel Unleash flag is ON
-  - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
-  - Stub Kessel workspace endpoint to return default workspace
-  - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=client_id`
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub RBACv1 endpoint to return `subscriptions:*:*` for this identity
+  - RBAC V2:
+    - Kessel Unleash flag is ON
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=client_id`
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 200 for all three endpoints
-- **Expected Result**: ServiceAccount with Kessel permission accesses all opt-in endpoints
+- **Verification**: HTTP 200 for GET and PUT, HTTP 204 for DELETE
+- **Expected Result**: ServiceAccount with admin permission accesses all opt-in endpoints
 
-**rbac-v2-optin-TC004 - ServiceAccount with no permissions denied all opt-in endpoints**
+**rbac-optin-TC005 - ServiceAccount with reader permission accesses all opt-in endpoints**
 
-- **Description**: Verify that a ServiceAccount with no Kessel permissions is denied access to all opt-in endpoints (E5, E6, E7) under RBACv2.
+- **Description**: Verify that a ServiceAccount with reader permissions can access all opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2.
 - **Setup**:
-  - Kessel Unleash flag is ON
-  - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
-  - Stub Kessel workspace endpoint to return default workspace
-  - Stub Kessel check endpoint to return `ALLOWED_FALSE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=client_id`
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub RBACv1 endpoint to return `subscriptions:reports:read` for this identity
+  - RBAC V2:
+    - Kessel Unleash flag is ON
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_TRUE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=client_id`
+- **Action**:
+  - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
+- **Verification**: HTTP 200 for GET and PUT, HTTP 204 for DELETE
+- **Expected Result**: ServiceAccount with reader permission accesses all opt-in endpoints
+
+**rbac-optin-TC006 - ServiceAccount with no permissions denied all opt-in endpoints**
+
+- **Description**: Verify that a ServiceAccount with no permissions is denied access to all opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2.
+- **Setup**:
+  - RBAC V1:
+    - Kessel Unleash flag is OFF
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub RBACv1 endpoint to return no subscriptions permissions (`{"data": [], "meta": {"count": 0}}`)
+  - RBAC V2:
+    - Kessel Unleash flag is ON
+    - Prepare `x-rh-identity` header with `type=ServiceAccount`, `org_id`, `client_id`
+    - Stub Kessel workspace endpoint to return default workspace
+    - Stub Kessel check endpoint to return `ALLOWED_FALSE` for `relation=subscriptions_report_view`, `subject.resource.resourceId=client_id`
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
   - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
 - **Verification**: HTTP 403 for all three endpoints
-- **Expected Result**: ServiceAccount with no Kessel permissions is denied access to all opt-in endpoints
+- **Expected Result**: ServiceAccount with no permissions is denied all opt-in endpoints
 
-**rbac-v2-optin-TC005 - Associate identity denied opt-in endpoint**
+**rbac-optin-TC007 - Associate identity denied opt-in endpoints**
 
-- **Description**: Verify that an Associate identity is denied access to opt-in endpoint (E5) under RBACv2.
+- **Description**: Verify that an Associate identity is denied access to opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2. `ROLE_INTERNAL` is not accepted by @SubscriptionWatchAdminOnly.
 - **Setup**:
-  - Kessel Unleash flag is ON
+  - Test with Kessel Unleash flag both OFF and ON
   - Prepare `x-rh-identity` header with `type=Associate`, `associate.email`
-  - No Kessel stub needed (Associate bypasses RBAC, gets `ROLE_INTERNAL`)
+  - No RBAC/Kessel stub needed (Associate bypasses RBAC, receives `ROLE_INTERNAL`)
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for opt-in endpoint
-- **Expected Result**: Associate identity denied opt-in endpoint
+  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
+- **Verification**: HTTP 403 for all three endpoints
+- **Expected Result**: Associate identity denied opt-in endpoints (INTERNAL role not accepted)
 
-**rbac-v2-optin-TC006 - X509 identity denied opt-in endpoint**
+**rbac-optin-TC008 - X509 identity denied opt-in endpoints**
 
-- **Description**: Verify that an X509/Turnpike identity is denied access to opt-in endpoint (E5) under RBACv2.
+- **Description**: Verify that an X509/Turnpike identity is denied access to opt-in endpoints (E5, E6, E7) under both RBACv1 and RBACv2. `ROLE_INTERNAL` is not accepted by @SubscriptionWatchAdminOnly.
 - **Setup**:
-  - Kessel Unleash flag is ON
+  - Test with Kessel Unleash flag both OFF and ON
   - Prepare `x-rh-identity` header with `type=X509`
-  - No Kessel stub needed (X509 bypasses RBAC, gets `ROLE_INTERNAL`)
+  - No RBAC/Kessel stub needed (X509 bypasses RBAC, receives `ROLE_INTERNAL`)
 - **Action**:
   - `GET /api/rhsm-subscriptions/v1/opt-in` with the identity header
-- **Verification**: HTTP 403 for opt-in endpoint
-- **Expected Result**: X509 identity denied opt-in endpoint
-
+  - `PUT /api/rhsm-subscriptions/v1/opt-in` with the identity header
+  - `DELETE /api/rhsm-subscriptions/v1/opt-in` with the identity header
+- **Verification**: HTTP 403 for all three endpoints
+- **Expected Result**: X509 identity denied opt-in endpoints (INTERNAL role not accepted)
 
 ### Resilience
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -81,6 +81,37 @@ public final class SwatchUtils {
   }
 
   /**
+   * Returns headers for a ServiceAccount identity with org and client identifiers (RBAC component
+   * tests).
+   */
+  public static Map<String, String> securityHeadersWithServiceAccount(
+      String orgId, String clientId) {
+    String json =
+        "{\"identity\":{\"type\":\"ServiceAccount\",\"org_id\":\""
+            + orgId
+            + "\",\"service_account\":{\"client_id\":\""
+            + clientId
+            + "\"}}}";
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
+  }
+
+  /**
+   * Returns headers for an Associate identity with org and email identifiers (RBAC component
+   * tests).
+   */
+  public static Map<String, String> securityHeadersWithAssociate(String orgId, String email) {
+    String json =
+        "{\"identity\":{\"type\":\"Associate\",\"org_id\":\""
+            + orgId
+            + "\",\"associate\":{\"email\":\""
+            + email
+            + "\"}}}";
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
+  }
+
+  /**
    * This is used to create a User type identity header that includes org_id for Springboot services
    * in DEV_MODE
    *


### PR DESCRIPTION
Jira issue: SWATCH-5272

## Description

Add ServiceAccount authentication support to InsightsUserPrincipal and comprehensive RBAC authorization component tests for opt-in (both v1 and v2).

Changes:

- client_id check added to InsightsUserPrincipal to support ServiceAccount for Kessel as well
- RhIdentity: Added ServiceAccount as a valid JsonSubType mapping to InsightsUserPrincipal
- Added additional methods to BaseTallyComponentTest to better support rbac v1/v2 and opt-in
- New RbacAccessTestHelper file to be able to use rbac v1/v2 access across multiple tally component test files
- New component test file OptInRbacAccessComponentTest that implements all rbac opt-in tests from test plan(rbac-optin-TC001-8)
- Updated some existing tally component tests to properly stub RBAC access for tests using static/custom org IDs
- Updated rbac-authorization.md test plan to consolidate RBACv1 and RBACv2 opt-in test cases 

## Testing

### Setup (local)
1. Start local dependencies
```
podman compose up -d kafka kafka-bridge kafka-setup amqp wiremock db
```

### Steps
1. Run swatch-tally component tests
```
./mvnw clean install -Pcomponent-tests -pl swatch-tally/ct -am
```

### Verification
1. All tally component tests pass, including all tests in OptInRbacAccessComponentTest (16 tests total)
