### PR TITLE
SWATCH-5082:Write component tests for the IT Product Service Kafka consumer

### DIFF
--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1555,6 +1555,8 @@ This section verifies the automatic contract termination behavior when contracts
 
 ### UMB Consumer - Message Processing
 
+`product-umb-TC001` through `product-umb-TC003` are component tests. `product-umb-TC004` is a unit test because `UMB_ENABLED` is a startup property and also gates the AMQP incoming channel; the disabled branch cannot be reached in the shared `quarkus:dev` process. `product-umb-TC005` through `product-umb-TC008` stay as component tests with those IDs.
+
 **product-umb-TC001 - Process valid parent SKU message from UMB**
 - **Description**: Verify that a valid parent SKU operational product event from UMB is processed and the sync service is invoked.
 - **Setup**:
@@ -1609,21 +1611,19 @@ This section verifies the automatic contract termination behavior when contracts
   - Consumer does not crash
   - Consumer ready for next message
 
-**product-umb-TC004 - Ignore message when UMB_ENABLED is false**
-- **Description**: Verify that UMB messages are not processed when UMB integration is globally disabled.
+**product-umb-TC004 - Ignore message when UMB_ENABLED is false** (unit test)
+- **Description**: Verify that `ProductStatusUMBMessageConsumer` does not process messages when `UMB_ENABLED` is false. Covered by `ProductStatusUMBMessageConsumerWhenUmbDisabledTest`, not a component test.
 - **Setup**:
-  - Ensure `UMB_ENABLED=false`
-  - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.eng.product-service.offering.sync`
+  - Quarkus test profile `DisableUmbResource` (`UMB_ENABLED=false`)
+  - Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` enabled (UMB consumer)
+  - Mock `OfferingSyncService`
+- **Action**: Call `consumeMessage` with valid `OperationalProductEvent` JSON
 - **Verification**:
-  - Verify message is not processed
-  - Check debug log contains “UMB processing is not enabled”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was never called
+  - Verify `OfferingSyncService.consumeProduct` is never invoked
+  - Verify `OfferingSyncService.syncProductFromEvent` is never invoked
 - **Expected Result**:
-  - Message not consumed or processed
-  - No product data logged
-  - Sync service not invoked
+  - Message is ignored because `umbEnabled` is false
+  - `consumeProduct` is not called. This is distinct from the Unleash flag case in `product-umb-TC005`.
 
 **product-umb-TC005 - Ignore message when feature flag is disabled**
 - **Description**: Verify that when the parent feature flag is disabled, UMB messages are not processed.
@@ -1655,7 +1655,6 @@ This section verifies the automatic contract termination behavior when contracts
   - Verify `OfferingSyncService.syncUmbProductFromEvent()` was never called
 - **Expected Result**:
   - UMB consumer does not process message
-  - Kafka consumer remains operational
   - Sync service not invoked
 
 **product-umb-TC007 - Process message when UMB enabled and Kafka disabled via variant**
@@ -1674,7 +1673,6 @@ This section verifies the automatic contract termination behavior when contracts
   - UMB consumer processes message successfully
   - Info log emitted with product details
   - Sync service invoked with the product event
-  - Kafka consumer is independently disabled
 
 **product-umb-TC008 - Process message when both consumers enabled via variant**
 - **Description**: Verify that both consumers can operate simultaneously when explicitly enabled via variant.
@@ -1691,7 +1689,6 @@ This section verifies the automatic contract termination behavior when contracts
 - **Expected Result**:
   - UMB consumer processes message successfully
   - Sync service invoked with the product event
-  - Both Kafka and UMB consumers are operational
 
 ### Duplicate SKU Processing Scenarios
 

--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1736,8 +1736,8 @@ This section verifies the automatic contract termination behavior when contracts
   - Prepare `OperationalProductEvent` JSON with null `productCode`
 - **Action**: Publish message to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message is processed without crash
-  - Check info log contains "productCode=null"
+  - Check info log contains “IT Product message consumed: source=kafka” with `productCode=null` and `childSku=false`
+  - Publish a subsequent valid message and verify it is consumed (consumer continues)
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Null `productCode` logged
@@ -1767,8 +1767,8 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service Kafka consumer)
 - **Action**: Publish empty JSON object `{}` to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message is processed without crash
-  - Check info log shows null values for all fields
+  - Check info log contains “IT Product message consumed: source=kafka” with null `productCode`, `eventType`, and `productCategory`
+  - Publish a subsequent valid message and verify it is consumed (consumer continues)
 - **Expected Result**:
   - `OperationalProductEvent` deserialized with all fields as null
   - Null values logged for `productCode`, `eventType`, `productCategory`
@@ -1782,8 +1782,9 @@ This section verifies the automatic contract termination behavior when contracts
   - Prepare `OperationalProductEvent` JSON with valid required fields plus unexpected additional fields
 - **Action**: Publish message to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message is processed successfully
-  - Check info log contains expected fields
+  - Check info log contains “IT Product message consumed: source=kafka” with the expected fields
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
+  - Verify logs do not contain “Unrecognized field”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully (extra fields ignored)
   - Expected fields logged correctly

--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1449,12 +1449,13 @@ This section verifies the automatic contract termination behavior when contracts
   - Prepare a valid `OperationalProductEvent` JSON with parent SKU (productCode not starting with “SVC”)
 - **Action**: Publish message to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message was consumed
   - Check info log contains “IT Product message consumed: source=kafka”
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Info log emitted with `productCode`, `eventType`, `productCategory`
   - `childSku` field logged as `false`
+  - Offering sync service invoked with the product event
 
 **product-kafka-TC002 - Process valid child SKU message from Kafka**
 - **Description**: Verify that a child SKU (productCode starting with “SVC”) is correctly identified and processed.
@@ -1464,12 +1465,13 @@ This section verifies the automatic contract termination behavior when contracts
   - Prepare a valid `OperationalProductEvent` JSON with child SKU (productCode starts with “SVC”)
 - **Action**: Publish message to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message was consumed
   - Check info log contains “IT Product message consumed: source=kafka”
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Info log emitted with `productCode`, `eventType`, `productCategory`
   - `childSku` field logged as `true`
+  - Offering sync service invoked with the product event
 
 **product-kafka-TC003 - Handle malformed JSON message from Kafka**
 - **Description**: Verify that malformed JSON messages are handled gracefully without disrupting the consumer.
@@ -1479,11 +1481,12 @@ This section verifies the automatic contract termination behavior when contracts
 - **Action**: Publish invalid JSON string (e.g., “not-valid-json”) to `product-service.operationalproduct.protected` topic
 - **Verification**:
   - Check warn log contains “Unable to read IT Product Kafka message from JSON”
-  - Verify consumer continues processing
+  - Verify no consume log for the malformed payload
+  - Publish a subsequent valid message and verify it is consumed (consumer continues)
 - **Expected Result**:
   - `JsonProcessingException` thrown and logged as warning
   - Consumer does not crash
-  - No info log for successful consumption
+  - No info log for successful consumption of the malformed payload
 
 **product-kafka-TC004 - Ignore null message from Kafka**
 - **Description**: Verify that null messages are silently ignored without processing or logging.
@@ -1492,11 +1495,11 @@ This section verifies the automatic contract termination behavior when contracts
   - Kafka consumer is enabled
 - **Action**: Send null message to Kafka consumer
 - **Verification**:
-  - Verify no processing occurs
-  - Verify no logs emitted
+  - Publish a subsequent valid message and verify it is consumed (consumer continues)
+  - Verify the null payload produced no consume log and no malformed-JSON warn log
 - **Expected Result**:
   - Null message ignored
-  - No processing or logging occurs
+  - No consume or parse-error log for the null payload
   - Consumer ready for next message
 
 **product-kafka-TC005 - Ignore message when feature flag is disabled**
@@ -1505,12 +1508,14 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is **disabled**
 - **Action**: Publish valid `OperationalProductEvent` JSON to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify message is not processed
   - Check debug log contains “IT Product Kafka consumer is disabled by feature flag”
+  - Verify message is not consumed
+  - Verify `OfferingSyncService.syncProductFromEvent` is not invoked for the SKU
 - **Expected Result**:
   - Message not consumed or processed
   - No product data logged
   - Consumer indicates disabled state
+  - Sync service not invoked
 
 **product-kafka-TC006 - Ignore message when Kafka consumer disabled via variant**
 - **Description**: Verify that Kafka consumer can be independently disabled via variant configuration.
@@ -1519,12 +1524,14 @@ This section verifies the automatic contract termination behavior when contracts
   - Variant `config` set with `{“kafka_consumer_enabled”: false, “umb_consumer_enabled”: true}`
 - **Action**: Publish valid `OperationalProductEvent` JSON to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify Kafka consumer does not process message
   - Check debug log contains “IT Product Kafka consumer is disabled by feature flag”
+  - Verify Kafka consumer does not process message
+  - Verify `OfferingSyncService.syncProductFromEvent` is not invoked for the SKU
 - **Expected Result**:
   - Kafka consumer does not process message
-  - UMB consumer remains operational
   - No product data logged from Kafka
+  - Sync service not invoked
+  - This case does not publish on UMB. Cross-channel coverage is `product-duplicate-*`.
 
 **product-kafka-TC007 - Process message when Kafka enabled and UMB disabled via variant**
 - **Description**: Verify that Kafka consumer operates independently when UMB consumer is disabled via variant.
@@ -1533,25 +1540,27 @@ This section verifies the automatic contract termination behavior when contracts
   - Variant `config` set with `{“kafka_consumer_enabled”: true, “umb_consumer_enabled”: false}`
 - **Action**: Publish valid `OperationalProductEvent` JSON to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify Kafka consumer processes message
   - Check info log contains “IT Product message consumed: source=kafka”
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - Kafka consumer processes message successfully
   - Info log emitted with product details
-  - UMB consumer is independently disabled
+  - Sync service invoked with the product event
+  - This case does not publish on UMB. Cross-channel coverage is `product-duplicate-*`.
 
 **product-kafka-TC008 - Process message when both consumers enabled via variant**
-- **Description**: Verify that both consumers can operate simultaneously when explicitly enabled via variant.
+- **Description**: Verify that the Kafka consumer processes a message when both consumers are enabled via variant.
 - **Setup**:
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service consumers)
   - Variant `config` set with `{“kafka_consumer_enabled”: true, “umb_consumer_enabled”: true}`
 - **Action**: Publish valid `OperationalProductEvent` JSON to `product-service.operationalproduct.protected` topic
 - **Verification**:
-  - Verify Kafka consumer processes message
   - Check info log contains “IT Product message consumed: source=kafka”
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - Kafka consumer processes message successfully
-  - Both Kafka and UMB consumers are operational
+  - Sync service invoked with the product event
+  - This case does not publish on UMB. Cross-channel coverage is `product-duplicate-*`.
 
 ### UMB Consumer - Message Processing
 
@@ -1563,13 +1572,11 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
   - UMB consumer is enabled
-  - OfferingSyncService is mocked/stubbed
   - Prepare a valid `OperationalProductEvent` JSON with parent SKU (productCode not starting with “SVC”)
-- **Action**: Publish message to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish message to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify message was consumed
   - Check info log contains “IT Product message consumed: source=umb”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called with the deserialized event
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Info log emitted with `productCode`, `eventType`, `productCategory`
@@ -1581,13 +1588,11 @@ This section verifies the automatic contract termination behavior when contracts
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
-  - OfferingSyncService is mocked/stubbed
   - Prepare a valid `OperationalProductEvent` JSON with child SKU (productCode starts with “SVC”)
-- **Action**: Publish message to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish message to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify message was consumed
   - Check info log contains “IT Product message consumed: source=umb”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Info log emitted with `productCode`, `eventType`, `productCategory`
@@ -1599,15 +1604,14 @@ This section verifies the automatic contract termination behavior when contracts
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish invalid JSON string to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish invalid JSON string to `VirtualTopic.services.productservice.Product`
 - **Verification**:
   - Check error log contains “Unable to read UMB product message for JSON”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was never called
-  - Verify consumer continues processing
+  - Verify no consume log for the malformed payload. Sync runs only after consume, so this also covers sync not invoked. Malformed JSON has no SKU to match.
+  - Publish a subsequent valid message and verify it is consumed (consumer continues)
 - **Expected Result**:
   - Exception caught and logged as error
-  - Sync service not invoked
+  - Sync service not invoked for the malformed payload
   - Consumer does not crash
   - Consumer ready for next message
 
@@ -1630,12 +1634,11 @@ This section verifies the automatic contract termination behavior when contracts
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is **disabled**
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify message is not processed
   - Check debug log contains “IT Product UMB consumer is disabled by feature flag”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was never called
+  - Verify message is not consumed
+  - Verify `OfferingSyncService.syncProductFromEvent` is not invoked for the SKU
 - **Expected Result**:
   - Message not consumed or processed
   - Consumer indicates disabled state
@@ -1647,15 +1650,15 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
   - Variant `config` set with `{“kafka_consumer_enabled”: true, “umb_consumer_enabled”: false}`
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify UMB consumer does not process message
   - Check debug log contains “IT Product UMB consumer is disabled by feature flag”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was never called
+  - Verify UMB consumer does not process message
+  - Verify `OfferingSyncService.syncProductFromEvent` is not invoked for the SKU
 - **Expected Result**:
   - UMB consumer does not process message
   - Sync service not invoked
+  - This case does not publish on Kafka. Cross-channel coverage is `product-duplicate-*`.
 
 **product-umb-TC007 - Process message when UMB enabled and Kafka disabled via variant**
 - **Description**: Verify that UMB consumer operates independently when Kafka consumer is disabled via variant.
@@ -1663,32 +1666,30 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
   - Variant `config` set with `{“kafka_consumer_enabled”: false, “umb_consumer_enabled”: true}`
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify UMB consumer processes message
   - Check info log contains “IT Product message consumed: source=umb”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - UMB consumer processes message successfully
   - Info log emitted with product details
   - Sync service invoked with the product event
+  - This case does not publish on Kafka. Cross-channel coverage is `product-duplicate-*`.
 
 **product-umb-TC008 - Process message when both consumers enabled via variant**
-- **Description**: Verify that both consumers can operate simultaneously when explicitly enabled via variant.
+- **Description**: Verify that the UMB consumer processes a message when both consumers are enabled via variant.
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service consumers)
   - Variant `config` set with `{“kafka_consumer_enabled”: true, “umb_consumer_enabled”: true}`
-  - OfferingSyncService is mocked/stubbed
-- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish valid `OperationalProductEvent` JSON to `VirtualTopic.services.productservice.Product`
 - **Verification**:
-  - Verify UMB consumer processes message
   - Check info log contains “IT Product message consumed: source=umb”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - UMB consumer processes message successfully
   - Sync service invoked with the product event
+  - This case does not publish on Kafka. Cross-channel coverage is `product-duplicate-*`.
 
 ### Duplicate SKU Processing Scenarios
 
@@ -1698,21 +1699,16 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service consumers)
   - Both Kafka and UMB consumers enabled
-  - OfferingSyncService is mocked/stubbed
   - Prepare identical `OperationalProductEvent` JSON for both channels
-- **Action**:
-  - Publish message to `product-service.operationalproduct.protected` topic
-  - Publish same message to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish the same event to Kafka (`product-service.operationalproduct.protected`) and UMB (`VirtualTopic.services.productservice.Product`)
 - **Verification**:
-  - Verify both consumers process the message
-  - Check info logs contain both “source=kafka” and “source=umb”
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called once (UMB only)
+  - Check info logs contain both “source=kafka” and “source=umb” for the SKU
+  - Verify `OfferingSyncService.syncProductFromEvent` is invoked by both consumers
 - **Expected Result**:
   - Kafka consumer logs product event with `source=kafka`
   - UMB consumer logs product event with `source=umb`
-  - Sync service invoked only by UMB consumer
+  - Both consumers invoke offering sync for the SKU
   - Both messages processed successfully
-  - No duplicate sync issues
 
 **product-duplicate-TC002 - Same SKU with different event types**
 - **Description**: Verify that different event types for the same SKU are processed correctly by different consumers.
@@ -1720,19 +1716,15 @@ This section verifies the automatic contract termination behavior when contracts
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service consumers)
   - Both consumers enabled
-  - OfferingSyncService is mocked/stubbed
   - Prepare two `OperationalProductEvent` messages for same `productCode` with different `eventType` (Create and Update)
-- **Action**:
-  - Publish “Create” event to `product-service.operationalproduct.protected` topic
-  - Publish “Update” event to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish “Create” to Kafka and “Update” to UMB
 - **Verification**:
-  - Verify both consumers process their respective messages
-  - Check logs show correct `eventType` for each
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called with Update event
+  - Check logs show `eventType=Create` with `source=kafka` and `eventType=Update` with `source=umb`
+  - Verify `OfferingSyncService.syncProductFromEvent` is invoked by both consumers
 - **Expected Result**:
   - Create event logged via Kafka with `eventType=Create`
   - Update event logged via UMB with `eventType=Update`
-  - Sync service invoked with Update event
+  - Both consumers invoke offering sync for the SKU
   - Both event types processed independently
 
 ### Edge Cases and Error Scenarios
@@ -1757,13 +1749,12 @@ This section verifies the automatic contract termination behavior when contracts
 - **Setup**:
   - Ensure `UMB_ENABLED=true`
   - Ensure Unleash toggle `swatch.swatch-contracts.enable-product-service-consumer` is enabled (IT Product Service UMB consumer)
-  - OfferingSyncService is mocked/stubbed
   - Prepare `OperationalProductEvent` JSON with null `eventType`
-- **Action**: Publish message to `VirtualTopic.eng.product-service.offering.sync`
+- **Action**: Publish message to `VirtualTopic.services.productservice.Product`
 - **Verification**:
   - Verify message is processed
   - Check info log shows "eventType=null"
-  - Verify `OfferingSyncService.syncUmbProductFromEvent()` was called
+  - Verify `OfferingSyncService.syncProductFromEvent` via log “Received product message for productSku=”
 - **Expected Result**:
   - `OperationalProductEvent` deserialized successfully
   - Null `eventType` logged

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -78,8 +78,28 @@ public class ContractsUnleashService extends UnleashService {
     disableFlag(IT_SUBSCRIPTION_SERVICE);
   }
 
-  public void enableProductServiceConsumer() {
+  public void enableProductServiceConsumerKafkaOnly() {
     enableFlag(PRODUCT_SERVICE_CONSUMER);
+    setVariant(
+        PRODUCT_SERVICE_CONSUMER,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":false}");
+  }
+
+  public void enableProductServiceConsumerUmbOnly() {
+    enableFlag(PRODUCT_SERVICE_CONSUMER);
+    setVariant(
+        PRODUCT_SERVICE_CONSUMER,
+        "config",
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
+  }
+
+  public void enableProductServiceConsumerBothConsumers() {
+    enableFlag(PRODUCT_SERVICE_CONSUMER);
+    setVariant(
+        PRODUCT_SERVICE_CONSUMER,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":true}");
   }
 
   public void disableProductServiceConsumer() {

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -28,6 +28,8 @@ public class ContractsUnleashService extends UnleashService {
       "swatch.swatch-contracts.enable-partner-gateway-contracts";
   public static final String IT_SUBSCRIPTION_SERVICE =
       "swatch.swatch-contracts.enable-it-subscription-service";
+  public static final String PRODUCT_SERVICE_CONSUMER =
+      "swatch.swatch-contracts.enable-product-service-consumer";
 
   /** Matches {@code KesselRolesAugmentor.KESSEL_FLAG} in swatch-common-security. */
   public static final String USE_KESSEL_RBAC = "swatch.common-security.use-kessel-rbac";
@@ -74,6 +76,14 @@ public class ContractsUnleashService extends UnleashService {
 
   public void disableItSubscriptionService() {
     disableFlag(IT_SUBSCRIPTION_SERVICE);
+  }
+
+  public void enableProductServiceConsumer() {
+    enableFlag(PRODUCT_SERVICE_CONSUMER);
+  }
+
+  public void disableProductServiceConsumer() {
+    disableFlag(PRODUCT_SERVICE_CONSUMER);
   }
 
   public void enableKesselRbac() {

--- a/swatch-contracts/ct/java/api/OperationalProductArtemisSender.java
+++ b/swatch-contracts/ct/java/api/OperationalProductArtemisSender.java
@@ -53,6 +53,10 @@ public class OperationalProductArtemisSender {
     sendMessage(fromOffering(offering));
   }
 
+  public void send(OperationalProductEvent event) {
+    sendMessage(event);
+  }
+
   /**
    * Send a malformed JSON message that cannot be deserialized.
    *

--- a/swatch-contracts/ct/java/api/ProductApiStubs.java
+++ b/swatch-contracts/ct/java/api/ProductApiStubs.java
@@ -20,6 +20,8 @@
  */
 package api;
 
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import domain.Offering;
 import java.util.ArrayList;
 import java.util.Map;
@@ -155,8 +157,36 @@ public class ProductApiStubs {
             "Service Unavailable"));
   }
 
+  public int countProductTreeRequests(String sku) {
+    return wiremockService.countRequests(productTreeUrlPath(sku));
+  }
+
+  public void awaitProductTreeNotRequested(String sku) {
+    AwaitilityUtils.untilAsserted(
+        () -> verifyProductTreeNotRequested(sku),
+        AwaitilitySettings.defaults()
+            .timeoutMessage("Product tree should not be requested for SKU %s", sku));
+  }
+
+  public void verifyProductTreeNotRequested(String sku) {
+    var path = productTreeUrlPath(sku);
+    var count = countProductTreeRequests(sku);
+    if (count > 0) {
+      throw new AssertionError(
+          "Unexpected "
+              + count
+              + " product tree request(s) found at "
+              + path
+              + " but none were expected");
+    }
+  }
+
+  private static String productTreeUrlPath(String sku) {
+    return String.format("/mock/product/products/%s/tree", sku);
+  }
+
   private static String productTreeUrlPattern(String sku) {
-    return String.format("/mock/product/products/%s/tree.*", sku);
+    return productTreeUrlPath(sku) + ".*";
   }
 
   private void registerProductTreeStub(String sku, int priority, Map<String, Object> response) {

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -21,8 +21,6 @@
 package tests;
 
 import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import api.ContractsSwatchService;
@@ -124,7 +122,7 @@ public class BaseContractComponentTest {
   void givenContractIsCreated(Contract contract) {
     givenOfferingIsSynced(contract);
     Response create = service.createContract(contract);
-    assertThat("Creating contract should succeed", create.statusCode(), is(HttpStatus.SC_OK));
+    assertEquals(HttpStatus.SC_OK, create.statusCode(), "Creating contract should succeed");
   }
 
   protected void givenOfferingIsSynced(Contract contract) {

--- a/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
@@ -20,15 +20,38 @@
  */
 package tests;
 
+import static com.redhat.swatch.component.tests.utils.Topics.IT_PRODUCT_SYNC;
+
 import com.redhat.swatch.contract.test.model.OperationalProductEvent;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
 import java.time.OffsetDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 
 public abstract class BaseProductConsumerComponentTest extends BaseContractComponentTest {
 
+  @BeforeAll
+  static void enableProductServiceConsumer() {
+    unleash.enableProductServiceConsumerBothConsumers();
+  }
+
+  private static boolean isChildSku(String productCode) {
+    return productCode != null && productCode.startsWith("SVC");
+  }
+
+  @AfterEach
+  void restoreProductServiceConsumerFlag() {
+    unleash.enableProductServiceConsumerBothConsumers();
+  }
+
   protected OperationalProductEvent givenParentSkuEvent(String productCode) {
-    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
+    return givenParentSkuEvent(productCode, EventTypeEnum.UPDATE);
+  }
+
+  protected OperationalProductEvent givenParentSkuEvent(
+      String productCode, EventTypeEnum eventType) {
+    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU, eventType);
   }
 
   protected OperationalProductEvent givenChildSkuEvent(String productCode) {
@@ -37,12 +60,21 @@ public abstract class BaseProductConsumerComponentTest extends BaseContractCompo
 
   protected OperationalProductEvent givenProductEvent(
       String productCode, ProductCategoryEnum category) {
+    return givenProductEvent(productCode, category, EventTypeEnum.UPDATE);
+  }
+
+  protected OperationalProductEvent givenProductEvent(
+      String productCode, ProductCategoryEnum category, EventTypeEnum eventType) {
     OperationalProductEvent event = new OperationalProductEvent();
     event.setProductCode(productCode);
     event.setProductCategory(category);
-    event.setEventType(EventTypeEnum.UPDATE);
+    event.setEventType(eventType);
     event.setOccurredOn(OffsetDateTime.now().toString());
     return event;
+  }
+
+  protected void whenKafkaMessageIsPublished(OperationalProductEvent event) {
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, event);
   }
 
   protected void thenMessageIsNotConsumed(OperationalProductEvent event, String source) {
@@ -51,8 +83,7 @@ public abstract class BaseProductConsumerComponentTest extends BaseContractCompo
         .assertDoesNotContain("source=" + source + ", productCode=" + event.getProductCode());
   }
 
-  protected void thenMessageIsConsumedWithChildSkuFlag(
-      OperationalProductEvent event, boolean isChildSku, String source) {
+  protected void thenMessageIsConsumed(OperationalProductEvent event, String source) {
     service
         .logs()
         .assertContains(
@@ -63,7 +94,24 @@ public abstract class BaseProductConsumerComponentTest extends BaseContractCompo
                 event.getProductCode(),
                 event.getEventType(),
                 event.getProductCategory(),
-                isChildSku));
+                isChildSku(event.getProductCode())));
+  }
+
+  protected void thenMessageIsConsumedAndSynced(OperationalProductEvent event, String source) {
+    thenMessageIsConsumed(event, source);
+    thenSyncServiceWasInvoked(event);
+  }
+
+  protected void thenSyncServiceWasInvoked(OperationalProductEvent event) {
+    service
+        .logs()
+        .assertContains("Received product message for productSku=" + event.getProductCode());
+  }
+
+  protected void thenSyncServiceWasNotInvoked(OperationalProductEvent event) {
+    service
+        .logs()
+        .assertDoesNotContain("Received product message for productSku=" + event.getProductCode());
   }
 
   protected int countLogsContaining(String text) {

--- a/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
+import java.time.OffsetDateTime;
+
+public abstract class BaseProductConsumerComponentTest extends BaseContractComponentTest {
+
+  protected OperationalProductEvent givenParentSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
+  }
+
+  protected OperationalProductEvent givenChildSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.CHILD_SKU);
+  }
+
+  protected OperationalProductEvent givenProductEvent(
+      String productCode, ProductCategoryEnum category) {
+    OperationalProductEvent event = new OperationalProductEvent();
+    event.setProductCode(productCode);
+    event.setProductCategory(category);
+    event.setEventType(EventTypeEnum.UPDATE);
+    event.setOccurredOn(OffsetDateTime.now().toString());
+    return event;
+  }
+
+  protected void thenMessageIsNotConsumed(OperationalProductEvent event, String source) {
+    service
+        .logs()
+        .assertDoesNotContain("source=" + source + ", productCode=" + event.getProductCode());
+  }
+
+  protected void thenMessageIsConsumedWithChildSkuFlag(
+      OperationalProductEvent event, boolean isChildSku, String source) {
+    service
+        .logs()
+        .assertContains(
+            String.format(
+                "IT Product message consumed: source=%s, productCode=%s, eventType=%s, "
+                    + "productCategory=%s, childSku=%s",
+                source,
+                event.getProductCode(),
+                event.getEventType(),
+                event.getProductCategory(),
+                isChildSku));
+  }
+
+  protected int countLogsContaining(String text) {
+    return (int) service.getLogs().stream().filter(line -> line.contains(text)).count();
+  }
+}

--- a/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseProductConsumerComponentTest.java
@@ -109,9 +109,7 @@ public abstract class BaseProductConsumerComponentTest extends BaseContractCompo
   }
 
   protected void thenSyncServiceWasNotInvoked(OperationalProductEvent event) {
-    service
-        .logs()
-        .assertDoesNotContain("Received product message for productSku=" + event.getProductCode());
+    wiremock.forProductAPI().awaitProductTreeNotRequested(event.getProductCode());
   }
 
   protected int countLogsContaining(String text) {

--- a/swatch-contracts/ct/java/tests/BaseProductUmbComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseProductUmbComponentTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import api.ContractsArtemisService;
+import com.redhat.swatch.component.tests.api.Artemis;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+
+public abstract class BaseProductUmbComponentTest extends BaseProductConsumerComponentTest {
+
+  @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
+
+  protected void whenUmbMessageIsPublished(OperationalProductEvent event) {
+    artemis.forOfferings().send(event);
+  }
+
+  protected void whenMalformedUmbMessageIsPublished(String malformedJson) {
+    artemis.forOfferings().sendMalformed(malformedJson);
+  }
+}

--- a/swatch-contracts/ct/java/tests/ProductDuplicateComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductDuplicateComponentTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
+import org.junit.jupiter.api.Test;
+
+public class ProductDuplicateComponentTest extends BaseProductUmbComponentTest {
+
+  @TestPlanName("product-duplicate-TC001")
+  @Test
+  void shouldProcessSameSkuFromKafkaAndUmb() {
+    // Given: The same parent SKU operational product event for both channels
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing the same event to Kafka and UMB
+    whenSameEventIsPublishedToKafkaAndUmb(event);
+
+    // Then: Both consumers process the event and each invokes offering sync
+    thenMessageIsConsumed(event, "kafka");
+    thenMessageIsConsumed(event, "umb");
+    thenBothConsumersInvokedSync(event);
+  }
+
+  @TestPlanName("product-duplicate-TC002")
+  @Test
+  void shouldProcessSameSkuWithDifferentEventTypes() {
+    // Given: Create on Kafka and Update on UMB for the same parent SKU
+    String productCode = "RH" + RandomUtils.generateRandom();
+    OperationalProductEvent createEvent = givenParentSkuEvent(productCode, EventTypeEnum.CREATE);
+    OperationalProductEvent updateEvent = givenParentSkuEvent(productCode, EventTypeEnum.UPDATE);
+
+    // When: Publishing Create to Kafka and Update to UMB
+    whenCreateGoesToKafkaAndUpdateGoesToUmb(createEvent, updateEvent);
+
+    // Then: Each consumer logs its event type and both invoke offering sync
+    thenMessageIsConsumed(createEvent, "kafka");
+    thenMessageIsConsumed(updateEvent, "umb");
+    thenBothConsumersInvokedSync(updateEvent);
+  }
+
+  private void whenSameEventIsPublishedToKafkaAndUmb(OperationalProductEvent event) {
+    whenKafkaMessageIsPublished(event);
+    whenUmbMessageIsPublished(event);
+  }
+
+  private void whenCreateGoesToKafkaAndUpdateGoesToUmb(
+      OperationalProductEvent createEvent, OperationalProductEvent updateEvent) {
+    whenKafkaMessageIsPublished(createEvent);
+    whenUmbMessageIsPublished(updateEvent);
+  }
+
+  private void thenBothConsumersInvokedSync(OperationalProductEvent event) {
+    AwaitilityUtils.until(
+        () ->
+            countLogsContaining(
+                "Received product message for productSku=" + event.getProductCode()),
+        count -> count == 2,
+        AwaitilitySettings.defaults()
+            .timeoutMessage(
+                "Expected both Kafka and UMB to invoke offering sync for productSku=%s",
+                event.getProductCode()));
+  }
+}

--- a/swatch-contracts/ct/java/tests/ProductEdgeComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductEdgeComponentTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.Topics.IT_PRODUCT_SYNC;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ProductEdgeComponentTest extends BaseProductUmbComponentTest {
+
+  @TestPlanName("product-edge-TC001")
+  @Test
+  void shouldProcessMessageWhenProductCodeIsMissing() {
+    // Given: A parent SKU event with a null productCode
+    OperationalProductEvent event = givenParentSkuEvent(null);
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Message is consumed with productCode=null and childSku=false
+    thenMessageIsConsumed(event, "kafka");
+
+    // And: a subsequent valid message is still consumed
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenKafkaMessageIsPublished(probe);
+    thenMessageIsConsumedAndSynced(probe, "kafka");
+  }
+
+  @TestPlanName("product-edge-TC002")
+  @Test
+  void shouldProcessMessageWhenEventTypeIsMissing() {
+    // Given: A parent SKU event with a null eventType
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    event.setEventType(null);
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: Message is consumed with eventType=null and sync is invoked
+    thenMessageIsConsumedAndSynced(event, "umb");
+  }
+
+  @TestPlanName("product-edge-TC003")
+  @Test
+  void shouldProcessEmptyJsonObjectMessage() {
+    // Given: An empty JSON object
+    OperationalProductEvent event = givenEmptyProductEvent();
+
+    // When: Publishing {} to Kafka
+    whenKafkaPayloadIsPublished(Map.of());
+
+    // Then: Message is consumed with null fields
+    thenMessageIsConsumed(event, "kafka");
+
+    // And: a subsequent valid message is still consumed
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenKafkaMessageIsPublished(probe);
+    thenMessageIsConsumedAndSynced(probe, "kafka");
+  }
+
+  @TestPlanName("product-edge-TC004")
+  @Test
+  void shouldProcessMessageWithUnexpectedFields() {
+    // Given: A valid parent SKU event plus fields that are not in the schema
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    Map<String, Object> payload = givenPayloadWithUnexpectedFields(event);
+
+    // When: Publishing the payload to Kafka
+    whenKafkaPayloadIsPublished(payload);
+
+    // Then: Expected fields are consumed and extra fields are ignored
+    thenMessageIsConsumedAndSynced(event, "kafka");
+    thenUnknownFieldsWereIgnored();
+  }
+
+  private OperationalProductEvent givenEmptyProductEvent() {
+    return new OperationalProductEvent();
+  }
+
+  private Map<String, Object> givenPayloadWithUnexpectedFields(OperationalProductEvent event) {
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("productCode", event.getProductCode());
+    payload.put("productCategory", "Parent SKU");
+    payload.put("eventType", "Update");
+    payload.put("occurredOn", event.getOccurredOn());
+    payload.put("unexpectedField", "should-be-ignored");
+    payload.put("extraNumber", 42);
+    return payload;
+  }
+
+  private void whenKafkaPayloadIsPublished(Object payload) {
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, payload);
+  }
+
+  private void thenUnknownFieldsWereIgnored() {
+    service.logs().assertDoesNotContain("Unrecognized field");
+  }
+}

--- a/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
@@ -26,14 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent;
-import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
-import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
-import java.time.OffsetDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ProductKafkaComponentTest extends BaseContractComponentTest {
+public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest {
 
   @BeforeAll
   static void enableProductServiceConsumer() {
@@ -171,24 +168,6 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
     thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
   }
 
-  private OperationalProductEvent givenParentSkuEvent(String productCode) {
-    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
-  }
-
-  private OperationalProductEvent givenChildSkuEvent(String productCode) {
-    return givenProductEvent(productCode, ProductCategoryEnum.CHILD_SKU);
-  }
-
-  private OperationalProductEvent givenProductEvent(
-      String productCode, ProductCategoryEnum category) {
-    OperationalProductEvent event = new OperationalProductEvent();
-    event.setProductCode(productCode);
-    event.setProductCategory(category);
-    event.setEventType(EventTypeEnum.UPDATE);
-    event.setOccurredOn(OffsetDateTime.now().toString());
-    return event;
-  }
-
   private void whenKafkaMessageIsPublished(OperationalProductEvent event) {
     kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, event);
   }
@@ -201,30 +180,5 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
 
   private void thenKafkaConsumerReportsDisabled() {
     service.logs().assertContains("IT Product Kafka consumer is disabled by feature flag.");
-  }
-
-  private void thenMessageIsNotConsumed(OperationalProductEvent event, String source) {
-    service
-        .logs()
-        .assertDoesNotContain("source=" + source + ", productCode=" + event.getProductCode());
-  }
-
-  private void thenMessageIsConsumedWithChildSkuFlag(
-      OperationalProductEvent event, boolean isChildSku, String source) {
-    service
-        .logs()
-        .assertContains(
-            String.format(
-                "IT Product message consumed: source=%s, productCode=%s, eventType=%s, "
-                    + "productCategory=%s, childSku=%s",
-                source,
-                event.getProductCode(),
-                event.getEventType(),
-                event.getProductCategory(),
-                isChildSku));
-  }
-
-  private int countLogsContaining(String text) {
-    return (int) service.getLogs().stream().filter(line -> line.contains(text)).count();
   }
 }

--- a/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
@@ -26,21 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest {
-
-  @BeforeAll
-  static void enableProductServiceConsumer() {
-    unleash.enableProductServiceConsumerBothConsumers();
-  }
-
-  @AfterEach
-  void restoreProductServiceConsumerFlag() {
-    unleash.enableProductServiceConsumerBothConsumers();
-  }
 
   @TestPlanName("product-kafka-TC001")
   @Test
@@ -51,8 +39,8 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // When: Publishing message to Kafka
     whenKafkaMessageIsPublished(event);
 
-    // Then: Message is consumed successfully
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
+    // Then: Message is consumed and the offering sync service is invoked
+    thenMessageIsConsumedAndSynced(event, "kafka");
   }
 
   @TestPlanName("product-kafka-TC002")
@@ -64,8 +52,8 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // When: Publishing message to Kafka
     whenKafkaMessageIsPublished(event);
 
-    // Then: Message is consumed with childSku flag as true
-    thenMessageIsConsumedWithChildSkuFlag(event, true, "kafka");
+    // Then: Message is consumed with childSku flag as true and sync is invoked
+    thenMessageIsConsumedAndSynced(event, "kafka");
   }
 
   @TestPlanName("product-kafka-TC003")
@@ -76,15 +64,19 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=kafka");
 
     // When: Publishing malformed message to Kafka
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, malformedJson);
+    whenMalformedKafkaMessageIsPublished(malformedJson);
 
-    // Then: Warning is logged, the bad payload is not consumed, and the consumer continues
+    // Then: Warning is logged and the bad payload is not consumed
     service.logs().assertContains("Unable to read IT Product Kafka message from JSON");
     assertEquals(
         consumeLogsBefore,
         countLogsContaining("IT Product message consumed: source=kafka"),
         "Malformed JSON must not produce a consume log");
-    thenKafkaConsumerAcceptsSubsequentMessages();
+
+    // And: a subsequent valid message is still consumed
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenKafkaMessageIsPublished(probe);
+    thenMessageIsConsumedAndSynced(probe, "kafka");
   }
 
   @TestPlanName("product-kafka-TC004")
@@ -96,10 +88,12 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
         countLogsContaining("Unable to read IT Product Kafka message from JSON");
 
     // When: Publishing a null message to Kafka
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, null);
+    whenNullKafkaMessageIsPublished();
 
-    // Then: Null is ignored; the consumer continues processing
-    thenKafkaConsumerAcceptsSubsequentMessages();
+    // Then: Null is ignored and a subsequent valid message is still consumed
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenKafkaMessageIsPublished(probe);
+    thenMessageIsConsumedAndSynced(probe, "kafka");
     assertEquals(
         consumeLogsBefore + 1,
         countLogsContaining("IT Product message consumed: source=kafka"),
@@ -123,6 +117,7 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // Then: Consumer is disabled and the message is not processed
     thenKafkaConsumerReportsDisabled();
     thenMessageIsNotConsumed(event, "kafka");
+    thenSyncServiceWasNotInvoked(event);
   }
 
   @TestPlanName("product-kafka-TC006")
@@ -138,6 +133,7 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // Then: Kafka is independently disabled
     thenKafkaConsumerReportsDisabled();
     thenMessageIsNotConsumed(event, "kafka");
+    thenSyncServiceWasNotInvoked(event);
   }
 
   @TestPlanName("product-kafka-TC007")
@@ -150,8 +146,8 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // When: Publishing message to Kafka
     whenKafkaMessageIsPublished(event);
 
-    // Then: Kafka consumes independently
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
+    // Then: Kafka consumes independently and the sync service is invoked
+    thenMessageIsConsumedAndSynced(event, "kafka");
   }
 
   @TestPlanName("product-kafka-TC008")
@@ -164,18 +160,16 @@ public class ProductKafkaComponentTest extends BaseProductConsumerComponentTest 
     // When: Publishing message to Kafka
     whenKafkaMessageIsPublished(event);
 
-    // Then: Kafka consumes
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
+    // Then: Kafka consumes and the sync service is invoked
+    thenMessageIsConsumedAndSynced(event, "kafka");
   }
 
-  private void whenKafkaMessageIsPublished(OperationalProductEvent event) {
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, event);
+  private void whenMalformedKafkaMessageIsPublished(String malformedJson) {
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, malformedJson);
   }
 
-  private void thenKafkaConsumerAcceptsSubsequentMessages() {
-    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
-    whenKafkaMessageIsPublished(probe);
-    thenMessageIsConsumedWithChildSkuFlag(probe, false, "kafka");
+  private void whenNullKafkaMessageIsPublished() {
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, null);
   }
 
   private void thenKafkaConsumerReportsDisabled() {

--- a/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ProductKafkaComponentTest extends BaseContractComponentTest {
+
+  private static final String IT_PRODUCT_TOPIC = "product-service.operationalproduct.protected";
+
+  @BeforeAll
+  static void enableProductServiceConsumer() {
+    unleash.enableProductServiceConsumer();
+  }
+
+  @TestPlanName("product-kafka-TC001")
+  @Test
+  void shouldProcessValidParentSkuMessage() {
+    // Given: A valid parent SKU operational product event
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Message is consumed successfully
+    thenMessageIsConsumedWithChildSkuFlag(event, false);
+  }
+
+  @TestPlanName("product-kafka-TC002")
+  @Test
+  void shouldProcessValidChildSkuMessage() {
+    // Given: A valid child SKU operational product event (starts with "SVC")
+    OperationalProductEvent event = givenChildSkuEvent("SVC" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Message is consumed with childSku flag as true
+    thenMessageIsConsumedWithChildSkuFlag(event, true);
+  }
+
+  @TestPlanName("product-kafka-TC003")
+  @Test
+  void shouldHandleMalformedJsonMessage() {
+    // Given: A malformed JSON message and baseline consume log count
+    String malformedJson = "not-valid-json";
+    int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=kafka");
+
+    // When: Publishing malformed message to Kafka
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, malformedJson);
+
+    // Then: Warning is logged, the bad payload is not consumed, and the consumer continues
+    service.logs().assertContains("Unable to read IT Product Kafka message from JSON");
+    assertEquals(
+        consumeLogsBefore,
+        countLogsContaining("IT Product message consumed: source=kafka"),
+        "Malformed JSON must not produce a consume log");
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  @TestPlanName("product-kafka-TC004")
+  @Test
+  void shouldIgnoreNullMessage() {
+    // Given: Baseline consume and parse-error log counts
+    int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=kafka");
+    int parseErrorLogsBefore =
+        countLogsContaining("Unable to read IT Product Kafka message from JSON");
+
+    // When: Publishing a null message to Kafka
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, null);
+
+    // Then: Null is ignored; the consumer continues processing
+    thenKafkaConsumerAcceptsSubsequentMessages();
+    assertEquals(
+        consumeLogsBefore + 1,
+        countLogsContaining("IT Product message consumed: source=kafka"),
+        "Null message must not produce a consume log");
+    assertEquals(
+        parseErrorLogsBefore,
+        countLogsContaining("Unable to read IT Product Kafka message from JSON"),
+        "Null message must not be treated as malformed JSON");
+  }
+
+  private OperationalProductEvent givenParentSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
+  }
+
+  private OperationalProductEvent givenChildSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.CHILD_SKU);
+  }
+
+  private OperationalProductEvent givenProductEvent(
+      String productCode, ProductCategoryEnum category) {
+    OperationalProductEvent event = new OperationalProductEvent();
+    event.setProductCode(productCode);
+    event.setProductCategory(category);
+    event.setEventType(EventTypeEnum.UPDATE);
+    event.setOccurredOn(OffsetDateTime.now().toString());
+    return event;
+  }
+
+  private void whenKafkaMessageIsPublished(OperationalProductEvent event) {
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, event);
+  }
+
+  private void thenKafkaConsumerAcceptsSubsequentMessages() {
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenKafkaMessageIsPublished(probe);
+    thenMessageIsConsumedWithChildSkuFlag(probe, false);
+  }
+
+  private void thenMessageIsConsumedWithChildSkuFlag(
+      OperationalProductEvent event, boolean isChildSku) {
+    service
+        .logs()
+        .assertContains(
+            String.format(
+                "IT Product message consumed: source=kafka, productCode=%s, eventType=%s, "
+                    + "productCategory=%s, childSku=%s",
+                event.getProductCode(),
+                event.getEventType(),
+                event.getProductCategory(),
+                isChildSku));
+  }
+
+  private int countLogsContaining(String text) {
+    return (int) service.getLogs().stream().filter(line -> line.contains(text)).count();
+  }
+}

--- a/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductKafkaComponentTest.java
@@ -20,6 +20,7 @@
  */
 package tests;
 
+import static com.redhat.swatch.component.tests.utils.Topics.IT_PRODUCT_SYNC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
@@ -28,16 +29,20 @@ import com.redhat.swatch.contract.test.model.OperationalProductEvent;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
 import java.time.OffsetDateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class ProductKafkaComponentTest extends BaseContractComponentTest {
 
-  private static final String IT_PRODUCT_TOPIC = "product-service.operationalproduct.protected";
-
   @BeforeAll
   static void enableProductServiceConsumer() {
-    unleash.enableProductServiceConsumer();
+    unleash.enableProductServiceConsumerBothConsumers();
+  }
+
+  @AfterEach
+  void restoreProductServiceConsumerFlag() {
+    unleash.enableProductServiceConsumerBothConsumers();
   }
 
   @TestPlanName("product-kafka-TC001")
@@ -50,7 +55,7 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
     whenKafkaMessageIsPublished(event);
 
     // Then: Message is consumed successfully
-    thenMessageIsConsumedWithChildSkuFlag(event, false);
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
   }
 
   @TestPlanName("product-kafka-TC002")
@@ -63,7 +68,7 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
     whenKafkaMessageIsPublished(event);
 
     // Then: Message is consumed with childSku flag as true
-    thenMessageIsConsumedWithChildSkuFlag(event, true);
+    thenMessageIsConsumedWithChildSkuFlag(event, true, "kafka");
   }
 
   @TestPlanName("product-kafka-TC003")
@@ -74,7 +79,7 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
     int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=kafka");
 
     // When: Publishing malformed message to Kafka
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, malformedJson);
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, malformedJson);
 
     // Then: Warning is logged, the bad payload is not consumed, and the consumer continues
     service.logs().assertContains("Unable to read IT Product Kafka message from JSON");
@@ -94,7 +99,7 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
         countLogsContaining("Unable to read IT Product Kafka message from JSON");
 
     // When: Publishing a null message to Kafka
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, null);
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, null);
 
     // Then: Null is ignored; the consumer continues processing
     thenKafkaConsumerAcceptsSubsequentMessages();
@@ -106,6 +111,64 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
         parseErrorLogsBefore,
         countLogsContaining("Unable to read IT Product Kafka message from JSON"),
         "Null message must not be treated as malformed JSON");
+  }
+
+  @TestPlanName("product-kafka-TC005")
+  @Test
+  void shouldIgnoreMessageWhenFeatureFlagDisabled() {
+    // Given: Feature flag is disabled and a valid parent SKU event
+    unleash.disableProductServiceConsumer();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Consumer is disabled and the message is not processed
+    thenKafkaConsumerReportsDisabled();
+    thenMessageIsNotConsumed(event, "kafka");
+  }
+
+  @TestPlanName("product-kafka-TC006")
+  @Test
+  void shouldIgnoreMessageWhenKafkaDisabledViaVariant() {
+    // Given: Flag enabled with Kafka disabled and UMB enabled via variant
+    unleash.enableProductServiceConsumerUmbOnly();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Kafka is independently disabled
+    thenKafkaConsumerReportsDisabled();
+    thenMessageIsNotConsumed(event, "kafka");
+  }
+
+  @TestPlanName("product-kafka-TC007")
+  @Test
+  void shouldProcessWhenKafkaEnabledAndUmbDisabled() {
+    // Given: Flag enabled with Kafka enabled and UMB disabled via variant
+    unleash.enableProductServiceConsumerKafkaOnly();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Kafka consumes independently
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
+  }
+
+  @TestPlanName("product-kafka-TC008")
+  @Test
+  void shouldProcessMessageWhenBothConsumersEnabled() {
+    // Given: Flag enabled with both Kafka and UMB consumers enabled via variant
+    unleash.enableProductServiceConsumerBothConsumers();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to Kafka
+    whenKafkaMessageIsPublished(event);
+
+    // Then: Kafka consumes
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "kafka");
   }
 
   private OperationalProductEvent givenParentSkuEvent(String productCode) {
@@ -127,23 +190,34 @@ public class ProductKafkaComponentTest extends BaseContractComponentTest {
   }
 
   private void whenKafkaMessageIsPublished(OperationalProductEvent event) {
-    kafkaBridge.produceKafkaMessage(IT_PRODUCT_TOPIC, event);
+    kafkaBridge.produceKafkaMessage(IT_PRODUCT_SYNC, event);
   }
 
   private void thenKafkaConsumerAcceptsSubsequentMessages() {
     OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
     whenKafkaMessageIsPublished(probe);
-    thenMessageIsConsumedWithChildSkuFlag(probe, false);
+    thenMessageIsConsumedWithChildSkuFlag(probe, false, "kafka");
+  }
+
+  private void thenKafkaConsumerReportsDisabled() {
+    service.logs().assertContains("IT Product Kafka consumer is disabled by feature flag.");
+  }
+
+  private void thenMessageIsNotConsumed(OperationalProductEvent event, String source) {
+    service
+        .logs()
+        .assertDoesNotContain("source=" + source + ", productCode=" + event.getProductCode());
   }
 
   private void thenMessageIsConsumedWithChildSkuFlag(
-      OperationalProductEvent event, boolean isChildSku) {
+      OperationalProductEvent event, boolean isChildSku, String source) {
     service
         .logs()
         .assertContains(
             String.format(
-                "IT Product message consumed: source=kafka, productCode=%s, eventType=%s, "
+                "IT Product message consumed: source=%s, productCode=%s, eventType=%s, "
                     + "productCategory=%s, childSku=%s",
+                source,
                 event.getProductCode(),
                 event.getEventType(),
                 event.getProductCategory(),

--- a/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
@@ -22,28 +22,12 @@ package tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import api.ContractsArtemisService;
-import com.redhat.swatch.component.tests.api.Artemis;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
-
-  @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
-
-  @BeforeAll
-  static void enableProductServiceConsumer() {
-    unleash.enableProductServiceConsumerBothConsumers();
-  }
-
-  @AfterEach
-  void restoreProductServiceConsumerFlag() {
-    unleash.enableProductServiceConsumerBothConsumers();
-  }
+public class ProductUmbComponentTest extends BaseProductUmbComponentTest {
 
   @TestPlanName("product-umb-TC001")
   @Test
@@ -55,8 +39,7 @@ public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: Message is consumed and the offering sync service is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
-    thenSyncServiceWasInvoked(event);
+    thenMessageIsConsumedAndSynced(event, "umb");
   }
 
   @TestPlanName("product-umb-TC002")
@@ -69,8 +52,7 @@ public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: Message is consumed with childSku flag as true and sync is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, true, "umb");
-    thenSyncServiceWasInvoked(event);
+    thenMessageIsConsumedAndSynced(event, "umb");
   }
 
   @TestPlanName("product-umb-TC003")
@@ -81,15 +63,19 @@ public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
     int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=umb");
 
     // When: Publishing malformed message to UMB
-    artemis.forOfferings().sendMalformed(malformedJson);
+    whenMalformedUmbMessageIsPublished(malformedJson);
 
-    // Then: Error is logged, the bad payload is not consumed, and the consumer continues
+    // Then: Error is logged and the bad payload is not consumed
     service.logs().assertContains("Unable to read UMB product message for JSON");
     assertEquals(
         consumeLogsBefore,
         countLogsContaining("IT Product message consumed: source=umb"),
         "Malformed JSON must not produce a consume log");
-    thenUmbConsumerAcceptsSubsequentMessages();
+
+    // And: a subsequent valid message is still consumed
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenUmbMessageIsPublished(probe);
+    thenMessageIsConsumedAndSynced(probe, "umb");
   }
 
   @TestPlanName("product-umb-TC005")
@@ -135,8 +121,7 @@ public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: UMB consumes independently and the sync service is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
-    thenSyncServiceWasInvoked(event);
+    thenMessageIsConsumedAndSynced(event, "umb");
   }
 
   @TestPlanName("product-umb-TC008")
@@ -150,33 +135,10 @@ public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: UMB consumes and the sync service is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
-    thenSyncServiceWasInvoked(event);
-  }
-
-  private void whenUmbMessageIsPublished(OperationalProductEvent event) {
-    artemis.forOfferings().send(event);
+    thenMessageIsConsumedAndSynced(event, "umb");
   }
 
   private void thenUmbConsumerReportsDisabled() {
     service.logs().assertContains("IT Product UMB consumer is disabled by feature flag.");
-  }
-
-  private void thenUmbConsumerAcceptsSubsequentMessages() {
-    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
-    whenUmbMessageIsPublished(probe);
-    thenMessageIsConsumedWithChildSkuFlag(probe, false, "umb");
-  }
-
-  private void thenSyncServiceWasInvoked(OperationalProductEvent event) {
-    service
-        .logs()
-        .assertContains("Received product message for productSku=" + event.getProductCode());
-  }
-
-  private void thenSyncServiceWasNotInvoked(OperationalProductEvent event) {
-    service
-        .logs()
-        .assertDoesNotContain("Received product message for productSku=" + event.getProductCode());
   }
 }

--- a/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import api.ContractsArtemisService;
+import com.redhat.swatch.component.tests.api.Artemis;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
+import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ProductUmbComponentTest extends BaseContractComponentTest {
+
+  @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
+
+  @BeforeAll
+  static void enableProductServiceConsumer() {
+    unleash.enableProductServiceConsumerBothConsumers();
+  }
+
+  @AfterEach
+  void restoreProductServiceConsumerFlag() {
+    unleash.enableProductServiceConsumerBothConsumers();
+  }
+
+  @TestPlanName("product-umb-TC001")
+  @Test
+  void shouldProcessValidParentSkuMessage() {
+    // Given: A valid parent SKU operational product event
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: Message is consumed and the offering sync service is invoked
+    thenMessageIsConsumedWithChildSkuFlag(event, false);
+    thenSyncServiceWasInvoked(event);
+  }
+
+  @TestPlanName("product-umb-TC002")
+  @Test
+  void shouldProcessValidChildSkuMessage() {
+    // Given: A valid child SKU operational product event (starts with "SVC")
+    OperationalProductEvent event = givenChildSkuEvent("SVC" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: Message is consumed with childSku flag as true and sync is invoked
+    thenMessageIsConsumedWithChildSkuFlag(event, true);
+    thenSyncServiceWasInvoked(event);
+  }
+
+  @TestPlanName("product-umb-TC003")
+  @Test
+  void shouldHandleMalformedJsonMessage() {
+    // Given: A malformed JSON message and baseline consume log count
+    String malformedJson = "not-valid-json";
+    int consumeLogsBefore = countLogsContaining("IT Product message consumed: source=umb");
+
+    // When: Publishing malformed message to UMB
+    artemis.forOfferings().sendMalformed(malformedJson);
+
+    // Then: Error is logged, the bad payload is not consumed, and the consumer continues
+    service.logs().assertContains("Unable to read UMB product message for JSON");
+    assertEquals(
+        consumeLogsBefore,
+        countLogsContaining("IT Product message consumed: source=umb"),
+        "Malformed JSON must not produce a consume log");
+    thenUmbConsumerAcceptsSubsequentMessages();
+  }
+
+  private OperationalProductEvent givenParentSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
+  }
+
+  private OperationalProductEvent givenChildSkuEvent(String productCode) {
+    return givenProductEvent(productCode, ProductCategoryEnum.CHILD_SKU);
+  }
+
+  private OperationalProductEvent givenProductEvent(
+      String productCode, ProductCategoryEnum category) {
+    OperationalProductEvent event = new OperationalProductEvent();
+    event.setProductCode(productCode);
+    event.setProductCategory(category);
+    event.setEventType(EventTypeEnum.UPDATE);
+    event.setOccurredOn(OffsetDateTime.now().toString());
+    return event;
+  }
+
+  private void whenUmbMessageIsPublished(OperationalProductEvent event) {
+    artemis.forOfferings().send(event);
+  }
+
+  private void thenUmbConsumerAcceptsSubsequentMessages() {
+    OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+    whenUmbMessageIsPublished(probe);
+    thenMessageIsConsumedWithChildSkuFlag(probe, false);
+  }
+
+  private void thenMessageIsConsumedWithChildSkuFlag(
+      OperationalProductEvent event, boolean isChildSku) {
+    service
+        .logs()
+        .assertContains(
+            String.format(
+                "IT Product message consumed: source=umb, productCode=%s, eventType=%s, "
+                    + "productCategory=%s, childSku=%s",
+                event.getProductCode(),
+                event.getEventType(),
+                event.getProductCategory(),
+                isChildSku));
+  }
+
+  private void thenSyncServiceWasInvoked(OperationalProductEvent event) {
+    service
+        .logs()
+        .assertContains("Received product message for productSku=" + event.getProductCode());
+  }
+
+  private int countLogsContaining(String text) {
+    return (int) service.getLogs().stream().filter(line -> line.contains(text)).count();
+  }
+}

--- a/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ProductUmbComponentTest.java
@@ -27,14 +27,11 @@ import com.redhat.swatch.component.tests.api.Artemis;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import com.redhat.swatch.contract.test.model.OperationalProductEvent;
-import com.redhat.swatch.contract.test.model.OperationalProductEvent.EventTypeEnum;
-import com.redhat.swatch.contract.test.model.OperationalProductEvent.ProductCategoryEnum;
-import java.time.OffsetDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ProductUmbComponentTest extends BaseContractComponentTest {
+public class ProductUmbComponentTest extends BaseProductConsumerComponentTest {
 
   @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
 
@@ -58,7 +55,7 @@ public class ProductUmbComponentTest extends BaseContractComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: Message is consumed and the offering sync service is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, false);
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
     thenSyncServiceWasInvoked(event);
   }
 
@@ -72,7 +69,7 @@ public class ProductUmbComponentTest extends BaseContractComponentTest {
     whenUmbMessageIsPublished(event);
 
     // Then: Message is consumed with childSku flag as true and sync is invoked
-    thenMessageIsConsumedWithChildSkuFlag(event, true);
+    thenMessageIsConsumedWithChildSkuFlag(event, true, "umb");
     thenSyncServiceWasInvoked(event);
   }
 
@@ -95,46 +92,80 @@ public class ProductUmbComponentTest extends BaseContractComponentTest {
     thenUmbConsumerAcceptsSubsequentMessages();
   }
 
-  private OperationalProductEvent givenParentSkuEvent(String productCode) {
-    return givenProductEvent(productCode, ProductCategoryEnum.PARENT_SKU);
+  @TestPlanName("product-umb-TC005")
+  @Test
+  void shouldIgnoreMessageWhenFeatureFlagDisabled() {
+    // Given: Feature flag is disabled and a valid parent SKU event
+    unleash.disableProductServiceConsumer();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: Consumer is disabled and the message is not processed
+    thenUmbConsumerReportsDisabled();
+    thenMessageIsNotConsumed(event, "umb");
+    thenSyncServiceWasNotInvoked(event);
   }
 
-  private OperationalProductEvent givenChildSkuEvent(String productCode) {
-    return givenProductEvent(productCode, ProductCategoryEnum.CHILD_SKU);
+  @TestPlanName("product-umb-TC006")
+  @Test
+  void shouldIgnoreMessageWhenUmbDisabledViaVariant() {
+    // Given: Flag enabled with Kafka enabled and UMB disabled via variant
+    unleash.enableProductServiceConsumerKafkaOnly();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: UMB is independently disabled
+    thenUmbConsumerReportsDisabled();
+    thenMessageIsNotConsumed(event, "umb");
+    thenSyncServiceWasNotInvoked(event);
   }
 
-  private OperationalProductEvent givenProductEvent(
-      String productCode, ProductCategoryEnum category) {
-    OperationalProductEvent event = new OperationalProductEvent();
-    event.setProductCode(productCode);
-    event.setProductCategory(category);
-    event.setEventType(EventTypeEnum.UPDATE);
-    event.setOccurredOn(OffsetDateTime.now().toString());
-    return event;
+  @TestPlanName("product-umb-TC007")
+  @Test
+  void shouldProcessWhenUmbEnabledAndKafkaDisabled() {
+    // Given: Flag enabled with UMB enabled and Kafka disabled via variant
+    unleash.enableProductServiceConsumerUmbOnly();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: UMB consumes independently and the sync service is invoked
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
+    thenSyncServiceWasInvoked(event);
+  }
+
+  @TestPlanName("product-umb-TC008")
+  @Test
+  void shouldProcessMessageWhenBothConsumersEnabled() {
+    // Given: Flag enabled with both Kafka and UMB consumers enabled via variant
+    unleash.enableProductServiceConsumerBothConsumers();
+    OperationalProductEvent event = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
+
+    // When: Publishing message to UMB
+    whenUmbMessageIsPublished(event);
+
+    // Then: UMB consumes and the sync service is invoked
+    thenMessageIsConsumedWithChildSkuFlag(event, false, "umb");
+    thenSyncServiceWasInvoked(event);
   }
 
   private void whenUmbMessageIsPublished(OperationalProductEvent event) {
     artemis.forOfferings().send(event);
   }
 
+  private void thenUmbConsumerReportsDisabled() {
+    service.logs().assertContains("IT Product UMB consumer is disabled by feature flag.");
+  }
+
   private void thenUmbConsumerAcceptsSubsequentMessages() {
     OperationalProductEvent probe = givenParentSkuEvent("RH" + RandomUtils.generateRandom());
     whenUmbMessageIsPublished(probe);
-    thenMessageIsConsumedWithChildSkuFlag(probe, false);
-  }
-
-  private void thenMessageIsConsumedWithChildSkuFlag(
-      OperationalProductEvent event, boolean isChildSku) {
-    service
-        .logs()
-        .assertContains(
-            String.format(
-                "IT Product message consumed: source=umb, productCode=%s, eventType=%s, "
-                    + "productCategory=%s, childSku=%s",
-                event.getProductCode(),
-                event.getEventType(),
-                event.getProductCategory(),
-                isChildSku));
+    thenMessageIsConsumedWithChildSkuFlag(probe, false, "umb");
   }
 
   private void thenSyncServiceWasInvoked(OperationalProductEvent event) {
@@ -143,7 +174,9 @@ public class ProductUmbComponentTest extends BaseContractComponentTest {
         .assertContains("Received product message for productSku=" + event.getProductCode());
   }
 
-  private int countLogsContaining(String text) {
-    return (int) service.getLogs().stream().filter(line -> line.contains(text)).count();
+  private void thenSyncServiceWasNotInvoked(OperationalProductEvent event) {
+    service
+        .logs()
+        .assertDoesNotContain("Received product message for productSku=" + event.getProductCode());
   }
 }

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 @TestProfile(EnableUmbResource.class)
 class ProductStatusUMBMessageConsumerTest {
 
-  private static final String VALID_JSON_MESSAGE =
+  static final String VALID_JSON_MESSAGE =
       """
         {
           "occurredOn": "2023-05-29T16:00:54.279Z",

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerWhenUmbDisabledTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerWhenUmbDisabledTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.redhat.swatch.contract.openapi.model.OperationalProductEvent;
+import com.redhat.swatch.contract.test.LoggerCaptor;
+import com.redhat.swatch.contract.test.resources.DisableUmbResource;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(DisableUmbResource.class)
+class ProductStatusUMBMessageConsumerWhenUmbDisabledTest {
+
+  @InjectMock OfferingSyncService offeringSyncService;
+  @InjectSpy ProductStatusUMBMessageConsumer consumer;
+
+  @BeforeAll
+  static void configureLogging() {
+    LoggerCaptor.registerHandler(ProductStatusUMBMessageConsumer.class);
+  }
+
+  @BeforeEach
+  void setUp() {
+    LoggerCaptor.clearRecords();
+  }
+
+  @Test
+  void shouldIgnoreMessagesWhenUmbIsNotEnabled() {
+    consumer.consumeMessage(ProductStatusUMBMessageConsumerTest.VALID_JSON_MESSAGE);
+    verify(consumer, never())
+        .consumeProduct(ProductStatusUMBMessageConsumerTest.VALID_JSON_MESSAGE);
+    verify(offeringSyncService, never()).syncProductFromEvent(any(OperationalProductEvent.class));
+  }
+}

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerWhenUmbDisabledTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ProductStatusUMBMessageConsumerWhenUmbDisabledTest.java
@@ -52,6 +52,7 @@ class ProductStatusUMBMessageConsumerWhenUmbDisabledTest {
     LoggerCaptor.clearRecords();
   }
 
+  // product-umb-TC004
   @Test
   void shouldIgnoreMessagesWhenUmbIsNotEnabled() {
     consumer.consumeMessage(ProductStatusUMBMessageConsumerTest.VALID_JSON_MESSAGE);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/DisableUmbResource.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/test/resources/DisableUmbResource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.contract.test.resources;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class DisableUmbResource implements QuarkusTestProfile {
+
+  @Override
+  public Map<String, String> getConfigOverrides() {
+    return Map.of("UMB_ENABLED", "false");
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
@@ -39,6 +39,7 @@ public final class Topics {
   public static final String CAPACITY_RECONCILE = SUFFIX + "capacity-reconcile";
   public static final String IT_SUBSCRIPTION_SYNC = "subscription.subscriptions.private";
   public static final String EXPORT_REQUESTS = "platform.export.requests";
+  public static final String IT_PRODUCT_SYNC = "product-service.operationalproduct.protected";
 
   private Topics() {}
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5082


## Description

- Adds component tests for the IT Product Service Kafka and UMB consumers: parent/child SKU happy paths, malformed JSON, Unleash flag and variant gating, duplicate-SKU processing on both channels, and edge payloads (missing fields, empty JSON, extra fields).
- Covers product-umb-TC004 (UMB_ENABLED=false) as a unit test. That property is fixed at startup in the shared quarkus:dev component-test process, so it cannot be flipped per test.
- Updates COMPONENT_TEST_PLAN.md to match production behavior: topic product-service.operationalproduct.protected, UMB address VirtualTopic.services.productservice.Product, consume/sync log assertions, and Unleash flag swatch.swatch-contracts.enable-product-service-consumer.

## Testing
**Unit tests**
```
./mvnw test -pl swatch-contracts \
  -Dtest=ProductStatusKafkaMessageConsumerTest,ProductStatusUMBMessageConsumerTest,ProductStatusUMBMessageConsumerWhenUmbDisabledTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dquarkus.analytics.disabled=true
```

**Component tests**
```
./mvnw test -pl swatch-contracts/ct -Pcomponent-tests \
  -Dtest=ProductKafkaComponentTest,ProductUmbComponentTest,ProductDuplicateComponentTest,ProductEdgeComponentTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dquarkus.analytics.disabled=true
```
