### PR TITLE
Revert ACM managed/self-managed dimension split

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
+++ b/src/main/java/org/candlepin/subscriptions/tally/export/InstancesCsvDataMapperService.java
@@ -54,24 +54,16 @@ public class InstancesCsvDataMapperService implements DataMapperService<TallyIns
   private final HostRepository hostRepository;
 
   public static final Map<MetricId, ObjDoubleConsumer<InstancesExportCsvItem>> METRIC_MAPPER =
-      Map.ofEntries(
-          Map.entry(MetricIdUtils.getCores(), InstancesExportCsvItem::setMeasurementCores),
-          Map.entry(
-              MetricIdUtils.getInstanceHours(),
-              InstancesExportCsvItem::setMeasurementInstanceHours),
-          Map.entry(MetricIdUtils.getSockets(), InstancesExportCsvItem::setMeasurementSockets),
-          Map.entry(
-              MetricIdUtils.getStorageGibibyteMonths(),
-              InstancesExportCsvItem::setMeasurementStorageGibibyteMonths),
-          Map.entry(
-              MetricIdUtils.getTransferGibibytes(),
-              InstancesExportCsvItem::setMeasurementTransferGibibytes),
-          Map.entry(MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus),
-          Map.entry(
-              MetricIdUtils.getManagedNodes(), InstancesExportCsvItem::setMeasurementManagedNodes),
-          Map.entry(
-              MetricIdUtils.getVCpusSelfManaged(),
-              InstancesExportCsvItem::setMeasurementVcpusSelfManaged));
+      Map.of(
+          MetricIdUtils.getCores(), InstancesExportCsvItem::setMeasurementCores,
+          MetricIdUtils.getInstanceHours(), InstancesExportCsvItem::setMeasurementInstanceHours,
+          MetricIdUtils.getSockets(), InstancesExportCsvItem::setMeasurementSockets,
+          MetricIdUtils.getStorageGibibyteMonths(),
+              InstancesExportCsvItem::setMeasurementStorageGibibyteMonths,
+          MetricIdUtils.getTransferGibibytes(),
+              InstancesExportCsvItem::setMeasurementTransferGibibytes,
+          MetricIdUtils.getVCpus(), InstancesExportCsvItem::setMeasurementVcpus,
+          MetricIdUtils.getManagedNodes(), InstancesExportCsvItem::setMeasurementManagedNodes);
 
   @Override
   public List<Object> mapDataItem(TallyInstanceView item, ExportServiceRequest request) {

--- a/swatch-core/schemas/instances_export_csv_item.yaml
+++ b/swatch-core/schemas/instances_export_csv_item.yaml
@@ -36,9 +36,6 @@ properties:
   measurement_managed_nodes:
     type: number
     format: double
-  measurement_vcpus_self_managed:
-    type: number
-    format: double
   category:
     type: string
   last_seen:

--- a/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
+++ b/swatch-product-configuration/src/main/java/com/redhat/swatch/configuration/util/MetricIdUtils.java
@@ -62,10 +62,6 @@ public class MetricIdUtils {
     return MetricId.fromString("Managed-nodes");
   }
 
-  public static MetricId getVCpusSelfManaged() {
-    return MetricId.fromString("vCPUs-self-managed");
-  }
-
   public static Stream<MetricId> getMetricIdsFromConfigForTag(String tag) {
     return getMetricIdsFromConfigForVariant(Variant.findByTag(tag).orElse(null));
   }

--- a/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
+++ b/swatch-product-configuration/src/main/resources/subscription_configs/OpenShift/rhacm.yaml
@@ -23,22 +23,10 @@ metrics:
   - id: vCPUs
     type: counter
     awsDimension: acm_vcpu_hours
-    azureDimension: acm_vcpu_hours_mng
     prometheus:
       queryKey: rosa
       queryParams:
         instanceKey: _id
         productLabelRegex: (moa-hostedcontrolplane|moa)
-        metric: acm:managed_cluster_worker_cores:managed:sum
-        metadataMetric: ocm_subscription
-  - id: vCPUs-self-managed
-    type: counter
-    awsDimension: acm_vcpu_hours_slfmng
-    azureDimension: acm_vcpu_hours_slfmng
-    prometheus:
-      queryKey: rosa
-      queryParams:
-        instanceKey: _id
-        productLabelRegex: (moa-hostedcontrolplane|moa|ocp-assistedinstall)
-        metric: acm:managed_cluster_worker_cores:self_managed:sum
+        metric: acm_capacity_effective_cpu_cores:sum
         metadataMetric: ocm_subscription


### PR DESCRIPTION
## Summary
- Reverts #6549 ("Split the ACM offering into managed & self-managed dimensions") and #6557 ("Add vCPUs-self-managed metric to CSV export mapper")
- Temporarily reverting these changes to verify a release candidate without them

## Test plan
- [ ] Confirm rhacm.yaml is restored to the single `vCPUs` metric
- [ ] Confirm CSV export no longer includes `measurement_vcpus_self_managed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated instance exports to remove the self-managed vCPU measurement field.
  * Revised the vCPU metric configuration to use effective CPU cores.
  * Removed the separate self-managed vCPU metric from subscription configuration.
* **Bug Fixes**
  * Improved consistency between configured metrics and the fields included in instance export data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->