### PR TITLE
Swatch-metrics CT ACM Metrics Split

### DIFF
--- a/swatch-metrics/COMPONENT_TEST_PLAN.md
+++ b/swatch-metrics/COMPONENT_TEST_PLAN.md
@@ -4,7 +4,7 @@ The **swatch-metrics** module is a service within the Subscription Watch platfor
 
 The service queries Prometheus for usage data (such as vCPUs), enriches the metrics with subscription metadata (organization, billing provider, product identifiers), and publishes metering events to Kafka for downstream consumption by billing systems.
 
-This document outlines the test plan for swatch-metrics, which involves Prometheus-based metering for RHEL PAYG products.
+This document outlines the test plan for swatch-metrics, which involves Prometheus-based metering for RHEL PAYG and ACM products.
 
 **Purpose:** To ensure the swatch-metrics service is functional, reliable, and meets all defined requirements for Prometheus metric collection and metering event generation.
 
@@ -14,6 +14,7 @@ This document outlines the test plan for swatch-metrics, which involves Promethe
 * Internal metering API
 * Metering event production to Kafka
 * RHEL PAYG addon product metering
+* ACM (Advanced Cluster Management) managed and self-managed worker cores metering
 
 **Assumptions:**
 
@@ -39,16 +40,136 @@ Test cases should be testable locally and in ephemeral environments.
 
 **swatch-metrics-prometheus-TC001 - Process RHEL PAYG addon metrics from Prometheus**
 
-- **Description**: Verify swatch-metrics translates Prometheus metrics to swatch-events for RHEL PAYG products.
+- **Description**: Verify swatch-metrics translates `system_cpu_logical_count` Prometheus metrics to metering events for RHEL PAYG addon products with AWS billing.
 - **Setup**:
-  - Prometheus and Kafka services running
-  - Prepare RHEL PAYG addon metrics with vCPU data for AWS billing provider
-  - Import metrics to Prometheus
+  - Mock Prometheus returns `system_cpu_logical_count` metric with value 4.0
+  - Labels include: `product=204`, `billing_model=marketplace`, `support=Premium`, `usage=Production`
+  - Instance ID, org ID, AWS billing provider and account ID are randomly generated
 - **Action**:
-  - Trigger internal metering API
+  - Trigger internal metering API for `rhel-for-x86-els-payg-addon` product
 - **Verification**:
-  - Wait for metering events on Kafka topic
-  - Verify event contains correct metadata and measurements
+  - Wait for metering event on `service-instance-ingress` Kafka topic
+  - Verify event metadata: org ID matches, instance ID matches
+  - Verify billing provider is AWS and billing account ID matches
+  - Verify product tag contains `rhel-for-x86-els-payg-addon`
+  - Verify measurement contains metric ID `vCPUs` with value 4.0
 - **Expected Result**:
   - HTTP 204 response from metering API
-  - Events produced with accurate billing information, product data, and vCPU measurements
+  - Event produced with vCPUs metric value of 4.0, AWS billing provider, and RHEL PAYG product tag
+
+**swatch-metrics-prometheus-TC002 - Process ACM managed worker cores metrics from Prometheus (AWS)**
+
+- **Description**: Verify swatch-metrics translates `acm:managed_cluster_worker_cores:managed:sum` Prometheus metrics to metering events for ACM products with AWS billing.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:managed:sum` with value 8.0
+  - Labels include: `_id` (cluster ID), `product=moa`, `billing_marketplace=aws`, `billing_model=marketplace`
+  - Cluster ID, org ID, and AWS billing account ID are randomly generated
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag
+- **Verification**:
+  - Wait for metering event on `service-instance-ingress` Kafka topic filtered by cluster ID and metric ID `vCPUs`
+  - Verify event metadata: org ID matches, instance ID equals cluster ID, display name equals cluster ID
+  - Verify billing provider is `AWS` and billing account ID matches stubbed value
+  - Verify product tag contains `rhacm`
+  - Verify measurement contains metric ID `vCPUs` with value 8.0
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Event produced with vCPUs metric value of 8.0, AWS billing provider, cluster ID as instance ID, and rhacm product tag
+
+**swatch-metrics-prometheus-TC003 - Process ACM managed worker cores metrics from Prometheus (Azure)**
+
+- **Description**: Verify swatch-metrics translates `acm:managed_cluster_worker_cores:managed:sum` Prometheus metrics to metering events for ACM products with Azure billing.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:managed:sum` with value 16.0
+  - Labels include: `_id` (cluster ID), `product=moa`, `billing_marketplace=azure`, `billing_model=marketplace`
+  - Cluster ID, org ID, and Azure billing account ID are randomly generated
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag
+- **Verification**:
+  - Wait for metering event on `service-instance-ingress` Kafka topic filtered by cluster ID and metric ID `vCPUs`
+  - Verify event metadata: org ID matches, instance ID equals cluster ID, display name equals cluster ID
+  - Verify billing provider is `AZURE` and billing account ID matches stubbed value
+  - Verify product tag contains `rhacm`
+  - Verify measurement contains metric ID `vCPUs` with value 16.0
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Event produced with vCPUs metric value of 16.0, Azure billing provider, cluster ID as instance ID, and rhacm product tag
+
+**swatch-metrics-prometheus-TC004 - Process ACM self-managed worker cores metrics from Prometheus (AWS)**
+
+- **Description**: Verify swatch-metrics translates `acm:managed_cluster_worker_cores:self_managed:sum` Prometheus metrics to metering events for ACM products with AWS billing.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:self_managed:sum` with value 12.0
+  - Labels include: `_id` (cluster ID), `product=moa`, `billing_marketplace=aws`, `billing_model=marketplace`
+  - Cluster ID, org ID, and AWS billing account ID are randomly generated
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag
+- **Verification**:
+  - Wait for metering event on `service-instance-ingress` Kafka topic filtered by cluster ID and metric ID `vCPUs-self-managed`
+  - Verify event metadata: org ID matches, instance ID equals cluster ID, display name equals cluster ID
+  - Verify billing provider is `AWS` and billing account ID matches stubbed value
+  - Verify product tag contains `rhacm`
+  - Verify measurement contains metric ID `vCPUs-self-managed` with value 12.0
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Event produced with vCPUs-self-managed metric value of 12.0, AWS billing provider, cluster ID as instance ID, and rhacm product tag
+
+**swatch-metrics-prometheus-TC005 - Process ACM self-managed worker cores metrics from Prometheus (Azure)**
+
+- **Description**: Verify swatch-metrics translates `acm:managed_cluster_worker_cores:self_managed:sum` Prometheus metrics to metering events for ACM products with Azure billing.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:self_managed:sum` with value 20.0
+  - Labels include: `_id` (cluster ID), `product=moa`, `billing_marketplace=azure`, `billing_model=marketplace`
+  - Cluster ID, org ID, and Azure billing account ID are randomly generated
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag
+- **Verification**:
+  - Wait for metering event on `service-instance-ingress` Kafka topic filtered by cluster ID and metric ID `vCPUs-self-managed`
+  - Verify event metadata: org ID matches, instance ID equals cluster ID, display name equals cluster ID
+  - Verify billing provider is `AZURE` and billing account ID matches stubbed value
+  - Verify product tag contains `rhacm`
+  - Verify measurement contains metric ID `vCPUs-self-managed` with value 20.0
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Event produced with vCPUs-self-managed metric value of 20.0, Azure billing provider, cluster ID as instance ID, and rhacm product tag
+
+**swatch-metrics-prometheus-TC006 - Process ACM managed and self-managed cores for same cluster**
+
+- **Description**: Verify swatch-metrics correctly produces separate metering events when a single cluster reports both `acm:managed_cluster_worker_cores:managed:sum` and `acm:managed_cluster_worker_cores:self_managed:sum` metrics in one metering run.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:managed:sum` with value 10.0
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:self_managed:sum` with value 15.0
+  - Both metrics share the same `_id` (cluster ID), org ID, and AWS billing details
+  - Labels include: `product=moa`, `billing_marketplace=aws`, `billing_model=marketplace`
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag once
+- **Verification**:
+  - Wait for metering events on `service-instance-ingress` Kafka topic filtered by cluster ID
+  - Verify events are produced for both dimensions on the cluster
+  - Managed event: metric ID `vCPUs` with value 10.0
+  - Self-managed event: metric ID `vCPUs-self-managed` with value 15.0
+  - Both events have matching metadata (org ID, instance ID equals cluster ID, AWS billing provider)
+  - Verify values do not cross-contaminate between dimensions (managed reports 10.0, self-managed reports 15.0)
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Distinct events produced for each dimension: managed (vCPUs=10.0) and self-managed (vCPUs-self-managed=15.0), both for the same cluster
+
+**swatch-metrics-prometheus-TC007 - ACM product label regex filters self-managed-only products**
+
+- **Description**: Verify swatch-metrics respects dimension-specific `productLabelRegex` filters. The self-managed dimension includes `ocp-assistedinstall` while the managed dimension does not, so clusters with `product=ocp-assistedinstall` should only produce self-managed events. The mock Prometheus matches the generated PromQL's `product=~"(...)"` selector, so the managed query (which excludes `ocp-assistedinstall`) returns no data — mirroring real Prometheus label filtering.
+- **Setup**:
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:managed:sum` with value 8.0, `product=ocp-assistedinstall`
+  - Mock Prometheus returns metric `acm:managed_cluster_worker_cores:self_managed:sum` with value 12.0, `product=ocp-assistedinstall`
+  - Both metrics share the same `_id` (cluster ID), org ID, and AWS billing details
+  - Labels include: `billing_marketplace=aws`, `billing_model=marketplace`
+- **Action**:
+  - Trigger internal metering API for `rhacm` product tag once
+- **Verification**:
+  - Wait for self-managed events on `service-instance-ingress` Kafka topic filtered by cluster ID
+  - Verify self-managed events are produced with metric ID `vCPUs-self-managed` and value 12.0
+  - Event metadata: org ID matches, instance ID equals cluster ID, AWS billing provider, rhacm product tag
+  - After the self-managed sync point, verify NO managed event (metric ID `vCPUs`) is produced despite the managed metric being stubbed — the managed `productLabelRegex` excludes `ocp-assistedinstall`
+- **Expected Result**:
+  - HTTP 204 response from metering API
+  - Self-managed events produced with vCPUs-self-managed metric value of 12.0
+  - No managed (vCPUs) event produced, demonstrating productLabelRegex filtering

--- a/swatch-metrics/ct/java/api/PrometheusStubs.java
+++ b/swatch-metrics/ct/java/api/PrometheusStubs.java
@@ -22,6 +22,7 @@ package api;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Stubs for mocking Prometheus API endpoints using WireMock.
@@ -35,6 +36,16 @@ public class PrometheusStubs {
 
   public PrometheusStubs(PrometheusWiremockService wiremock) {
     this.wiremock = wiremock;
+  }
+
+  /**
+   * Start building a Prometheus metric stub with a fluent API.
+   *
+   * @param metricName the Prometheus metric name (e.g., "system_cpu_logical_count")
+   * @return a builder for configuring labels and value
+   */
+  public PrometheusMetricStubBuilder metric(String metricName) {
+    return new PrometheusMetricStubBuilder(metricName);
   }
 
   /**
@@ -150,5 +161,70 @@ public class PrometheusStubs {
         .post("/__admin/mappings")
         .then()
         .statusCode(201);
+  }
+
+  /**
+   * Fluent builder for Prometheus metric stubs. Hides Prometheus label keys behind semantic method
+   * names and provides a clean API for test setup.
+   */
+  public class PrometheusMetricStubBuilder {
+    private final String metricName;
+    private final Map<String, String> labels = new LinkedHashMap<>();
+    private double metricValue;
+
+    PrometheusMetricStubBuilder(String metricName) {
+      this.metricName = Objects.requireNonNull(metricName, "metricName must not be null");
+      // billing_model is the only universal default
+      labels.put("billing_model", "marketplace");
+    }
+
+    public PrometheusMetricStubBuilder orgId(String orgId) {
+      labels.put("external_organization", orgId);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder displayName(String displayName) {
+      labels.put("display_name", displayName);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder instanceId(String instanceId) {
+      labels.put("billing_marketplace_instance_id", instanceId);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder product(String product) {
+      labels.put("product", product);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder billingProvider(String billingProvider) {
+      labels.put("billing_marketplace", billingProvider);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder billingAccountId(String billingAccountId) {
+      labels.put("billing_marketplace_account", billingAccountId);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder billingModel(String billingModel) {
+      labels.put("billing_model", billingModel);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder label(String key, String value) {
+      labels.put(key, value);
+      return this;
+    }
+
+    public PrometheusMetricStubBuilder value(double value) {
+      this.metricValue = value;
+      return this;
+    }
+
+    public void stub() {
+      stubQueryRangeWithMetricData(metricName, labels, metricValue);
+    }
   }
 }

--- a/swatch-metrics/ct/java/api/PrometheusStubs.java
+++ b/swatch-metrics/ct/java/api/PrometheusStubs.java
@@ -82,6 +82,22 @@ public class PrometheusStubs {
     responseBody.put("status", "success");
     responseBody.put("data", data);
 
+    // Match the query on both the metric name and the series' product label. This mirrors how
+    // Prometheus itself filters: the generated PromQL embeds a product=~"(...)" selector, so a
+    // series is only returned when the query's product filter includes that series' product. Two
+    // metrics that share a cluster but differ in productLabelRegex (e.g. ACM managed vs
+    // self-managed) therefore behave exactly as they would against a real Prometheus.
+    Object queryMatcher;
+    String product = labels != null ? labels.get("product") : null;
+    if (product != null && !product.isBlank()) {
+      queryMatcher =
+          Map.of(
+              "and",
+              java.util.List.of(Map.of("contains", metricName), Map.of("contains", product)));
+    } else {
+      queryMatcher = Map.of("contains", metricName);
+    }
+
     Map<String, Object> mapping = new LinkedHashMap<>();
     mapping.put(
         "request",
@@ -91,7 +107,7 @@ public class PrometheusStubs {
             "urlPathPattern",
             "/api/v1/query_range",
             "queryParameters",
-            Map.of("query", Map.of("contains", metricName))));
+            Map.of("query", queryMatcher)));
     Map<String, Object> response = new LinkedHashMap<>();
     response.put("status", 200);
     response.put("headers", Map.of("Content-Type", "application/json"));

--- a/swatch-metrics/ct/java/tests/BaseMetricsComponentTest.java
+++ b/swatch-metrics/ct/java/tests/BaseMetricsComponentTest.java
@@ -68,4 +68,18 @@ public class BaseMetricsComponentTest {
         MessageValidators.isEventForInstance(instanceId, metricId),
         1);
   }
+
+  /**
+   * Returns matching events already present on the topic without blocking for new ones. Used to
+   * assert the <em>absence</em> of events: an expected count of 0 makes the underlying consumer
+   * return immediately with whatever currently matches instead of blocking until timeout. Only
+   * reliable after a synchronization point (e.g. a later event in the same metering run has already
+   * been observed), so any earlier event would already be cached.
+   */
+  protected List<Event> thenEventsAlreadyProduced(String instanceId, String metricId) {
+    return kafkaBridge.waitForKafkaMessage(
+        SWATCH_SERVICE_INSTANCE_INGRESS,
+        MessageValidators.isEventForInstance(instanceId, metricId),
+        0);
+  }
 }

--- a/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
+++ b/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.candlepin.subscriptions.json.Event;
+import org.candlepin.subscriptions.json.Measurement;
+import org.junit.jupiter.api.Test;
+
+class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
+
+  private static final String ACM_PRODUCT_TAG = "rhacm";
+  private static final String VCPUS_METRIC_ID = VCPUS.getValue();
+  private static final String VCPUS_SELF_MANAGED_METRIC_ID = "vCPUs-self-managed";
+  private static final int METERING_API_RANGE_MINUTES = 120;
+
+  @Test
+  void shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAws() {
+    // Given: ACM managed cores metrics from mock Prometheus with AWS billing
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "aws";
+    String billingAccountId = "aws-" + RandomUtils.generateRandom();
+    double expectedCores = 8.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    givenPrometheusReturnsAcmManagedMetrics(
+        clusterId, billingProvider, billingAccountId, expectedCores);
+
+    // When: Internal metering is triggered
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Metering events are produced with managed cores metric
+    var events = thenEventsAreProduced(clusterId, VCPUS_METRIC_ID);
+    assertFalse(events.isEmpty(), "Events should be produced");
+
+    Event event = events.get(0);
+    thenEventHasCorrectMetadata(event, clusterId);
+    thenEventHasCorrectBillingInfo(event, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(event);
+    thenEventHasCorrectMeasurements(event, VCPUS_METRIC_ID, expectedCores);
+  }
+
+  @Test
+  void shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAzure() {
+    // Given: ACM managed cores metrics from mock Prometheus with Azure billing
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "azure";
+    String billingAccountId = "azure-" + RandomUtils.generateRandom();
+    double expectedCores = 16.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    givenPrometheusReturnsAcmManagedMetrics(
+        clusterId, billingProvider, billingAccountId, expectedCores);
+
+    // When: Internal metering is triggered
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Metering events are produced with managed cores metric
+    var events = thenEventsAreProduced(clusterId, VCPUS_METRIC_ID);
+    assertFalse(events.isEmpty(), "Events should be produced");
+
+    Event event = events.get(0);
+    thenEventHasCorrectMetadata(event, clusterId);
+    thenEventHasCorrectBillingInfo(event, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(event);
+    thenEventHasCorrectMeasurements(event, VCPUS_METRIC_ID, expectedCores);
+  }
+
+  @Test
+  void shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAws() {
+    // Given: ACM self-managed cores metrics from mock Prometheus with AWS billing
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "aws";
+    String billingAccountId = "aws-" + RandomUtils.generateRandom();
+    double expectedCores = 12.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    givenPrometheusReturnsAcmSelfManagedMetrics(
+        clusterId, billingProvider, billingAccountId, expectedCores);
+
+    // When: Internal metering is triggered
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Metering events are produced with self-managed cores metric
+    var events = thenEventsAreProduced(clusterId, VCPUS_SELF_MANAGED_METRIC_ID);
+    assertFalse(events.isEmpty(), "Events should be produced");
+
+    Event event = events.get(0);
+    thenEventHasCorrectMetadata(event, clusterId);
+    thenEventHasCorrectBillingInfo(event, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(event);
+    thenEventHasCorrectMeasurements(event, VCPUS_SELF_MANAGED_METRIC_ID, expectedCores);
+  }
+
+  @Test
+  void shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAzure() {
+    // Given: ACM self-managed cores metrics from mock Prometheus with Azure billing
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "azure";
+    String billingAccountId = "azure-" + RandomUtils.generateRandom();
+    double expectedCores = 20.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    givenPrometheusReturnsAcmSelfManagedMetrics(
+        clusterId, billingProvider, billingAccountId, expectedCores);
+
+    // When: Internal metering is triggered
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Metering events are produced with self-managed cores metric
+    var events = thenEventsAreProduced(clusterId, VCPUS_SELF_MANAGED_METRIC_ID);
+    assertFalse(events.isEmpty(), "Events should be produced");
+
+    Event event = events.get(0);
+    thenEventHasCorrectMetadata(event, clusterId);
+    thenEventHasCorrectBillingInfo(event, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(event);
+    thenEventHasCorrectMeasurements(event, VCPUS_SELF_MANAGED_METRIC_ID, expectedCores);
+  }
+
+  private static OffsetDateTime currentUtcHourStart() {
+    return OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
+  }
+
+  private void givenPrometheusReturnsAcmManagedMetrics(
+      String clusterId, String billingProvider, String billingAccountId, double coresValue) {
+    Map<String, String> labels = buildAcmLabels(clusterId, billingProvider, billingAccountId);
+    wiremock
+        .forPrometheus()
+        .stubQueryRangeWithMetricData(
+            "acm:managed_cluster_worker_cores:managed:sum", labels, coresValue);
+  }
+
+  private void givenPrometheusReturnsAcmSelfManagedMetrics(
+      String clusterId, String billingProvider, String billingAccountId, double coresValue) {
+    Map<String, String> labels = buildAcmLabels(clusterId, billingProvider, billingAccountId);
+    wiremock
+        .forPrometheus()
+        .stubQueryRangeWithMetricData(
+            "acm:managed_cluster_worker_cores:self_managed:sum", labels, coresValue);
+  }
+
+  private Map<String, String> buildAcmLabels(
+      String clusterId, String billingProvider, String billingAccountId) {
+    Map<String, String> labels = new java.util.HashMap<>();
+    labels.put("_id", clusterId);
+    labels.put("billing_marketplace", billingProvider);
+    labels.put("billing_marketplace_account", billingAccountId);
+    labels.put("billing_model", "marketplace");
+    labels.put("display_name", clusterId);
+    labels.put("external_organization", orgId);
+    labels.put("product", "moa");
+    return labels;
+  }
+
+  private void thenEventHasCorrectMetadata(Event event, String clusterId) {
+    assertNotNull(event.getEventSource(), "event_source should not be null");
+    assertEquals(orgId, event.getOrgId(), "org_id should match");
+    assertEquals(clusterId, event.getInstanceId(), "instance_id should match");
+    assertEquals(
+        clusterId, event.getDisplayName().orElse(null), "display_name should match cluster_id");
+    assertNotNull(event.getMeteringBatchId(), "metering_batch_id should not be null");
+    assertNotNull(event.getTimestamp(), "timestamp should not be null");
+    assertNotNull(event.getExpiration(), "expiration should not be null");
+  }
+
+  private void thenEventHasCorrectBillingInfo(
+      Event event, String billingProvider, String billingAccountId) {
+    assertEquals(
+        Event.BillingProvider.valueOf(billingProvider.toUpperCase()),
+        event.getBillingProvider(),
+        "billing_provider should match");
+    assertEquals(
+        billingAccountId,
+        event.getBillingAccountId().orElse(null),
+        "billing_account_id should match");
+  }
+
+  private void thenEventHasCorrectProductInfo(Event event) {
+    assertNotNull(event.getProductTag(), "product_tag should not be null");
+    assertFalse(event.getProductTag().isEmpty(), "product_tag should not be empty");
+    assertTrue(
+        event.getProductTag().contains(ACM_PRODUCT_TAG), "product_tag should contain expected tag");
+  }
+
+  private void thenEventHasCorrectMeasurements(Event event, String metricId, double expectedValue) {
+    assertFalse(event.getMeasurements().isEmpty(), "measurements should not be empty");
+
+    Measurement measurement = event.getMeasurements().get(0);
+    assertEquals(metricId, measurement.getMetricId(), "metric_id should match");
+    assertEquals(expectedValue, measurement.getValue(), 0.01, "metric value should match");
+  }
+}

--- a/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
+++ b/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
@@ -29,7 +29,6 @@ import com.redhat.swatch.component.tests.utils.RandomUtils;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Measurement;
 import org.junit.jupiter.api.Test;
@@ -50,8 +49,17 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     double expectedCores = 8.0;
     OffsetDateTime meteringEnd = currentUtcHourStart();
 
-    givenPrometheusReturnsAcmManagedMetrics(
-        clusterId, billingProvider, billingAccountId, expectedCores);
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedCores)
+        .stub();
 
     // When: Internal metering is triggered
     service.triggerInternalMetering(
@@ -77,8 +85,17 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     double expectedCores = 16.0;
     OffsetDateTime meteringEnd = currentUtcHourStart();
 
-    givenPrometheusReturnsAcmManagedMetrics(
-        clusterId, billingProvider, billingAccountId, expectedCores);
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedCores)
+        .stub();
 
     // When: Internal metering is triggered
     service.triggerInternalMetering(
@@ -104,8 +121,17 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     double expectedCores = 12.0;
     OffsetDateTime meteringEnd = currentUtcHourStart();
 
-    givenPrometheusReturnsAcmSelfManagedMetrics(
-        clusterId, billingProvider, billingAccountId, expectedCores);
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:self_managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedCores)
+        .stub();
 
     // When: Internal metering is triggered
     service.triggerInternalMetering(
@@ -131,8 +157,17 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     double expectedCores = 20.0;
     OffsetDateTime meteringEnd = currentUtcHourStart();
 
-    givenPrometheusReturnsAcmSelfManagedMetrics(
-        clusterId, billingProvider, billingAccountId, expectedCores);
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:self_managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedCores)
+        .stub();
 
     // When: Internal metering is triggered
     service.triggerInternalMetering(
@@ -151,37 +186,6 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
 
   private static OffsetDateTime currentUtcHourStart() {
     return OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.HOURS);
-  }
-
-  private void givenPrometheusReturnsAcmManagedMetrics(
-      String clusterId, String billingProvider, String billingAccountId, double coresValue) {
-    Map<String, String> labels = buildAcmLabels(clusterId, billingProvider, billingAccountId);
-    wiremock
-        .forPrometheus()
-        .stubQueryRangeWithMetricData(
-            "acm:managed_cluster_worker_cores:managed:sum", labels, coresValue);
-  }
-
-  private void givenPrometheusReturnsAcmSelfManagedMetrics(
-      String clusterId, String billingProvider, String billingAccountId, double coresValue) {
-    Map<String, String> labels = buildAcmLabels(clusterId, billingProvider, billingAccountId);
-    wiremock
-        .forPrometheus()
-        .stubQueryRangeWithMetricData(
-            "acm:managed_cluster_worker_cores:self_managed:sum", labels, coresValue);
-  }
-
-  private Map<String, String> buildAcmLabels(
-      String clusterId, String billingProvider, String billingAccountId) {
-    Map<String, String> labels = new java.util.HashMap<>();
-    labels.put("_id", clusterId);
-    labels.put("billing_marketplace", billingProvider);
-    labels.put("billing_marketplace_account", billingAccountId);
-    labels.put("billing_model", "marketplace");
-    labels.put("display_name", clusterId);
-    labels.put("external_organization", orgId);
-    labels.put("product", "moa");
-    return labels;
   }
 
   private void thenEventHasCorrectMetadata(Event event, String clusterId) {

--- a/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
+++ b/swatch-metrics/ct/java/tests/SwatchMetricsAcmPrometheusTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -40,6 +41,7 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
   private static final String VCPUS_SELF_MANAGED_METRIC_ID = "vCPUs-self-managed";
   private static final int METERING_API_RANGE_MINUTES = 120;
 
+  @TestPlanName("swatch-metrics-prometheus-TC002")
   @Test
   void shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAws() {
     // Given: ACM managed cores metrics from mock Prometheus with AWS billing
@@ -76,6 +78,7 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     thenEventHasCorrectMeasurements(event, VCPUS_METRIC_ID, expectedCores);
   }
 
+  @TestPlanName("swatch-metrics-prometheus-TC003")
   @Test
   void shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAzure() {
     // Given: ACM managed cores metrics from mock Prometheus with Azure billing
@@ -112,6 +115,7 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     thenEventHasCorrectMeasurements(event, VCPUS_METRIC_ID, expectedCores);
   }
 
+  @TestPlanName("swatch-metrics-prometheus-TC004")
   @Test
   void shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAws() {
     // Given: ACM self-managed cores metrics from mock Prometheus with AWS billing
@@ -148,6 +152,7 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     thenEventHasCorrectMeasurements(event, VCPUS_SELF_MANAGED_METRIC_ID, expectedCores);
   }
 
+  @TestPlanName("swatch-metrics-prometheus-TC005")
   @Test
   void shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAzure() {
     // Given: ACM self-managed cores metrics from mock Prometheus with Azure billing
@@ -182,6 +187,130 @@ class SwatchMetricsAcmPrometheusTest extends BaseMetricsComponentTest {
     thenEventHasCorrectBillingInfo(event, billingProvider, billingAccountId);
     thenEventHasCorrectProductInfo(event);
     thenEventHasCorrectMeasurements(event, VCPUS_SELF_MANAGED_METRIC_ID, expectedCores);
+  }
+
+  @TestPlanName("swatch-metrics-prometheus-TC006")
+  @Test
+  void shouldCreateSeparateEventsForBothManagedAndSelfManagedCoresFromSameCluster() {
+    // Given: Single cluster reporting both managed and self-managed cores
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "aws";
+    String billingAccountId = "aws-" + RandomUtils.generateRandom();
+    double expectedManagedCores = 10.0;
+    double expectedSelfManagedCores = 15.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    // Stub both dimension metrics for the same cluster
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedManagedCores)
+        .stub();
+
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:self_managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("moa")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(expectedSelfManagedCores)
+        .stub();
+
+    // When: Internal metering is triggered once
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Two distinct events are produced - one for each dimension
+    var managedEvents = thenEventsAreProduced(clusterId, VCPUS_METRIC_ID);
+    assertFalse(managedEvents.isEmpty(), "Managed events should be produced");
+
+    var selfManagedEvents = thenEventsAreProduced(clusterId, VCPUS_SELF_MANAGED_METRIC_ID);
+    assertFalse(selfManagedEvents.isEmpty(), "Self-managed events should be produced");
+
+    // Verify managed event has correct value (verifies no cross-contamination)
+    Event managedEvent = managedEvents.get(0);
+    thenEventHasCorrectMetadata(managedEvent, clusterId);
+    thenEventHasCorrectBillingInfo(managedEvent, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(managedEvent);
+    thenEventHasCorrectMeasurements(managedEvent, VCPUS_METRIC_ID, expectedManagedCores);
+
+    // Verify self-managed event has correct value (verifies no cross-contamination)
+    Event selfManagedEvent = selfManagedEvents.get(0);
+    thenEventHasCorrectMetadata(selfManagedEvent, clusterId);
+    thenEventHasCorrectBillingInfo(selfManagedEvent, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(selfManagedEvent);
+    thenEventHasCorrectMeasurements(
+        selfManagedEvent, VCPUS_SELF_MANAGED_METRIC_ID, expectedSelfManagedCores);
+  }
+
+  @TestPlanName("swatch-metrics-prometheus-TC007")
+  @Test
+  void shouldFilterManagedEventsForOcpAssistedInstallProduct() {
+    // Given: Cluster with product=ocp-assistedinstall (self-managed regex only)
+    String clusterId = "cluster-" + RandomUtils.generateRandom();
+    String billingProvider = "aws";
+    String billingAccountId = "aws-" + RandomUtils.generateRandom();
+    double managedCores = 8.0;
+    double selfManagedCores = 12.0;
+    OffsetDateTime meteringEnd = currentUtcHourStart();
+
+    // Stub both metrics with ocp-assistedinstall product
+    // Only self-managed dimension includes this product in its regex
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("ocp-assistedinstall")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(managedCores)
+        .stub();
+
+    wiremock
+        .forPrometheus()
+        .metric("acm:managed_cluster_worker_cores:self_managed:sum")
+        .label("_id", clusterId)
+        .displayName(clusterId)
+        .orgId(orgId)
+        .product("ocp-assistedinstall")
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .value(selfManagedCores)
+        .stub();
+
+    // When: Internal metering is triggered
+    service.triggerInternalMetering(
+        ACM_PRODUCT_TAG, orgId, meteringEnd, METERING_API_RANGE_MINUTES);
+
+    // Then: Only self-managed event is produced (managed is filtered by regex)
+    var selfManagedEvents = thenEventsAreProduced(clusterId, VCPUS_SELF_MANAGED_METRIC_ID);
+    assertFalse(selfManagedEvents.isEmpty(), "Self-managed events should be produced");
+
+    Event selfManagedEvent = selfManagedEvents.get(0);
+    thenEventHasCorrectMetadata(selfManagedEvent, clusterId);
+    thenEventHasCorrectBillingInfo(selfManagedEvent, billingProvider, billingAccountId);
+    thenEventHasCorrectProductInfo(selfManagedEvent);
+    thenEventHasCorrectMeasurements(
+        selfManagedEvent, VCPUS_SELF_MANAGED_METRIC_ID, selfManagedCores);
+
+    // Verify no managed events are produced (productLabelRegex filters them out). The self-managed
+    // events above are our sync point: the service processes the managed metric first, so any
+    // managed event would already be cached by now. A non-blocking read confirms there are none.
+    var managedEvents = thenEventsAlreadyProduced(clusterId, VCPUS_METRIC_ID);
+    assertTrue(
+        managedEvents.isEmpty(),
+        "No managed events should be produced for ocp-assistedinstall product");
   }
 
   private static OffsetDateTime currentUtcHourStart() {

--- a/swatch-metrics/ct/java/tests/SwatchMetricsPrometheusTest.java
+++ b/swatch-metrics/ct/java/tests/SwatchMetricsPrometheusTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -49,6 +50,7 @@ class SwatchMetricsPrometheusTest extends BaseMetricsComponentTest {
    * Exercises rhelemeter PromQL against mocked Prometheus responses, internal metering, and
    * Kafka-bound events. Flow: stub query_range results → POST metering → assert event payload.
    */
+  @TestPlanName("swatch-metrics-prometheus-TC001")
   @Test
   void shouldCreateMeteringEventsForRhelPaygAddonFromPrometheus() {
     // Given: RHEL PAYG addon metrics will be returned from mock Prometheus

--- a/swatch-metrics/ct/java/tests/SwatchMetricsPrometheusTest.java
+++ b/swatch-metrics/ct/java/tests/SwatchMetricsPrometheusTest.java
@@ -29,7 +29,6 @@ import com.redhat.swatch.component.tests.utils.RandomUtils;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 import org.candlepin.subscriptions.json.Event;
 import org.candlepin.subscriptions.json.Measurement;
 import org.junit.jupiter.api.Test;
@@ -63,18 +62,18 @@ class SwatchMetricsPrometheusTest extends BaseMetricsComponentTest {
 
     // Stub the query_range endpoint to return metric data
     // The metering service will query Prometheus for VCPU metrics
-    Map<String, String> labels = new java.util.HashMap<>();
-    labels.put("billing_marketplace_instance_id", instanceId);
-    labels.put("external_organization", orgId);
-    labels.put("billing_marketplace", billingProvider);
-    labels.put("billing_marketplace_account", billingAccountId);
-    labels.put("product", "204");
-    labels.put("billing_model", "marketplace");
-    labels.put("support", "Premium");
-    labels.put("usage", "Production");
     wiremock
         .forPrometheus()
-        .stubQueryRangeWithMetricData("system_cpu_logical_count", labels, expectedVcpu);
+        .metric("system_cpu_logical_count")
+        .instanceId(instanceId)
+        .orgId(orgId)
+        .billingProvider(billingProvider)
+        .billingAccountId(billingAccountId)
+        .product("204")
+        .label("support", "Premium")
+        .label("usage", "Production")
+        .value(expectedVcpu)
+        .stub();
 
     // When: Internal metering is triggered
     service.triggerInternalMetering(


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-XXXX

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
RHACM is splitting the metric into:  
- `acm:managed_cluster_worker_cores:managed:sum`  
- ``acm:managed_cluster_worker_cores:self_managed:sum``  

The following component tests added to `swatch-metrics` to validate we process the new metrics:  
- `shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAws`  
- `shouldCreateMeteringEventsForAcmManagedCoresFromPrometheusAzure`  
- `shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAws`  
- `shouldCreateMeteringEventsForAcmSelfManagedCoresFromPrometheusAzure`  
- `shouldCreateSeparateEventsForBothManagedAndSelfManagedCoresFromSameCluster`  
- `shouldFilterManagedEventsForOcpAssistedInstallProduct`


## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
IQE Test MR: <!-- IQE MR link here -->

```
If you want to override the default IQE test image tag (rhsm-subscriptions), add /use-iqe-image-tag=XXX anywhere in this PR description, replacing XXX with your tag. If you leave XXX unchanged, CI keeps the default tag.
```

### Setup
<!-- Add any steps required to set up the test case -->
1. `podman-compose down`
2.. `podman-compose up -d`

### Steps
<!-- Enter each step of the test below -->
1. `PROM_URL=http://localhost:8006/api/v1 ./mvnw clean install -Pcomponent-tests -pl swatch-metrics/ct -am`
1.

### Verification
<!-- Enter the steps needed to verify the test passed -->
1. swatch-metrics component tests pass
1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Added coverage for ACM managed and self-managed core metering across AWS and Azure billing.
- Added validation of event metadata, billing details, product tags, metric identifiers, and metric values.
- Added scenarios for clusters reporting both managed and self-managed cores.
- Verified product-specific filtering keeps applicable self-managed events while excluding managed events where required.
- Expanded component test coverage for RHEL PAYG and ACM metering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->