### PR TITLE
SWATCH-5498: Configure kessel-sdk to use our grpc dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <insights-notification-schemas-java.version>1.1.0</insights-notification-schemas-java.version>
     <rest-assured.version>6.0.1</rest-assured.version>
     <kessel-sdk.version>1.9.0</kessel-sdk.version>
-    <grpc.version>1.82.2</grpc.version>
+    <grpc.version>1.83.1</grpc.version>
     <oauth2-oidc-sdk.version>11.38.2</oauth2-oidc-sdk.version>
 
     <!-- Plugins -->

--- a/swatch-common-kessel/pom.xml
+++ b/swatch-common-kessel/pom.xml
@@ -18,6 +18,20 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- Adding the grpc-bom dependency here, so kessel-sdk, grpc-testing and
+      grpc-netty-shaded dependencies use the same grpc dependency -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>
@@ -37,7 +51,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <version>${grpc.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -52,7 +65,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
-      <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/swatch-common-security/pom.xml
+++ b/swatch-common-security/pom.xml
@@ -90,7 +90,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
-      <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Jira issue: SWATCH-5498

## Description

### Context & Problem
- Version Mismatch: kessel-sdk pinned its gRPC version internally to 1.82.2, while our project maintained grpc-testing and grpc-netty-shaded independently. Upgrading our project to gRPC 1.83.1 caused runtime incompatibilities with kessel-sdk.

### Solution

- Unified gRPC Management: Configured Maven <dependencyManagement> to enforce gRPC 1.83.1 globally, overriding kessel-sdk's internal version to eliminate version drift and runtime conflicts.

## Testing
Regression testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated gRPC components to version 1.83.1.
* Standardized gRPC version management across shared modules.
* Improved dependency consistency by centralizing gRPC version resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->