### PR TITLE
SWATCH-5270: Implement utilization rbac component tests

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -64,6 +64,25 @@ public final class SwatchUtils {
     return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
   }
 
+  /** Returns headers for a User identity with org, user identifiers, and org_admin flag. */
+  public static Map<String, String> securityHeadersWithUserRole(
+      String orgId, String userId, boolean isOrgAdmin) {
+    String json =
+        "{\"identity\":{\"type\":\"User\",\"org_id\":\""
+            + orgId
+            + "\",\"internal\":{\"org_id\":\""
+            + orgId
+            + "\"},\"user\":{\"username\":\""
+            + userId
+            + "\",\"user_id\":\""
+            + userId
+            + "\",\"is_org_admin\":"
+            + isOrgAdmin
+            + "}}}";
+    String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);
+  }
+
   /** Returns headers for a User identity with org and user identifiers (RBAC component tests). */
   public static Map<String, String> securityHeadersWithUserRole(String orgId, String userId) {
     String json =

--- a/swatch-utilization/ct/java/api/UtilizationSwatchService.java
+++ b/swatch-utilization/ct/java/api/UtilizationSwatchService.java
@@ -29,6 +29,7 @@ import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
 import com.redhat.swatch.utilization.openapi.model.OrgPreferencesResponse;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import java.util.Map;
 import java.util.Objects;
 
 public class UtilizationSwatchService extends SwatchService {
@@ -43,6 +44,25 @@ public class UtilizationSwatchService extends SwatchService {
         .headers(securityHeadersWithServiceRole(orgId))
         .when()
         .get(ORG_PREFERENCES_ENDPOINT);
+  }
+
+  public Response getOrgPreferences(Map<String, String> requestHeaders) {
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+
+    return given().headers(requestHeaders).when().get(ORG_PREFERENCES_ENDPOINT);
+  }
+
+  public Response updateOrgPreferences(
+      Map<String, String> requestHeaders, OrgPreferencesRequest request) {
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+    Objects.requireNonNull(request, "request must not be null");
+
+    return given()
+        .headers(requestHeaders)
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when()
+        .post(ORG_PREFERENCES_ENDPOINT);
   }
 
   public OrgPreferencesResponse getOrgPreferencesExpectSuccess(String orgId) {

--- a/swatch-utilization/ct/java/api/UtilizationUnleashService.java
+++ b/swatch-utilization/ct/java/api/UtilizationUnleashService.java
@@ -26,6 +26,7 @@ import com.redhat.swatch.utilization.model.SendNotificationVariantPayload;
 import java.util.List;
 
 public class UtilizationUnleashService extends UnleashService {
+  private static final String USE_KESSEL_RBAC = "swatch.common-security.use-kessel-rbac";
   private static final String SEND_NOTIFICATIONS = "swatch.swatch-notifications.send-notifications";
   private static final String SEND_NOTIFICATIONS_CONFIG_VARIANT = "send-notifications-config";
   private static final String SEND_NOTIFICATIONS_ORGS_ALLOWLIST =
@@ -60,6 +61,14 @@ public class UtilizationUnleashService extends UnleashService {
 
   public void clearSendNotificationsVariants() {
     clearVariants(SEND_NOTIFICATIONS);
+  }
+
+  public void enableKesselRbac() {
+    enableFlag(USE_KESSEL_RBAC);
+  }
+
+  public void disableKesselRbac() {
+    disableFlag(USE_KESSEL_RBAC);
   }
 
   private static String buildEventTypesDenylistJson(String... eventTypes) {

--- a/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
@@ -127,8 +127,7 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
         "org-preferences endpoint responses",
         () -> assertEquals(HttpStatus.SC_OK, postResponse.statusCode(), "POST org-preferences"),
         () ->
-            assertEquals(
-                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"));
+            assertEquals(HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"));
   }
 
   @Test
@@ -164,8 +163,7 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
   @ParameterizedTest(name = "authorizationModel={0}")
   @EnumSource(AuthorizationModel.class)
   @TestPlanName("org-preferences-auth-TC008")
-  void shouldDenyBothEndpointsWhenServiceAccountHasNoAccess(
-      AuthorizationModel authorizationModel) {
+  void shouldDenyBothEndpointsWhenServiceAccountHasNoAccess(AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
@@ -178,8 +176,7 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
     assertAll(
         "org-preferences endpoint responses",
         () ->
-            assertEquals(
-                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
+            assertEquals(HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
         () ->
             assertEquals(
                 HttpStatus.SC_FORBIDDEN, postResponse.statusCode(), "POST org-preferences"));
@@ -210,8 +207,7 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
     assertAll(
         "org-preferences endpoint responses",
         () ->
-            assertEquals(
-                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
+            assertEquals(HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
         () ->
             assertEquals(
                 HttpStatus.SC_FORBIDDEN, postResponse.statusCode(), "POST org-preferences"));

--- a/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.X_RH_IDENTITY_HEADER;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.swatch.component.tests.api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.api.Wiremock;
+import com.redhat.swatch.component.tests.api.WiremockService;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.component.tests.utils.SwatchUtils;
+import com.redhat.swatch.utilization.openapi.model.OrgPreferencesRequest;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
+
+  @Wiremock static WiremockService wiremock = new WiremockService();
+
+  @AfterAll
+  static void resetKesselRbacFlag() {
+    unleash.disableKesselRbac();
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC001")
+  void shouldAllowGetOrgPreferencesWhenUserHasAdminAccess(AuthorizationModel authorizationModel) {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC002")
+  void shouldAllowGetOrgPreferencesWhenUserHasReaderAccess(AuthorizationModel authorizationModel) {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC003")
+  void shouldDenyGetOrgPreferencesWhenUserHasNoAccess(AuthorizationModel authorizationModel) {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC004")
+  void shouldDenyPostOrgPreferencesWhenUserIsNotOrgAdmin(AuthorizationModel authorizationModel) {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    Response response = whenPostOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC005")
+  void shouldAllowPostButDenyGetWhenOrgAdminWithoutPermission(
+      AuthorizationModel authorizationModel) {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId, true);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    Response postResponse = whenPostOrgPreferences(requestHeaders);
+    Response getResponse = whenGetOrgPreferences(requestHeaders);
+
+    assertAll(
+        "org-preferences endpoint responses",
+        () -> assertEquals(HttpStatus.SC_OK, postResponse.statusCode(), "POST org-preferences"),
+        () ->
+            assertEquals(
+                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"));
+  }
+
+  @Test
+  @TestPlanName("org-preferences-auth-TC006")
+  void shouldAllowBothEndpointsForServiceRole() {
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceRole(orgId);
+
+    Response getResponse = whenGetOrgPreferences(requestHeaders);
+    Response postResponse = whenPostOrgPreferences(requestHeaders);
+
+    assertAll(
+        "org-preferences endpoint responses",
+        () -> assertEquals(HttpStatus.SC_OK, getResponse.statusCode(), "GET org-preferences"),
+        () -> assertEquals(HttpStatus.SC_OK, postResponse.statusCode(), "POST org-preferences"));
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC007")
+  void shouldAllowGetOrgPreferencesWhenServiceAccountHasAdminAccess(
+      AuthorizationModel authorizationModel) {
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("org-preferences-auth-TC008")
+  void shouldDenyBothEndpointsWhenServiceAccountHasNoAccess(
+      AuthorizationModel authorizationModel) {
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+
+    Response getResponse = whenGetOrgPreferences(requestHeaders);
+    Response postResponse = whenPostOrgPreferences(requestHeaders);
+
+    assertAll(
+        "org-preferences endpoint responses",
+        () ->
+            assertEquals(
+                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
+        () ->
+            assertEquals(
+                HttpStatus.SC_FORBIDDEN, postResponse.statusCode(), "POST org-preferences"));
+  }
+
+  @Test
+  @TestPlanName("org-preferences-auth-TC009")
+  void shouldDenyGetOrgPreferencesWhenKesselUnavailable() {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    unleash.enableKesselRbac();
+    wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @Test
+  @TestPlanName("org-preferences-auth-TC010")
+  void shouldDenyBothEndpointsForAssociateIdentity() {
+    String email = RandomUtils.generateRandom() + "@redhat.com";
+    var requestHeaders = SwatchUtils.securityHeadersWithAssociate(orgId, email);
+
+    Response getResponse = whenGetOrgPreferences(requestHeaders);
+    Response postResponse = whenPostOrgPreferences(requestHeaders);
+
+    assertAll(
+        "org-preferences endpoint responses",
+        () ->
+            assertEquals(
+                HttpStatus.SC_FORBIDDEN, getResponse.statusCode(), "GET org-preferences"),
+        () ->
+            assertEquals(
+                HttpStatus.SC_FORBIDDEN, postResponse.statusCode(), "POST org-preferences"));
+  }
+
+  @Test
+  @TestPlanName("org-preferences-auth-TC011")
+  void shouldDenyGetOrgPreferencesWhenRbacUnavailable() {
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    unleash.disableKesselRbac();
+
+    Response response = whenGetOrgPreferences(requestHeaders);
+
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  private Response whenGetOrgPreferences(Map<String, String> requestHeaders) {
+    return service.getOrgPreferences(requestHeaders);
+  }
+
+  private Response whenPostOrgPreferences(Map<String, String> requestHeaders) {
+    return service.updateOrgPreferences(requestHeaders, defaultRequest());
+  }
+
+  private void thenResponseStatusIs(Response response, int expectedStatus) {
+    assertEquals(expectedStatus, response.statusCode());
+  }
+
+  private void givenUserHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String userId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(userId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  private void givenServiceAccountHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String clientId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(clientId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  private static OrgPreferencesRequest defaultRequest() {
+    return new OrgPreferencesRequest().customThreshold(50);
+  }
+}

--- a/swatch-utilization/ct/resources/test.properties
+++ b/swatch-utilization/ct/resources/test.properties
@@ -1,4 +1,5 @@
 swatch.component-tests.services.kafkaBridge.log.enabled=false
+swatch.component-tests.services.wiremock.log.enabled=false
 swatch.component-tests.services.unleash.log.enabled=false
 # Enable it for debug purposes:
 # swatch.component-tests.services.service.log.level=FINE


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5270

## Description
This card implements the RBAC v1 and v2 component tests for watch utilization.

## Testing
podman compose up -d
./mvnw clean install -Pcomponent-tests -pl swatch-utilization/ct -am

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and updating organization preferences with caller-provided identity headers.
  * Added controls for enabling or disabling Kessel-based role-based access control.

* **Bug Fixes**
  * Improved authorization coverage for organization-preferences access across users, service accounts, service roles, and associate identities.

* **Tests**
  * Added comprehensive component tests covering authorization scenarios and unavailable authorization services.
  * Reduced unnecessary service logging during component tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->