### PR TITLE
Revert "Validate quarkus plugin resolution on Mintmaker bumps"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,16 +5,5 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["* * * * *"]
-  },
-  "packageRules": [
-    {
-      "matchPackageNames": ["io.quarkus:quarkus-bom"],
-      "postUpgradeTasks": {
-        "commands": [
-          "./mvnw validate -N -q -pl swatch-quarkus-parent"
-        ],
-        "executionMode": "branch"
-      }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Reverts RedHatInsights/rhsm-subscriptions#6551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration.
  * Removed an automatic validation task previously triggered during Quarkus BOM upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->