### PR TITLE
SWATCH-5465: Tally Floorist query changes to include more columns and primary row filtering

### DIFF
--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -305,12 +305,14 @@ parameters:
       s.id,
       s.org_id,
       s.snapshot_date,
-      s.product_id
+      s.product_id,
+      s.sla,
+      s.usage,
+      s.billing_provider,
+      s.billing_account_id,
+      s.granularity
       from tally_snapshots s
-      where s.sla = '_ANY'
-      and s.usage = '_ANY'
-      and s.billing_provider = '_ANY'
-      and s.billing_account_id = '_ANY'
+      where s.is_primary = true
       and s.granularity = 'DAILY'
       and s.last_modified >= date_trunc('day', now() at time zone 'utc' - interval '2 day')
     chunksize: 50000
@@ -385,9 +387,22 @@ parameters:
     chunksize: 50000
   - prefix: ${FLOORIST_S3_SNOWPIPE_PATH}/host_tally_buckets
     query: >-
-      SELECT *
-      FROM host_tally_buckets
-      WHERE last_modified >= date_trunc('day', now() at time zone 'utc' - interval '2 day')
+      select
+        b.host_id,
+        b.product_id,
+        b.sla,
+        b.usage,
+        b.billing_provider,
+        b.billing_account_id,
+        b.as_hypervisor,
+        b.cores,
+        b.sockets,
+        b.measurement_type,
+        b.version,
+        b.last_modified
+      from host_tally_buckets b
+      where b.is_primary = true
+        and b.last_modified >= date_trunc('day', now() at time zone 'utc' - interval '2 day')
     chunksize: 50000
   - prefix: ${FLOORIST_S3_SNOWPIPE_PATH}/instance_measurements
     query: >-


### PR DESCRIPTION
Jira issue: SWATCH-5465

## Description
As a part of having an updated, more useful tally mart, these changes include adding 5 new columns to the tally_snapshots query: billing_provider, billing_account_id, granularity, sla, usage. There are also updates to filter on primary records only for tally_snapshots and host_tally_buckets due to _ANY work for both tables being completed.

## Testing
Confirm new queries work and show correct columns filtered on is_primary=true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FloorPlan export accuracy by selecting only primary snapshot and host-tally records.
  * Preserved filtering for recently modified records and daily granularity.
  * Removed overly broad export selections that could include unintended data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->