### PR TITLE
SWATCH-5444: Fall back to entitlement end date for contract sync

### DIFF
--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -949,6 +949,18 @@ This section verifies the automatic contract termination behavior when contracts
 - **Verification**: One contract for the org; sync status SUCCESS
 - **Expected Result**: HTTP 200; sync succeeds with no failure when `partnerIdentities.licenseArn` is absent
 
+**contracts-sync-TC022 - Entitlement end date when contract segment omits endDate**
+- **Description**: Partner Gateway may return a purchase contract segment with `startDate` only. When `entitlementDates.endDate` is in the past, sync must persist that termination date on the contract and subscription.
+- **Setup**:
+  - Stub one marketplace entitlement with `purchase.contracts[]` containing `startDate` only (no segment `endDate`)
+  - Set `entitlementDates.endDate` to a timestamp in the past
+  - Stub Search API and sync offering
+- **Action**: POST `/api/swatch-contracts/internal/rpc/sync/contracts/{org_id}`
+- **Verification**:
+  - Contract `end_date` matches `entitlementDates.endDate`
+  - Contract is terminated (`end_date` before now)
+- **Expected Result**: HTTP 200; sync status SUCCESS; termination date applied from entitlement dates
+
 ## Subscription Management via IT Subscription
 
 **subscriptions-creation-TC001 - Process a valid UMB subscription XML message from UMB**  

--- a/swatch-contracts/ct/java/api/PartnerApiStubs.java
+++ b/swatch-contracts/ct/java/api/PartnerApiStubs.java
@@ -24,7 +24,6 @@ import com.redhat.swatch.component.tests.utils.JsonUtils;
 import domain.BillingProvider;
 import domain.Contract;
 import io.restassured.http.ContentType;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -234,7 +233,7 @@ public class PartnerApiStubs {
     var body = new HashMap<String, Object>();
     body.put("rhAccountId", contract.getOrgId());
     body.put("sourcePartner", "aws_marketplace");
-    body.put("entitlementDates", buildEntitlementDates(contract));
+    body.put("entitlementDates", PartnerEntitlementStubPayloads.buildEntitlementDates(contract));
     var partnerIdentities = new HashMap<String, Object>();
     partnerIdentities.put("awsCustomerId", contract.getCustomerId());
     partnerIdentities.put("customerAwsAccountId", contract.getBillingAccountId());
@@ -249,8 +248,8 @@ public class PartnerApiStubs {
             "vendorProductCode",
             contract.getProductCode(),
             "contracts",
-            List.of(buildContractDetails(contract))));
-    body.put("rhEntitlements", buildRhEntitlements(contract));
+            List.of(PartnerEntitlementStubPayloads.buildCurrentContractSegment(contract))));
+    body.put("rhEntitlements", PartnerEntitlementStubPayloads.buildRhEntitlements(contract));
     return body;
   }
 
@@ -262,13 +261,14 @@ public class PartnerApiStubs {
    * @return Azure contract response body map
    */
   private Map<String, Object> buildAzureContractBody(Contract contract) {
-    var contractDetails = new HashMap<>(buildContractDetails(contract));
+    var contractDetails =
+        new HashMap<>(PartnerEntitlementStubPayloads.buildCurrentContractSegment(contract));
     contractDetails.put("planId", contract.getPlanId());
 
     var body = new HashMap<String, Object>();
     body.put("rhAccountId", contract.getOrgId());
     body.put("sourcePartner", "azure_marketplace");
-    body.put("entitlementDates", buildEntitlementDates(contract));
+    body.put("entitlementDates", PartnerEntitlementStubPayloads.buildEntitlementDates(contract));
     body.put(
         "partnerIdentities",
         Map.of(
@@ -289,39 +289,7 @@ public class PartnerApiStubs {
             contract.getResourceId(),
             "contracts",
             List.of(contractDetails)));
-    body.put("rhEntitlements", buildRhEntitlements(contract));
+    body.put("rhEntitlements", PartnerEntitlementStubPayloads.buildRhEntitlements(contract));
     return body;
-  }
-
-  /** Build common entitlement dates map. */
-  private Map<String, String> buildEntitlementDates(Contract contract) {
-    return Map.of(
-        "startDate",
-        contract.getStartDate().format(DateTimeFormatter.ISO_INSTANT),
-        "endDate",
-        contract.getEndDate().format(DateTimeFormatter.ISO_INSTANT));
-  }
-
-  /** Build common RH entitlements list. */
-  private List<Map<String, String>> buildRhEntitlements(Contract contract) {
-    return List.of(
-        Map.of(
-            "sku",
-            contract.getOffering().getSku(),
-            "subscriptionNumber",
-            contract.getSubscriptionNumber()));
-  }
-
-  /** Build common contract details (dates and dimensions). */
-  private Map<String, Object> buildContractDetails(Contract contract) {
-    return Map.of(
-        "startDate",
-        contract.getStartDate().format(DateTimeFormatter.ISO_INSTANT),
-        "endDate",
-        contract.getEndDate().format(DateTimeFormatter.ISO_INSTANT),
-        "dimensions",
-        contract.getContractMetrics().entrySet().stream()
-            .map(e -> Map.of("name", e.getKey(), "value", e.getValue()))
-            .toList());
   }
 }

--- a/swatch-contracts/ct/java/api/PartnerEntitlementStubPayloads.java
+++ b/swatch-contracts/ct/java/api/PartnerEntitlementStubPayloads.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import domain.Contract;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Builds Partner Gateway entitlement JSON fragments for Wiremock stubs. */
+public final class PartnerEntitlementStubPayloads {
+
+  private PartnerEntitlementStubPayloads() {}
+
+  /**
+   * Current purchase contract segment: startDate and dimensions only. Termination dates belong on
+   * entitlementDates.endDate.
+   */
+  public static Map<String, Object> buildCurrentContractSegment(Contract contract) {
+    return Map.of(
+        "startDate",
+        contract.getStartDate().format(DateTimeFormatter.ISO_INSTANT),
+        "dimensions",
+        buildDimensions(contract));
+  }
+
+  /** Closed historical purchase contract segment including segment endDate. */
+  public static Map<String, Object> buildClosedContractSegment(Contract contract) {
+    var segment = new HashMap<>(buildCurrentContractSegment(contract));
+    segment.put("endDate", contract.getEndDate().format(DateTimeFormatter.ISO_INSTANT));
+    return Map.copyOf(segment);
+  }
+
+  public static Map<String, String> buildEntitlementDates(Contract contract) {
+    return Map.of(
+        "startDate",
+        contract.getStartDate().format(DateTimeFormatter.ISO_INSTANT),
+        "endDate",
+        contract.getEndDate().format(DateTimeFormatter.ISO_INSTANT));
+  }
+
+  public static List<Map<String, String>> buildRhEntitlements(Contract contract) {
+    return List.of(
+        Map.of(
+            "sku",
+            contract.getOffering().getSku(),
+            "subscriptionNumber",
+            contract.getSubscriptionNumber()));
+  }
+
+  private static List<Map<String, Object>> buildDimensions(Contract contract) {
+    return contract.getContractMetrics().entrySet().stream()
+        .map(e -> Map.<String, Object>of("name", e.getKey(), "value", e.getValue()))
+        .toList();
+  }
+}

--- a/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsSyncComponentTest.java
@@ -883,6 +883,30 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
     assertEquals(beforeB.getUuid(), afterB.getUuid(), "Contract B UUID must not change");
   }
 
+  @TestPlanName("contracts-sync-TC022")
+  @Test
+  void shouldApplyEntitlementEndDateWhenContractSegmentOmitsEndDate() {
+    String sku = RandomUtils.generateRandom();
+    OffsetDateTime terminationDate = OffsetDateTime.now().minusDays(7);
+    Contract contract =
+        Contract.buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, 10.0), sku).toBuilder()
+            .endDate(terminationDate)
+            .build();
+    stubContractsForOrgSync(contract);
+
+    Response syncResponse = service.syncContractsByOrg(orgId);
+
+    assertEquals(HttpStatus.SC_OK, syncResponse.statusCode(), "Sync should succeed");
+    syncResponse.then().body("status", equalTo(STATUS_SUCCESS));
+    var persisted = getPersistedContract(contract);
+    assertDatesAreEqual(terminationDate, persisted.getEndDate());
+    var subscription = getPersistedSubscription(contract);
+    assertDatesAreEqual(terminationDate, subscription.getEndDate());
+    assertTrue(
+        persisted.getEndDate().isBefore(OffsetDateTime.now()),
+        "Contract should be terminated from entitlementDates.endDate");
+  }
+
   @TestPlanName("contracts-sync-TC021")
   @Test
   void shouldSyncAwsEntitlementWhenLicenseArnIsAbsent() {
@@ -1143,6 +1167,17 @@ public class ContractsSyncComponentTest extends BaseContractComponentTest {
             () ->
                 new AssertionError(
                     "No contract for subscriptionNumber=" + expected.getSubscriptionNumber()));
+  }
+
+  private com.redhat.swatch.contract.test.model.Subscription getPersistedSubscription(
+      Contract expected) {
+    return service.getSubscriptionsByOrgId(orgId).stream()
+        .filter(s -> expected.getSubscriptionNumber().equals(s.getSubscriptionNumber()))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "No subscription for subscriptionNumber=" + expected.getSubscriptionNumber()));
   }
 
   private static String awsDimensionFor(MetricId metricId) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/model/ContractEntityMapper.java
@@ -183,11 +183,11 @@ public interface ContractEntityMapper {
 
   @Named("endDate")
   default OffsetDateTime extractEndDate(PartnerEntitlementV1 entitlement, SaasContractV1 contract) {
-    // If the start_date is populated then take end_date from the contract
-    if (contract != null && contract.getStartDate() != null) {
+    if (contract != null && contract.getEndDate() != null) {
       return truncateToMicroPrecision(contract.getEndDate());
     }
-    if (entitlement.getEntitlementDates() != null) {
+    if (entitlement.getEntitlementDates() != null
+        && entitlement.getEntitlementDates().getEndDate() != null) {
       return truncateToMicroPrecision(entitlement.getEntitlementDates().getEndDate());
     }
     return null;

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/model/ContractEntityMapperTest.java
@@ -192,6 +192,35 @@ class ContractEntityMapperTest {
     assertNull(entity.getLicenseId());
   }
 
+  @Test
+  void testExtractEndDateFallsBackToEntitlementDatesWhenContractSegmentHasNoEndDate() {
+    givenAwsEntitlement();
+    givenEntitlementDates("2022-01-01T00:00Z", "2023-01-01T00:00Z");
+    saasContract =
+        new SaasContractV1()
+            .startDate(OffsetDateTime.parse("2022-01-01T00:00Z"))
+            .planId(V_CPU_HOURS_PLAN);
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(entitlement.getEntitlementDates().getEndDate(), entity.getEndDate());
+  }
+
+  @Test
+  void testExtractEndDatePrefersContractSegmentEndDateWhenPresent() {
+    givenAzureEntitlement();
+    givenEntitlementDates("2022-01-01T00:00Z", "2023-01-01T00:00Z");
+    saasContract =
+        new SaasContractV1()
+            .startDate(OffsetDateTime.parse("2022-01-01T00:00Z"))
+            .endDate(OffsetDateTime.parse("2022-06-01T00:00Z"))
+            .planId(V_CPU_HOURS_PLAN);
+
+    var entity = whenMapEntitlementToContractEntity();
+
+    assertEquals(OffsetDateTime.parse("2022-06-01T00:00Z"), entity.getEndDate());
+  }
+
   private void givenContractWithPlanId(String planId) {
     var contract = givenContract(0, null, null);
     contract.setPlanId(planId);

--- a/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
+++ b/swatch-contracts/src/test/java/com/redhat/swatch/contract/service/ContractServiceTest.java
@@ -1020,7 +1020,7 @@ class ContractServiceTest extends BaseUnitTest {
 
   private ContractRequest givenContractRequest(String subscriptionNumber) {
     return givenContractRequestWithDates(
-        "2023-03-17T12:29:48.569Z", "2024-03-17T12:29:48.569Z", subscriptionNumber);
+        "2023-03-17T12:29:48.569Z", DEFAULT_END_DATE.toString(), subscriptionNumber);
   }
 
   private ContractRequest givenContractRequestWithDates(String startDate, String endDate) {


### PR DESCRIPTION
When purchase contract segments omit endDate, use entitlementDates.endDate so terminated marketplace entitlements close contracts in SWATCH. Add CT coverage and PartnerEntitlementStubPayloads for stub payload building.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5444

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Unit:
```
./mvnw test -pl swatch-contracts -Dtest=ContractEntityMapperTest
```
Component:
```
./mvnw test -Pcomponent-tests -pl swatch-contracts/ct
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Contract synchronization now correctly applies the entitlement end date when a contract segment does not include one.
  - Existing contract segment end dates continue to take precedence when available.
  - Subscription termination dates now remain consistent with the applicable contract end date.

- **Tests**
  - Added coverage for past entitlement end dates and fallback date handling.
  - Improved test payload construction for contract synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->