### PR TITLE
Add vCPUs-self-managed metric to CSV export mapper

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -54,16 +54,24 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
   private final HostRepository hostRepository;
 
   public static final Map<MetricId, ObjDoubleConsumer<InstancesExportCsvItem>> METRIC_MAPPER =
-      Map.of(
-          MetricIdUtils.getCores(), InstancesExportCsvItem::setMeasurementCores,
-          MetricIdUtils.getInstanceHours(), InstancesExportCsvItem::setMeasurementInstanceHours,
-          MetricIdUtils.getSockets(), InstancesExportCsvItem::setMeasurementSockets,
-          MetricIdUtils.getStorageGibibyteMonths(),
-              InstancesExportCsvItem::setMeasurementStorageGibibyteMonths,
-          MetricIdUtils.getTransferGibibytes(),
-              InstancesExportCsvItem::setMeasurementTransferGibibytes,
-          MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus,
-          MetricIdUtils.getManagedNodes(), InstancesExportCsvItem::setMeasurementManagedNodes);
+      Map.ofEntries(
+          Map.entry(MetricIdUtils.getCores(), InstancesExportCsvItem::setMeasurementCores),
+          Map.entry(
+              MetricIdUtils.getInstanceHours(),
+              InstancesExportCsvItem::setMeasurementInstanceHours),
+          Map.entry(MetricIdUtils.getSockets(), InstancesExportCsvItem::setMeasurementSockets),
+          Map.entry(
+              MetricIdUtils.getStorageGibibyteMonths(),
+              InstancesExportCsvItem::setMeasurementStorageGibibyteMonths),
+          Map.entry(
+              MetricIdUtils.getTransferGibibytes(),
+              InstancesExportCsvItem::setMeasurementTransferGibibytes),
+          Map.entry(MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus),
+          Map.entry(
+              MetricIdUtils.getManagedNodes(), InstancesExportCsvItem::setMeasurementManagedNodes),
+          Map.entry(
+              MetricIdUtils.getVCpusSelfManaged(),
+              InstancesExportCsvItem::setMeasurementVcpusSelfManaged));
 
   @Override
   public List<Object> mapDataItem(TallyInstanceView item, ExportServiceRequest request) {

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -36,6 +36,9 @@ properties:
   measurement_managed_nodes:
     type: number
     format: double
+  measurement_vcpus_self_managed:
+    type: number
+    format: double
   category:
     type: string
   last_seen:

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
@@ -62,6 +62,10 @@ public class MetricIdUtils {
     return MetricId.fromString("Managed-nodes");
   }
 
+  public static MetricId getVCpusSelfManaged() {
+    return MetricId.fromString("vCPUs-self-managed");
+  }
+
   public static Stream<MetricId> getMetricIdsFromConfigForTag(String tag) {
     return getMetricIdsFromConfigForVariant(Variant.findByTag(tag).orElse(null));
   }

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
@@ -31,7 +31,7 @@ metrics:
         productLabelRegex: (moa-hostedcontrolplane|moa)
         metric: acm:managed_cluster_worker_cores:managed:sum
         metadataMetric: ocm_subscription
-  - id: vCPUs_self_managed
+  - id: vCPUs-self-managed
     type: counter
     awsDimension: acm_vcpu_hours_slfmng
     azureDimension: acm_vcpu_hours_slfmng


### PR DESCRIPTION
## Summary
- Wires the new `vCPUs-self-managed` metric (from #6549) into `METRIC_MAPPER` so it's included in CSV instance exports
- Adds `measurement_vcpus_self_managed` field to the `instances_export_csv_item` schema
- Adds `getVCpusSelfManaged()` helper to `MetricIdUtils`
- Renames the metric ID in `rhacm.yaml` from `vCPUs_self_managed` to `vCPUs-self-managed` to match the hyphenated convention used by all other metric IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-managed vCPU measurements to instance exports.
  * Exported data now includes an optional `measurement_vcpus_self_managed` field.
* **Updates**
  * Standardized the self-managed vCPU metric identifier across configuration and exported data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->