### PR TITLE
Split the ACM offering into managed & self-managed dimensions.

### DIFF
--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
@@ -23,10 +23,22 @@ metrics:
   - id: vCPUs
     type: counter
     awsDimension: acm_vcpu_hours
+    azureDimension: acm_vcpu_hours_mng
     prometheus:
       queryKey: rosa
       queryParams:
         instanceKey: _id
         productLabelRegex: (moa-hostedcontrolplane|moa)
-        metric: acm_capacity_effective_cpu_cores:sum
+        metric: acm:managed_cluster_worker_cores:managed:sum
+        metadataMetric: ocm_subscription
+  - id: vCPUs_self_managed
+    type: counter
+    awsDimension: acm_vcpu_hours_slfmng
+    azureDimension: acm_vcpu_hours_slfmng
+    prometheus:
+      queryKey: rosa
+      queryParams:
+        instanceKey: _id
+        productLabelRegex: (moa-hostedcontrolplane|moa)
+        metric: acm:managed_cluster_worker_cores:self_managed:sum
         metadataMetric: ocm_subscription

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
@@ -39,6 +39,6 @@ metrics:
       queryKey: rosa
       queryParams:
         instanceKey: _id
-        productLabelRegex: (moa-hostedcontrolplane|moa)
+        productLabelRegex: (moa-hostedcontrolplane|moa|ocp-assistedinstall)
         metric: acm:managed_cluster_worker_cores:self_managed:sum
         metadataMetric: ocm_subscription


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C0BFKD84MPE/p1787775750637339

https://promlens.devshift.net/?l=e8w4My_TSyi

```
max(acm:managed_cluster_worker_cores:managed:sum) by (_id)
* on(_id) group_right topk by (_id)
(1, min_over_time(
ocm_subscription{product=~"(moa-hostedcontrolplane|moa)",
external_organization=~".*",
support=~"Premium|Standard|Self-Support|None",
metered_by_rh!='false'}[1h]))
```

```
max(acm:managed_cluster_worker_cores:self_managed:sum) by (_id)
* on(_id) group_right topk by (_id)
(1, min_over_time(ocm_subscription{product=~"(moa-hostedcontrolplane|moa|ocp-assistedinstall)",
external_organization=~".*",
support=~"Premium|Standard|Self-Support|None",
metered_by_rh!='false'}[1h]))
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate usage tracking for self-managed vCPUs.
  - Added subscription metadata to vCPU usage reporting.
  - Expanded product recognition to include assisted installation deployments.

- **Improvements**
  - Updated managed vCPU measurement to use worker-core usage data for more accurate subscription reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->