### PR TITLE
fix(ct): reuse HTTP connections through OpenShift port-forwards

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
@@ -27,9 +27,9 @@ import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.JsonUtils;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
 import io.restassured.response.Response;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -108,7 +108,7 @@ public class KafkaBridgeService extends RestService {
 
     given()
         .config(
-            RestAssuredConfig.config()
+            PooledRestAssured.config()
                 .objectMapperConfig(
                     ObjectMapperConfig.objectMapperConfig()
                         .jackson2ObjectMapperFactory((cls, charset) -> JsonUtils.getObjectMapper()))
@@ -277,9 +277,9 @@ public class KafkaBridgeService extends RestService {
   }
 
   /**
-   * Starts a background process that polls consumers every 2 seconds to keep them alive. This
-   * prevents Kafka Bridge from automatically deleting inactive consumers. Also caches all received
-   * messages in memory for later retrieval.
+   * Starts a background process that polls consumers every 500 milliseconds to keep them alive.
+   * This prevents Kafka Bridge from automatically deleting inactive consumers. Also caches all
+   * received messages in memory for later retrieval.
    */
   private void startConsumerKeepAlive() {
     if (keepAliveScheduler != null) {
@@ -310,6 +310,7 @@ public class KafkaBridgeService extends RestService {
                 // Poll for messages to keep consumer alive AND cache messages
                 Response response =
                     given()
+                        .config(PooledRestAssured.keepAliveConfig())
                         .accept(CONTENT_TYPE)
                         .queryParam("timeout", 1000) // Slightly longer timeout to get messages
                         .when()

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/RestService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/RestService.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.component.tests.utils.Ports.DEFAULT_HTTP_PORT;
 
 import com.redhat.swatch.component.tests.core.BaseService;
 import com.redhat.swatch.component.tests.logging.Log;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 
@@ -45,6 +46,7 @@ public class RestService extends BaseService<RestService> {
   }
 
   public RequestSpecification given() {
+    PooledRestAssured.install();
     return RestAssured.given()
         .baseUri(HTTP + getHost())
         .basePath(basePath)
@@ -66,5 +68,6 @@ public class RestService extends BaseService<RestService> {
   public void stop() {
     super.stop();
     RestAssured.reset();
+    PooledRestAssured.install();
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
@@ -28,6 +28,7 @@ import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.model.InfoFeatureFlag;
 import com.redhat.swatch.component.tests.model.InfoFeatureFlags;
 import com.redhat.swatch.component.tests.utils.JsonUtils;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -44,6 +45,7 @@ public class SwatchService extends RestService {
   private static final String FEATURE_FLAGS_SECTION = "feature-flags";
 
   public RequestSpecification managementServer() {
+    PooledRestAssured.install();
     return RestAssured.given()
         .baseUri(HTTP + getHost())
         .basePath(BASE_PATH)

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Shared Apache HttpClient for RestAssured so HTTP keep-alive reuses localhost sockets. Fabric8
+ * LocalPortForward opens a Kubernetes websocket per TCP connect; a new client per request leaks
+ * native threads.
+ *
+ * <p>RestAssured 6 still requires {@code AbstractHttpClient} ({@code DefaultHttpClient}). That
+ * client synchronizes {@code execute}, so Kafka Bridge keep-alive polling uses a second instance
+ * and does not block test traffic.
+ *
+ * <p>RestAssured does not consume the Apache entity unless a body matcher is set. Buffering the
+ * entity inside {@code execute()} returns the lease to the pool.
+ *
+ * <p>Fabric8 port-forwards close idle TCP without Apache noticing. Unbounded keep-alive then reuses
+ * a dead socket ({@code NoHttpResponseException}). Keep-alive is capped and idle connections are
+ * closed on that same interval.
+ */
+@SuppressWarnings("deprecation")
+public final class PooledRestAssured {
+
+  private static final int MAX_TOTAL = 64;
+  private static final int MAX_PER_ROUTE = 8;
+  private static final int KEEP_ALIVE_MAX_TOTAL = 8;
+  private static final int KEEP_ALIVE_MAX_PER_ROUTE = 2;
+  private static final int SO_TIMEOUT_MS = 30_000;
+  private static final int CONNECT_TIMEOUT_MS = 10_000;
+  private static final long CONN_MANAGER_TIMEOUT_MS = 10_000L;
+  static final int KEEP_ALIVE_MS = 3_000;
+  private static final long IDLE_TIMEOUT_SECONDS = 3L;
+  private static final List<PoolingClientConnectionManager> MANAGERS = new CopyOnWriteArrayList<>();
+  private static final ScheduledExecutorService EVICTOR =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread thread = new Thread(r, "pooled-restassured-evictor");
+            thread.setDaemon(true);
+            return thread;
+          });
+  private static final RestAssuredConfig CONFIG = buildConfig(MAX_TOTAL, MAX_PER_ROUTE);
+  private static final RestAssuredConfig KEEP_ALIVE_CONFIG =
+      buildConfig(KEEP_ALIVE_MAX_TOTAL, KEEP_ALIVE_MAX_PER_ROUTE);
+
+  static {
+    startEvictor();
+    install();
+  }
+
+  private PooledRestAssured() {}
+
+  public static void install() {
+    RestAssured.config = CONFIG;
+  }
+
+  public static RestAssuredConfig config() {
+    return CONFIG;
+  }
+
+  public static RestAssuredConfig keepAliveConfig() {
+    return KEEP_ALIVE_CONFIG;
+  }
+
+  static int leasedCount() {
+    int leased = 0;
+    for (PoolingClientConnectionManager manager : MANAGERS) {
+      leased += manager.getTotalStats().getLeased();
+    }
+    return leased;
+  }
+
+  private static RestAssuredConfig buildConfig(int maxTotal, int maxPerRoute) {
+    PoolingClientConnectionManager connections = new PoolingClientConnectionManager();
+    connections.setMaxTotal(maxTotal);
+    connections.setDefaultMaxPerRoute(maxPerRoute);
+    MANAGERS.add(connections);
+    DefaultHttpClient httpClient = new DefaultHttpClient(connections);
+    httpClient.getParams().setIntParameter(CoreConnectionPNames.SO_TIMEOUT, SO_TIMEOUT_MS);
+    httpClient
+        .getParams()
+        .setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, CONNECT_TIMEOUT_MS);
+    httpClient.getParams().setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, true);
+    httpClient
+        .getParams()
+        .setLongParameter(ClientPNames.CONN_MANAGER_TIMEOUT, CONN_MANAGER_TIMEOUT_MS);
+    httpClient.setKeepAliveStrategy((response, context) -> KEEP_ALIVE_MS);
+    // Retry connect/stale-socket failures before bytes are sent. Bodyless DELETE
+    // is treated as idempotent by DefaultHttpRequestRetryHandler, so sent
+    // mutations are rejected here before delegating.
+    httpClient.setHttpRequestRetryHandler(new NoSentMutationRetryHandler());
+    // RestAssured does not EntityUtils.consume unless a body matcher is set, so
+    // the Apache connection stays leased. Buffering the entity consumes the
+    // stream inside execute() and still leaves the body for RestAssured.
+    httpClient.addResponseInterceptor(
+        (response, context) -> {
+          HttpEntity entity = response.getEntity();
+          if (entity != null) {
+            response.setEntity(new BufferedHttpEntity(entity));
+          }
+          connections.closeExpiredConnections();
+          connections.closeIdleConnections(KEEP_ALIVE_MS, TimeUnit.MILLISECONDS);
+        });
+    return RestAssuredConfig.config()
+        .httpClient(
+            HttpClientConfig.httpClientConfig()
+                .setParam(CoreConnectionPNames.STALE_CONNECTION_CHECK, true)
+                .httpClientFactory(() -> httpClient)
+                .reuseHttpClientInstance());
+  }
+
+  private static void startEvictor() {
+    EVICTOR.scheduleAtFixedRate(
+        PooledRestAssured::evictIdleConnections,
+        IDLE_TIMEOUT_SECONDS,
+        IDLE_TIMEOUT_SECONDS,
+        TimeUnit.SECONDS);
+    // JVM exit is suite teardown for Surefire. RestService.stop() must not
+    // shut down these managers: other services still use the shared pool.
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(PooledRestAssured::shutdownManagers, "pooled-restassured-shutdown"));
+  }
+
+  private static void evictIdleConnections() {
+    for (PoolingClientConnectionManager manager : MANAGERS) {
+      manager.closeExpiredConnections();
+      manager.closeIdleConnections(IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+  }
+
+  private static void shutdownManagers() {
+    EVICTOR.shutdownNow();
+    for (PoolingClientConnectionManager manager : MANAGERS) {
+      manager.shutdown();
+    }
+  }
+
+  /**
+   * Apache retries bodyless DELETE after send. Kafka Bridge consumer teardown and Wiremock DELETE
+   * must not be replayed.
+   */
+  static final class NoSentMutationRetryHandler extends DefaultHttpRequestRetryHandler {
+
+    private static final Set<String> MUTATIONS = Set.of("POST", "PUT", "PATCH", "DELETE");
+
+    NoSentMutationRetryHandler() {
+      super(3, false);
+    }
+
+    @Override
+    public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+      HttpClientContext clientContext = HttpClientContext.adapt(context);
+      HttpRequest request = clientContext.getRequest();
+      if (request != null && isMutation(request) && clientContext.isRequestSent()) {
+        return false;
+      }
+      return super.retryRequest(exception, executionCount, context);
+    }
+
+    private static boolean isMutation(HttpRequest request) {
+      return MUTATIONS.contains(request.getRequestLine().getMethod());
+    }
+  }
+}

--- a/swatch-test-framework/src/test/java/com/redhat/swatch/component/tests/utils/PooledRestAssuredTest.java
+++ b/swatch-test-framework/src/test/java/com/redhat/swatch/component/tests/utils/PooledRestAssuredTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.utils;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.http.HttpRequest;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PooledRestAssuredTest {
+
+  // One more than PoolingClientConnectionManager defaultMaxPerRoute (8).
+  private static final int REQUESTS_BEYOND_MAX_PER_ROUTE = 9;
+  private static final byte[] EMPTY = new byte[0];
+
+  private KeepAliveServer server;
+
+  @BeforeEach
+  void givenKeepAliveServer() throws IOException {
+    server = new KeepAliveServer();
+    server.start();
+    PooledRestAssured.install();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.close();
+    }
+  }
+
+  @Test
+  void shouldReleaseConnectionsAfterKeepAliveResponses() {
+    for (int i = 0; i < REQUESTS_BEYOND_MAX_PER_ROUTE; i++) {
+      int request = i;
+      assertDoesNotThrow(
+          this::whenPostEmptyOk,
+          () ->
+              "request "
+                  + request
+                  + " failed with "
+                  + PooledRestAssured.leasedCount()
+                  + " leased connections");
+      assertEquals(0, PooledRestAssured.leasedCount(), "leased after request " + request);
+    }
+  }
+
+  @Test
+  void shouldReusePoolAfterServerDropsKeepAliveSocket() {
+    whenPostEmptyOk();
+    server.dropClientSockets();
+    assertDoesNotThrow(this::whenPostEmptyOk);
+    assertEquals(0, PooledRestAssured.leasedCount());
+  }
+
+  @Test
+  void shouldOpenNewConnectionWhenIdleKeepAliveForwardDies() throws Exception {
+    server.closeWithoutResponseOnReusedSocket();
+    whenPostEmptyOk();
+    assertEquals(1, server.acceptedConnections());
+    Thread.sleep(PooledRestAssured.KEEP_ALIVE_MS + 500L);
+    assertDoesNotThrow(this::whenPostEmptyOk);
+    assertEquals(2, server.acceptedConnections());
+    assertEquals(0, PooledRestAssured.leasedCount());
+  }
+
+  @Test
+  void shouldNotRetrySentDelete() {
+    assertFalse(retryRequest(new HttpDelete("/consumers/x"), true));
+  }
+
+  @Test
+  void shouldRetryUnsentDelete() {
+    assertTrue(retryRequest(new HttpDelete("/consumers/x"), false));
+  }
+
+  @Test
+  void shouldRetrySentGet() {
+    assertTrue(retryRequest(new HttpGet("/"), true));
+  }
+
+  private static boolean retryRequest(HttpRequest request, boolean sent) {
+    HttpClientContext context = HttpClientContext.create();
+    context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+    context.setAttribute(HttpCoreContext.HTTP_REQ_SENT, sent);
+    return new PooledRestAssured.NoSentMutationRetryHandler()
+        .retryRequest(new NoHttpResponseException("dropped"), 1, context);
+  }
+
+  private void whenPostEmptyOk() {
+    given()
+        .baseUri("http://127.0.0.1")
+        .port(server.port())
+        .contentType("application/json")
+        .body(Map.of("contains", "component-test-generated"))
+        .when()
+        .post("/__admin/mappings/remove-by-metadata")
+        .then()
+        .statusCode(200);
+  }
+
+  /**
+   * HTTP/1.1 keep-alive server that reuses the accepted TCP socket. Closing the client socket after
+   * a response mimics Fabric8 LocalPortForward dropping a tunnel while RestAssured still has the
+   * connection in the pool.
+   */
+  private static final class KeepAliveServer implements AutoCloseable {
+    private final ServerSocket serverSocket;
+    private final ExecutorService workers = Executors.newCachedThreadPool();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final AtomicBoolean dropReuse = new AtomicBoolean();
+    private final AtomicInteger accepted = new AtomicInteger();
+    private volatile Socket currentClient;
+
+    KeepAliveServer() throws IOException {
+      this.serverSocket = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"));
+    }
+
+    int port() {
+      return serverSocket.getLocalPort();
+    }
+
+    void start() {
+      workers.submit(this::acceptLoop);
+    }
+
+    int acceptedConnections() {
+      return accepted.get();
+    }
+
+    void closeWithoutResponseOnReusedSocket() {
+      dropReuse.set(true);
+    }
+
+    void dropClientSockets() {
+      Socket client = currentClient;
+      if (client != null) {
+        try {
+          client.close();
+        } catch (IOException ignored) {
+          // test fixture
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      running.set(false);
+      workers.shutdownNow();
+      try {
+        serverSocket.close();
+      } catch (IOException ignored) {
+        // test fixture
+      }
+      dropClientSockets();
+    }
+
+    private void acceptLoop() {
+      while (running.get()) {
+        try {
+          Socket client = serverSocket.accept();
+          accepted.incrementAndGet();
+          currentClient = client;
+          workers.submit(() -> handleClient(client));
+        } catch (IOException e) {
+          if (running.get()) {
+            throw new IllegalStateException(e);
+          }
+        }
+      }
+    }
+
+    private void handleClient(Socket client) {
+      try (Socket ignored = client;
+          InputStream raw = client.getInputStream();
+          OutputStream out = client.getOutputStream()) {
+        InputStream in = new BufferedInputStream(raw);
+        boolean first = true;
+        while (running.get() && !client.isClosed()) {
+          if (!consumeRequest(in)) {
+            return;
+          }
+          if (dropReuse.get() && !first) {
+            return;
+          }
+          first = false;
+          out.write(response());
+          out.flush();
+        }
+      } catch (IOException ignored) {
+        // client or test closed the socket
+      }
+    }
+
+    private static boolean consumeRequest(InputStream in) throws IOException {
+      StringBuilder headers = new StringBuilder();
+      int seen = 0;
+      while (seen < 4) {
+        int b = in.read();
+        if (b == -1) {
+          return false;
+        }
+        headers.append((char) b);
+        if (b == '\r' || b == '\n') {
+          seen++;
+        } else {
+          seen = 0;
+        }
+      }
+      int contentLength = 0;
+      for (String line : headers.toString().split("\r\n")) {
+        int colon = line.indexOf(':');
+        if (colon > 0 && line.substring(0, colon).equalsIgnoreCase("Content-Length")) {
+          contentLength = Integer.parseInt(line.substring(colon + 1).trim());
+        }
+      }
+      in.readNBytes(contentLength);
+      return true;
+    }
+
+    private static byte[] response() {
+      String header =
+          "HTTP/1.1 200 OK\r\n"
+              + "Content-Length: "
+              + EMPTY.length
+              + "\r\n"
+              + "Connection: keep-alive\r\n"
+              + "\r\n";
+      return header.getBytes(StandardCharsets.US_ASCII);
+    }
+  }
+}


### PR DESCRIPTION
## Description
RestAssured opened a new localhost TCP connection per request. Fabric8 LocalPortForward creates a Kubernetes websocket (and native threads) per TCP accept, which exhausted nproc in Konflux component tests.
Use a pooled Apache HttpClient with keep-alive so those sockets, and their port-forward websockets, are reused.

## Testing
Regression testing only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved HTTP connection reuse for test-service requests, reducing repeated connection setup.
  * Added connection pooling and response handling for more efficient request processing.
  * Keep-alive polling now runs every 500 milliseconds instead of every 2 seconds.

* **Reliability**
  * Improved recovery when keep-alive connections are interrupted or closed unexpectedly.
  * Prevented retries for requests that may have already been sent, reducing the risk of duplicate operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->