### PR TITLE
swatch-5081: Align IT Product Service Kafka consumer logic with UMB consumer

### DIFF
--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/OfferingSyncService.java
@@ -273,17 +273,17 @@ public class OfferingSyncService {
   }
 
   /**
-   * Sync offering state based on a Json UMB event.
+   * Sync offering state based on a Json product event.
    *
    * <p>See syncRootSku and syncChildSku for more details.
    *
-   * @param productEvent UMB event for product
+   * @param productEvent product event for a SKU
    * @return result describing results of sync (for testing purposes)
    */
   @Transactional
-  public SyncResult syncUmbProductFromEvent(OperationalProductEvent productEvent) {
+  public SyncResult syncProductFromEvent(OperationalProductEvent productEvent) {
 
-    // The event from the Product Service UMB topic only has the SKU and no attributes
+    // The event from the Product Service topic only has the SKU and no attributes
     UmbOperationalProduct product =
         UmbOperationalProduct.builder()
             .sku(productEvent.getProductCode())
@@ -294,7 +294,7 @@ public class OfferingSyncService {
   }
 
   private SyncResult syncUmbProduct(UmbOperationalProduct umbOperationalProduct) {
-    log.info("Received UMB message for productSku={}", umbOperationalProduct.getSku());
+    log.info("Received product message for productSku={}", umbOperationalProduct.getSku());
     if (umbOperationalProduct.getSku().startsWith("SVC")) {
       syncChildSku(umbOperationalProduct.getSku());
       return SyncResult.FETCHED_AND_SYNCED;
@@ -328,7 +328,7 @@ public class OfferingSyncService {
       return syncOffering(newState.get(), existing);
     } else {
       log.warn(
-          "Unable to sync offering from UMB message for sku={}, because product service has no records for it",
+          "Unable to sync offering from product message for sku={}, because product service has no records for it",
           umbOperationalProduct.getSku());
       return SyncResult.SKIPPED_NOT_FOUND;
     }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumer.java
@@ -38,6 +38,7 @@ public class ProductStatusKafkaMessageConsumer {
 
   @Inject FeatureFlags featureFlags;
   @Inject ObjectMapper mapper;
+  @Inject OfferingSyncService service;
 
   @Blocking
   @Incoming(IT_OFFERING_SYNC)
@@ -69,6 +70,9 @@ public class ProductStatusKafkaMessageConsumer {
         productEvent.getEventType(),
         productEvent.getProductCategory(),
         isChildSku(productEvent.getProductCode()));
+
+    var response = service.syncProductFromEvent(productEvent);
+    log.debug("kafka response: {}", response);
   }
 
   private static boolean isChildSku(String productCode) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumer.java
@@ -79,7 +79,7 @@ public class ProductStatusUMBMessageConsumer {
           productEvent.getProductCategory(),
           isChildSku(productEvent.getProductCode()));
 
-      service.syncUmbProductFromEvent(productEvent);
+      service.syncProductFromEvent(productEvent);
     } catch (Exception e) {
       log.error("Unable to read UMB product message for JSON: {}", message, e);
     }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/OfferingSyncServiceTest.java
@@ -271,7 +271,7 @@ class OfferingSyncServiceTest {
     when(repo.findByIdOptional(any())).thenReturn(Optional.of(testOffering));
     ObjectMapper mapper = new ObjectMapper();
     OperationalProductEvent event = mapper.readValue(read(), OperationalProductEvent.class);
-    subject.syncUmbProductFromEvent(event);
+    subject.syncProductFromEvent(event);
     var actual = ArgumentCaptor.forClass(OfferingEntity.class);
     verify(repo).merge(actual.capture());
     // this shows that the eng ids were derived from the product service's definition of the SVC sku

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusKafkaMessageConsumerTest.java
@@ -22,6 +22,7 @@ package com.redhat.swatch.contract.service;
 
 import static com.redhat.swatch.contract.config.Channels.IT_OFFERING_SYNC;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
@@ -29,6 +30,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.redhat.swatch.contract.config.FeatureFlags;
+import com.redhat.swatch.contract.model.SyncResult;
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
 import com.redhat.swatch.contract.test.LoggerCaptor;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -41,6 +44,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 @QuarkusTest
 class ProductStatusKafkaMessageConsumerTest {
@@ -66,6 +70,7 @@ class ProductStatusKafkaMessageConsumerTest {
         """;
 
   @InjectMock FeatureFlags featureFlags;
+  @InjectMock OfferingSyncService offeringSyncService;
   @Inject @Any InMemoryConnector connector;
   @InjectSpy ProductStatusKafkaMessageConsumer consumer;
 
@@ -80,7 +85,10 @@ class ProductStatusKafkaMessageConsumerTest {
   void setUp() {
     productKafkaChannel = connector.source(IT_OFFERING_SYNC);
     LoggerCaptor.clearRecords();
+    Mockito.reset(offeringSyncService, featureFlags);
     when(featureFlags.isProductServiceKafkaConsumerEnabled()).thenReturn(true);
+    when(offeringSyncService.syncProductFromEvent(any(OperationalProductEvent.class)))
+        .thenReturn(SyncResult.FETCHED_AND_SYNCED);
   }
 
   @Test
@@ -92,6 +100,7 @@ class ProductStatusKafkaMessageConsumerTest {
             () -> {
               verify(consumer).consumeProduct(VALID_JSON_MESSAGE);
               LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=kafka");
+              verify(offeringSyncService).syncProductFromEvent(any(OperationalProductEvent.class));
             });
   }
 
@@ -104,6 +113,7 @@ class ProductStatusKafkaMessageConsumerTest {
             () -> {
               verify(consumer).consumeProduct(CHILD_SKU_JSON_MESSAGE);
               LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=kafka");
+              verify(offeringSyncService).syncProductFromEvent(any(OperationalProductEvent.class));
             });
   }
 
@@ -116,6 +126,8 @@ class ProductStatusKafkaMessageConsumerTest {
             () -> {
               verify(consumer).consumeProduct("not-valid-json");
               LoggerCaptor.thenWarnLogWithMessage("Unable to read IT Product Kafka message");
+              verify(offeringSyncService, never())
+                  .syncProductFromEvent(any(OperationalProductEvent.class));
             });
   }
 
@@ -125,6 +137,7 @@ class ProductStatusKafkaMessageConsumerTest {
 
     LoggerCaptor.thenLogNothing();
     verify(consumer, never()).consumeProduct(anyString());
+    verify(offeringSyncService, never()).syncProductFromEvent(any(OperationalProductEvent.class));
   }
 
   @Test
@@ -132,6 +145,8 @@ class ProductStatusKafkaMessageConsumerTest {
     when(featureFlags.isProductServiceKafkaConsumerEnabled()).thenReturn(false);
     whenSendMessage(VALID_JSON_MESSAGE);
     verify(consumer, after(500).never()).consumeProduct(VALID_JSON_MESSAGE);
+    verify(offeringSyncService, after(500).never())
+        .syncProductFromEvent(any(OperationalProductEvent.class));
   }
 
   private void whenSendMessage(String message) {

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
@@ -86,8 +86,7 @@ class ProductStatusUMBMessageConsumerTest {
             () -> {
               verify(consumer).consumeProduct(VALID_JSON_MESSAGE);
               LoggerCaptor.thenInfoLogWithMessage("IT Product message consumed: source=umb");
-              verify(offeringSyncService)
-                  .syncUmbProductFromEvent(any(OperationalProductEvent.class));
+              verify(offeringSyncService).syncProductFromEvent(any(OperationalProductEvent.class));
             });
   }
 
@@ -96,8 +95,7 @@ class ProductStatusUMBMessageConsumerTest {
     when(featureFlags.isProductServiceUmbConsumerEnabled()).thenReturn(false);
     consumer.consumeMessage(VALID_JSON_MESSAGE);
     verify(consumer, never()).consumeProduct(VALID_JSON_MESSAGE);
-    verify(offeringSyncService, never())
-        .syncUmbProductFromEvent(any(OperationalProductEvent.class));
+    verify(offeringSyncService, never()).syncProductFromEvent(any(OperationalProductEvent.class));
   }
 
   private void whenSendMessage(String message) {


### PR DESCRIPTION
jira issue: SWATCH-5081

## Description
Aligns the ProductStatusKafkaMessageConsumer logic with the existing UMB consumer.

Error handling matches other Kafka Consumers, such as `ContractsPartnerEntitlementMessageConsumer`

## Testing
Unit tests are updated.

[SWATCH-5082](https://redhat.atlassian.net/browse/SWATCH-5082) is for the component tests.


[SWATCH-5082]: https://redhat.atlassian.net/browse/SWATCH-5082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product events received through Kafka are now automatically synchronized.
  * Synchronization results are logged for successfully processed product messages.

* **Bug Fixes**
  * Improved terminology in synchronization logs and warnings for clearer product-event processing.

* **Tests**
  * Added coverage for successful synchronization, invalid messages, null messages, and disabled processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->