### PR TITLE
SWATCH-5280 Add rbac/V2_EDIT_API_ENABLED=True flag to EE deployment

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -53,7 +53,7 @@ spec:
         -p rbac/NOTIFICATIONS_ENABLED=False
         -p rbac/NOTIFICATIONS_RH_ENABLED=False
         -p rbac/KAFKA_ENABLED=True
-        -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0
+        -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=1
         -p rbac/V2_EDIT_API_ENABLED=True
         -p host-inventory/GUNICORN_WORKERS=1
         -p host-inventory/GUNICORN_THREADS=1

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -54,6 +54,7 @@ spec:
         -p rbac/NOTIFICATIONS_RH_ENABLED=False
         -p rbac/KAFKA_ENABLED=False
         -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0
+        -p rbac/V2_EDIT_API_ENABLED=True
         -p host-inventory/GUNICORN_WORKERS=1
         -p host-inventory/GUNICORN_THREADS=1
         -p host-inventory/REPLICAS_EXPORT_SVC=0

--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -52,7 +52,7 @@ spec:
         -p rbac/MIN_POSTGRES_EXPORTER_REPLICAS=0
         -p rbac/NOTIFICATIONS_ENABLED=False
         -p rbac/NOTIFICATIONS_RH_ENABLED=False
-        -p rbac/KAFKA_ENABLED=False
+        -p rbac/KAFKA_ENABLED=True
         -p rbac/RBAC_KAFKA_CONSUMER_REPLICAS=0
         -p rbac/V2_EDIT_API_ENABLED=True
         -p host-inventory/GUNICORN_WORKERS=1


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

Add `rbac/V2_EDIT_API_ENABLED=True` flag to get Kessel API enabled in ephemeral

Recommendation form this thread:
https://redhat-internal.slack.com/archives/C064X43CMLK/p1787767227332079?thread_ts=1787579922.009009&cid=C064X43CMLK

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

```
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
```

### Setup
<!-- Add any steps required to set up the test case -->
1.
1.

### Steps
<!-- Enter each step of the test below -->
1.
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1.
1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the RBAC Kafka consumer in integration test deployments.
  * Enabled the V2 edit API for integration test deployments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->