### PR TITLE
SWATCH-5300: Log contract allocation audit for AWS billable usage

### DIFF
--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditService.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+
+/**
+ * Audit-only BRD allocation across licensed contracts for a billing account. Emits one INFO line
+ * per billable usage with a key=value preface and JSON allocation payload for Sumo reconstruction.
+ */
+@Slf4j
+@ApplicationScoped
+public class ContractAllocationAuditService {
+
+  private static final ObjectMapper ALLOCATION_JSON = new ObjectMapper();
+
+  static final Comparator<Contract> ALLOCATION_ORDER =
+      Comparator.comparing(Contract::getEndDate, Comparator.nullsLast(Comparator.naturalOrder()))
+          .thenComparing(Contract::getStartDate, Comparator.nullsLast(Comparator.reverseOrder()))
+          .thenComparing(Contract::getLicenseId, Comparator.naturalOrder());
+
+  AllocationResult allocate(
+      List<Contract> contracts, String contractMetricId, double monthToDateUsage) {
+    double remainingUsage = monthToDateUsage;
+    List<AllocationLine> lines = new ArrayList<>();
+
+    List<Contract> sortedContracts =
+        licensedContractsOnly(contracts).stream().sorted(ALLOCATION_ORDER).toList();
+
+    for (Contract contract : sortedContracts) {
+      double capacity = ContractMetricCapacity.sumForMetric(contract, contractMetricId);
+      double allocated = Math.min(remainingUsage, capacity);
+      double remainingCapacity = capacity - allocated;
+      lines.add(
+          new AllocationLine(contract.getLicenseId(), capacity, allocated, remainingCapacity));
+      remainingUsage -= allocated;
+    }
+
+    return new AllocationResult(lines, Math.max(0.0, remainingUsage));
+  }
+
+  public void logAllocation(
+      BillableUsage usage, List<Contract> contracts, String contractMetricId) {
+    if (licensedContractsOnly(contracts).isEmpty()) {
+      return;
+    }
+
+    Double monthToDateUsage = usage.getCurrentTotal();
+    if (monthToDateUsage == null) {
+      log.warn(formatMissingMonthToDateUsageWarning(usage));
+      return;
+    }
+
+    AllocationResult result = allocate(contracts, contractMetricId, monthToDateUsage);
+    AuditPayload payload = buildAuditPayload(contracts, contractMetricId, result);
+    log.info(formatAuditLogLine(usage, monthToDateUsage, payload));
+  }
+
+  static AuditPayload buildAuditPayload(
+      List<Contract> contracts, String contractMetricId, AllocationResult result) {
+    List<AuditPayload.LicensedEntry> licensed = new ArrayList<>();
+
+    for (int index = 0; index < result.lines().size(); index++) {
+      AllocationLine line = result.lines().get(index);
+      licensed.add(
+          new AuditPayload.LicensedEntry(
+              index + 1,
+              line.licenseId(),
+              line.capacity(),
+              line.allocated(),
+              line.capacityExhausted(),
+              line.remainingCapacity()));
+    }
+
+    double remainingAfterLicensed = result.unallocatedUsage();
+    AuditPayload.UnlicensedSummary unlicensed = null;
+    double unallocatedAboveAll = remainingAfterLicensed;
+
+    List<Contract> unlicensedContracts = contractsWithoutLicenseId(contracts);
+    if (!unlicensedContracts.isEmpty()) {
+      double totalUnlicensedCapacity =
+          totalCapacityForMetric(unlicensedContracts, contractMetricId);
+      double usageWithoutLicenseId = Math.min(remainingAfterLicensed, totalUnlicensedCapacity);
+      unlicensed =
+          new AuditPayload.UnlicensedSummary(
+              unlicensedContracts.size(), totalUnlicensedCapacity, usageWithoutLicenseId);
+      unallocatedAboveAll = Math.max(0.0, remainingAfterLicensed - totalUnlicensedCapacity);
+    }
+
+    return new AuditPayload(licensed, unlicensed, unallocatedAboveAll);
+  }
+
+  static String formatAuditLogLine(
+      BillableUsage usage, double monthToDateUsage, AuditPayload payload) {
+    try {
+      String allocationJson = ALLOCATION_JSON.writeValueAsString(payload);
+      return formatAuditHeader(usage, monthToDateUsage) + " allocation=" + allocationJson;
+    } catch (JsonProcessingException exception) {
+      throw new IllegalStateException("Failed to serialize contract allocation audit", exception);
+    }
+  }
+
+  static String formatAuditHeader(BillableUsage usage, double monthToDateUsage) {
+    return "Contract allocation audit orgId=%s productId=%s metric=%s billingAccountId=%s snapshotDate=%s monthToDateUsage=%s"
+        .formatted(
+            usage.getOrgId(),
+            usage.getProductId(),
+            usage.getMetricId(),
+            usage.getBillingAccountId(),
+            usage.getSnapshotDate(),
+            monthToDateUsage);
+  }
+
+  static String formatMissingMonthToDateUsageWarning(BillableUsage usage) {
+    return "Skipping contract allocation audit because monthToDateUsage is null orgId=%s productId=%s metric=%s billingAccountId=%s snapshotDate=%s"
+        .formatted(
+            usage.getOrgId(),
+            usage.getProductId(),
+            usage.getMetricId(),
+            usage.getBillingAccountId(),
+            usage.getSnapshotDate());
+  }
+
+  private static double totalCapacityForMetric(List<Contract> contracts, String contractMetricId) {
+    return contracts.stream()
+        .mapToDouble(contract -> ContractMetricCapacity.sumForMetric(contract, contractMetricId))
+        .sum();
+  }
+
+  private static List<Contract> licensedContractsOnly(List<Contract> contracts) {
+    return contracts.stream().filter(ContractAllocationAuditService::hasLicenseId).toList();
+  }
+
+  private static List<Contract> contractsWithoutLicenseId(List<Contract> contracts) {
+    return contracts.stream().filter(contract -> !hasLicenseId(contract)).toList();
+  }
+
+  private static boolean hasLicenseId(Contract contract) {
+    String licenseId = contract.getLicenseId();
+    return licenseId != null && !licenseId.isBlank();
+  }
+
+  record AllocationLine(
+      String licenseId, double capacity, double allocated, double remainingCapacity) {
+
+    boolean capacityExhausted() {
+      return remainingCapacity <= 0.0;
+    }
+  }
+
+  record AllocationResult(List<AllocationLine> lines, double unallocatedUsage) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record AuditPayload(
+      List<LicensedEntry> licensed, UnlicensedSummary unlicensed, double unallocatedUsage) {
+
+    record LicensedEntry(
+        int index,
+        String licenseId,
+        double capacity,
+        double allocated,
+        boolean exhausted,
+        double remainingCapacity) {}
+
+    record UnlicensedSummary(
+        int contractCount, double totalCapacity, double usageWithoutLicenseId) {}
+  }
+}

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractCoverageService.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractCoverageService.java
@@ -23,7 +23,6 @@ package com.redhat.swatch.billable.usage.services;
 import com.redhat.swatch.billable.usage.exceptions.ContractMissingException;
 import com.redhat.swatch.billable.usage.services.model.ContractCoverage;
 import com.redhat.swatch.clients.contracts.api.model.Contract;
-import com.redhat.swatch.clients.contracts.api.model.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.registry.SubscriptionDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,10 +37,15 @@ import org.candlepin.subscriptions.billable.usage.BillableUsage;
 public class ContractCoverageService {
 
   private final ContractsController contractsController;
+  private final ContractAllocationAuditService contractAllocationAuditService;
   private final ApplicationClock clock;
 
-  public ContractCoverageService(ContractsController contractsController, ApplicationClock clock) {
+  public ContractCoverageService(
+      ContractsController contractsController,
+      ContractAllocationAuditService contractAllocationAuditService,
+      ApplicationClock clock) {
     this.contractsController = contractsController;
+    this.contractAllocationAuditService = contractAllocationAuditService;
     this.clock = clock;
   }
 
@@ -62,6 +66,10 @@ public class ContractCoverageService {
       }
     }
 
+    if (BillableUsage.BillingProvider.AWS.equals(usage.getBillingProvider())) {
+      contractAllocationAuditService.logAllocation(usage, contracts, contractMetricId);
+    }
+
     ContractCoverage coverage =
         ContractCoverage.builder()
             .metricId(contractMetricId)
@@ -79,10 +87,7 @@ public class ContractCoverageService {
   }
 
   private static double getValueByContractMetricId(Contract contract, String contractMetricId) {
-    return contract.getMetrics().stream()
-        .filter(metric -> metric.getMetricId().equals(contractMetricId))
-        .map(Metric::getValue)
-        .reduce(0, Integer::sum);
+    return ContractMetricCapacity.sumForMetric(contract, contractMetricId);
   }
 
   private static String getContractMetricId(BillableUsage usage) {

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractMetricCapacity.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/services/ContractMetricCapacity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import com.redhat.swatch.clients.contracts.api.model.Metric;
+
+final class ContractMetricCapacity {
+
+  private ContractMetricCapacity() {}
+
+  static double sumForMetric(Contract contract, String contractMetricId) {
+    return contract.getMetrics().stream()
+        .filter(metric -> metric.getMetricId().equals(contractMetricId))
+        .mapToInt(Metric::getValue)
+        .sum();
+  }
+}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditServiceLogTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditServiceLogTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import static com.redhat.swatch.billable.usage.services.ContractAllocationAuditTestFixtures.CONTRACT_METRIC_ID;
+import static com.redhat.swatch.billable.usage.services.ContractAllocationAuditTestFixtures.REFERENCE_DATE;
+import static com.redhat.swatch.billable.usage.services.ContractAllocationAuditTestFixtures.SNAPSHOT_DATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import com.redhat.swatch.clients.contracts.api.model.Metric;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.jboss.logmanager.LogContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks SWATCH-5300 audit log field names for support reconstruction in Sumo. Format follows the
+ * ticket example and Jira AC; confirm with support before changing keys.
+ */
+class ContractAllocationAuditServiceLogTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final LoggerCaptor LOGGER_CAPTOR = new LoggerCaptor();
+
+  private final ContractAllocationAuditService allocationAuditService =
+      new ContractAllocationAuditService();
+
+  @BeforeAll
+  static void configureLogging() {
+    LogContext.getLogContext()
+        .getLogger(ContractAllocationAuditService.class.getName())
+        .addHandler(LOGGER_CAPTOR);
+  }
+
+  @BeforeEach
+  void clearCapturedLogs() {
+    LOGGER_CAPTOR.clearRecords();
+  }
+
+  @Test
+  void logAllocationSkipsWhenAllContractsAreUnlicensed() {
+    allocationAuditService.logAllocation(
+        awsUsage(80.0), List.of(contract(null, 60), contract(" ", 40)), CONTRACT_METRIC_ID);
+
+    assertTrue(LOGGER_CAPTOR.records.isEmpty());
+  }
+
+  @Test
+  void logAllocationWarnsWhenMonthToDateUsageIsNull() {
+    allocationAuditService.logAllocation(
+        awsUsage(null),
+        List.of(contract("arn:aws:license-manager:us-east-1:1:license:licensed", 60)),
+        CONTRACT_METRIC_ID);
+
+    assertEquals(1, LOGGER_CAPTOR.records.size());
+    assertEquals(Level.WARNING, LOGGER_CAPTOR.records.get(0).getLevel());
+    assertTrue(LOGGER_CAPTOR.records.get(0).getMessage().contains("monthToDateUsage is null"));
+  }
+
+  @Test
+  void logAllocationEmitsSingleInfoLineForLicensedContracts() throws Exception {
+    allocationAuditService.logAllocation(
+        awsUsage(75.0),
+        List.of(
+            contract("arn:aws:license-manager:us-east-1:1:license:first", 50),
+            contract("arn:aws:license-manager:us-east-1:1:license:second", 50)),
+        CONTRACT_METRIC_ID);
+
+    List<LogRecord> infoRecords =
+        LOGGER_CAPTOR.records.stream()
+            .filter(record -> record.getLevel().equals(Level.INFO))
+            .toList();
+    assertEquals(1, infoRecords.size());
+    assertTrue(infoRecords.get(0).getMessage().startsWith("Contract allocation audit "));
+    assertTrue(infoRecords.get(0).getMessage().contains(" allocation="));
+    assertEquals(
+        25.0,
+        parseAllocationJson(infoRecords.get(0).getMessage())
+            .get("licensed")
+            .get(1)
+            .get("allocated")
+            .asDouble());
+  }
+
+  @Test
+  void formatAuditLogLineIncludesUnallocatedUsageForLicensedOnlyContracts() throws Exception {
+    BillableUsage usage = awsUsage(120.0);
+    Contract first = contract("arn:aws:license-manager:us-east-1:1:license:first", 50);
+    Contract second = contract("arn:aws:license-manager:us-east-1:1:license:second", 50);
+
+    var result = allocationAuditService.allocate(List.of(first, second), CONTRACT_METRIC_ID, 120.0);
+    ContractAllocationAuditService.AuditPayload payload =
+        ContractAllocationAuditService.buildAuditPayload(
+            List.of(first, second), CONTRACT_METRIC_ID, result);
+    String line = ContractAllocationAuditService.formatAuditLogLine(usage, 120.0, payload);
+
+    JsonNode allocation = parseAllocationJson(line);
+    assertEquals(20.0, allocation.get("unallocatedUsage").asDouble());
+    assertNull(allocation.get("unlicensed"));
+  }
+
+  @Test
+  void formatAuditLogLineIncludesPrefaceAndAllocationJson() throws Exception {
+    BillableUsage usage = awsUsage(75.0);
+    Contract first =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:first",
+            REFERENCE_DATE.minusMonths(2),
+            REFERENCE_DATE.plusMonths(1),
+            50);
+    Contract second =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:second",
+            REFERENCE_DATE.minusMonths(1),
+            REFERENCE_DATE.plusMonths(2),
+            50);
+
+    var result = allocationAuditService.allocate(List.of(second, first), CONTRACT_METRIC_ID, 75.0);
+    ContractAllocationAuditService.AuditPayload payload =
+        ContractAllocationAuditService.buildAuditPayload(
+            List.of(second, first), CONTRACT_METRIC_ID, result);
+    String line = ContractAllocationAuditService.formatAuditLogLine(usage, 75.0, payload);
+
+    assertTrue(line.startsWith("Contract allocation audit "));
+    assertTrue(line.contains("orgId=org123"));
+    assertTrue(line.contains("productId=rosa"));
+    assertTrue(line.contains("metric=Cores"));
+    assertTrue(line.contains("billingAccountId=ba123"));
+    assertTrue(line.contains("snapshotDate=" + SNAPSHOT_DATE));
+    assertTrue(line.contains("monthToDateUsage=75.0"));
+    assertTrue(line.contains(" allocation="));
+
+    JsonNode allocation = parseAllocationJson(line);
+    assertEquals(2, allocation.get("licensed").size());
+    assertEquals(1, allocation.get("licensed").get(0).get("index").asInt());
+    assertEquals(first.getLicenseId(), allocation.get("licensed").get(0).get("licenseId").asText());
+    assertEquals(50.0, allocation.get("licensed").get(0).get("allocated").asDouble());
+    assertEquals(25.0, allocation.get("licensed").get(1).get("allocated").asDouble());
+    assertEquals(0.0, allocation.get("unallocatedUsage").asDouble());
+    assertNull(allocation.get("unlicensed"));
+  }
+
+  @Test
+  void formatAuditLogLineDocumentsUsageWithoutLicenseIdOnMixedContracts() throws Exception {
+    BillableUsage usage = awsUsage(80.0);
+    Contract unlicensed = contract(null, 60);
+    Contract licensed = contract("arn:aws:license-manager:us-east-1:1:license:licensed", 60);
+
+    var result =
+        allocationAuditService.allocate(List.of(unlicensed, licensed), CONTRACT_METRIC_ID, 80.0);
+    ContractAllocationAuditService.AuditPayload payload =
+        ContractAllocationAuditService.buildAuditPayload(
+            List.of(unlicensed, licensed), CONTRACT_METRIC_ID, result);
+    String line = ContractAllocationAuditService.formatAuditLogLine(usage, 80.0, payload);
+
+    JsonNode allocation = parseAllocationJson(line);
+    assertEquals(60.0, allocation.get("licensed").get(0).get("allocated").asDouble());
+    assertEquals(1, allocation.get("unlicensed").get("contractCount").asInt());
+    assertEquals(60.0, allocation.get("unlicensed").get("totalCapacity").asDouble());
+    assertEquals(20.0, allocation.get("unlicensed").get("usageWithoutLicenseId").asDouble());
+    assertEquals(0.0, allocation.get("unallocatedUsage").asDouble());
+  }
+
+  @Test
+  void formatAuditLogLineDocumentsUnallocatedUsageAboveAllCapacity() throws Exception {
+    BillableUsage usage = awsUsage(130.0);
+    Contract unlicensed = contract(null, 60);
+    Contract licensed = contract("arn:aws:license-manager:us-east-1:1:license:licensed", 60);
+
+    var result =
+        allocationAuditService.allocate(List.of(unlicensed, licensed), CONTRACT_METRIC_ID, 130.0);
+    ContractAllocationAuditService.AuditPayload payload =
+        ContractAllocationAuditService.buildAuditPayload(
+            List.of(unlicensed, licensed), CONTRACT_METRIC_ID, result);
+    String line = ContractAllocationAuditService.formatAuditLogLine(usage, 130.0, payload);
+
+    JsonNode allocation = parseAllocationJson(line);
+    assertEquals(60.0, allocation.get("unlicensed").get("usageWithoutLicenseId").asDouble());
+    assertEquals(10.0, allocation.get("unallocatedUsage").asDouble());
+  }
+
+  @Test
+  void formatMissingMonthToDateUsageWarningDocumentsSkippedAudit() {
+    BillableUsage usage = awsUsage(null);
+
+    String warning = ContractAllocationAuditService.formatMissingMonthToDateUsageWarning(usage);
+
+    assertTrue(warning.contains("monthToDateUsage is null"));
+    assertTrue(warning.contains("snapshotDate=" + SNAPSHOT_DATE));
+  }
+
+  @Test
+  void licensedEntriesIncludeExhaustedFlag() throws Exception {
+    Contract licensed = contract("arn:aws:license-manager:us-east-1:1:license:licensed", 60);
+
+    var result = allocationAuditService.allocate(List.of(licensed), CONTRACT_METRIC_ID, 60.0);
+    ContractAllocationAuditService.AuditPayload payload =
+        ContractAllocationAuditService.buildAuditPayload(
+            List.of(licensed), CONTRACT_METRIC_ID, result);
+    String line = ContractAllocationAuditService.formatAuditLogLine(awsUsage(60.0), 60.0, payload);
+
+    JsonNode licensedEntry = parseAllocationJson(line).get("licensed").get(0);
+    assertEquals(licensed.getLicenseId(), licensedEntry.get("licenseId").asText());
+    assertTrue(licensedEntry.get("exhausted").asBoolean());
+    assertEquals(0.0, licensedEntry.get("remainingCapacity").asDouble());
+  }
+
+  private static JsonNode parseAllocationJson(String auditLogLine) throws Exception {
+    int allocationIndex = auditLogLine.indexOf(" allocation=");
+    assertTrue(allocationIndex > 0);
+    String json = auditLogLine.substring(allocationIndex + " allocation=".length());
+    return OBJECT_MAPPER.readTree(json);
+  }
+
+  private static BillableUsage awsUsage(Double currentTotal) {
+    BillableUsage usage =
+        new BillableUsage()
+            .withOrgId("org123")
+            .withProductId("rosa")
+            .withMetricId("Cores")
+            .withBillingProvider(BillableUsage.BillingProvider.AWS)
+            .withBillingAccountId("ba123")
+            .withSnapshotDate(SNAPSHOT_DATE);
+    if (currentTotal != null) {
+      usage.withCurrentTotal(currentTotal);
+    }
+    return usage;
+  }
+
+  private static Contract contract(String licenseId, double capacity) {
+    return contract(licenseId, SNAPSHOT_DATE.minusMonths(1), SNAPSHOT_DATE.plusMonths(1), capacity);
+  }
+
+  private static Contract contract(
+      String licenseId, OffsetDateTime startDate, OffsetDateTime endDate, double capacity) {
+    return new Contract()
+        .licenseId(licenseId)
+        .startDate(startDate)
+        .endDate(endDate)
+        .addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value((int) capacity));
+  }
+
+  private static final class LoggerCaptor extends Handler {
+
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {
+      clearRecords();
+    }
+
+    void clearRecords() {
+      records.clear();
+    }
+  }
+}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditServiceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditServiceTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import static com.redhat.swatch.billable.usage.services.ContractAllocationAuditTestFixtures.CONTRACT_METRIC_ID;
+import static com.redhat.swatch.billable.usage.services.ContractAllocationAuditTestFixtures.REFERENCE_DATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.clients.contracts.api.model.Contract;
+import com.redhat.swatch.clients.contracts.api.model.Metric;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ContractAllocationAuditServiceTest {
+
+  private final ContractAllocationAuditService allocationAuditService =
+      new ContractAllocationAuditService();
+
+  @Test
+  void allocateSortsByEndDateThenStartDateThenLicenseId() {
+    Contract soonestEnd =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:soonest-end",
+            REFERENCE_DATE.minusMonths(2),
+            REFERENCE_DATE.plusMonths(1),
+            50);
+    Contract laterEnd =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:later-end",
+            REFERENCE_DATE.minusMonths(1),
+            REFERENCE_DATE.plusMonths(2),
+            50);
+    Contract openEnded =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:open-ended",
+            REFERENCE_DATE.minusMonths(3),
+            null,
+            50);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(
+            List.of(openEnded, laterEnd, soonestEnd), CONTRACT_METRIC_ID, 75.0);
+
+    assertEquals(3, result.lines().size());
+    assertEquals(soonestEnd.getLicenseId(), result.lines().get(0).licenseId());
+    assertEquals(50.0, result.lines().get(0).allocated());
+    assertTrue(result.lines().get(0).capacityExhausted());
+
+    assertEquals(laterEnd.getLicenseId(), result.lines().get(1).licenseId());
+    assertEquals(25.0, result.lines().get(1).allocated());
+    assertEquals(25.0, result.lines().get(1).remainingCapacity());
+
+    assertEquals(openEnded.getLicenseId(), result.lines().get(2).licenseId());
+    assertEquals(0.0, result.lines().get(2).allocated());
+    assertEquals(0.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateUsesNewerStartDateWhenEndDatesMatch() {
+    OffsetDateTime sharedEnd = REFERENCE_DATE.plusMonths(3);
+    Contract newerStart =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:newer",
+            REFERENCE_DATE.minusDays(10),
+            sharedEnd,
+            40);
+    Contract olderStart =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:older",
+            REFERENCE_DATE.minusMonths(2),
+            sharedEnd,
+            40);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(olderStart, newerStart), CONTRACT_METRIC_ID, 50.0);
+
+    assertEquals(newerStart.getLicenseId(), result.lines().get(0).licenseId());
+    assertEquals(40.0, result.lines().get(0).allocated());
+    assertEquals(olderStart.getLicenseId(), result.lines().get(1).licenseId());
+    assertEquals(10.0, result.lines().get(1).allocated());
+  }
+
+  @Test
+  void allocateUsesLexicographicLicenseIdWhenStartAndEndDatesMatch() {
+    OffsetDateTime sharedStart = REFERENCE_DATE.minusMonths(1);
+    OffsetDateTime sharedEnd = REFERENCE_DATE.plusMonths(1);
+    Contract largerLicense =
+        contract("arn:aws:license-manager:us-east-1:1:license:z", sharedStart, sharedEnd, 30);
+    Contract smallerLicense =
+        contract("arn:aws:license-manager:us-east-1:1:license:a", sharedStart, sharedEnd, 30);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(
+            List.of(largerLicense, smallerLicense), CONTRACT_METRIC_ID, 35.0);
+
+    assertEquals(smallerLicense.getLicenseId(), result.lines().get(0).licenseId());
+    assertEquals(30.0, result.lines().get(0).allocated());
+    assertEquals(largerLicense.getLicenseId(), result.lines().get(1).licenseId());
+    assertEquals(5.0, result.lines().get(1).allocated());
+  }
+
+  @Test
+  void allocateFillsFirstContractOnlyWhenUsageWithinCapacity() {
+    Contract first = contract("arn:aws:license-manager:us-east-1:1:license:first", 100);
+    Contract second = contract("arn:aws:license-manager:us-east-1:1:license:second", 100);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(first, second), CONTRACT_METRIC_ID, 75.0);
+
+    ContractAllocationAuditService.AllocationLine firstLine = result.lines().get(0);
+    assertEquals(75.0, firstLine.allocated());
+    assertFalse(firstLine.capacityExhausted());
+    assertEquals(25.0, firstLine.remainingCapacity());
+
+    ContractAllocationAuditService.AllocationLine secondLine = result.lines().get(1);
+    assertEquals(0.0, secondLine.allocated());
+    assertEquals(0.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateSpillsToSecondContractWhenFirstCapacityIsExhausted() {
+    Contract first = contract("arn:aws:license-manager:us-east-1:1:license:first", 50);
+    Contract second = contract("arn:aws:license-manager:us-east-1:1:license:second", 50);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(first, second), CONTRACT_METRIC_ID, 75.0);
+
+    assertEquals(50.0, result.lines().get(0).allocated());
+    assertTrue(result.lines().get(0).capacityExhausted());
+    assertEquals(25.0, result.lines().get(1).allocated());
+    assertEquals(25.0, result.lines().get(1).remainingCapacity());
+    assertEquals(0.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateLeavesRemainderUnallocatedWhenUsageExceedsTotalCapacity() {
+    Contract first = contract("arn:aws:license-manager:us-east-1:1:license:first", 50);
+    Contract second = contract("arn:aws:license-manager:us-east-1:1:license:second", 50);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(first, second), CONTRACT_METRIC_ID, 120.0);
+
+    assertEquals(50.0, result.lines().get(0).allocated());
+    assertEquals(50.0, result.lines().get(1).allocated());
+    assertEquals(20.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateExcludesContractsWithoutLicenseId() {
+    Contract unlicensed = contract(null, 60);
+    Contract licensed = contract("arn:aws:license-manager:us-east-1:1:license:licensed", 60);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(unlicensed, licensed), CONTRACT_METRIC_ID, 80.0);
+
+    assertEquals(1, result.lines().size());
+    assertEquals(licensed.getLicenseId(), result.lines().get(0).licenseId());
+    assertEquals(60.0, result.lines().get(0).allocated());
+    assertEquals(20.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateExcludesBlankLicenseIdContracts() {
+    OffsetDateTime sharedStart = REFERENCE_DATE.minusMonths(1);
+    OffsetDateTime sharedEnd = REFERENCE_DATE.plusMonths(1);
+    Contract blankLicense = contract(" ", sharedStart, sharedEnd, 30);
+    Contract licensed =
+        contract(
+            "arn:aws:license-manager:us-east-1:1:license:licensed", sharedStart, sharedEnd, 30);
+
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(blankLicense, licensed), CONTRACT_METRIC_ID, 35.0);
+
+    assertEquals(1, result.lines().size());
+    assertEquals(licensed.getLicenseId(), result.lines().get(0).licenseId());
+    assertEquals(30.0, result.lines().get(0).allocated());
+    assertEquals(5.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateReturnsEmptyWhenAllContractsLackLicenseId() {
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(
+            List.of(contract(null, 60), contract(" ", 40)), CONTRACT_METRIC_ID, 80.0);
+
+    assertTrue(result.lines().isEmpty());
+    assertEquals(80.0, result.unallocatedUsage());
+  }
+
+  @Test
+  void allocateReturnsEmptyWhenNoContractHasLicenseId() {
+    ContractAllocationAuditService.AllocationResult result =
+        allocationAuditService.allocate(List.of(contract(null, 60)), CONTRACT_METRIC_ID, 80.0);
+
+    assertTrue(result.lines().isEmpty());
+    assertEquals(80.0, result.unallocatedUsage());
+  }
+
+  private static Contract contract(String licenseId, double capacity) {
+    return contract(
+        licenseId, REFERENCE_DATE.minusMonths(1), REFERENCE_DATE.plusMonths(1), capacity);
+  }
+
+  private static Contract contract(
+      String licenseId, OffsetDateTime startDate, OffsetDateTime endDate, double capacity) {
+    return new Contract()
+        .licenseId(licenseId)
+        .startDate(startDate)
+        .endDate(endDate)
+        .addMetricsItem(new Metric().metricId(CONTRACT_METRIC_ID).value((int) capacity));
+  }
+}

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditTestFixtures.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/services/ContractAllocationAuditTestFixtures.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.billable.usage.services;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+final class ContractAllocationAuditTestFixtures {
+
+  static final String CONTRACT_METRIC_ID = "four_vcpu_0";
+  static final OffsetDateTime REFERENCE_DATE =
+      OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+  static final OffsetDateTime SNAPSHOT_DATE = REFERENCE_DATE.plusDays(14).withHour(12);
+
+  private ContractAllocationAuditTestFixtures() {}
+}


### PR DESCRIPTION
Emit one INFO line per billable usage with allocation payload for support reconstruction. Waterfall allocate among licensed contracts, then summarize unlicensed capacity.

<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5300

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Unit tests:
```
/mvnw test -pl swatch-billable-usage
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allocation auditing for billable usage across licensed contracts.
  * Audit records now show contract allocation, remaining capacity, exhausted contracts, unlicensed usage, and usage exceeding available capacity.
  * Added allocation details to AWS billing usage processing.

* **Bug Fixes**
  * Improved contract metric capacity calculations for more accurate coverage results.

* **Tests**
  * Added coverage for allocation ordering, capacity distribution, missing licenses, null usage, and over-capacity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->