### PR TITLE
Validate quarkus plugin resolution on Mintmaker bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,16 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["* * * * *"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["io.quarkus:quarkus-bom"],
+      "postUpgradeTasks": {
+        "commands": [
+          "./mvnw validate -N -q -pl swatch-quarkus-parent"
+        ],
+        "executionMode": "branch"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds a `postUpgradeTasks` rule to `renovate.json` that runs `mvn validate` on `swatch-quarkus-parent` after Mintmaker bumps `io.quarkus:quarkus-bom`
- Prevents PRs like #6538 from being created when `io.quarkus.platform:quarkus-maven-plugin` hasn't been published yet (the BOM and platform plugin artifacts aren't published atomically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update validation for Quarkus upgrades.
  * Added a Maven validation step to run after applicable dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->