### PR TITLE
fix(ct): cut OpenShift client thread leaks in component tests 

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/KafkaBridgeService.java
@@ -27,9 +27,9 @@ import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.JsonUtils;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
 import io.restassured.response.Response;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -108,7 +108,7 @@ public class KafkaBridgeService extends RestService {
 
     given()
         .config(
-            RestAssuredConfig.config()
+            PooledRestAssured.config()
                 .objectMapperConfig(
                     ObjectMapperConfig.objectMapperConfig()
                         .jackson2ObjectMapperFactory((cls, charset) -> JsonUtils.getObjectMapper()))
@@ -277,9 +277,9 @@ public class KafkaBridgeService extends RestService {
   }
 
   /**
-   * Starts a background process that polls consumers every 2 seconds to keep them alive. This
-   * prevents Kafka Bridge from automatically deleting inactive consumers. Also caches all received
-   * messages in memory for later retrieval.
+   * Starts a background process that polls consumers every 500 milliseconds to keep them alive.
+   * This prevents Kafka Bridge from automatically deleting inactive consumers. Also caches all
+   * received messages in memory for later retrieval.
    */
   private void startConsumerKeepAlive() {
     if (keepAliveScheduler != null) {
@@ -310,6 +310,7 @@ public class KafkaBridgeService extends RestService {
                 // Poll for messages to keep consumer alive AND cache messages
                 Response response =
                     given()
+                        .config(PooledRestAssured.keepAliveConfig())
                         .accept(CONTENT_TYPE)
                         .queryParam("timeout", 1000) // Slightly longer timeout to get messages
                         .when()

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/RestService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/RestService.java
@@ -24,6 +24,7 @@ import static com.redhat.swatch.component.tests.utils.Ports.DEFAULT_HTTP_PORT;
 
 import com.redhat.swatch.component.tests.core.BaseService;
 import com.redhat.swatch.component.tests.logging.Log;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 
@@ -45,6 +46,7 @@ public class RestService extends BaseService<RestService> {
   }
 
   public RequestSpecification given() {
+    PooledRestAssured.install();
     return RestAssured.given()
         .baseUri(HTTP + getHost())
         .basePath(basePath)
@@ -66,5 +68,6 @@ public class RestService extends BaseService<RestService> {
   public void stop() {
     super.stop();
     RestAssured.reset();
+    PooledRestAssured.install();
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/SwatchService.java
@@ -28,6 +28,7 @@ import com.redhat.swatch.component.tests.logging.Log;
 import com.redhat.swatch.component.tests.model.InfoFeatureFlag;
 import com.redhat.swatch.component.tests.model.InfoFeatureFlags;
 import com.redhat.swatch.component.tests.utils.JsonUtils;
+import com.redhat.swatch.component.tests.utils.PooledRestAssured;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -44,6 +45,7 @@ public class SwatchService extends RestService {
   private static final String FEATURE_FLAGS_SECTION = "feature-flags";
 
   public RequestSpecification managementServer() {
+    PooledRestAssured.install();
     return RestAssured.given()
         .baseUri(HTTP + getHost())
         .basePath(BASE_PATH)

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/api/clients/BaseKubernetesClient.java
@@ -42,8 +42,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public abstract class BaseKubernetesClient<
     T extends io.fabric8.kubernetes.client.KubernetesClient> {
@@ -162,7 +160,7 @@ public abstract class BaseKubernetesClient<
   }
 
   /** Resolve the port by the service. */
-  public int port(String serviceName, int port, Service service, Map<String, String> podLabels) {
+  public int port(String serviceName, int port, Service service) {
     String svcPortForwardKey = serviceName + "-" + port;
     KeyValueEntry<Service, LocalPortForwardWrapper> portForwardByService =
         portForwardsByService.get(svcPortForwardKey);
@@ -175,8 +173,7 @@ public abstract class BaseKubernetesClient<
               .portForward(port, SocketUtils.findAvailablePort(service));
       Log.trace(service, "Opening port forward from local port " + process.getLocalPort());
 
-      portForwardByService =
-          new KeyValueEntry<>(service, new LocalPortForwardWrapper(process, podLabels));
+      portForwardByService = new KeyValueEntry<>(service, new LocalPortForwardWrapper(process));
       portForwardsByService.put(svcPortForwardKey, portForwardByService);
     }
 
@@ -242,33 +239,42 @@ public abstract class BaseKubernetesClient<
     client = (T) initializeClient(config);
   }
 
+  public void close() {
+    try {
+      portForwardsByService
+          .values()
+          .forEach(
+              portForward -> {
+                try {
+                  closePortForward(portForward);
+                } catch (Exception ex) {
+                  Log.warn("Failed to close port forward", ex);
+                }
+              });
+    } finally {
+      portForwardsByService.clear();
+      if (client != null) {
+        client.close();
+        client = null;
+      }
+    }
+  }
+
   class LocalPortForwardWrapper {
     int localPort;
     LocalPortForward process;
-    Map<String, String> podLabels;
-    Set<String> podIds;
 
-    LocalPortForwardWrapper(LocalPortForward process, Map<String, String> podLabels) {
+    LocalPortForwardWrapper(LocalPortForward process) {
       this.localPort = process.getLocalPort();
       this.process = process;
-      this.podLabels = podLabels;
-      this.podIds = resolvePodIds();
     }
 
-    /** Needs to recreate the port forward if the pods have changed or the process was stopped. */
+    /**
+     * Recreate only when the tunnel itself died. Listing pods on every RestAssured call exhausts
+     * Konflux nproc via Fabric8's unbounded OkHttp dispatcher.
+     */
     boolean needsToRecreate() {
-      if (!process.isAlive()) {
-        return true;
-      }
-
-      Set<String> newPodIds = resolvePodIds();
-      return !podIds.containsAll(newPodIds);
-    }
-
-    private Set<String> resolvePodIds() {
-      return podsInService(podLabels).stream()
-          .map(p -> p.getMetadata().getName())
-          .collect(Collectors.toSet());
+      return !process.isAlive();
     }
   }
 }

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/core/extensions/OpenShiftExtensionBootstrap.java
@@ -34,7 +34,7 @@ import com.redhat.swatch.component.tests.utils.FileUtils;
 import com.redhat.swatch.component.tests.utils.InjectUtils;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.nio.file.Path;
@@ -48,6 +48,15 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
   public static final String CLIENT = "oc-client";
   public static final String TARGET_OPENSHIFT = "openshift";
 
+  /**
+   * One Fabric8/OkHttp client for the JVM. JUnit constructs a new bootstrap per test class;
+   * creating a client each time leaks OkHttp dispatcher threads and exhausts the ephemeral runner's
+   * native-thread limit.
+   */
+  private static final Object SUITE_CLIENT_LOCK = new Object();
+
+  private static OpenshiftClient suiteClient;
+
   private OpenshiftClient client;
 
   @Override
@@ -60,8 +69,7 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
     OpenShiftConfiguration configuration =
         context.loadCustomConfiguration(TARGET_OPENSHIFT, new OpenShiftConfigurationBuilder());
 
-    client = new OpenshiftClient();
-    client.initializeClientUsingNamespace(new DefaultKubernetesClient().getNamespace());
+    client = suiteClient();
 
     if (configuration.getAdditionalResources() != null) {
       for (String additionalResource : configuration.getAdditionalResources()) {
@@ -143,6 +151,48 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
 
   private Path logsTestFolder(ComponentTestContext context) {
     return context.getLogFolder().resolve(context.getRunningTestClassName());
+  }
+
+  private static OpenshiftClient suiteClient() {
+    synchronized (SUITE_CLIENT_LOCK) {
+      if (suiteClient == null) {
+        String namespace = currentNamespace();
+        OpenshiftClient initializedClient = new OpenshiftClient();
+        try {
+          initializedClient.initializeClientUsingNamespace(namespace);
+          suiteClient = initializedClient;
+        } catch (RuntimeException | Error e) {
+          initializedClient.close();
+          throw e;
+        }
+        registerSuiteClientShutdownHook();
+      }
+      return suiteClient;
+    }
+  }
+
+  private static void registerSuiteClientShutdownHook() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  synchronized (SUITE_CLIENT_LOCK) {
+                    if (suiteClient != null) {
+                      Log.debug("Closing suite-level OpenShift client");
+                      suiteClient.close();
+                      suiteClient = null;
+                    }
+                  }
+                },
+                "openshift-client-cleanup"));
+  }
+
+  private static String currentNamespace() {
+    String namespace = Config.autoConfigure(null).getNamespace();
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalStateException("Unable to resolve OpenShift namespace");
+    }
+    return namespace;
   }
 
   public static boolean isEnabled(ComponentTestContext context) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/OpenShiftLoggingHandler.java
@@ -26,6 +26,7 @@ import com.redhat.swatch.component.tests.core.extensions.OpenShiftExtensionBoots
 import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -83,6 +84,16 @@ public class OpenShiftLoggingHandler extends ServiceLoggingHandler {
     this.logsSince = null;
   }
 
+  @Override
+  public synchronized List<String> logs() {
+    handle();
+    return super.logs();
+  }
+
+  /**
+   * Fetch when tests read logs. Do not poll {@code getLog()} from a background thread; that creates
+   * unbounded OkHttp dispatcher threads on the Konflux CT runner.
+   */
   @Override
   protected synchronized void handle() {
     if (!isTestActive() || logsSince == null || !isLogEnabled()) {

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/containers/OpenShiftContainerManagedResource.java
@@ -59,7 +59,6 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
     if (loggingHandler == null) {
       loggingHandler = new OpenShiftLoggingHandler(podLabels(), containerName(), context);
-      loggingHandler.startWatching();
     }
 
     running = true;
@@ -86,8 +85,8 @@ public abstract class OpenShiftContainerManagedResource extends ManagedResource 
 
   @Override
   public int getMappedPort(int port) {
-    return client.port(
-        serviceName(), portsMapping.getOrDefault(port, port), context.getOwner(), podLabels());
+    int mapped = portsMapping.getOrDefault(port, port);
+    return client.port(serviceName(), mapped, context.getOwner());
   }
 
   @Override

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.swatch.component.tests.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.filter.Filter;
+import io.restassured.filter.FilterContext;
+import io.restassured.response.Response;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.FilterableResponseSpecification;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.params.CoreConnectionPNames;
+
+/**
+ * Shared Apache HttpClient for RestAssured so HTTP keep-alive reuses localhost sockets. Fabric8
+ * LocalPortForward opens a Kubernetes websocket per TCP connect; a new client per request leaks
+ * native threads.
+ *
+ * <p>RestAssured 6 still requires {@code AbstractHttpClient} ({@code DefaultHttpClient}). That
+ * client synchronizes {@code execute}, so Kafka Bridge keep-alive polling uses a second instance
+ * and does not block test traffic.
+ */
+public final class PooledRestAssured {
+
+  private static final int MAX_TOTAL = 64;
+  private static final int MAX_PER_ROUTE = 8;
+  private static final int KEEP_ALIVE_MAX_TOTAL = 8;
+  private static final int KEEP_ALIVE_MAX_PER_ROUTE = 2;
+  private static final int SO_TIMEOUT_MS = 30_000;
+  private static final int CONNECT_TIMEOUT_MS = 10_000;
+  private static final long CONN_MANAGER_TIMEOUT_MS = 10_000L;
+  private static final RestAssuredConfig CONFIG = buildConfig(MAX_TOTAL, MAX_PER_ROUTE);
+  private static final RestAssuredConfig KEEP_ALIVE_CONFIG =
+      buildConfig(KEEP_ALIVE_MAX_TOTAL, KEEP_ALIVE_MAX_PER_ROUTE);
+  private static final Filter CONSUME_RESPONSE = new ConsumeResponseFilter();
+
+  static {
+    install();
+  }
+
+  private PooledRestAssured() {}
+
+  public static void install() {
+    RestAssured.config = CONFIG;
+    if (!RestAssured.filters().contains(CONSUME_RESPONSE)) {
+      RestAssured.filters(CONSUME_RESPONSE);
+    }
+  }
+
+  public static RestAssuredConfig config() {
+    return CONFIG;
+  }
+
+  public static RestAssuredConfig keepAliveConfig() {
+    return KEEP_ALIVE_CONFIG;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static RestAssuredConfig buildConfig(int maxTotal, int maxPerRoute) {
+    PoolingClientConnectionManager connections = new PoolingClientConnectionManager();
+    connections.setMaxTotal(maxTotal);
+    connections.setDefaultMaxPerRoute(maxPerRoute);
+    DefaultHttpClient httpClient = new DefaultHttpClient(connections);
+    httpClient.getParams().setIntParameter(CoreConnectionPNames.SO_TIMEOUT, SO_TIMEOUT_MS);
+    httpClient
+        .getParams()
+        .setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, CONNECT_TIMEOUT_MS);
+    httpClient
+        .getParams()
+        .setLongParameter(ClientPNames.CONN_MANAGER_TIMEOUT, CONN_MANAGER_TIMEOUT_MS);
+    return RestAssuredConfig.config()
+        .httpClient(
+            HttpClientConfig.httpClientConfig()
+                .httpClientFactory(() -> httpClient)
+                .reuseHttpClientInstance());
+  }
+
+  // RestAssured skips EntityUtils.consume unless body matchers are present.
+  private static final class ConsumeResponseFilter implements Filter {
+    @Override
+    public Response filter(
+        FilterableRequestSpecification requestSpec,
+        FilterableResponseSpecification responseSpec,
+        FilterContext ctx) {
+      Response response = ctx.next(requestSpec, responseSpec);
+      response.asByteArray();
+      return response;
+    }
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/PooledRestAssured.java
@@ -28,10 +28,15 @@ import io.restassured.filter.FilterContext;
 import io.restassured.response.Response;
 import io.restassured.specification.FilterableRequestSpecification;
 import io.restassured.specification.FilterableResponseSpecification;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.params.ClientPNames;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.util.EntityUtils;
 
 /**
  * Shared Apache HttpClient for RestAssured so HTTP keep-alive reuses localhost sockets. Fabric8
@@ -41,6 +46,14 @@ import org.apache.http.params.CoreConnectionPNames;
  * <p>RestAssured 6 still requires {@code AbstractHttpClient} ({@code DefaultHttpClient}). That
  * client synchronizes {@code execute}, so Kafka Bridge keep-alive polling uses a second instance
  * and does not block test traffic.
+ *
+ * <p>RestAssured buffers the body without consuming the Apache {@code HttpEntity}, so pooled
+ * connections stay leased and later calls fail with {@code ConnectionPoolTimeoutException}. A
+ * response interceptor copies the entity to a {@code ByteArrayEntity} so the lease is released.
+ *
+ * <p>Kubernetes port-forwards close idle streams without Apache noticing. Infinite keep-alive then
+ * reuses a dead socket and tests fail with {@code NoHttpResponseException}. Keep-alive is capped,
+ * stale connections are checked, and {@code NoHttpResponseException} is retried on a new socket.
  */
 public final class PooledRestAssured {
 
@@ -51,6 +64,8 @@ public final class PooledRestAssured {
   private static final int SO_TIMEOUT_MS = 30_000;
   private static final int CONNECT_TIMEOUT_MS = 10_000;
   private static final long CONN_MANAGER_TIMEOUT_MS = 10_000L;
+  private static final int KEEP_ALIVE_MS = 3_000;
+  private static final int RETRY_COUNT = 3;
   private static final RestAssuredConfig CONFIG = buildConfig(MAX_TOTAL, MAX_PER_ROUTE);
   private static final RestAssuredConfig KEEP_ALIVE_CONFIG =
       buildConfig(KEEP_ALIVE_MAX_TOTAL, KEEP_ALIVE_MAX_PER_ROUTE);
@@ -90,6 +105,34 @@ public final class PooledRestAssured {
     httpClient
         .getParams()
         .setLongParameter(ClientPNames.CONN_MANAGER_TIMEOUT, CONN_MANAGER_TIMEOUT_MS);
+    httpClient.getParams().setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, true);
+    httpClient.setKeepAliveStrategy((response, context) -> KEEP_ALIVE_MS);
+    httpClient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(RETRY_COUNT, true));
+    httpClient.addResponseInterceptor(
+        (response, context) -> {
+          HttpEntity entity = response.getEntity();
+          if (entity == null) {
+            connections.closeExpiredConnections();
+            connections.closeIdleConnections(KEEP_ALIVE_MS, TimeUnit.MILLISECONDS);
+            return;
+          }
+          byte[] data;
+          try {
+            data = EntityUtils.toByteArray(entity);
+          } finally {
+            EntityUtils.consumeQuietly(entity);
+            connections.closeExpiredConnections();
+            connections.closeIdleConnections(KEEP_ALIVE_MS, TimeUnit.MILLISECONDS);
+          }
+          ByteArrayEntity copy = new ByteArrayEntity(data);
+          if (entity.getContentType() != null) {
+            copy.setContentType(entity.getContentType());
+          }
+          if (entity.getContentEncoding() != null) {
+            copy.setContentEncoding(entity.getContentEncoding());
+          }
+          response.setEntity(copy);
+        });
     return RestAssuredConfig.config()
         .httpClient(
             HttpClientConfig.httpClientConfig()


### PR DESCRIPTION
## Description
Contains the component test framework improvements to release ephemeral resources.

These changes fix allow more tests: https://github.com/RedHatInsights/rhsm-subscriptions/pull/6579 to run without running out of resources.

The 3 included commits are:
1. "fix(ct): cut OpenShift client thread leaks in component tests" - My original commit.  Good improvement for: fetching the logs on demand.  And stops listing pods on every RestAssured call. 
2. "fix(ct): reuse HTTP connections through OpenShift port-forwards" - Jose's fix for reusing the HTTP Connections.  This commit is required.
3. "fix(ct): ensure Http Pooled Connections Release" - Releases pooled Apache leases and drops dead keep-alive sockets.  This commit is required.

## Testing
```
./mvnw install -Pcomponent-tests -pl swatch-contracts/ct -am     -Dswatch.component-tests.global.target=openshift | tee comp-test-results
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added billing-account lookups and expanded capacity-report access.
  - Added automatic setup for export request processing and local export-service configuration.
  - Added export callback testing support.

- **Bug Fixes**
  - Restricted billing-account access to customer and support roles, removing test-role bypasses.

- **Tests**
  - Expanded authorization coverage across reporting, billing-account, service-account, associate, and export workflows.
  - Improved test reliability with pooled HTTP connections and shared OpenShift resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->