### PR TITLE
Fix Kessel url for tally and contracts

### DIFF
--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
@@ -57,7 +57,7 @@ public class KesselAuthorizationService {
         new KesselConfig() {
           @Override
           public String endpoint() {
-            return properties.endpoint();
+            return properties.resolvedEndpoint();
           }
 
           @Override

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
@@ -22,10 +22,13 @@ package com.redhat.swatch.common.security;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import java.net.URI;
 import java.util.Optional;
 
 @ConfigMapping(prefix = "swatch.kessel")
 public interface KesselProperties {
+
+  int GRPC_PORT = 9000;
 
   @WithDefault("localhost:9000")
   String endpoint();
@@ -44,4 +47,16 @@ public interface KesselProperties {
   Optional<String> authClientId();
 
   Optional<String> authClientSecret();
+
+  default String resolvedEndpoint() {
+    var ep = endpoint();
+    if (!ep.contains("://")) {
+      return ep;
+    }
+    var host = URI.create(ep).getHost();
+    if (host == null) {
+      throw new IllegalArgumentException("Cannot resolve hostname from Kessel endpoint: " + ep);
+    }
+    return host + ":" + GRPC_PORT;
+  }
 }

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -30,7 +30,9 @@ quarkus.unleash.devservices.enabled=${ENABLE_UNLEASH_DEV_SERVICES:false}
 %test.quarkus.unleash.active=false
 
 # Kessel / RBACv2 configuration
-KESSEL_ENDPOINT=${clowder.endpoints.kessel-inventory-api.hostname:localhost}:9000
+# Using .url instead of .hostname because clowder-quarkus-config-source does not support .hostname.
+# KesselProperties.resolvedEndpoint() extracts the hostname from the URL and appends the gRPC port.
+KESSEL_ENDPOINT=${clowder.endpoints.kessel-inventory-api.url:http://localhost:9000}
 %dev.KESSEL_ENDPOINT=localhost:8006
 %test.KESSEL_ENDPOINT=localhost:9000
 %component-tests.KESSEL_ENDPOINT=wiremock-service:8000

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPropertiesTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPropertiesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class KesselPropertiesTest {
+
+  @Test
+  void resolvedEndpointPassesThroughSchemelessValues() {
+    var props = withEndpoint("localhost:9000");
+    assertEquals("localhost:9000", props.resolvedEndpoint());
+  }
+
+  @Test
+  void resolvedEndpointPassesThroughSchemelessHostPort() {
+    var props = withEndpoint("wiremock-service:8000");
+    assertEquals("wiremock-service:8000", props.resolvedEndpoint());
+  }
+
+  @Test
+  void resolvedEndpointExtractsHostFromHttpUrl() {
+    var props = withEndpoint("http://kessel-inventory-api.namespace.svc:8000");
+    assertEquals(
+        "kessel-inventory-api.namespace.svc:" + KesselProperties.GRPC_PORT,
+        props.resolvedEndpoint());
+  }
+
+  @Test
+  void resolvedEndpointExtractsHostFromHttpsUrl() {
+    var props = withEndpoint("https://kessel-inventory-api.namespace.svc:8000");
+    assertEquals(
+        "kessel-inventory-api.namespace.svc:" + KesselProperties.GRPC_PORT,
+        props.resolvedEndpoint());
+  }
+
+  @Test
+  void resolvedEndpointThrowsOnMalformedUrl() {
+    var props = withEndpoint("http://:8000");
+    assertThrows(IllegalArgumentException.class, props::resolvedEndpoint);
+  }
+
+  private static KesselProperties withEndpoint(String endpoint) {
+    return new KesselProperties() {
+      @Override
+      public String endpoint() {
+        return endpoint;
+      }
+
+      @Override
+      public boolean insecure() {
+        return true;
+      }
+
+      @Override
+      public long timeoutMs() {
+        return 5000;
+      }
+
+      @Override
+      public String rbacBaseEndpoint() {
+        return "http://localhost:8080";
+      }
+
+      @Override
+      public Optional<String> authDiscoveryIssuerUrl() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> authClientId() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<String> authClientSecret() {
+        return Optional.empty();
+      }
+    };
+  }
+}

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySource.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySource.java
@@ -53,8 +53,9 @@ import org.springframework.web.context.support.StandardServletEnvironment;
  *   <li>clowder.kafka.brokers
  *   <li>clowder.kafka.brokers.(sasl.securityProtocol|sasl.mechanism|sasl.jaas.config|cacert|cacert.type)
  *   <li>clowder.kafka.topics.&lt;topics[?].requestedName(*)&gt;.name
- *   <li>clowder.endpoints.&lt;endpoints[?].app&gt;-&lt;endpoints[?].name&gt;.url For example:
- *       "clowder.endpoints.index-service.url"
+ *   <li>clowder.endpoints.&lt;endpoints[?].app&gt;-&lt;endpoints[?].name&gt;.(url|hostname) For
+ *       example: "clowder.endpoints.index-service.url" or
+ *       "clowder.endpoints.kessel-inventory-api.hostname"
  *   <li>clowder.endpoints.&lt;endpoints[?].app&gt;-&lt;endpoints[?].name&gt;.(trust-store-path|trust-store-password|trust-store-type)
  *       are special synthetic properties that are generated based on the clowder.tlsCAPath
  *   <li>clowder.privateEndpoints.&lt;privateEndpoints[?].app(*)&gt;-&lt;privateEndpoints[?].name(*)&gt;(url|trust-store-path|trust-store-password|trust-store-type).
@@ -114,6 +115,7 @@ public class ClowderJsonPropertySource extends PropertySource<ClowderJson>
   private static final Map<String, EndpointConfigMapper> ENDPOINTS_PROPERTIES =
       Map.of(
           ".url", ClowderJsonPropertySource::endpointToUrl,
+          ".hostname", ClowderJsonPropertySource::endpointToHostname,
           ".trust-store-path", ClowderJsonPropertySource::endpointToTrustStorePath,
           ".trust-store-password", ClowderJsonPropertySource::endpointToTrustStorePassword,
           ".trust-store-type", ClowderJsonPropertySource::endpointToTrustStoreType);
@@ -375,6 +377,11 @@ public class ClowderJsonPropertySource extends PropertySource<ClowderJson>
     String url = String.format("%s://%s:%s", protocol, hostName, port);
     log.info("Endpoint '{}' using '{}'", getEndpointName(endpointConfig), url);
     return url;
+  }
+
+  public static Object endpointToHostname(
+      ClowderJsonPropertySource root, Map<String, Object> endpointConfig) {
+    return endpointConfig.get("hostname");
   }
 
   public static Object endpointToTrustStorePath(

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/clowder/ClowderJsonPropertySourceTest.java
@@ -118,6 +118,7 @@ class ClowderJsonPropertySourceTest {
         "clowder.kafka.brokers.cacert|Dummy value",
         "clowder.kafka.brokers.cacert.type|PEM",
         "clowder.endpoints.rhsm-clowdapp-service.url|http://rhsm-clowdapp-service.rhsm.svc:8000",
+        "clowder.endpoints.rhsm-clowdapp-service.hostname|rhsm-clowdapp-service.rhsm.svc",
         "clowder.endpoints.index-service.url|https://index.rhsm.svc:8800",
         "clowder.endpoints.index-service.trust-store-path|file:/.*/truststore.*.trust",
         "clowder.endpoints.index-service.trust-store-password|.+",


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

Testing RBAC Kessel in IQE

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

```
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
```

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Endpoint configuration now supports resolving hostnames in addition to URLs.
  * Kessel endpoint settings accept complete inventory API URLs.
  * Endpoint handling works consistently with or without an HTTP or HTTPS scheme.

* **Bug Fixes**
  * Improved default endpoint behavior for local development environments.
  * Kessel connections now use the resolved endpoint and configured gRPC port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->