### PR TITLE
temporary fix for bonfire deploy kessel-inventory

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -60,6 +60,7 @@ spec:
         -p host-inventory/REPLICAS_WORKSPACES=0
         -p host-inventory/REPLICAS_WORKSPACES_BULK=0
         -p host-inventory/REPLICAS_HOST_APP_DATA=0
+        --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=6917808
     - name: DEPLOY_OPTIONAL_DEPS_METHOD
       value: "none"
     - name: DEPLOY_FRONTENDS


### PR DESCRIPTION
This change needs to be reverted once the template has working version of: quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api 

As part of the `bonfire deploy` the https://quay.io/repository/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api image has a tag that doesn't exist.
I tried with the `latest` / `8d3c743` and many of the inventory pods were failing to initialize, waiting on migration.
And I found yesterday's image `6917808` worked for me.

Can be tested with a local deploy to bonfire adding ` --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=6917808` to the deploy line.

Currently without this change `bonfire deploy ... rhsm` fails to pull the image.