### PR TITLE
SWATCH-5305: Omit ProductCode when metering with LicenseArn

### DIFF
--- a/swatch-producer-aws/TEST_PLAN.md
+++ b/swatch-producer-aws/TEST_PLAN.md
@@ -94,7 +94,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
   - Inspect captured `BatchMeterUsage` request and status payload
 - **Expected Result**:
   - `UsageRecords[0].LicenseArn` equals the aggregate `licenseId`
-  - `ProductCode` is still present
+  - `ProductCode` is absent from the request (license-based metering)
   - Status message / aggregate on `billable-usage.status` carries the same `licenseId`
   - Remittance status is `SUCCEEDED`
 
@@ -133,7 +133,7 @@ Usage records always use `CustomerAWSAccountId` from `AwsUsageContext.customerAw
   - `UsageRecords[0].CustomerAWSAccountId` matches context
   - `UsageRecords[0].LicenseArn` matches aggregate `licenseId`
   - `CustomerIdentifier` absent
-  - `ProductCode` still present
+  - `ProductCode` is absent from the request
 
 **producer-aws-license-TC005 - Pass licenseId to getAwsUsageContext when looking up context**
 

--- a/swatch-producer-aws/ct/java/api/AwsWiremockService.java
+++ b/swatch-producer-aws/ct/java/api/AwsWiremockService.java
@@ -193,6 +193,11 @@ public class AwsWiremockService extends WiremockService {
     assertEquals(expectedProductCode, batchRequest.productCode(), "productCode mismatch");
   }
 
+  public void verifyBatchMeterUsageProductCodeAbsent() {
+    BatchMeterUsageRequest batchRequest = findLatestBatchMeterUsageRequest();
+    assertFieldAbsent("productCode", batchRequest.productCode());
+  }
+
   public void verifyAwsUsageContextLicenseId(String expectedLicenseId) {
     String requestUrl = findLatestAwsUsageContextRequestUrl();
     String decodedUrl = URLDecoder.decode(requestUrl, StandardCharsets.UTF_8);

--- a/swatch-producer-aws/ct/java/tests/LicenseArnComponentTest.java
+++ b/swatch-producer-aws/ct/java/tests/LicenseArnComponentTest.java
@@ -68,7 +68,7 @@ public class LicenseArnComponentTest extends BaseAwsComponentTest {
 
     thenRemittanceSucceedsWithLicense();
     thenLicenseArnMatchesAggregate();
-    thenProductCodeIsPresent();
+    thenProductCodeIsAbsent();
   }
 
   @TestPlanName("producer-aws-license-TC003")
@@ -95,7 +95,7 @@ public class LicenseArnComponentTest extends BaseAwsComponentTest {
     thenRemittanceSucceedsWithLicense();
     wiremock.verifyBatchMeterUsageCustomerAwsAccountId(CUSTOMER_AWS_ACCOUNT_ID);
     thenLicenseArnMatchesAggregate();
-    thenProductCodeIsPresent();
+    thenProductCodeIsAbsent();
   }
 
   @TestPlanName("producer-aws-license-TC005")
@@ -207,6 +207,10 @@ public class LicenseArnComponentTest extends BaseAwsComponentTest {
 
   private void thenProductCodeIsPresent() {
     wiremock.verifyBatchMeterUsageProductCode(productCode);
+  }
+
+  private void thenProductCodeIsAbsent() {
+    wiremock.verifyBatchMeterUsageProductCodeAbsent();
   }
 
   private void thenNoAwsUsageIsSent() {

--- a/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
+++ b/swatch-producer-aws/src/main/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumer.java
@@ -255,10 +255,7 @@ public class AwsBillableUsageAggregateConsumer {
           AwsUsageNotAcceptedException,
           UsageTimestampOutOfBoundsException {
     BatchMeterUsageRequest request =
-        BatchMeterUsageRequest.builder()
-            .productCode(context.getProductCode())
-            .usageRecords(transformToAwsUsage(context, billableUsageAggregate, metric))
-            .build();
+        buildBatchMeterUsageRequest(context, billableUsageAggregate, metric);
 
     if (isDryRun.isPresent() && Boolean.TRUE.equals(isDryRun.get())) {
       log.info(
@@ -343,25 +340,46 @@ public class AwsBillableUsageAggregateConsumer {
     return usageRecord.build();
   }
 
+  private BatchMeterUsageRequest buildBatchMeterUsageRequest(
+      AwsUsageContext context, BillableUsageAggregate billableUsageAggregate, Metric metric)
+      throws UsageTimestampOutOfBoundsException {
+    BatchMeterUsageRequest.Builder requestBuilder =
+        BatchMeterUsageRequest.builder()
+            .usageRecords(transformToAwsUsage(context, billableUsageAggregate, metric));
+
+    if (!usesLicenseArnMetering(billableUsageAggregate)) {
+      requestBuilder.productCode(context.getProductCode());
+    }
+
+    return requestBuilder.build();
+  }
+
   private void applyLicenseArnIfEnabled(
       UsageRecord.Builder usageRecord, BillableUsageAggregate billableUsageAggregate) {
-    if (!featureFlags.useLicense()) {
-      log.debug(
-          "use-license flag off; omitting LicenseArn for aggregateId={}",
-          billableUsageAggregate.getAggregateId());
+    if (usesLicenseArnMetering(billableUsageAggregate)) {
+      usageRecord.licenseArn(billableUsageAggregate.getLicenseId());
       return;
     }
 
-    String licenseId = billableUsageAggregate.getLicenseId();
-    if (licenseId == null || licenseId.isBlank()) {
+    if (featureFlags.useLicense()) {
       log.warn(
           "use-license is enabled but licenseId is missing; omitting LicenseArn"
               + " for aggregateId={}",
           billableUsageAggregate.getAggregateId());
-      return;
+    } else {
+      log.debug(
+          "use-license flag off; omitting LicenseArn for aggregateId={}",
+          billableUsageAggregate.getAggregateId());
     }
+  }
 
-    usageRecord.licenseArn(licenseId);
+  /** True when the aggregate should be metered with {@code LicenseArn} (no {@code ProductCode}). */
+  private boolean usesLicenseArnMetering(BillableUsageAggregate billableUsageAggregate) {
+    if (!featureFlags.useLicense()) {
+      return false;
+    }
+    String licenseId = billableUsageAggregate.getLicenseId();
+    return licenseId != null && !licenseId.isBlank();
   }
 
   private boolean isForAws(BillableUsageAggregateKey aggregationKey) {

--- a/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
+++ b/swatch-producer-aws/src/test/java/com/redhat/swatch/aws/service/AwsBillableUsageAggregateConsumerTest.java
@@ -235,9 +235,11 @@ class AwsBillableUsageAggregateConsumerTest {
     BillableUsageAggregate aggregateWithLicense =
         createAggregateWithLicense("arn:aws:license:test");
 
-    UsageRecord record = processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
+    BatchMeterUsageRequest request =
+        processUsageAndCaptureRequest(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
 
-    assertNull(record.licenseArn());
+    assertNull(request.usageRecords().getFirst().licenseArn());
+    assertEquals(MOCK_AWS_USAGE_CONTEXT.getProductCode(), request.productCode());
     verify(contractsApi).getAwsUsageContext(any(), any(), any(), any(), any(), any(), isNull());
   }
 
@@ -247,19 +249,22 @@ class AwsBillableUsageAggregateConsumerTest {
     String licenseId = "arn:aws:license-manager:us-east-1:123:license:swatch-test";
     BillableUsageAggregate aggregateWithLicense = createAggregateWithLicense(licenseId);
 
-    UsageRecord record = processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
+    BatchMeterUsageRequest request =
+        processUsageAndCaptureRequest(MOCK_AWS_USAGE_CONTEXT, aggregateWithLicense);
 
-    assertEquals(licenseId, record.licenseArn());
+    assertEquals(licenseId, request.usageRecords().getFirst().licenseArn());
+    assertNull(request.productCode());
   }
 
   @Test
-  void shouldOmitLicenseArnWhenFlagOnButLicenseIdMissing() throws ApiException {
+  void shouldIncludeProductCodeWhenFlagOnButLicenseIdMissing() throws ApiException {
     when(featureFlags.useLicense()).thenReturn(true);
 
-    UsageRecord record =
-        processUsageAndCaptureRecord(MOCK_AWS_USAGE_CONTEXT, ROSA_INSTANCE_HOURS_RECORD);
+    BatchMeterUsageRequest request =
+        processUsageAndCaptureRequest(MOCK_AWS_USAGE_CONTEXT, ROSA_INSTANCE_HOURS_RECORD);
 
-    assertNull(record.licenseArn());
+    assertNull(request.usageRecords().getFirst().licenseArn());
+    assertEquals(MOCK_AWS_USAGE_CONTEXT.getProductCode(), request.productCode());
   }
 
   @Test
@@ -661,6 +666,11 @@ class AwsBillableUsageAggregateConsumerTest {
 
   private UsageRecord processUsageAndCaptureRecord(
       AwsUsageContext context, BillableUsageAggregate aggregate) throws ApiException {
+    return processUsageAndCaptureRequest(context, aggregate).usageRecords().getFirst();
+  }
+
+  private BatchMeterUsageRequest processUsageAndCaptureRequest(
+      AwsUsageContext context, BillableUsageAggregate aggregate) throws ApiException {
     when(contractsApi.getAwsUsageContext(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(context);
     when(clientFactory.buildMarketplaceMeteringClient(any())).thenReturn(meteringClient);
@@ -671,8 +681,7 @@ class AwsBillableUsageAggregateConsumerTest {
         ArgumentCaptor.forClass(BatchMeterUsageRequest.class);
     consumer.process(aggregate);
     verify(meteringClient).batchMeterUsage(requestCaptor.capture());
-    var captured = requestCaptor.getValue();
-    return captured.usageRecords().getFirst();
+    return requestCaptor.getValue();
   }
 
   private static BillableUsageAggregate createAggregateWithLicense(String licenseId) {


### PR DESCRIPTION
AWS rejects BatchMeterUsage that sends both ProductCode and LicenseArn for concurrent-agreement products. Omit ProductCode when use-license is on and the aggregate has licenseId. Keep legacy ProductCode path otherwise.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5305

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
./mvnw test -pl swatch-producer-aws -Dtest=AwsBillableUsageAggregateConsumerTest

./mvnw clean install -Pcomponent-tests -pl swatch-producer-aws/ct -am


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS Marketplace usage requests now omit the product code when valid license-based metering is enabled.
  * Product code remains included when license-based metering is unavailable or incomplete.
  * License ARN and product code fields now reflect the applicable metering configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->