### PR TITLE
fix(ct): cap Fabric8 OkHttp dispatcher threads on the Konflux CT runner

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/OpenshiftClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/OpenshiftClient.java
@@ -24,6 +24,11 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
 import io.fabric8.openshift.client.OpenShiftClient;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.Dispatcher;
 
 public final class OpenshiftClient extends BaseKubernetesClient<OpenShiftClient> {
 
@@ -31,8 +36,38 @@ public final class OpenshiftClient extends BaseKubernetesClient<OpenShiftClient>
   public OpenShiftClient initializeClient(Config config) {
     return new KubernetesClientBuilder()
         .withConfig(config)
-        .withHttpClientFactory(new OkHttpClientFactory())
+        .withHttpClientFactory(new BoundedOkHttpClientFactory())
         .build()
         .adapt(OpenShiftClient.class);
+  }
+
+  static final class BoundedOkHttpClientFactory extends OkHttpClientFactory {
+    static final int MAX_REQUESTS = 32;
+    static final int MAX_REQUESTS_PER_HOST = 16;
+    static final int MAX_DISPATCHER_THREADS = 32;
+
+    @Override
+    protected Dispatcher initDispatcher() {
+      AtomicInteger threadIndex = new AtomicInteger();
+      ThreadPoolExecutor executor =
+          new ThreadPoolExecutor(
+              0,
+              MAX_DISPATCHER_THREADS,
+              60L,
+              TimeUnit.SECONDS,
+              new SynchronousQueue<>(),
+              runnable -> newDispatcherThread(runnable, threadIndex),
+              new ThreadPoolExecutor.CallerRunsPolicy());
+      Dispatcher dispatcher = new Dispatcher(executor);
+      dispatcher.setMaxRequests(MAX_REQUESTS);
+      dispatcher.setMaxRequestsPerHost(MAX_REQUESTS_PER_HOST);
+      return dispatcher;
+    }
+
+    private static Thread newDispatcherThread(Runnable runnable, AtomicInteger threadIndex) {
+      Thread thread = new Thread(runnable, "okhttp-ct-dispatcher-" + threadIndex.incrementAndGet());
+      thread.setDaemon(true);
+      return thread;
+    }
   }
 }


### PR DESCRIPTION
Jira issue: SWATCH-XXXX

## Description

Follow-up to #6576. That change stopped recreating port-forwards on sticky `errorOccurred()`, but `bonfire-component-tests-pipelinerun-gdvfw` still hung: `OutOfMemoryError: unable to create native thread` on **OkHttp Dispatcher** (~1.7Gi RSS, swatch-contracts).

Fabric8 sets `maxRequests` / `maxRequestsPerHost` to `Integer.MAX_VALUE` on an unbounded OkHttp pool. Port-forward websockets are long-running async calls and never release those slots, so native threads keep growing until nproc.

This caps the dispatcher at 32 threads / 32 requests. Extra calls wait in OkHttp's ready queue (or run on the caller via `CallerRunsPolicy`) instead of creating another LWP.

## Testing
Regression testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of concurrent OpenShift API requests by applying controlled request limits.
  * Enhanced stability during periods of high request volume, helping prevent excessive resource consumption and maintain responsive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->