### PR TITLE
Revert "temporary fix for bonfire deploy kessel-inventory"

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -60,7 +60,6 @@ spec:
         -p host-inventory/REPLICAS_WORKSPACES=0
         -p host-inventory/REPLICAS_WORKSPACES_BULK=0
         -p host-inventory/REPLICAS_HOST_APP_DATA=0
-        --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-inventory/inventory-api=6917808
     - name: DEPLOY_OPTIONAL_DEPS_METHOD
       value: "none"
     - name: DEPLOY_FRONTENDS


### PR DESCRIPTION
Reverts RedHatInsights/rhsm-subscriptions#6540

The deploy to ephemeral is working today without this :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary deployment override for the Kessel inventory API image tag, allowing the integration test deployment to use its standard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->