### PR TITLE
SWATCH-5452: Treat non-Success AWS BatchMeterUsage results as remittance failures

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceErrorCode.java
@@ -39,6 +39,8 @@ public enum RemittanceErrorCode {
   UNKNOWN("unknown"),
   UNSUPPORTED_METRIC("unsupported_metric"),
   MARKETPLACE_RATE_LIMIT("marketplace_rate_limit"),
+  MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED("marketplace_customer_not_subscribed"),
+  MARKETPLACE_DUPLICATE_RECORD("marketplace_duplicate_record"),
   SENDING_TO_AGGREGATE_TOPIC("error_sending_to_aggregate_topic");
 
   private static final Map<String, RemittanceErrorCode> VALUE_ENUM_MAP =

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/BillableUsageStatusConsumerTest.java
@@ -128,6 +128,30 @@ class BillableUsageStatusConsumerTest {
   }
 
   @Test
+  void testWhenUsageThatFailedWithMarketplaceCustomerNotSubscribedThenUsageSetFailed() {
+    var existingRemittance = givenExistingRemittance();
+    var message =
+        createBillableUsageAggregate(
+            Status.FAILED, ErrorCode.MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED, null, existingRemittance);
+    whenSendResponse(message);
+    Awaitility.await()
+        .untilAsserted(
+            () -> verifyUpdateForFailure(RemittanceErrorCode.MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED));
+  }
+
+  @Test
+  void testWhenUsageThatFailedWithMarketplaceDuplicateRecordThenUsageSetFailed() {
+    var existingRemittance = givenExistingRemittance();
+    var message =
+        createBillableUsageAggregate(
+            Status.FAILED, ErrorCode.MARKETPLACE_DUPLICATE_RECORD, null, existingRemittance);
+    whenSendResponse(message);
+    Awaitility.await()
+        .untilAsserted(
+            () -> verifyUpdateForFailure(RemittanceErrorCode.MARKETPLACE_DUPLICATE_RECORD));
+  }
+
+  @Test
   void testWhenConsumeSuccessStatusThenExistingFailedRemittanceNotUpdated() {
     var existingRemittance = givenExistingRemittance();
     var failedMessage =

--- a/swatch-core/schemas/billable_usage.yaml
+++ b/swatch-core/schemas/billable_usage.yaml
@@ -64,6 +64,8 @@ properties:
       - unsupported_metric
       - unknown
       - marketplace_rate_limit
+      - marketplace_customer_not_subscribed
+      - marketplace_duplicate_record
   billed_on:
     type: string
     format: date-time

--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -198,3 +198,67 @@ Contracts `awsUsageContext` lookup failures and remittance error classification.
 - **Expected Result**:
   - Remittance status is `FAILED` with `SUBSCRIPTION_TERMINATED`
   - AWS Marketplace is not called
+
+## BatchMeterUsage non-Success response handling
+
+**producer-aws-batch-meter-usage-TC001 - CustomerNotSubscribed emits FAILED**
+
+- **Description**: Verify that when AWS `BatchMeterUsage` returns `UsageRecordResult.Status=CustomerNotSubscribed`, remittance status is `FAILED` with `marketplace_customer_not_subscribed` (not `SUCCEEDED`).
+- **Setup**:
+  - WireMock returns a valid `awsUsageContext`
+  - WireMock `BatchMeterUsage` stub returns `Status=CustomerNotSubscribed`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `FAILED` on `billable-usage.status` with error code `marketplace_customer_not_subscribed`
+  - Inspect captured `BatchMeterUsage` request in WireMock
+- **Expected Result**:
+  - Remittance status is `FAILED` with `marketplace_customer_not_subscribed`
+  - AWS Marketplace was called
+
+**producer-aws-batch-meter-usage-TC002 - DuplicateRecord emits FAILED**
+
+- **Description**: Verify that when AWS `BatchMeterUsage` returns `UsageRecordResult.Status=DuplicateRecord`, remittance status is `FAILED` with `marketplace_duplicate_record` (not `SUCCEEDED`).
+- **Setup**:
+  - WireMock returns a valid `awsUsageContext`
+  - WireMock `BatchMeterUsage` stub returns `Status=DuplicateRecord`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `FAILED` on `billable-usage.status` with error code `marketplace_duplicate_record`
+  - Inspect captured `BatchMeterUsage` request in WireMock
+- **Expected Result**:
+  - Remittance status is `FAILED` with `marketplace_duplicate_record`
+  - AWS Marketplace was called
+
+**producer-aws-batch-meter-usage-TC003 - Unrecognized status emits FAILED with unknown**
+
+- **Description**: Verify that when AWS `BatchMeterUsage` returns a `UsageRecordResult.Status` the SDK does not recognize (`UnknownToSdkVersion`), remittance status is `FAILED` with `unknown`.
+- **Setup**:
+  - WireMock returns a valid `awsUsageContext`
+  - WireMock `BatchMeterUsage` stub returns a `Status` that is not `Success`, `CustomerNotSubscribed`, or `DuplicateRecord`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `FAILED` on `billable-usage.status` with error code `unknown`
+- **Expected Result**:
+  - Remittance status is `FAILED` with `unknown`
+  - AWS Marketplace was called
+
+**producer-aws-batch-meter-usage-TC004 - ThrottlingException emits FAILED**
+
+- **Description**: Verify that when AWS `BatchMeterUsage` returns HTTP 429 / `ThrottlingException`, remittance status is `FAILED` with `marketplace_rate_limit` (not `SUCCEEDED`).
+- **Setup**:
+  - WireMock returns a valid `awsUsageContext`
+  - WireMock `BatchMeterUsage` stub returns HTTP 429 with `ThrottlingException`
+  - Kafka topics for billable-usage hourly aggregate and status are available
+- **Action**:
+  - Produce a valid AWS billable-usage aggregate to Kafka
+- **Verification**:
+  - Wait for `FAILED` on `billable-usage.status` with error code `marketplace_rate_limit`
+- **Expected Result**:
+  - Remittance status is `FAILED` with `marketplace_rate_limit`
+  - AWS Marketplace was called

--- a/swatch-producer-aws/ct/java/api/AwsWiremockService.java
+++ b/swatch-producer-aws/ct/java/api/AwsWiremockService.java
@@ -65,18 +65,42 @@ public class AwsWiremockService extends WiremockService {
       String customerId,
       String productCode,
       String customerAwsAccountId) {
-    var contextData = new HashMap<String, Object>();
-    contextData.put("rhSubscriptionId", rhSubscriptionId);
-    contextData.put("customerId", customerId);
-    contextData.put("productCode", productCode);
-    contextData.put("awsSellerAccountId", awsSellerAccountId);
-    contextData.put("subscriptionStartDate", "2020-01-01T00:00:00Z");
-    if (customerAwsAccountId != null) {
-      contextData.put("customerAwsAccountId", customerAwsAccountId);
-    }
+    setupAwsUsageContextWithBatchMeterResultStatus(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        customerAwsAccountId,
+        "Success");
+  }
 
-    registerAwsUsageContextStub(awsAccountId, jsonResponse(200, contextData));
-    setupAwsBatchMeterUsage();
+  public void setupAwsUsageContextWithBatchMeterResultStatus(
+      String awsAccountId,
+      String awsSellerAccountId,
+      String rhSubscriptionId,
+      String customerId,
+      String productCode,
+      String batchMeterResultStatus) {
+    setupAwsUsageContextWithBatchMeterResultStatus(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        null,
+        batchMeterResultStatus);
+  }
+
+  public void setupAwsUsageContextWithBatchMeterThrottling(
+      String awsAccountId,
+      String awsSellerAccountId,
+      String rhSubscriptionId,
+      String customerId,
+      String productCode) {
+    registerAwsUsageContextForBatchMeterUsage(
+        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode, null);
+    setupAwsBatchMeterUsageThrottling();
   }
 
   public void setupAwsUsageContextToReturnSubscriptionRecentlyTerminated(String awsAccountId) {
@@ -297,9 +321,50 @@ public class AwsWiremockService extends WiremockService {
     }
   }
 
-  private void setupAwsBatchMeterUsage() {
-    // The AWS SDK v2 sends JSON (application/x-amz-json-1.1) with the X-Amz-Target header
-    // to identify the operation. We return a minimal valid BatchMeterUsage JSON response.
+  private void setupAwsUsageContextWithBatchMeterResultStatus(
+      String awsAccountId,
+      String awsSellerAccountId,
+      String rhSubscriptionId,
+      String customerId,
+      String productCode,
+      String customerAwsAccountId,
+      String batchMeterResultStatus) {
+    registerAwsUsageContextForBatchMeterUsage(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        customerAwsAccountId);
+    setupAwsBatchMeterUsageResultStatus(batchMeterResultStatus);
+  }
+
+  private void registerAwsUsageContextForBatchMeterUsage(
+      String awsAccountId,
+      String awsSellerAccountId,
+      String rhSubscriptionId,
+      String customerId,
+      String productCode,
+      String customerAwsAccountId) {
+    var contextData = new HashMap<String, Object>();
+    contextData.put("rhSubscriptionId", rhSubscriptionId);
+    contextData.put("customerId", customerId);
+    contextData.put("productCode", productCode);
+    contextData.put("awsSellerAccountId", awsSellerAccountId);
+    contextData.put("subscriptionStartDate", "2020-01-01T00:00:00Z");
+    if (customerAwsAccountId != null) {
+      contextData.put("customerAwsAccountId", customerAwsAccountId);
+    }
+
+    registerAwsUsageContextStub(awsAccountId, jsonResponse(200, contextData));
+  }
+
+  private void setupAwsBatchMeterUsageResultStatus(String status) {
+    Map<String, Object> result = new HashMap<>();
+    result.put("Status", status);
+    if ("Success".equals(status)) {
+      result.put("MeteringRecordId", "test-record-id");
+    }
     given()
         .contentType("application/json")
         .body(
@@ -319,11 +384,40 @@ public class AwsWiremockService extends WiremockService {
                     "headers",
                     Map.of("Content-Type", "application/x-amz-json-1.1"),
                     "jsonBody",
+                    Map.of("Results", List.of(result), "UnprocessedRecords", List.of())),
+                "priority",
+                9,
+                "metadata",
+                getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+
+  private void setupAwsBatchMeterUsageThrottling() {
+    given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "POST",
+                    "urlPathPattern",
+                    AWS_USAGE_EVENT_PATH + ".*",
+                    "headers",
+                    Map.of("X-Amz-Target", Map.of("equalTo", BATCH_METER_USAGE_TARGET))),
+                "response",
+                Map.of(
+                    "status",
+                    429,
+                    "headers",
+                    Map.of("Content-Type", "application/x-amz-json-1.1"),
+                    "jsonBody",
                     Map.of(
-                        "Results",
-                        List.of(Map.of("MeteringRecordId", "test-record-id", "Status", "Success")),
-                        "UnprocessedRecords",
-                        List.of())),
+                        "__type", "ThrottlingException",
+                        "message", "Rate exceeded")),
                 "priority",
                 9,
                 "metadata",

--- a/swatch-producer-aws/ct/java/tests/SimpleAwsComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/SimpleAwsComponentTest.java
@@ -25,6 +25,7 @@ import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_HOUR
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE_STATUS;
 
 import api.MessageValidators;
+import com.redhat.swatch.component.tests.api.TestPlanName;
 import domain.Product;
 import java.util.Map;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
@@ -100,5 +101,114 @@ public class SimpleAwsComponentTest extends BaseAwsComponentTest {
         1);
 
     wiremock.verifyNoAwsUsage();
+  }
+
+  /**
+   * Verify AWS CustomerNotSubscribed response results in FAILED status with
+   * marketplace_customer_not_subscribed error code.
+   */
+  @TestPlanName("producer-aws-batch-meter-usage-TC001")
+  @Test
+  @Tag("unhappy")
+  public void testAwsCustomerNotSubscribed() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    wiremock.setupAwsUsageContextWithBatchMeterResultStatus(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        "CustomerNotSubscribed");
+
+    BillableUsageAggregate aggregateData =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
+
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateFailure(
+            awsAccountId, BillableUsage.ErrorCode.MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED),
+        1);
+  }
+
+  /**
+   * Verify AWS DuplicateRecord response results in FAILED status with marketplace_duplicate_record
+   * error code.
+   */
+  @TestPlanName("producer-aws-batch-meter-usage-TC002")
+  @Test
+  @Tag("unhappy")
+  public void testAwsDuplicateRecord() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    wiremock.setupAwsUsageContextWithBatchMeterResultStatus(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        "DuplicateRecord");
+
+    BillableUsageAggregate aggregateData =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
+
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateFailure(
+            awsAccountId, BillableUsage.ErrorCode.MARKETPLACE_DUPLICATE_RECORD),
+        1);
+  }
+
+  /**
+   * Verify an unrecognized AWS BatchMeterUsage status results in FAILED with unknown error code.
+   */
+  @TestPlanName("producer-aws-batch-meter-usage-TC003")
+  @Test
+  @Tag("unhappy")
+  public void testAwsUnrecognizedBatchMeterStatus() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    wiremock.setupAwsUsageContextWithBatchMeterResultStatus(
+        awsAccountId,
+        awsSellerAccountId,
+        rhSubscriptionId,
+        customerId,
+        productCode,
+        "UnrecognizedStatus");
+
+    BillableUsageAggregate aggregateData =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
+
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateFailure(awsAccountId, BillableUsage.ErrorCode.UNKNOWN),
+        1);
+  }
+
+  /**
+   * Verify AWS ThrottlingException response results in FAILED status with marketplace_rate_limit
+   * error code.
+   */
+  @TestPlanName("producer-aws-batch-meter-usage-TC004")
+  @Test
+  @Tag("unhappy")
+  public void testAwsRateLimit() {
+    String metricId = Product.ROSA.getFirstMetric().getId();
+
+    wiremock.setupAwsUsageContextWithBatchMeterThrottling(
+        awsAccountId, awsSellerAccountId, rhSubscriptionId, customerId, productCode);
+
+    BillableUsageAggregate aggregateData =
+        createUsageAggregate(Product.ROSA.getName(), awsAccountId, metricId, TOTAL_VALUE, orgId);
+    kafkaBridge.produceKafkaMessage(BILLABLE_USAGE_HOURLY_AGGREGATE, aggregateData);
+
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE_STATUS,
+        MessageValidators.aggregateFailure(
+            awsAccountId, BillableUsage.ErrorCode.MARKETPLACE_RATE_LIMIT),
+        1);
   }
 }

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsUsageNotAcceptedException.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/AwsUsageNotAcceptedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.aws.exception;
+
+import lombok.Getter;
+import software.amazon.awssdk.services.marketplacemetering.model.UsageRecordResultStatus;
+
+@Getter
+public class AwsUsageNotAcceptedException extends AwsProducerException {
+
+  private final UsageRecordResultStatus resultStatus;
+
+  public AwsUsageNotAcceptedException(UsageRecordResultStatus resultStatus) {
+    super(ErrorCode.AWS_USAGE_NOT_ACCEPTED, String.format("status=%s", resultStatus));
+    this.resultStatus = resultStatus;
+  }
+}

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
       "Multiple possible matches found. Likely a subscription is missing part of its billingAccountId."),
   SUBSCRIPTION_MISSING_BILLING_ACCOUNT_ID(
       1012, "Subscription missing billingAccountId required for customerAwsAccountId"),
-  AWS_THROTTLING_ERROR(1011, "AWS throttling error");
+  AWS_THROTTLING_ERROR(1011, "AWS throttling error"),
+  AWS_USAGE_NOT_ACCEPTED(1013, "AWS returned non-Success status for usage record");
 
   private static final String CODE_PREFIX = "SWATCHAWS";
 

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -28,6 +28,7 @@ import com.redhat.swatch.aws.exception.AwsMissingCredentialsException;
 import com.redhat.swatch.aws.exception.AwsThrottlingException;
 import com.redhat.swatch.aws.exception.AwsUnprocessedRecordsException;
 import com.redhat.swatch.aws.exception.AwsUsageContextLookupException;
+import com.redhat.swatch.aws.exception.AwsUsageNotAcceptedException;
 import com.redhat.swatch.aws.exception.DefaultApiException;
 import com.redhat.swatch.aws.exception.SubscriptionCanNotBeDeterminedException;
 import com.redhat.swatch.aws.exception.SubscriptionMissingBillingAccountIdException;
@@ -181,6 +182,16 @@ public class AwsBillableUsageAggregateConsumer {
           context.getProductCode(),
           context.getSubscriptionStartDate());
       ignoreCounter.increment();
+    } catch (AwsUsageNotAcceptedException e) {
+      emitErrorStatusOnUsage(
+          billableUsageAggregate, errorCodeForAwsUsageResult(e.getResultStatus()));
+      log.warn(
+          "AWS usage not accepted for rhSubscriptionId={} aggregate={} awsCustomerId={} awsProductCode={} resultStatus={}",
+          context.getRhSubscriptionId(),
+          billableUsageAggregate,
+          context.getCustomerId(),
+          context.getProductCode(),
+          e.getResultStatus());
     } catch (AwsThrottlingException e) {
       emitErrorStatusOnUsage(
           billableUsageAggregate, BillableUsage.ErrorCode.MARKETPLACE_RATE_LIMIT);
@@ -240,7 +251,9 @@ public class AwsBillableUsageAggregateConsumer {
 
   private void transformAndSend(
       AwsUsageContext context, BillableUsageAggregate billableUsageAggregate, Metric metric)
-      throws AwsUnprocessedRecordsException, UsageTimestampOutOfBoundsException {
+      throws AwsUnprocessedRecordsException,
+          AwsUsageNotAcceptedException,
+          UsageTimestampOutOfBoundsException {
     BatchMeterUsageRequest request =
         BatchMeterUsageRequest.builder()
             .productCode(context.getProductCode())
@@ -262,28 +275,23 @@ public class AwsBillableUsageAggregateConsumer {
           awsMarketplaceMeteringClientFactory.buildMarketplaceMeteringClient(context);
       BatchMeterUsageResponse response = send(marketplaceMeteringClient, request);
       log.debug("{}", response);
-      response
-          .results()
-          .forEach(
-              result -> {
-                if (result.status() == UsageRecordResultStatus.CUSTOMER_NOT_SUBSCRIBED) {
-                  log.warn(
-                      "AWS BatchMeterUsage CUSTOMER_NOT_SUBSCRIBED (No subscription found) for aggregate={}, result={}",
-                      billableUsageAggregate,
-                      result);
-                } else if (result.status() != UsageRecordResultStatus.SUCCESS) {
-                  log.warn("{}, aggregate={}", result, billableUsageAggregate);
-                } else {
-                  log.info(
-                      "Sent usage request to AWS: result={}, aggregate={}",
-                      result,
-                      billableUsageAggregate);
-                  acceptedCounter.increment(response.results().size());
-                }
-              });
       if (!response.unprocessedRecords().isEmpty()) {
         rejectedCounter.increment(response.unprocessedRecords().size());
         throw new AwsUnprocessedRecordsException(response.unprocessedRecords().size());
+      }
+      for (var result : response.results()) {
+        if (result.status() == UsageRecordResultStatus.SUCCESS) {
+          log.info(
+              "Sent usage request to AWS: result={}, aggregate={}", result, billableUsageAggregate);
+          acceptedCounter.increment();
+        } else {
+          log.warn(
+              "AWS BatchMeterUsage returned non-Success status for aggregate={}, result={}",
+              billableUsageAggregate,
+              result);
+          rejectedCounter.increment();
+          throw new AwsUsageNotAcceptedException(result.status());
+        }
       }
     } catch (ThrottlingException e) {
       rejectedCounter.increment(request.usageRecords().size());
@@ -399,6 +407,17 @@ public class AwsBillableUsageAggregateConsumer {
     usage.setErrorCode(errorCode);
     incrementMeteredTotal(usage);
     billableUsageStatusProducer.emitStatus(usage);
+  }
+
+  private static BillableUsage.ErrorCode errorCodeForAwsUsageResult(
+      UsageRecordResultStatus resultStatus) {
+    if (resultStatus == UsageRecordResultStatus.CUSTOMER_NOT_SUBSCRIBED) {
+      return BillableUsage.ErrorCode.MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED;
+    }
+    if (resultStatus == UsageRecordResultStatus.DUPLICATE_RECORD) {
+      return BillableUsage.ErrorCode.MARKETPLACE_DUPLICATE_RECORD;
+    }
+    return BillableUsage.ErrorCode.UNKNOWN;
   }
 
   private void incrementMeteredTotal(BillableUsageAggregate usage) {

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -597,6 +597,45 @@ class AwsBillableUsageAggregateConsumerTest {
                             usage.getErrorCode())));
   }
 
+  static Stream<Arguments> nonSuccessUsageRecordResults() {
+    return Stream.of(
+        Arguments.of(
+            UsageRecordResultStatus.CUSTOMER_NOT_SUBSCRIBED,
+            BillableUsage.ErrorCode.MARKETPLACE_CUSTOMER_NOT_SUBSCRIBED),
+        Arguments.of(
+            UsageRecordResultStatus.DUPLICATE_RECORD,
+            BillableUsage.ErrorCode.MARKETPLACE_DUPLICATE_RECORD),
+        Arguments.of(
+            UsageRecordResultStatus.UNKNOWN_TO_SDK_VERSION, BillableUsage.ErrorCode.UNKNOWN));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonSuccessUsageRecordResults")
+  void shouldEmitFailedAndIncrementRejectedCounterOnNonSuccessResult(
+      UsageRecordResultStatus resultStatus, BillableUsage.ErrorCode errorCode) throws ApiException {
+    double currentRejected = rejectedCounter.count();
+    when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull()))
+        .thenReturn(MOCK_AWS_USAGE_CONTEXT);
+    when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
+    when(meteringClient.batchMeterUsage(any(BatchMeterUsageRequest.class)))
+        .thenReturn(
+            BatchMeterUsageResponse.builder()
+                .results(
+                    UsageRecordResult.builder()
+                        .usageRecord(UsageRecord.builder().build())
+                        .status(resultStatus)
+                        .build())
+                .build());
+    consumer.process(ROSA_INSTANCE_HOURS_RECORD);
+    assertEquals(currentRejected + 1, rejectedCounter.count());
+    verify(billableUsageStatusProducer)
+        .emitStatus(
+            argThat(
+                usage ->
+                    BillableUsage.Status.FAILED.equals(usage.getStatus())
+                        && errorCode.equals(usage.getErrorCode())));
+  }
+
   static Stream<Arguments> usageWindowTestArgs() {
     OffsetDateTime now = OffsetDateTime.now(clock);
     OffsetDateTime startOfCurrentHour = now.minusMinutes(30);


### PR DESCRIPTION
Jira issue: SWATCH-5452

## Description

When AWS `BatchMeterUsage` returns a non-`Success` `UsageRecordResult`, emit `FAILED` remittance instead of `SUCCEEDED`.

Known statuses map to explicit `error_code` values: `CustomerNotSubscribed` → `marketplace_customer_not_subscribed`, `DuplicateRecord` → `marketplace_duplicate_record`. Other non-Success statuses (including `UnknownToSdkVersion`) remain `unknown`.

`swatch-billable-usage` persists the new marketplace error codes on remittance rows.

Producer logs no longer include the literal `CUSTOMER_NOT_SUBSCRIBED`. After deploy, search `CustomerNotSubscribed` or `AWS BatchMeterUsage returned non-Success`, or filter remittance `error_code=marketplace_customer_not_subscribed`. Sumo queries for `"AWS BatchMeterUsage CUSTOMER_NOT_SUBSCRIBED"` will not match.

## Testing

IQE Test MR: https://gitlab.cee.redhat.com/insights-qe/iqe-rhsm-subscriptions-plugin/-/merge_requests/1578

/use-iqe-image-tag=rhsm-subscriptions-d5d80351b6b7df2e45a4b0e27b69a9a8efa2c5fd

Unit:
```
./mvnw test -pl swatch-producer-aws,swatch-billable-usage -Dtest=AwsBillableUsageAggregateConsumerTest,BillableUsageStatusConsumerTest -am -Dsurefire.failIfNoSpecifiedTests=false
```

Component:
```
./mvnw clean install -Pcomponent-tests -pl swatch-producer-aws/ct -am
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added handling for AWS Marketplace usage records rejected because a customer is unsubscribed or a record is duplicated.
  - Added specific failure codes for these scenarios; unrecognized rejection statuses are reported as unknown.

- **Bug Fixes**
  - Failed usage submissions now correctly update rejection counters and billable usage status.

- **Tests**
  - Added coverage for Marketplace rejection, duplicate records, unrecognized responses, throttling, and corresponding remittance outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->