### PR TITLE
fix(ct): disable Quarkus dev console to fix service readiness detection

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
@@ -105,6 +105,7 @@ public class LocalQuarkusManagedResource extends DevProcessManagedResource {
     assignedHttpPort = getOrAssignPortByProperty(SERVER_PORT_PROPERTY);
     propertiesToOverwrite.put(SERVER_PORT_PROPERTY, "" + assignedHttpPort);
     this.assignedCustomPorts = assignCustomPorts();
+    propertiesToOverwrite.put("quarkus.console.enabled", "false");
   }
 
   protected Map<Integer, Integer> assignCustomPorts() {


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->

## Description
Problem:

After upgrading to Quarkus 3.38, local component tests on Linux with Java 22+ fail with a 5-minute timeout waiting for service readiness. The test framework detects readiness by checking the out.log file for "Installed features", but the Quarkus application output no longer appears in that file, only Maven build output does.

Fix:

Set quarkus.console.enabled=false on the quarkus:dev command. This disables the interactive dev console which is unused in automated tests. With it disabled, application output goes to stdout as expected and the readiness check succeeds.

## Testing
component tests run and pass. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the Quarkus console during managed test resource startup to prevent unwanted console output and improve test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->