### PR TITLE
fix(ct): stop recreating OpenShift port-forwards on sticky websocket errors

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
@@ -274,7 +274,7 @@ public abstract class BaseKubernetesClient<
      * Konflux nproc via Fabric8's unbounded OkHttp dispatcher.
      */
     boolean needsToRecreate() {
-      return !process.isAlive() || process.errorOccurred();
+      return !process.isAlive();
     }
   }
 }


### PR DESCRIPTION
## Description

Konflux `bonfire-component-tests` for **swatch-contracts** hangs in `run-tests` with `OutOfMemoryError: unable to create native thread` (~1.7Gi RSS, not a 4Gi heap OOM). Same failure on main (including Konflux references PRs), not only on later feature branches.

[#6569](https://github.com/RedHatInsights/rhsm-subscriptions/pull/6569) stopped listing pods on every RestAssured call (good) and started recreating the Fabric8 port-forward when `errorOccurred()` is true. That flag is **sticky**: after the first websocket glitch it stays true, and Kafka keep-alive / RestAssured call `port()` on every request. Each recreation leaks a `newSingleThreadExecutor` in `PortForwarderWebsocketListener` until nproc is exhausted (`pool-2800+`).

## Testing
Regression testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Port forwarding now recreates tunnels only when the connection process has stopped, improving stability when recoverable process errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->