### PR TITLE
swatch-5269: Implement RBAC component tests for swatch-contracts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.rhsm-subscriptions.billable-usage
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.rhsm-subscriptions.billable-usage-hourly-aggregate
         bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.rhsm-subscriptions.utilization
+        bin/kafka-topics.sh --bootstrap-server=kafka:29092 --create --if-not-exists --partitions 1 --replication-factor 1 --topic platform.export.requests
       "
     depends_on:
       kafka:

--- a/swatch-contracts/RBAC_PARITY_TEST_PLAN.md
+++ b/swatch-contracts/RBAC_PARITY_TEST_PLAN.md
@@ -33,7 +33,9 @@ Each test case exercises the same endpoint under both RBAC modes (flag OFF = v1,
 | E1 | GET | /api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id} | customer, service |
 | E2 | GET | /api/rhsm-subscriptions/v1/subscriptions/products/{product_id} | customer, service |
 | E3 | GET | /api/rhsm-subscriptions/v2/subscriptions/products/{product_id} | customer, service |
-| E4 | GET | /api/swatch-contracts/v1/subscriptions/billing_account_ids | customer, support, test |
+| E4 | GET | /api/swatch-contracts/v1/subscriptions/billing_account_ids | customer, support |
+
+E4 allows `customer` and `support` only. The `test` role is omitted so `SWATCH_TEST_APIS_ENABLED` cannot bypass RBAC on this path (same approach as the V2 subscription report).
 
 # Test Cases
 

--- a/swatch-contracts/ct/java/api/ContractsSwatchService.java
+++ b/swatch-contracts/ct/java/api/ContractsSwatchService.java
@@ -72,6 +72,8 @@ public class ContractsSwatchService extends SwatchService {
       "/api/rhsm-subscriptions/v2/subscriptions/products/{product_id}";
   private static final String CAPACITY_REPORT_ENDPOINT =
       "/api/rhsm-subscriptions/v1/capacity/products/{product_id}/{metric_id}";
+  private static final String BILLING_ACCOUNT_IDS_ENDPOINT =
+      "/api/swatch-contracts/v1/subscriptions/billing_account_ids";
   private static final String TERMINATE_SUBSCRIPTION_ENDPOINT =
       ENDPOINT_PREFIX + "/subscriptions/terminate/{subscription_id}";
   private static final String SYNC_CONTRACTS_BY_ORG_ENDPOINT =
@@ -279,7 +281,19 @@ public class ContractsSwatchService extends SwatchService {
         .as(SkuCapacityReportV2.class);
   }
 
-  public Response getSkuCapacityByProductId(Product product, Map<String, String> requestHeaders) {
+  public Response getSkuCapacityReportV1(Product product, Map<String, String> requestHeaders) {
+    Objects.requireNonNull(product, "product must not be null");
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+
+    return given()
+        .headers(requestHeaders)
+        .accept("application/vnd.api+json")
+        .pathParam("product_id", product.getName())
+        .when()
+        .get(GET_SKU_CAPACITY_REPORT_V1_ENDPOINT);
+  }
+
+  public Response getSkuCapacityReportV2(Product product, Map<String, String> requestHeaders) {
     Objects.requireNonNull(product, "product must not be null");
     Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
 
@@ -289,6 +303,38 @@ public class ContractsSwatchService extends SwatchService {
         .pathParam("product_id", product.getName())
         .when()
         .get(GET_SKU_CAPACITY_REPORT_V2_ENDPOINT);
+  }
+
+  public Response getCapacityReportByMetricId(
+      Product product, String metricId, Map<String, String> requestHeaders) {
+    Objects.requireNonNull(product, "product must not be null");
+    Objects.requireNonNull(metricId, "metricId must not be null");
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+
+    OffsetDateTime ending = OffsetDateTime.now();
+    OffsetDateTime beginning = ending.minusDays(1);
+    return given()
+        .headers(requestHeaders)
+        .accept("application/vnd.api+json")
+        .pathParam("product_id", product.getName())
+        .pathParam("metric_id", metricId)
+        .queryParam("beginning", beginning.toString())
+        .queryParam("ending", ending.toString())
+        .queryParam("granularity", GranularityType.DAILY)
+        .when()
+        .get(CAPACITY_REPORT_ENDPOINT);
+  }
+
+  public Response fetchBillingAccountIdsForOrg(String orgId, Map<String, String> requestHeaders) {
+    Objects.requireNonNull(orgId, "orgId must not be null");
+    Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
+
+    return given()
+        .headers(requestHeaders)
+        .accept("application/json")
+        .queryParam("org_id", orgId)
+        .when()
+        .get(BILLING_ACCOUNT_IDS_ENDPOINT);
   }
 
   public CapacityReportByMetricId getCapacityReportByMetricId(

--- a/swatch-contracts/ct/java/api/ContractsWiremockService.java
+++ b/swatch-contracts/ct/java/api/ContractsWiremockService.java
@@ -49,4 +49,13 @@ public class ContractsWiremockService extends WiremockService {
   public SearchApiStubs forSearchApi() {
     return new SearchApiStubs(this);
   }
+
+  /**
+   * Get facade for stubbing Export API endpoints.
+   *
+   * @return ExportApiStubs facade
+   */
+  public ExportApiStubs forExportAPI() {
+    return new ExportApiStubs(this);
+  }
 }

--- a/swatch-contracts/ct/java/api/ExportApiStubs.java
+++ b/swatch-contracts/ct/java/api/ExportApiStubs.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import java.util.Map;
+import org.apache.http.HttpStatus;
+
+/** Wiremock stubs for Insights export-service upload and error callbacks. */
+public class ExportApiStubs {
+
+  private static final String UPLOAD_PATH = "/app/export/v1/.*/.*/.*/upload";
+  private static final String ERROR_PATH = "/app/export/v1/.*/.*/.*/error";
+
+  private final ContractsWiremockService wiremockService;
+
+  ExportApiStubs(ContractsWiremockService wiremockService) {
+    this.wiremockService = wiremockService;
+  }
+
+  public void stubExportCallbacks() {
+    stubPath(UPLOAD_PATH);
+    stubPath(ERROR_PATH);
+  }
+
+  public int countUploadRequests() {
+    return wiremockService.countRequests("/upload");
+  }
+
+  public int countErrorRequests() {
+    return wiremockService.countRequests("/error");
+  }
+
+  private void stubPath(String urlPathPattern) {
+    wiremockService
+        .given()
+        .contentType("application/json")
+        .body(
+            Map.of(
+                "request",
+                Map.of("method", "POST", "urlPathPattern", urlPathPattern),
+                "response",
+                Map.of("status", HttpStatus.SC_ACCEPTED),
+                "priority",
+                1,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+}

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -57,6 +57,7 @@ import org.apache.http.HttpStatus;
 import org.candlepin.clock.ApplicationClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import utils.RbacAccessTestHelper;
 
 @ComponentTest(name = "swatch-contracts")
 public class BaseContractComponentTest {
@@ -80,11 +81,13 @@ public class BaseContractComponentTest {
   protected static final ApplicationClock clock = new ApplicationClock();
 
   protected String orgId;
+  protected RbacAccessTestHelper rbacHelper;
   private List<String> orgIds = new ArrayList<>();
 
   @BeforeEach
   void setUp() {
     orgId = givenOrgId();
+    rbacHelper = new RbacAccessTestHelper(unleash, wiremock, orgId);
   }
 
   @AfterEach

--- a/swatch-contracts/ct/java/tests/ContractsAccessComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsAccessComponentTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static com.redhat.swatch.component.tests.utils.SwatchUtils.X_RH_IDENTITY_HEADER;
+import static com.redhat.swatch.component.tests.utils.Topics.EXPORT_REQUESTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import api.ExportApiStubs;
+import com.redhat.swatch.component.tests.api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.component.tests.utils.SwatchUtils;
+import domain.Product;
+import io.restassured.response.Response;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ContractsAccessComponentTest extends BaseContractComponentTest {
+
+  static Stream<Arguments> reportingEndpoints() {
+    return combinations(
+        CustomerFacingEndpoint.CAPACITY,
+        CustomerFacingEndpoint.SUBSCRIPTIONS_V1,
+        CustomerFacingEndpoint.SUBSCRIPTIONS_V2);
+  }
+
+  static Stream<Arguments> allCustomerFacingEndpoints() {
+    return combinations(CustomerFacingEndpoint.values());
+  }
+
+  private static Stream<Arguments> combinations(CustomerFacingEndpoint... endpoints) {
+    return Stream.of(AuthorizationModel.values())
+        .flatMap(model -> Stream.of(endpoints).map(endpoint -> Arguments.of(model, endpoint)));
+  }
+
+  @AfterEach
+  void resetKesselRbacFlag() {
+    unleash.disableKesselRbac();
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("reportingEndpoints")
+  @TestPlanName("rbac-parity-TC001")
+  void shouldAllowReportingWhenAdminAccessGranted(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC002")
+  void shouldAllowBillingAccountIdsWhenAdminGranted(AuthorizationModel authorizationModel) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When
+    Response response =
+        whenGetCustomerFacingEndpoint(CustomerFacingEndpoint.BILLING_ACCOUNT_IDS, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("reportingEndpoints")
+  @TestPlanName("rbac-parity-TC003")
+  void shouldAllowReportingWhenReaderAccessGranted(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.GRANTED_READER);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC004")
+  void shouldAllowBillingAccountIdsWhenReaderGranted(AuthorizationModel authorizationModel) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.GRANTED_READER);
+
+    // When
+    Response response =
+        whenGetCustomerFacingEndpoint(CustomerFacingEndpoint.BILLING_ACCOUNT_IDS, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("reportingEndpoints")
+  @TestPlanName("rbac-parity-TC005")
+  void shouldDenyReportingWhenAccessDenied(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.DENIED);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC006")
+  void shouldDenyBillingAccountIdsWhenAccessDenied(AuthorizationModel authorizationModel) {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    givenUserAccess(authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.DENIED);
+
+    // When
+    Response response =
+        whenGetCustomerFacingEndpoint(CustomerFacingEndpoint.BILLING_ACCOUNT_IDS, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("allCustomerFacingEndpoints")
+  @TestPlanName("rbac-parity-TC007")
+  void shouldAllowAllEndpointsWhenServiceAccountAdmin(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    givenServiceAccountAccess(
+        authorizationModel, clientId, requestHeaders, SubscriptionsAccessLevel.GRANTED_ADMIN);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("allCustomerFacingEndpoints")
+  @TestPlanName("rbac-parity-TC008")
+  void shouldDenyAllEndpointsWhenServiceAccountDenied(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    String clientId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    givenServiceAccountAccess(
+        authorizationModel, clientId, requestHeaders, SubscriptionsAccessLevel.DENIED);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC009")
+  void shouldAllowBillingAccountIdsForAssociate(AuthorizationModel authorizationModel) {
+    // Given
+    givenAuthorizationModel(authorizationModel);
+    String email = RandomUtils.generateRandom() + "@redhat.com";
+    var requestHeaders = SwatchUtils.securityHeadersWithAssociate(orgId, email);
+
+    // When
+    Response response =
+        whenGetCustomerFacingEndpoint(CustomerFacingEndpoint.BILLING_ACCOUNT_IDS, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_OK);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}, endpoint={1}")
+  @MethodSource("reportingEndpoints")
+  @TestPlanName("rbac-parity-TC010")
+  void shouldDenyReportingForAssociate(
+      AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
+    // Given
+    givenAuthorizationModel(authorizationModel);
+    String email = RandomUtils.generateRandom() + "@redhat.com";
+    var requestHeaders = SwatchUtils.securityHeadersWithAssociate(orgId, email);
+
+    // When
+    Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @Test
+  @TestPlanName("rbac-parity-TC011")
+  void shouldDenyCapacityReportWhenKesselUnavailable() {
+    // Given
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    unleash.enableKesselRbac();
+    wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+
+    // When
+    Response response =
+        whenGetCustomerFacingEndpoint(CustomerFacingEndpoint.CAPACITY, requestHeaders);
+
+    // Then
+    thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC012")
+  void shouldCompleteExportWhenAdminAccessGranted(AuthorizationModel authorizationModel) {
+    // Given
+    ExportApiStubs exportApi = givenExportCallbacks();
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenExportAccess(
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+    Map<String, Object> exportRequest = givenExportRequest(identityHeader);
+
+    // When
+    whenExportRequestIsPublished(exportRequest);
+
+    // Then
+    thenExportUploadWasSent(exportApi);
+  }
+
+  @ParameterizedTest(name = "authorizationModel={0}")
+  @EnumSource(AuthorizationModel.class)
+  @TestPlanName("rbac-parity-TC013")
+  void shouldDenyExportWhenAccessDenied(AuthorizationModel authorizationModel) {
+    // Given
+    ExportApiStubs exportApi = givenExportCallbacks();
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
+    String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
+    givenExportAccess(authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
+    Map<String, Object> exportRequest = givenExportRequest(identityHeader);
+
+    // When
+    whenExportRequestIsPublished(exportRequest);
+
+    // Then
+    thenExportErrorWasSent(exportApi);
+  }
+
+  private void givenUserAccess(
+      AuthorizationModel authorizationModel,
+      String userId,
+      Map<String, String> requestHeaders,
+      SubscriptionsAccessLevel accessLevel) {
+    rbacHelper.givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, requestHeaders.get(X_RH_IDENTITY_HEADER), accessLevel);
+  }
+
+  private void givenServiceAccountAccess(
+      AuthorizationModel authorizationModel,
+      String clientId,
+      Map<String, String> requestHeaders,
+      SubscriptionsAccessLevel accessLevel) {
+    rbacHelper.givenServiceAccountHasSubscriptionsAccess(
+        authorizationModel, clientId, requestHeaders.get(X_RH_IDENTITY_HEADER), accessLevel);
+  }
+
+  private void givenAuthorizationModel(AuthorizationModel authorizationModel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+    } else {
+      unleash.disableKesselRbac();
+    }
+  }
+
+  private void givenExportAccess(
+      AuthorizationModel authorizationModel,
+      String userId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    rbacHelper.givenUserHasSubscriptionsAccess(
+        authorizationModel, userId, identityHeader, accessLevel);
+    // Export uses RbacDelegate, which always calls the RBAC v1 API
+    // regardless of the Kessel Unleash flag.
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+
+  private ExportApiStubs givenExportCallbacks() {
+    ExportApiStubs exportApi = wiremock.forExportAPI();
+    exportApi.stubExportCallbacks();
+    return exportApi;
+  }
+
+  private Map<String, Object> givenExportRequest(String identityHeader) {
+    return Map.of(
+        "id",
+        UUID.randomUUID().toString(),
+        "source",
+        "urn:redhat:source:console:app:export-service",
+        "specversion",
+        "1.0",
+        "type",
+        "com.redhat.console.export-service.request",
+        "time",
+        Instant.now().toString(),
+        "dataschema",
+        "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
+        "redhatorgid",
+        orgId,
+        "data",
+        Map.of(
+            "resource_request",
+            Map.of(
+                "application",
+                "subscriptions",
+                "export_request_uuid",
+                UUID.randomUUID().toString(),
+                "filters",
+                Map.of(),
+                "format",
+                "json",
+                "resource",
+                "subscriptions",
+                "uuid",
+                UUID.randomUUID().toString(),
+                "x-rh-identity",
+                identityHeader)));
+  }
+
+  private Response whenGetCustomerFacingEndpoint(
+      CustomerFacingEndpoint endpoint, Map<String, String> headers) {
+    return switch (endpoint) {
+      case CAPACITY ->
+          service.getCapacityReportByMetricId(Product.OPENSHIFT, CORES.toString(), headers);
+      case SUBSCRIPTIONS_V1 -> service.getSkuCapacityReportV1(Product.OPENSHIFT, headers);
+      case SUBSCRIPTIONS_V2 -> service.getSkuCapacityReportV2(Product.OPENSHIFT, headers);
+      case BILLING_ACCOUNT_IDS -> service.fetchBillingAccountIdsForOrg(orgId, headers);
+    };
+  }
+
+  private void whenExportRequestIsPublished(Map<String, Object> exportRequest) {
+    kafkaBridge.produceKafkaMessage(EXPORT_REQUESTS, exportRequest);
+  }
+
+  private void thenResponseStatusIs(Response response, int expectedStatus) {
+    assertEquals(
+        expectedStatus, response.statusCode(), "Unexpected status for " + response.getStatusLine());
+  }
+
+  private void thenExportUploadWasSent(ExportApiStubs exportApi) {
+    AwaitilityUtils.untilIsTrue(() -> exportApi.countUploadRequests() > 0);
+  }
+
+  private void thenExportErrorWasSent(ExportApiStubs exportApi) {
+    AwaitilityUtils.untilIsTrue(() -> exportApi.countErrorRequests() > 0);
+  }
+
+  private enum CustomerFacingEndpoint {
+    CAPACITY,
+    SUBSCRIPTIONS_V1,
+    SUBSCRIPTIONS_V2,
+    BILLING_ACCOUNT_IDS
+  }
+}

--- a/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
+++ b/swatch-contracts/ct/java/tests/SubscriptionReportAccessComponentTest.java
@@ -51,7 +51,7 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     String userId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
-    givenSubscriptionsAccess(
+    rbacHelper.givenUserHasSubscriptionsAccess(
         authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     // When
@@ -69,7 +69,7 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     String userId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
-    givenSubscriptionsAccess(
+    rbacHelper.givenUserHasSubscriptionsAccess(
         authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
 
     // When
@@ -87,7 +87,7 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     String userId = RandomUtils.generateRandom();
     var requestHeaders = SwatchUtils.securityHeadersWithUserRole(orgId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
-    givenSubscriptionsAccess(
+    rbacHelper.givenUserHasSubscriptionsAccess(
         authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     // When
@@ -97,23 +97,8 @@ public class SubscriptionReportAccessComponentTest extends BaseContractComponent
     thenResponseStatusIs(response, HttpStatus.SC_FORBIDDEN);
   }
 
-  private void givenSubscriptionsAccess(
-      AuthorizationModel authorizationModel,
-      String userId,
-      String identityHeader,
-      SubscriptionsAccessLevel accessLevel) {
-    if (authorizationModel == AuthorizationModel.KESSEL) {
-      unleash.enableKesselRbac();
-      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
-      wiremock.forKesselAccessControl().stubSubscriptionsAccess(userId, accessLevel);
-    } else {
-      unleash.disableKesselRbac();
-      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
-    }
-  }
-
   private Response whenGetV2SkuCapacityReport(Map<String, String> requestHeaders) {
-    return service.getSkuCapacityByProductId(Product.OPENSHIFT, requestHeaders);
+    return service.getSkuCapacityReportV2(Product.OPENSHIFT, requestHeaders);
   }
 
   private void thenResponseStatusIs(Response response, int expectedStatus) {

--- a/swatch-contracts/ct/java/utils/RbacAccessTestHelper.java
+++ b/swatch-contracts/ct/java/utils/RbacAccessTestHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package utils;
+
+import api.ContractsUnleashService;
+import api.ContractsWiremockService;
+import com.redhat.swatch.component.tests.api.AuthorizationModel;
+import com.redhat.swatch.component.tests.api.SubscriptionsAccessLevel;
+
+/** Configures RBAC v1 or Kessel stubs for contracts access-control tests. */
+public class RbacAccessTestHelper {
+
+  private final ContractsUnleashService unleash;
+  private final ContractsWiremockService wiremock;
+  private final String orgId;
+
+  public RbacAccessTestHelper(
+      ContractsUnleashService unleash, ContractsWiremockService wiremock, String orgId) {
+    this.unleash = unleash;
+    this.wiremock = wiremock;
+    this.orgId = orgId;
+  }
+
+  public void givenUserHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String userId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    givenPrincipalHasSubscriptionsAccess(authorizationModel, userId, identityHeader, accessLevel);
+  }
+
+  public void givenServiceAccountHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String clientId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    givenPrincipalHasSubscriptionsAccess(authorizationModel, clientId, identityHeader, accessLevel);
+  }
+
+  private void givenPrincipalHasSubscriptionsAccess(
+      AuthorizationModel authorizationModel,
+      String principalId,
+      String identityHeader,
+      SubscriptionsAccessLevel accessLevel) {
+    if (authorizationModel == AuthorizationModel.KESSEL) {
+      unleash.enableKesselRbac();
+      wiremock.forKesselAccessControl().stubDefaultWorkspace(orgId);
+      wiremock.forKesselAccessControl().stubSubscriptionsAccess(principalId, accessLevel);
+    } else {
+      unleash.disableKesselRbac();
+      wiremock.forRbacAccessControl().stubSubscriptionsAccess(identityHeader, accessLevel);
+    }
+  }
+}

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/ContractsV1Resource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/api/v1/ContractsV1Resource.java
@@ -49,7 +49,7 @@ public class ContractsV1Resource implements ContractsV1Api {
   }
 
   @Override
-  @RolesAllowed({"customer", "support", "test"})
+  @RolesAllowed({"customer", "support"})
   public BillingAccountIdResponse fetchBillingAccountIdsForOrg(String orgId, String productTag)
       throws ProcessingException {
     validateOrgIdAccess(orgId);

--- a/swatch-contracts/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-contracts/src/main/resources/META-INF/openapi.yaml
@@ -1249,7 +1249,6 @@ paths:
       security:
         - support: [ ]
         - customer: [ ]
-        - test: [ ]
 
 components:
   schemas:

--- a/swatch-contracts/src/main/resources/application.properties
+++ b/swatch-contracts/src/main/resources/application.properties
@@ -63,6 +63,7 @@ SUBSCRIPTION_IGNORE_STARTING_LATER_THAN=60d
 
 # Export Service configuration
 EXPORT_SERVICE_ENDPOINT=${clowder.optional-private-endpoints.export-service-service.url}
+%dev.EXPORT_SERVICE_ENDPOINT=http://localhost:8006
 %test.EXPORT_SERVICE_ENDPOINT=http://localhost:10000
 %component-tests.EXPORT_SERVICE_ENDPOINT=http://wiremock-service:8000
 
@@ -392,6 +393,8 @@ mp.messaging.incoming.export-requests.connector=smallrye-kafka
 mp.messaging.incoming.export-requests.topic=platform.export.requests
 mp.messaging.incoming.export-requests.group.id=swatch-subscription-export
 mp.messaging.incoming.export-requests.failure-strategy=ignore
+%dev.mp.messaging.incoming.export-requests.auto.offset.reset=earliest
+%component-tests.mp.messaging.incoming.export-requests.auto.offset.reset=earliest
 
 # Tally consumer configuration for batch processing
 mp.messaging.incoming.tally-in.connector=smallrye-kafka

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
@@ -42,8 +42,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public abstract class BaseKubernetesClient<
     T extends io.fabric8.kubernetes.client.KubernetesClient> {
@@ -162,7 +160,7 @@ public abstract class BaseKubernetesClient<
   }
 
   /** Resolve the port by the service. */
-  public int port(String serviceName, int port, Service service, Map<String, String> podLabels) {
+  public int port(String serviceName, int port, Service service) {
     String svcPortForwardKey = serviceName + "-" + port;
     KeyValueEntry<Service, LocalPortForwardWrapper> portForwardByService =
         portForwardsByService.get(svcPortForwardKey);
@@ -175,8 +173,7 @@ public abstract class BaseKubernetesClient<
               .portForward(port, SocketUtils.findAvailablePort(service));
       Log.trace(service, "Opening port forward from local port " + process.getLocalPort());
 
-      portForwardByService =
-          new KeyValueEntry<>(service, new LocalPortForwardWrapper(process, podLabels));
+      portForwardByService = new KeyValueEntry<>(service, new LocalPortForwardWrapper(process));
       portForwardsByService.put(svcPortForwardKey, portForwardByService);
     }
 
@@ -243,41 +240,41 @@ public abstract class BaseKubernetesClient<
   }
 
   public void close() {
-    portForwardsByService.values().forEach(this::closePortForward);
-    portForwardsByService.clear();
-    if (client != null) {
-      client.close();
-      client = null;
+    try {
+      portForwardsByService
+          .values()
+          .forEach(
+              portForward -> {
+                try {
+                  closePortForward(portForward);
+                } catch (Exception ex) {
+                  Log.warn("Failed to close port forward", ex);
+                }
+              });
+    } finally {
+      portForwardsByService.clear();
+      if (client != null) {
+        client.close();
+        client = null;
+      }
     }
   }
 
   class LocalPortForwardWrapper {
     int localPort;
     LocalPortForward process;
-    Map<String, String> podLabels;
-    Set<String> podIds;
 
-    LocalPortForwardWrapper(LocalPortForward process, Map<String, String> podLabels) {
+    LocalPortForwardWrapper(LocalPortForward process) {
       this.localPort = process.getLocalPort();
       this.process = process;
-      this.podLabels = podLabels;
-      this.podIds = resolvePodIds();
     }
 
-    /** Needs to recreate the port forward if the pods have changed or the process was stopped. */
+    /**
+     * Recreate only when the tunnel itself died. Listing pods on every RestAssured call exhausts
+     * Konflux nproc via Fabric8's unbounded OkHttp dispatcher.
+     */
     boolean needsToRecreate() {
-      if (!process.isAlive()) {
-        return true;
-      }
-
-      Set<String> newPodIds = resolvePodIds();
-      return !podIds.containsAll(newPodIds);
-    }
-
-    private Set<String> resolvePodIds() {
-      return podsInService(podLabels).stream()
-          .map(p -> p.getMetadata().getName())
-          .collect(Collectors.toSet());
+      return !process.isAlive() || process.errorOccurred();
     }
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
@@ -242,6 +242,15 @@ public abstract class BaseKubernetesClient<
     client = (T) initializeClient(config);
   }
 
+  public void close() {
+    portForwardsByService.values().forEach(this::closePortForward);
+    portForwardsByService.clear();
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+  }
+
   class LocalPortForwardWrapper {
     int localPort;
     LocalPortForward process;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
@@ -34,7 +34,7 @@ import com.redhat.swatch.component.tests.utils.FileUtils;
 import com.redhat.swatch.component.tests.utils.InjectUtils;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.nio.file.Path;
@@ -48,6 +48,15 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
   public static final String CLIENT = "oc-client";
   public static final String TARGET_OPENSHIFT = "openshift";
 
+  /**
+   * One Fabric8/OkHttp client for the JVM. JUnit constructs a new bootstrap per test class;
+   * creating a client each time leaks OkHttp dispatcher threads and exhausts the ephemeral runner's
+   * native-thread limit.
+   */
+  private static final Object SUITE_CLIENT_LOCK = new Object();
+
+  private static OpenshiftClient suiteClient;
+
   private OpenshiftClient client;
 
   @Override
@@ -60,8 +69,7 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
     OpenShiftConfiguration configuration =
         context.loadCustomConfiguration(TARGET_OPENSHIFT, new OpenShiftConfigurationBuilder());
 
-    client = new OpenshiftClient();
-    client.initializeClientUsingNamespace(new DefaultKubernetesClient().getNamespace());
+    client = suiteClient();
 
     if (configuration.getAdditionalResources() != null) {
       for (String additionalResource : configuration.getAdditionalResources()) {
@@ -143,6 +151,24 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
 
   private Path logsTestFolder(ComponentTestContext context) {
     return context.getLogFolder().resolve(context.getRunningTestClassName());
+  }
+
+  private static OpenshiftClient suiteClient() {
+    synchronized (SUITE_CLIENT_LOCK) {
+      if (suiteClient == null) {
+        suiteClient = new OpenshiftClient();
+        suiteClient.initializeClientUsingNamespace(currentNamespace());
+      }
+      return suiteClient;
+    }
+  }
+
+  private static String currentNamespace() {
+    String namespace = Config.autoConfigure(null).getNamespace();
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalStateException("Unable to resolve OpenShift namespace");
+    }
+    return namespace;
   }
 
   public static boolean isEnabled(ComponentTestContext context) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
@@ -156,11 +156,35 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
   private static OpenshiftClient suiteClient() {
     synchronized (SUITE_CLIENT_LOCK) {
       if (suiteClient == null) {
-        suiteClient = new OpenshiftClient();
-        suiteClient.initializeClientUsingNamespace(currentNamespace());
+        String namespace = currentNamespace();
+        OpenshiftClient initializedClient = new OpenshiftClient();
+        try {
+          initializedClient.initializeClientUsingNamespace(namespace);
+          suiteClient = initializedClient;
+        } catch (RuntimeException | Error e) {
+          initializedClient.close();
+          throw e;
+        }
+        registerSuiteClientShutdownHook();
       }
       return suiteClient;
     }
+  }
+
+  private static void registerSuiteClientShutdownHook() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  synchronized (SUITE_CLIENT_LOCK) {
+                    if (suiteClient != null) {
+                      Log.debug("Closing suite-level OpenShift client");
+                      suiteClient.close();
+                      suiteClient = null;
+                    }
+                  }
+                },
+                "openshift-client-cleanup"));
   }
 
   private static String currentNamespace() {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
@@ -26,6 +26,7 @@ import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBoots
 import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -83,6 +84,16 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
     this.logsSince = null;
   }
 
+  @Override
+  public synchronized List<String> logs() {
+    handle();
+    return super.logs();
+  }
+
+  /**
+   * Fetch when tests read logs. Do not poll {@code getLog()} from a background thread; that creates
+   * unbounded OkHttp dispatcher threads on the Konflux CT runner.
+   */
   @Override
   protected synchronized void handle() {
     if (!isTestActive() || logsSince == null || !isLogEnabled()) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
@@ -59,7 +59,6 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
     if (loggingHandler == null) {
       loggingHandler = new OpenShiftLoggingHandler(podLabels(), containerName(), context);
-      loggingHandler.startWatching();
     }
 
     running = true;

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
@@ -85,8 +85,8 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
   @Override
   public int getMappedPort(int port) {
-    return client.port(
-        serviceName(), portsMapping.getOrDefault(port, port), context.getOwner(), podLabels());
+    int mapped = portsMapping.getOrDefault(port, port);
+    return client.port(serviceName(), mapped, context.getOwner());
   }
 
   @Override

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
@@ -38,6 +38,7 @@ public final class Topics {
       "platform.rhsm-subscriptions.subscription-sync-task";
   public static final String CAPACITY_RECONCILE = SUFFIX + "capacity-reconcile";
   public static final String IT_SUBSCRIPTION_SYNC = "subscription.subscriptions.private";
+  public static final String EXPORT_REQUESTS = "platform.export.requests";
 
   private Topics() {}
 }


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5269

## Description
This card implements the RBAC v1 and v2 component tests for swatch-contracts.

To run the tests against ephemeral without running out of memory and threads.  The following changes were made to reduces thread count, HTTP connections, and memory footprint in Konflux CT runner:
- Stop background log polling that created unbounded OkHttp dispatcher threads
- Changed `OpenShiftLoggingHandler` to fetch logs on-demand instead of continuous watching
- Removed startWatching() - logs now pulled only when tests read them


## Testing
podman compose up -d
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added billing account ID retrieval for organizations.
  * Added access to V1 and V2 capacity reports, including metric-specific daily reports.
  * Improved export request processing and callback handling.

* **Security**
  * Restricted billing account lookups to customer and support roles.

* **Testing**
  * Expanded authorization coverage across subscription, capacity, billing, and export workflows.
  * Improved validation across legacy and modern authorization models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->