### PR TITLE
swatch-5455: parse IT Subscription Kafka JSON outbox instead of CanonicalMessage XML

### DIFF
--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1116,34 +1116,38 @@ This section verifies the automatic contract termination behavior when contracts
   - Kafka consumer is independently disabled (not tested in this TC)
 
 **subscriptions-creation-kafka-TC001 - Kafka consumer happy path**
-- **Description**: Verify that a valid `CanonicalMessage` XML delivered via Kafka is
+- **Description**: Verify that a valid `SubscriptionOutboxEvent` JSON delivered via Kafka is
   deserialized and persisted as a subscription (Kafka consumer smoke test).
 - **Setup**:
   - Unleash toggle `swatch.swatch-contracts.enable-it-subscription-service` is enabled
   - WireMock stubs for Search API (`getSubscriptionBySubscriptionNumber`) and Product API
     (`offeringData`) are in place
-- **Action**: Publish a valid `CanonicalMessage` XML string to the
-  `subscription.subscriptions.private` Kafka topic via Kafka Bridge
+- **Action**: Publish a valid `SubscriptionOutboxEvent` JSON string (with `entityType: "Subscription"`
+  and a `payload` containing `subscriptionNumber`, `customerId`, `quantity`, `effectiveStartDate`,
+  `effectiveEndDate`, and `product.sku`) to the `subscription.subscriptions.private` Kafka topic
+  via Kafka Bridge
 - **Verification**: Query subscriptions via internal API for the test org
 - **Expected Result**:
   - One subscription created with matching `subscription_number`, `quantity`, `sku`,
-    `start_date`, and `end_date` (dates converted from America/New_York to UTC)
+    `start_date`, and `end_date` (dates converted from epoch milliseconds to UTC)
 
-**subscriptions-creation-kafka-TC002 - Reject malformed XML from Kafka**
-- **Description**: Verify that unparseable XML causes a warn log and does not crash the
+**subscriptions-creation-kafka-TC002 - Reject malformed JSON from Kafka**
+- **Description**: Verify that unparseable JSON causes a warn log and does not crash the
   Kafka consumer or leave a partial subscription in the database (Kafka-specific error handling).
 - **Setup**: IT subscription service flag enabled; no WireMock setup needed
-- **Action**: Publish a non-XML string to the `subscription.subscriptions.private` topic
+- **Action**: Publish a non-JSON string to the `subscription.subscriptions.private` topic
 - **Verification**: Check service logs and subscription table
 - **Expected Result**:
-  - Warn log: `Unable to process IT Subscription Kafka message`
+  - Warn log: `Unable to read IT Subscription Kafka message from JSON.`
   - No subscription created for the test org
   - Consumer continues to accept subsequent messages (`failure-strategy=ignore`)
 
 **subscriptions-creation-kafka-TC003 - Reject Kafka message with missing required fields**
 - **Description**: Verify Kafka consumer validation for incomplete subscription data.
 - **Setup**: IT subscription service flag enabled; WireMock stubs in place
-- **Action**: Publish `CanonicalMessage` with missing required fields (e.g., missing `subscription_number` or `effectiveStartDate`) to the `subscription.subscriptions.private` topic
+- **Action**: Publish a `SubscriptionOutboxEvent` JSON with `entityType: "Subscription"` but
+  missing required payload fields (e.g., missing `subscriptionNumber` or `customerId`/`webCustomerId`)
+  to the `subscription.subscriptions.private` topic
 - **Verification**: Check service logs and subscription table
 - **Expected Result**:
   - Warn log or validation error logged
@@ -1154,7 +1158,7 @@ This section verifies the automatic contract termination behavior when contracts
 - **Description**: Verify that when the Unleash flag
   `swatch.swatch-contracts.enable-it-subscription-service` is **disabled**, the Kafka consumer exits early and no subscription is persisted.
 - **Setup**: Unleash toggle disabled; WireMock stubs in place
-- **Action**: Publish a valid `CanonicalMessage` XML to Kafka
+- **Action**: Publish a valid `SubscriptionOutboxEvent` JSON to Kafka
 - **Verification**: Poll subscriptions after 3 second delay via internal API
 - **Expected Result**: Zero subscriptions created for the test org
 
@@ -1163,7 +1167,7 @@ This section verifies the automatic contract termination behavior when contracts
   `{"kafka_consumer_enabled":false}` blocks the Kafka consumer while the flag itself
   remains enabled.
 - **Setup**: Unleash flag enabled; `config` variant set with `kafka_consumer_enabled=false`
-- **Action**: Publish a valid `CanonicalMessage` XML to Kafka
+- **Action**: Publish a valid `SubscriptionOutboxEvent` JSON to Kafka
 - **Verification**: Poll subscriptions after 3 second delay via internal API
 - **Expected Result**: Zero subscriptions created for the test org
 
@@ -1172,7 +1176,7 @@ This section verifies the automatic contract termination behavior when contracts
   (`umb_consumer_enabled=false`) does not prevent the Kafka consumer from working.
 - **Setup**: Unleash flag enabled; `config` variant set with
   `{"kafka_consumer_enabled":true,"umb_consumer_enabled":false}`; WireMock stubs in place
-- **Action**: Publish a valid `CanonicalMessage` XML to Kafka
+- **Action**: Publish a valid `SubscriptionOutboxEvent` JSON to Kafka
 - **Verification**: Poll subscriptions until created
 - **Expected Result**:
   - Subscription created with correct `quantity` and `sku`
@@ -1183,7 +1187,7 @@ This section verifies the automatic contract termination behavior when contracts
   (`{"kafka_consumer_enabled":true,"umb_consumer_enabled":true}`) allows both to function correctly.
 - **Setup**: Unleash flag enabled; `config` variant set with
   `{"kafka_consumer_enabled":true,"umb_consumer_enabled":true}`; WireMock stubs in place
-- **Action**: Publish a valid `CanonicalMessage` XML to Kafka
+- **Action**: Publish a valid `SubscriptionOutboxEvent` JSON to Kafka
 - **Verification**: Poll subscriptions until created
 - **Expected Result**:
   - Subscription created with correct `quantity` and `sku`

--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1073,11 +1073,11 @@ This section verifies the automatic contract termination behavior when contracts
 - **Verification**: Check service logs and subscription table
 - **Expected Result**:
   - Subscription is created with core fields (`subscription_number`, `quantity`, `sku`)
-  - Invalid billing provider value is either:
-    - Stored as-is for audit purposes, OR
-    - Filtered/nullified with a warning log
+  - Unknown billing provider is nullified
+  - `billing_provider` field is null in the persisted subscription
   - Consumer does not crash or reject the entire message
-  - Warn log indicates invalid billing provider value encountered
+  - Info log indicates subscription was consumed: "IT Subscription message consumed: source=umb"
+  - No `NullPointerException` or validation errors logged
 
 **subscriptions-creation-umb-TC008 - Ignore UMB message when IT subscription service flag is disabled**
 - **Description**: Verify that when the Unleash flag
@@ -1134,19 +1134,22 @@ This section verifies the automatic contract termination behavior when contracts
 **subscriptions-creation-kafka-TC002 - Reject malformed JSON from Kafka**
 - **Description**: Verify that unparseable JSON causes a warn log and does not crash the
   Kafka consumer or leave a partial subscription in the database (Kafka-specific error handling).
-- **Setup**: IT subscription service flag enabled; no WireMock setup needed
-- **Action**: Publish a non-JSON string to the `subscription.subscriptions.private` topic
+- **Setup**: IT subscription service flag enabled; WireMock stubs in place for valid message
+- **Action**: 
+  - Publish a non-JSON string to the `subscription.subscriptions.private` topic
+  - Publish a valid event after the malformed message and verify that the consumer processes it
 - **Verification**: Check service logs and subscription table
 - **Expected Result**:
   - Warn log: `Unable to read IT Subscription Kafka message from JSON.`
-  - No subscription created for the test org
+  - No subscription created for the test org from the malformed message
   - Consumer continues to accept subsequent messages (`failure-strategy=ignore`)
+  - Valid event after the malformed message is successfully processed and creates a subscription
 
 **subscriptions-creation-kafka-TC003 - Reject Kafka message with missing required fields**
 - **Description**: Verify Kafka consumer validation for incomplete subscription data.
 - **Setup**: IT subscription service flag enabled; WireMock stubs in place
 - **Action**: Publish a `SubscriptionOutboxEvent` JSON with `entityType: "Subscription"` but
-  missing required payload fields (e.g., missing `subscriptionNumber` or `customerId`/`webCustomerId`)
+  missing required payload fields (e.g., missing `subscriptionNumber` or `customerId`)
   to the `subscription.subscriptions.private` topic
 - **Verification**: Check service logs and subscription table
 - **Expected Result**:

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -40,6 +40,31 @@ public class ContractsUnleashService extends UnleashService {
     enableFlag(IT_SUBSCRIPTION_SERVICE);
   }
 
+  public void enableItSubscriptionServiceKafkaOnly() {
+    enableFlag(IT_SUBSCRIPTION_SERVICE);
+    setVariant(
+        IT_SUBSCRIPTION_SERVICE,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":false}");
+  }
+
+  public void disableItSubscriptionServiceKafkaConsumer() {
+    enableFlag(IT_SUBSCRIPTION_SERVICE);
+    setVariant(IT_SUBSCRIPTION_SERVICE, "config", "{\"kafka_consumer_enabled\":false}");
+  }
+
+  public void enableItSubscriptionServiceBothConsumers() {
+    enableFlag(IT_SUBSCRIPTION_SERVICE);
+    setVariant(
+        IT_SUBSCRIPTION_SERVICE,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":true}");
+  }
+
+  public void clearItSubscriptionServiceVariants() {
+    clearVariants(IT_SUBSCRIPTION_SERVICE);
+  }
+
   public void disablePartnerGatewayContracts() {
     disableFlag(PARTNER_GATEWAY_CONTRACTS);
   }

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -48,9 +48,12 @@ public class ContractsUnleashService extends UnleashService {
         "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":false}");
   }
 
-  public void disableItSubscriptionServiceKafkaConsumer() {
+  public void enableItSubscriptionServiceUmbOnly() {
     enableFlag(IT_SUBSCRIPTION_SERVICE);
-    setVariant(IT_SUBSCRIPTION_SERVICE, "config", "{\"kafka_consumer_enabled\":false}");
+    setVariant(
+        IT_SUBSCRIPTION_SERVICE,
+        "config",
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
   }
 
   public void enableItSubscriptionServiceBothConsumers() {

--- a/swatch-contracts/ct/java/api/SearchApiStubs.java
+++ b/swatch-contracts/ct/java/api/SearchApiStubs.java
@@ -54,6 +54,13 @@ public class SearchApiStubs {
         subscription.getSubscriptionNumber(), List.of(responseBody));
   }
 
+  public void stubGetSubscriptionWithUnknownBillingProvider(Subscription subscription) {
+    var responseBody = mapToApiModel(subscription);
+    responseBody.put("externalReferences", Map.of("UNKNOWN", Map.of()));
+    stubSubscriptionBySubscriptionNumber(
+        subscription.getSubscriptionNumber(), List.of(responseBody));
+  }
+
   /**
    * Stub the getSubscriptionBySubscriptionNumber endpoint to return an empty array (not found).
    * This simulates the scenario where a subscription is not found in the search API.

--- a/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionsCreationComponentTest.java
@@ -23,6 +23,7 @@ package tests;
 import static api.CanonicalMessageArtemisSender.SUBSCRIPTION_CHANNEL;
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
 import static com.redhat.swatch.component.tests.utils.DateUtils.assertDatesAreEqual;
+import static com.redhat.swatch.component.tests.utils.Topics.IT_SUBSCRIPTION_SYNC;
 import static com.redhat.swatch.contract.product.umb.UmbSubscription.convertToUtc;
 import static domain.Contract.buildRosaContract;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,6 +51,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,13 +66,19 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
 
   @BeforeAll
   static void enableItSubscriptionServiceFeatureFlag() {
-    unleash.enableItSubscriptionService();
+    // Enable both Kafka and UMB consumers for IT Subscription Service
+    unleash.enableItSubscriptionServiceBothConsumers();
   }
 
   @BeforeEach
   void setUp() {
     super.setUp();
     this.sku = RandomUtils.generateRandom();
+  }
+
+  @AfterEach
+  void restoreItSubscriptionServiceFlag() {
+    unleash.enableItSubscriptionServiceBothConsumers();
   }
 
   @TestPlanName("subscriptions-creation-TC001")
@@ -305,6 +313,173 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
     assertSubscription(secondSubscription, actualSecondSubscription.get());
   }
 
+  @TestPlanName("subscriptions-creation-TC008")
+  @Test
+  void shouldHandleNullEmptyOptionalFields() {
+    Subscription subscription = givenSubscription();
+    // Create subscription with null billing fields (optional)
+    Subscription subscriptionWithNulls =
+        subscription.toBuilder()
+            .billingProvider(null)
+            .billingAccountId(null)
+            .billingProviderId(null)
+            .build();
+
+    artemis.forSubscriptions().send(subscriptionWithNulls);
+
+    var actual = thenSubscriptionIsCreated(subscriptionWithNulls);
+    assertEquals(subscriptionWithNulls.getQuantity(), actual.getQuantity());
+    assertEquals(subscriptionWithNulls.getOffering().getSku(), actual.getSku());
+    assertNull(actual.getBillingProvider());
+    assertNull(actual.getBillingAccountId());
+    // Successful creation of subscription with null optional fields proves they're handled
+    // correctly
+    // (NPE would have prevented subscription creation)
+  }
+
+  @TestPlanName("subscriptions-creation-TC011")
+  @Test
+  void shouldHandleInvalidBillingProviderValue() {
+    Subscription subscription = givenSubscriptionWithUnknownBillingProvider();
+
+    artemis.forSubscriptions().send(subscription);
+
+    var actual = thenSubscriptionIsCreated(subscription);
+    assertEquals(subscription.getQuantity(), actual.getQuantity());
+    assertEquals(subscription.getOffering().getSku(), actual.getSku());
+    assertNull(
+        actual.getBillingProvider(), "Unknown billing provider should be filtered, not stored");
+    service.logs().assertContains("IT Subscription message consumed: source=umb");
+    // Successful creation proves invalid billing provider was handled gracefully (no NPE)
+  }
+
+  @TestPlanName("subscriptions-creation-umb-TC008")
+  @Test
+  void shouldIgnoreUmbMessageWhenItSubscriptionServiceFlagDisabled() {
+    unleash.disableItSubscriptionService();
+
+    Subscription subscription = givenSubscription();
+    artemis.forSubscriptions().send(subscription);
+
+    service.logs().assertContains("IT Subscription UMB consumer is disabled by feature flag.");
+    thenNoSubscriptionIsCreated();
+  }
+
+  @TestPlanName("subscriptions-creation-umb-TC009")
+  @Test
+  void shouldIgnoreUmbMessageWhenUmbConsumerDisabledViaVariant() {
+    unleash.enableItSubscriptionServiceKafkaOnly();
+
+    Subscription subscription = givenSubscription();
+    artemis.forSubscriptions().send(subscription);
+
+    service.logs().assertContains("IT Subscription UMB consumer is disabled by feature flag.");
+    thenNoSubscriptionIsCreated();
+  }
+
+  @TestPlanName("subscriptions-creation-umb-TC010")
+  @Test
+  void shouldProcessUmbMessageWhenUmbEnabledAndKafkaDisabledViaVariant() {
+    unleash.enableItSubscriptionServiceUmbOnly();
+
+    Subscription subscription = givenSubscription();
+    artemis.forSubscriptions().send(subscription);
+
+    var actual = thenSubscriptionIsCreated(subscription);
+    assertEquals(subscription.getQuantity(), actual.getQuantity());
+    assertEquals(subscription.getOffering().getSku(), actual.getSku());
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC001")
+  @Test
+  void shouldProcessValidKafkaMessage() {
+    Subscription subscription = givenSubscription();
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+
+    var actual = thenSubscriptionIsCreated(subscription);
+    thenSubscriptionMatchesKafkaEvent(subscription, actual);
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC002")
+  @Test
+  void shouldRejectMalformedJsonFromKafka() {
+    String malformedJson = "{invalid json}";
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, malformedJson);
+
+    // Wait for error log to appear
+    service.logs().assertContains("Unable to read IT Subscription Kafka message from JSON");
+
+    // Verify consumer continues processing valid messages after error
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC003")
+  @Test
+  void shouldRejectKafkaMessageWithMissingRequiredFields() {
+    kafkaBridge.produceKafkaMessage(
+        IT_SUBSCRIPTION_SYNC,
+        Map.of("entityType", "Subscription", "payload", Map.of("quantity", 5)));
+
+    service.logs().assertContains("IT Subscription Kafka payload is missing subscriptionNumber");
+
+    // Verify consumer continues processing valid messages after error
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC004")
+  @Test
+  void shouldIgnoreKafkaMessageWhenItSubscriptionServiceFlagDisabled() {
+    unleash.disableItSubscriptionService();
+
+    Subscription subscription = givenSubscription();
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+
+    service.logs().assertContains("IT Subscription Kafka consumer is disabled by feature flag.");
+    thenNoSubscriptionIsCreated();
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC005")
+  @Test
+  void shouldIgnoreKafkaMessageWhenKafkaConsumerDisabledViaVariant() {
+    unleash.enableItSubscriptionServiceUmbOnly();
+
+    Subscription subscription = givenSubscription();
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+
+    service.logs().assertContains("IT Subscription Kafka consumer is disabled by feature flag.");
+    thenNoSubscriptionIsCreated();
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC006")
+  @Test
+  void shouldProcessKafkaMessageWhenKafkaEnabledAndUmbDisabledViaVariant() {
+    unleash.enableItSubscriptionServiceKafkaOnly();
+
+    Subscription subscription = givenSubscription();
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+
+    var actual = thenSubscriptionIsCreated(subscription);
+    thenSubscriptionMatchesKafkaEvent(subscription, actual);
+  }
+
+  @TestPlanName("subscriptions-creation-kafka-TC007")
+  @Test
+  void shouldProcessKafkaMessageWhenBothConsumersEnabled() {
+    unleash.enableItSubscriptionServiceBothConsumers();
+
+    Subscription subscription = givenSubscription();
+
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+
+    var actual = thenSubscriptionIsCreated(subscription);
+    thenSubscriptionMatchesKafkaEvent(subscription, actual);
+  }
+
   private Subscription givenSubscription() {
     var subscription =
         Subscription.buildRhelSubscription(orgId, Map.of(SOCKETS, RHEL_SOCKETS_CAPACITY), sku);
@@ -330,6 +505,14 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
     return subscription;
   }
 
+  private Subscription givenSubscriptionWithUnknownBillingProvider() {
+    var subscription =
+        Subscription.buildRhelSubscription(orgId, Map.of(SOCKETS, RHEL_SOCKETS_CAPACITY), sku);
+    wiremock.forSearchApi().stubGetSubscriptionWithUnknownBillingProvider(subscription);
+    wiremock.forProductAPI().stubOfferingData(subscription.getOffering());
+    return subscription;
+  }
+
   private com.redhat.swatch.contract.test.model.Subscription thenSubscriptionIsCreated(
       Subscription expected) {
     return AwaitilityUtils.until(
@@ -342,6 +525,30 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
         .get(0);
   }
 
+  private void thenNoSubscriptionIsCreated() {
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                0,
+                service.getSubscriptionsByOrgId(orgId).size(),
+                "No subscription should be created"));
+  }
+
+  private void thenKafkaConsumerAcceptsSubsequentMessages() {
+    Subscription subscription = givenSubscription();
+    kafkaBridge.produceKafkaMessage(IT_SUBSCRIPTION_SYNC, buildKafkaMessage(subscription));
+    var actual = thenSubscriptionIsCreated(subscription);
+    thenSubscriptionMatchesKafkaEvent(subscription, actual);
+  }
+
+  private void thenSubscriptionMatchesKafkaEvent(
+      Subscription expected, com.redhat.swatch.contract.test.model.Subscription actual) {
+    assertEquals(expected.getQuantity(), actual.getQuantity());
+    assertEquals(expected.getOffering().getSku(), actual.getSku());
+    assertDatesAreEqual(expected.getStartDate(), actual.getStartDate());
+    assertDatesAreEqual(expected.getEndDate(), actual.getEndDate());
+  }
+
   private void assertSubscription(
       Contract expected, com.redhat.swatch.contract.test.model.Subscription actual) {
     assertEquals(expected.getSubscriptionNumber(), actual.getSubscriptionNumber());
@@ -350,5 +557,33 @@ public class SubscriptionsCreationComponentTest extends BaseContractComponentTes
     assertDatesAreEqual(expected.getEndDate(), actual.getEndDate());
     assertEquals(expected.getOrgId(), actual.getOrgId());
     assertEquals(expected.getBillingProvider().toString(), actual.getBillingProvider());
+  }
+
+  private Map<String, Object> buildKafkaMessage(Subscription subscription) {
+    return Map.of(
+        "eventId",
+        RandomUtils.generateRandom(),
+        "entityType",
+        "Subscription",
+        "eventType",
+        "CREATE",
+        "eventVersion",
+        "v1.0",
+        "createdAt",
+        System.currentTimeMillis(),
+        "payload",
+        Map.of(
+            "subscriptionNumber",
+            subscription.getSubscriptionNumber(),
+            "customerId",
+            subscription.getOrgId(),
+            "quantity",
+            subscription.getQuantity(),
+            "effectiveStartDate",
+            subscription.getStartDate().toInstant().toEpochMilli(),
+            "effectiveEndDate",
+            subscription.getEndDate().toInstant().toEpochMilli(),
+            "product",
+            Map.of("sku", subscription.getOffering().getSku())));
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumer.java
@@ -23,10 +23,9 @@ package com.redhat.swatch.contract.service;
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.swatch.contract.config.FeatureFlags;
-import com.redhat.swatch.contract.product.umb.CanonicalMessage;
-import com.redhat.swatch.contract.product.umb.UmbSubscription;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxEvent;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -39,48 +38,55 @@ public class SubscriptionKafkaMessageConsumer {
 
   @Inject FeatureFlags featureFlags;
   @Inject SubscriptionSyncService service;
-
-  private final XmlMapper xmlMapper = CanonicalMessage.createMapper();
+  @Inject ObjectMapper mapper;
 
   @Blocking
   @Incoming(IT_SUBSCRIPTION_SYNC)
-  public void consumeFromKafka(String subscriptionMessageXml) throws JsonProcessingException {
+  public void consumeMessage(String message) throws JsonProcessingException {
     log.debug("IT Subscription Kafka consumer was called");
-    if (subscriptionMessageXml == null) {
+    if (message == null) {
       return;
     }
     if (!featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()) {
       log.debug("IT Subscription Kafka consumer is disabled by feature flag.");
       return;
     }
-    consumeSubscription(subscriptionMessageXml);
+    consumeSubscription(message);
   }
 
-  public void consumeSubscription(String subscriptionMessageXml) throws JsonProcessingException {
-    CanonicalMessage subscriptionMessage;
+  public void consumeSubscription(String message) throws JsonProcessingException {
+    SubscriptionOutboxEvent event;
     try {
-      subscriptionMessage = xmlMapper.readValue(subscriptionMessageXml, CanonicalMessage.class);
+      event = mapper.readValue(message, SubscriptionOutboxEvent.class);
     } catch (JsonProcessingException e) {
-      log.warn(
-          "Unable to process IT Subscription Kafka message: messagePreview={}",
-          subscriptionMessageXml != null && subscriptionMessageXml.length() > 100
-              ? subscriptionMessageXml.substring(0, 100) + "..."
-              : subscriptionMessageXml,
-          e);
+      log.warn("Unable to read IT Subscription Kafka message from JSON.", e);
       throw e;
     }
-    UmbSubscription subscription = subscriptionMessage.getPayload().getSync().getSubscription();
+    if (event == null) {
+      log.warn("IT Subscription Kafka message deserialized to null, skipping");
+      return;
+    }
+    if (!"Subscription".equalsIgnoreCase(event.getEntityType())) {
+      log.debug("Ignoring IT Subscription Kafka message with entityType={}", event.getEntityType());
+      return;
+    }
+    var payload = event.getPayload();
+    if (payload == null) {
+      log.warn(
+          "Ignoring IT Subscription Kafka message with null payload: eventId={}, entityType={}",
+          event.getEventId(),
+          event.getEntityType());
+      return;
+    }
     log.info(
         "IT Subscription message consumed: source=kafka, "
-            + "subscriptionNumber={}, webCustomerId={}, sku={}, quantity={}, "
-            + "effectiveStartDate={}, effectiveEndDate={}, terminated={}",
-        subscription.getSubscriptionNumber(),
-        subscription.getWebCustomerId(),
-        subscription.findSku().orElse(null),
-        subscription.getQuantity(),
-        subscription.getEffectiveStartDate(),
-        subscription.getEffectiveEndDate(),
-        subscription.findTerminatedStatus().isPresent());
-    service.saveUmbSubscription(subscription);
+            + "subscriptionNumber={}, customerId={}, quantity={}, "
+            + "effectiveStartDate={}, effectiveEndDate={}",
+        payload.getSubscriptionNumber(),
+        payload.getCustomerId(),
+        payload.getQuantity(),
+        payload.getEffectiveStartDate(),
+        payload.getEffectiveEndDate());
+    service.saveSubscription(payload);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/SubscriptionSyncService.java
@@ -30,6 +30,9 @@ import com.redhat.swatch.contract.exception.ServiceException;
 import com.redhat.swatch.contract.exception.SubscriptionNotFoundException;
 import com.redhat.swatch.contract.model.PartnerEntitlementsRequest;
 import com.redhat.swatch.contract.model.SyncResult;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxChildProduct;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxPayload;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxProduct;
 import com.redhat.swatch.contract.product.umb.SubscriptionProductStatus;
 import com.redhat.swatch.contract.product.umb.UmbSubscription;
 import com.redhat.swatch.contract.repository.BillingProvider;
@@ -426,6 +429,64 @@ public class SubscriptionSyncService {
     return Optional.empty();
   }
 
+  private SubscriptionEntity convertDto(SubscriptionOutboxPayload payload) {
+    if (payload.getSubscriptionNumber() == null || payload.getSubscriptionNumber().isBlank()) {
+      throw new IllegalArgumentException(
+          "IT Subscription Kafka payload is missing subscriptionNumber");
+    }
+    String orgId = payload.getCustomerId();
+    if (orgId == null || orgId.isBlank()) {
+      throw new IllegalArgumentException("IT Subscription Kafka payload is missing customerId");
+    }
+    Integer quantity = payload.getQuantity();
+    OffsetDateTime endDate = toOffsetDateTime(payload.getEffectiveEndDate());
+
+    // Child products expose status (including Terminated) but no termination-date field.
+    // Use payload.effectiveEndDate as the subscription end. The guide marks that field
+    // required; if it is missing on a terminated child, fall back to now.
+    Optional<SubscriptionOutboxChildProduct> terminatedChild = findTerminatedChildProduct(payload);
+    if (terminatedChild.isPresent()) {
+      if (endDate == null) {
+        endDate = clock.now();
+        log.warn(
+            "Terminated child product with null effectiveEndDate; falling back to now for subscriptionNumber={}",
+            payload.getSubscriptionNumber());
+      } else {
+        log.debug(
+            "Terminated child product detected for subscriptionNumber={}, endDate={}",
+            payload.getSubscriptionNumber(),
+            endDate);
+      }
+    }
+
+    return SubscriptionEntity.builder()
+        .subscriptionNumber(payload.getSubscriptionNumber())
+        .orgId(orgId)
+        .quantity(quantity == null ? 0L : quantity.longValue())
+        .startDate(toOffsetDateTime(payload.getEffectiveStartDate()))
+        .endDate(endDate)
+        .build();
+  }
+
+  private static Optional<SubscriptionOutboxChildProduct> findTerminatedChildProduct(
+      SubscriptionOutboxPayload payload) {
+    SubscriptionOutboxProduct product = payload.getProduct();
+    if (product == null || product.getChildProducts() == null) {
+      return Optional.empty();
+    }
+    return product.getChildProducts().stream()
+        .filter(Objects::nonNull)
+        .filter(child -> "Terminated".equalsIgnoreCase(child.getStatus()))
+        .findFirst();
+  }
+
+  private OffsetDateTime toOffsetDateTime(Long epochMs) {
+    if (epochMs == null) {
+      return null;
+    }
+    return clock.dateFromMilliseconds(epochMs);
+  }
+
   private SubscriptionEntity convertDto(UmbSubscription subscription) {
 
     var endDate = subscription.getEffectiveEndDateInUtc();
@@ -534,6 +595,33 @@ public class SubscriptionSyncService {
     } else {
       syncSubscription(getSku(umbSubscription), subscription, subscriptions.stream().findFirst());
     }
+  }
+
+  @Transactional
+  public void saveSubscription(SubscriptionOutboxPayload payload) {
+    SubscriptionEntity subscription = convertDto(payload);
+    String sku = extractSku(payload);
+    if (sku == null) {
+      throw new IllegalStateException(
+          "Could not find top level SKU for subscription " + payload.getSubscriptionNumber());
+    }
+    var subscriptions =
+        subscriptionService.findBySubscriptionNumber(subscription.getSubscriptionNumber());
+    if (subscriptions.size() > 1) {
+      log.warn(
+          "Skipping message because multiple subscriptions were found for subscriptionNumber={}",
+          subscription.getSubscriptionNumber());
+    } else {
+      syncSubscription(sku, subscription, subscriptions.stream().findFirst());
+    }
+  }
+
+  private static String extractSku(SubscriptionOutboxPayload payload) {
+    SubscriptionOutboxProduct product = payload.getProduct();
+    if (product != null && product.getSku() != null && !product.getSku().isBlank()) {
+      return product.getSku();
+    }
+    return null;
   }
 
   @Asynchronous

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1452,6 +1452,89 @@ components:
           type: array
           items:
             type: string
+    SubscriptionOutboxEvent:
+      description: IT Subscription Service Kafka outbox envelope (v1.0)
+      properties:
+        eventId:
+          type: string
+        createdAt:
+          type: integer
+          format: int64
+        entityType:
+          type: string
+        eventType:
+          type: string
+        eventVersion:
+          type: string
+        expireAt:
+          type: integer
+          format: int64
+        payload:
+          $ref: '#/components/schemas/SubscriptionOutboxPayload'
+    SubscriptionOutboxPayload:
+      description: Kafka outbox payload from subscription-event v1.0
+      properties:
+        subscriptionNumber:
+          type: string
+        customerId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+        effectiveStartDate:
+          type: integer
+          format: int64
+        effectiveEndDate:
+          type: integer
+          format: int64
+        identifiers:
+          $ref: '#/components/schemas/SubscriptionOutboxIdentifiers'
+        product:
+          $ref: '#/components/schemas/SubscriptionOutboxProduct'
+    SubscriptionOutboxIdentifiers:
+      properties:
+        ebsAccountNumber:
+          type: string
+        priorEbsAccountNumber:
+          type: string
+        registrationNumber:
+          type: string
+        ebsInstallBaseNumber:
+          type: string
+    SubscriptionOutboxProduct:
+      properties:
+        sku:
+          type: string
+        childProducts:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionOutboxChildProduct'
+    SubscriptionOutboxChildProduct:
+      properties:
+        sku:
+          type: string
+        status:
+          type: string
+        contract:
+          $ref: '#/components/schemas/SubscriptionOutboxContract'
+        order:
+          $ref: '#/components/schemas/SubscriptionOutboxOrder'
+    SubscriptionOutboxContract:
+      properties:
+        contractNumber:
+          type: string
+        contractId:
+          type: string
+    SubscriptionOutboxOrder:
+      properties:
+        orderNumber:
+          type: string
+        orderLineItemId:
+          type: string
+        externalOrderNumber:
+          type: string
+        externalOrderSystem:
+          type: string
     OperationalProductEvent:
       properties:
         occurredOn:

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/SubscriptionOutboxEventTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/SubscriptionOutboxEventTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxEvent;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxPayload;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionOutboxEventTest {
+
+  private static final String GUIDE_EVENT =
+      """
+      {
+        "eventId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+        "entityType": "Subscription",
+        "eventType": "CREATE",
+        "eventVersion": "v1.0",
+        "createdAt": 1705328400000,
+        "expireAt": 1712411400000,
+        "payload": {
+          "subscriptionNumber": "12345678",
+          "customerId": "1234567",
+          "quantity": 10,
+          "effectiveStartDate": 1704067200000,
+          "effectiveEndDate": 1735689600000,
+          "product": {
+            "sku": "RH00001",
+            "childProducts": [
+              {"sku": "RH00002", "status": "Active"}
+            ]
+          }
+        }
+      }
+      """;
+
+  private final ObjectMapper mapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Test
+  void shouldParseGuideEvent() throws Exception {
+    SubscriptionOutboxEvent event = mapper.readValue(GUIDE_EVENT, SubscriptionOutboxEvent.class);
+    assertEquals("Subscription", event.getEntityType());
+
+    SubscriptionOutboxPayload payload = event.getPayload();
+
+    assertEquals("12345678", payload.getSubscriptionNumber());
+    assertEquals("1234567", payload.getCustomerId());
+    assertEquals("RH00001", payload.getProduct().getSku());
+    assertEquals(10, payload.getQuantity());
+    assertEquals(1704067200000L, payload.getEffectiveStartDate());
+    assertEquals(1735689600000L, payload.getEffectiveEndDate());
+    assertEquals("Active", payload.getProduct().getChildProducts().get(0).getStatus());
+  }
+
+  @Test
+  void shouldDetectTerminatedChildStatus() throws Exception {
+    String json =
+        """
+        {
+          "entityType": "Subscription",
+          "payload": {
+            "subscriptionNumber": "87654321",
+            "customerId": "9876543",
+            "quantity": 5,
+            "effectiveStartDate": 1706745600000,
+            "effectiveEndDate": 1738368000000,
+            "product": {
+              "sku": "RH00005",
+              "childProducts": [
+                {"sku": "RH00006", "status": "Terminated"}
+              ]
+            }
+          }
+        }
+        """;
+    SubscriptionOutboxEvent event = mapper.readValue(json, SubscriptionOutboxEvent.class);
+    assertEquals(
+        "Terminated", event.getPayload().getProduct().getChildProducts().get(0).getStatus());
+  }
+
+  @Test
+  void shouldHandleNullPayload() throws Exception {
+    String json =
+        """
+        {"entityType": "Subscription"}
+        """;
+    SubscriptionOutboxEvent event = mapper.readValue(json, SubscriptionOutboxEvent.class);
+    assertNull(event.getPayload());
+  }
+
+  @Test
+  void shouldReturnNullSkuWhenNoProductInfo() throws Exception {
+    String json =
+        """
+        {
+          "entityType": "Subscription",
+          "payload": {
+            "subscriptionNumber": "1234",
+            "customerId": "org123"
+          }
+        }
+        """;
+    SubscriptionOutboxEvent event = mapper.readValue(json, SubscriptionOutboxEvent.class);
+    SubscriptionOutboxPayload payload = event.getPayload();
+    assertNull(payload.getProduct());
+  }
+
+  @Test
+  void shouldIgnoreNonSubscriptionEntityType() throws Exception {
+    String json =
+        """
+        {"entityType": "Offering", "payload": {}}
+        """;
+    SubscriptionOutboxEvent event = mapper.readValue(json, SubscriptionOutboxEvent.class);
+    assertEquals("Offering", event.getEntityType());
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionKafkaMessageConsumerTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.IT_SUBSCRIPTION_SYNC;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.config.FeatureFlags;
-import com.redhat.swatch.contract.product.umb.UmbSubscription;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxPayload;
 import com.redhat.swatch.contract.test.LoggerCaptor;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -42,32 +43,45 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 @QuarkusTest
 class SubscriptionKafkaMessageConsumerTest {
 
-  private static final String SUBSCRIPTION_XML =
+  private static final String SUBSCRIPTION_JSON =
+      """
+      {
+        "eventId": "evt-1",
+        "createdAt": 1704067200000,
+        "entityType": "Subscription",
+        "eventType": "CREATE",
+        "eventVersion": "v1.0",
+        "payload": {
+          "subscriptionNumber": "1234",
+          "customerId": "org123",
+          "quantity": 10,
+          "effectiveStartDate": 1704067200000,
+          "effectiveEndDate": 1735689600000,
+          "product": {
+            "sku": "RH00001",
+            "childProducts": [
+              {"sku": "RH00002", "status": "Active"}
+            ]
+          }
+        }
+      }
+      """;
+
+  private static final String CANONICAL_MESSAGE_XML =
       """
       <CanonicalMessage>
         <Payload>
           <Sync>
             <Subscription>
               <Identifiers>
-                <Reference system="EBS" entity-name="Account" qualifier="number">account123</Reference>
-                <Reference system="WEB" entity-name="Customer" qualifier="id">org123_ICUST</Reference>
                 <Identifier system="SUBSCRIPTION" entity-name="Subscription" qualifier="number">1234</Identifier>
               </Identifiers>
               <Quantity>10</Quantity>
-              <effectiveStartDate>2024-01-01T00:00:00</effectiveStartDate>
-              <effectiveEndDate>2025-01-01T00:00:00</effectiveEndDate>
-              <Product>
-                <Sku>RH00001</Sku>
-                <Product>
-                  <Status>
-                    <State>Active</State>
-                  </Status>
-                </Product>
-              </Product>
             </Subscription>
           </Sync>
         </Payload>
@@ -94,41 +108,85 @@ class SubscriptionKafkaMessageConsumerTest {
   }
 
   @Test
-  void shouldProcessMessage() {
-    whenSendMessage(SUBSCRIPTION_XML);
+  void shouldProcessOutboxJsonMessage() {
+    whenSendMessage(SUBSCRIPTION_JSON);
 
     await()
         .atMost(Duration.ofMillis(500))
-        .untilAsserted(() -> verify(consumer).consumeSubscription(SUBSCRIPTION_XML));
+        .untilAsserted(() -> verify(consumer).consumeSubscription(SUBSCRIPTION_JSON));
     thenKafkaSubscriptionDeserializedSuccessfully();
-    verify(service).saveUmbSubscription(any(UmbSubscription.class));
+    ArgumentCaptor<SubscriptionOutboxPayload> captor =
+        ArgumentCaptor.forClass(SubscriptionOutboxPayload.class);
+    verify(service).saveSubscription(captor.capture());
+    SubscriptionOutboxPayload saved = captor.getValue();
+    assertEquals("1234", saved.getSubscriptionNumber());
+    assertEquals("org123", saved.getCustomerId());
+    assertEquals("RH00001", saved.getProduct().getSku());
+    assertEquals(10, saved.getQuantity());
+    assertEquals(1704067200000L, saved.getEffectiveStartDate());
+    assertEquals(1735689600000L, saved.getEffectiveEndDate());
   }
 
   @Test
-  void shouldNotLogSuccessWhenMalformedXml() {
-    whenSendMessage("this is not xml");
+  void shouldNotTreatCanonicalMessageXmlAsValid() {
+    whenSendMessage(CANONICAL_MESSAGE_XML);
 
     await()
         .atMost(Duration.ofMillis(500))
-        .untilAsserted(() -> verify(consumer).consumeSubscription("this is not xml"));
-    LoggerCaptor.thenWarnLogWithMessage("Unable to process IT Subscription Kafka message");
-    verify(service, never()).saveUmbSubscription(any(UmbSubscription.class));
+        .untilAsserted(() -> verify(consumer).consumeSubscription(CANONICAL_MESSAGE_XML));
+    LoggerCaptor.thenWarnLogWithMessage("Unable to read IT Subscription Kafka message from JSON.");
+    verify(service, never()).saveSubscription(any());
+  }
+
+  @Test
+  void shouldNotLogSuccessWhenMalformedJson() {
+    whenSendMessage("this is not json");
+
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(() -> verify(consumer).consumeSubscription("this is not json"));
+    LoggerCaptor.thenWarnLogWithMessage("Unable to read IT Subscription Kafka message from JSON.");
+    verify(service, never()).saveSubscription(any());
   }
 
   @Test
   void shouldIgnoreNullMessage() throws Exception {
-    consumer.consumeFromKafka(null);
+    consumer.consumeMessage(null);
 
     LoggerCaptor.thenLogNothing();
-    verify(service, never()).saveUmbSubscription(any(UmbSubscription.class));
+    verify(service, never()).saveSubscription(any());
   }
 
   @Test
   void shouldIgnoreMessagesWhenFeatureFlagIsDisabled() throws Exception {
     when(featureFlags.isItSubscriptionServiceKafkaConsumerEnabled()).thenReturn(false);
-    whenSendMessage(SUBSCRIPTION_XML);
+    whenSendMessage(SUBSCRIPTION_JSON);
     assertMessageIsNotProcessed();
-    verify(service, after(500).never()).saveUmbSubscription(any(UmbSubscription.class));
+    verify(service, after(500).never()).saveSubscription(any());
+  }
+
+  @Test
+  void shouldIgnoreNonSubscriptionEntityType() {
+    String otherEntity =
+        """
+        {"eventId":"evt-1","entityType":"Offering","payload":{}}
+        """;
+    whenSendMessage(otherEntity);
+
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(() -> verify(consumer).consumeSubscription(otherEntity));
+    verify(service, never()).saveSubscription(any());
+  }
+
+  @Test
+  void shouldIgnoreNullEventEnvelope() {
+    whenSendMessage("null");
+
+    await()
+        .atMost(Duration.ofMillis(500))
+        .untilAsserted(() -> verify(consumer).consumeSubscription("null"));
+    verify(service, never()).saveSubscription(any());
   }
 
   private void whenSendMessage(String message) {
@@ -136,11 +194,12 @@ class SubscriptionKafkaMessageConsumerTest {
   }
 
   private void assertMessageIsNotProcessed() throws Exception {
-    verify(consumer, after(500).never()).consumeSubscription(SUBSCRIPTION_XML);
+    verify(consumer, after(500).never()).consumeSubscription(SUBSCRIPTION_JSON);
   }
 
   private void thenKafkaSubscriptionDeserializedSuccessfully() {
     LoggerCaptor.thenInfoLogWithMessage("IT Subscription message consumed: source=kafka");
-    LoggerCaptor.thenNoErrorLogWithMessage("Unable to process IT Subscription Kafka message");
+    LoggerCaptor.thenNoErrorLogWithMessage(
+        "Unable to read IT Subscription Kafka message from JSON.");
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/SubscriptionSyncServiceTest.java
@@ -45,6 +45,9 @@ import com.redhat.swatch.clients.subscription.api.model.Subscription;
 import com.redhat.swatch.clients.subscription.api.model.SubscriptionProduct;
 import com.redhat.swatch.contract.config.ProductDenylist;
 import com.redhat.swatch.contract.model.SyncResult;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxChildProduct;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxPayload;
+import com.redhat.swatch.contract.openapi.model.SubscriptionOutboxProduct;
 import com.redhat.swatch.contract.repository.BillingProvider;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import com.redhat.swatch.contract.repository.OfferingRepository;
@@ -416,6 +419,118 @@ class SubscriptionSyncServiceTest {
     subscriptionSyncService.saveSubscriptions(subscriptionsJson, true);
     verify(subscriptionService).save(any(SubscriptionEntity.class));
     verify(capacityReconciliationService).reconcileCapacityForSubscription(any());
+  }
+
+  @Test
+  void shouldRejectOutboxPayloadWithoutSku() {
+    var payload =
+        new SubscriptionOutboxPayload()
+            .subscriptionNumber("1234")
+            .customerId("org123")
+            .quantity(10);
+    assertThrows(
+        IllegalStateException.class, () -> subscriptionSyncService.saveSubscription(payload));
+  }
+
+  @Test
+  void shouldRejectOutboxPayloadWithoutSubscriptionNumber() {
+    var payload =
+        new SubscriptionOutboxPayload()
+            .customerId("org123")
+            .quantity(10)
+            .product(new SubscriptionOutboxProduct().sku(SKU));
+    assertThrows(
+        IllegalArgumentException.class, () -> subscriptionSyncService.saveSubscription(payload));
+  }
+
+  @Test
+  void shouldLookUpExistingSubscriptionWhenSavingOutboxPayload() {
+    OfferingEntity offering = OfferingEntity.builder().sku(SKU).build();
+    when(offeringRepository.findById(SKU)).thenReturn(offering);
+    when(denylist.productIdMatches(any())).thenReturn(false);
+    when(subscriptionService.findBySubscriptionNumber("1234")).thenReturn(List.of());
+
+    var payload =
+        new SubscriptionOutboxPayload()
+            .subscriptionNumber("1234")
+            .customerId("org123")
+            .quantity(10)
+            .effectiveStartDate(1704067200000L)
+            .effectiveEndDate(1735689600000L)
+            .product(new SubscriptionOutboxProduct().sku(SKU));
+
+    subscriptionSyncService.saveSubscription(payload);
+
+    verify(subscriptionService).findBySubscriptionNumber("1234");
+  }
+
+  @Test
+  void shouldFallBackToNowWhenTerminatedChildAndNullEndDate() {
+    OfferingEntity offering = OfferingEntity.builder().sku(SKU).build();
+    when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
+    when(offeringRepository.findById(SKU)).thenReturn(offering);
+    when(denylist.productIdMatches(any())).thenReturn(false);
+    when(subscriptionService.findBySubscriptionNumber("1234")).thenReturn(List.of());
+    when(subscriptionSearchService.getSubscriptionBySubscriptionNumber("1234"))
+        .thenReturn(createDto(123, "100", "1234", 10));
+
+    var payload =
+        new SubscriptionOutboxPayload()
+            .subscriptionNumber("1234")
+            .customerId("org123")
+            .quantity(10)
+            .effectiveStartDate(1704067200000L)
+            .effectiveEndDate(null)
+            .product(
+                new SubscriptionOutboxProduct()
+                    .sku(SKU)
+                    .addChildProductsItem(
+                        new SubscriptionOutboxChildProduct().sku("RH00002").status("Terminated")));
+
+    subscriptionSyncService.saveSubscription(payload);
+
+    verify(subscriptionService)
+        .save(
+            argThat(
+                (ArgumentMatcher<SubscriptionEntity>)
+                    sub ->
+                        sub.getEndDate() != null
+                            && !sub.getEndDate().isAfter(clock.now().plusSeconds(5))));
+  }
+
+  @Test
+  void shouldNotAdjustEndDateWhenChildProductIsActive() {
+    OfferingEntity offering = OfferingEntity.builder().sku(SKU).build();
+    when(offeringRepository.findByIdOptional(SKU)).thenReturn(Optional.of(offering));
+    when(offeringRepository.findById(SKU)).thenReturn(offering);
+    when(denylist.productIdMatches(any())).thenReturn(false);
+    when(subscriptionService.findBySubscriptionNumber("1234")).thenReturn(List.of());
+    when(subscriptionSearchService.getSubscriptionBySubscriptionNumber("1234"))
+        .thenReturn(createDto(123, "100", "1234", 10));
+
+    long futureEndDate = clock.now().plusYears(1).toInstant().toEpochMilli();
+    var payload =
+        new SubscriptionOutboxPayload()
+            .subscriptionNumber("1234")
+            .customerId("org123")
+            .quantity(10)
+            .effectiveStartDate(1704067200000L)
+            .effectiveEndDate(futureEndDate)
+            .product(
+                new SubscriptionOutboxProduct()
+                    .sku(SKU)
+                    .addChildProductsItem(
+                        new SubscriptionOutboxChildProduct().sku("RH00002").status("Active")));
+
+    subscriptionSyncService.saveSubscription(payload);
+
+    verify(subscriptionService)
+        .save(
+            argThat(
+                (ArgumentMatcher<SubscriptionEntity>)
+                    sub ->
+                        sub.getEndDate() != null
+                            && sub.getEndDate().isAfter(clock.now().plusMonths(6))));
   }
 
   @Test

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
@@ -37,6 +37,7 @@ public final class Topics {
   public static final String SUBSCRIPTION_SYNC_TASK =
       "platform.rhsm-subscriptions.subscription-sync-task";
   public static final String CAPACITY_RECONCILE = SUFFIX + "capacity-reconcile";
+  public static final String IT_SUBSCRIPTION_SYNC = "subscription.subscriptions.private";
 
   private Topics() {}
 }


### PR DESCRIPTION
Jira issue: SWATCH-5455
jira issue: SWATCH-5174

## Description
`subscription.subscriptions.private` is publishing JSON outbox events, not XML.  This is to update the IT Subscription Kafka consumer to expect the json.

Followed the pattern from `IT Partner Gatewary` and `IT Product Service` use OpenAPI to generate the DTOs.  

## Testing
Unit tests are updated.
Includes implementation of component tests for SWATCH-5174

This will need to be tested on stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for processing subscription outbox events in JSON format.
  * Added OpenAPI schemas describing subscription events, products, contracts, orders, and identifiers.
  * Added configuration helpers for enabling or disabling subscription service consumers.
  * Added a shared topic for subscription synchronization testing.

* **Bug Fixes**
  * Improved handling of terminated child products and missing end dates.
  * Ignores unsupported event types, null payloads, and malformed messages safely.

* **Tests**
  * Expanded coverage for JSON deserialization, event filtering, consumer configurations, and date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->