### PR TITLE
SWATCH-5480: Support ENTITLEMENT_QTY attribute at offering sync

### DIFF
--- a/src/main/resources/liquibase/202101081600-tweak-offering.xml
+++ b/src/main/resources/liquibase/202101081600-tweak-offering.xml
@@ -5,7 +5,12 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="202001081600-1" author="khowell">
         <preConditions onFail="MARK_RAN">
-            <columnExists tableName="offering" columnName="entitlement_quantity"/>
+            <and>
+                <columnExists tableName="offering" columnName="entitlement_quantity"/>
+                <not>
+                    <tableExists tableName="databasechangelog_swatch_contracts"/>
+                </not>
+            </and>
         </preConditions>
         <comment>Drop entitlement_quantity column</comment>
         <dropColumn tableName="offering" columnName="entitlement_quantity"/>

--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -1848,6 +1848,24 @@ This section verifies the automatic contract termination behavior when contracts
   - Capacity values indicate unlimited status appropriately.
   - Subscription correctly linked to unlimited offering in response.
 
+**offering-capacity-TC003: Synchronize entitlement quantity attribute offering**
+- **Description:** Verify that entitlement quantity attribute in offerings are synchronized correctly with proper sockets capacity.
+- **Setup:** Create test product data with the ENTITLEMENT_QTY attribute set to 25 in external product service.
+- **Action:** Send Kafka message to trigger offering synchronization.
+- **Verification:** Use internal GET API to verify offering synchronization succeeded for the expected sockets capacity SKU.
+- **Expected Result:**
+  - API returns HTTP 200 response indicating successful synchronization.
+  - Capacity matches expected sockets values for the offering.
+
+**offering-capacity-TC004: Synchronize entitlement quantity attribute offering with unlimited**
+- **Description:** Verify that entitlement quantity attribute in offerings are synchronized correctly with unlimited sockets capacity.
+- **Setup:** Create test product data with the ENTITLEMENT_QTY attribute set to "Unlimited" in external product service.
+- **Action:** Send Kafka message to trigger offering synchronization.
+- **Verification:** Use internal GET API to verify offering synchronization succeeded for the expected unlimited sockets capacity SKU.
+- **Expected Result:**
+  - API returns HTTP 200 response indicating successful synchronization.
+  - Capacity values indicate unlimited status appropriately.
+
 ## Subscription Type (SKU capacity report meta)
 
 **subscription-type-TC001: Report On-demand subscription type on V1 for PAYG products**

--- a/swatch-contracts/ct/java/api/ProductApiStubs.java
+++ b/swatch-contracts/ct/java/api/ProductApiStubs.java
@@ -115,6 +115,9 @@ public class ProductApiStubs {
     if (offering.getRole() != null) {
       attributes.add(Map.of("code", "X_ROLE", "value", offering.getRole()));
     }
+    if (offering.getEntitlementQuantity() != null) {
+      attributes.add(Map.of("code", "ENTITLEMENT_QTY", "value", offering.getEntitlementQuantity()));
+    }
 
     var product =
         Map.of(

--- a/swatch-contracts/ct/java/domain/Offering.java
+++ b/swatch-contracts/ct/java/domain/Offering.java
@@ -72,6 +72,7 @@ public class Offering {
   private final Usage usage;
   private final String role;
   private final List<Integer> engProducts;
+  private final String entitlementQuantity;
 
   public static Offering buildRhelOffering(String sku, Double cores, Double sockets) {
     Objects.requireNonNull(sku, "sku cannot be null");

--- a/swatch-contracts/ct/java/tests/OfferingCapacityComponentTest.java
+++ b/swatch-contracts/ct/java/tests/OfferingCapacityComponentTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.swatch.component.tests.api.TestPlanName;
@@ -46,8 +48,8 @@ import org.junit.jupiter.api.Test;
 
 public class OfferingCapacityComponentTest extends BaseContractComponentTest {
 
-  private static final double OPENSHIFT_CORES_CAPACITY = 8.0;
-  private static final double OPENSHIFT_SOCKETS_CAPACITY = 2.0;
+  private static final double CORES_CAPACITY = 8.0;
+  private static final double SOCKETS_CAPACITY = 2.0;
   private static final int SUBSCRIPTION_QUANTITY = 3;
 
   @TestPlanName("offering-capacity-TC001")
@@ -56,8 +58,7 @@ public class OfferingCapacityComponentTest extends BaseContractComponentTest {
     // Given: A metered offering with multiple metrics (Cores and Sockets) and subscription with
     // quantity
     final String sku = RandomUtils.generateRandom();
-    Offering offering =
-        Offering.buildOpenShiftOffering(sku, OPENSHIFT_CORES_CAPACITY, OPENSHIFT_SOCKETS_CAPACITY);
+    Offering offering = Offering.buildOpenShiftOffering(sku, CORES_CAPACITY, SOCKETS_CAPACITY);
     Subscription createdSubscription =
         givenSubscriptionIsCreated(sku, offering, Product.OPENSHIFT, SUBSCRIPTION_QUANTITY);
 
@@ -82,39 +83,27 @@ public class OfferingCapacityComponentTest extends BaseContractComponentTest {
         "Should have measurements for Cores and Sockets", capacity.getMeasurements(), hasSize(2));
 
     // And: Verify measurements match expected values at correct indices (defined by meta)
-    assertThat("Report meta should not be null", report.getMeta(), notNullValue());
-    List<String> metricOrder = report.getMeta().getMeasurements();
-    List<Double> measurements = capacity.getMeasurements();
+    double expectedCoresCapacity = SUBSCRIPTION_QUANTITY * CORES_CAPACITY;
+    Double actualCoresCapacity = getMetricCapacityFromReport(CORES, capacity, report);
+    double expectedSocketsCapacity = SUBSCRIPTION_QUANTITY * SOCKETS_CAPACITY;
+    Double actualSocketsCapacity = getMetricCapacityFromReport(SOCKETS, capacity, report);
 
-    int coresIndex = metricOrder.indexOf("Cores");
-    int socketsIndex = metricOrder.indexOf("Sockets");
-
-    double expectedCoresCapacity = SUBSCRIPTION_QUANTITY * OPENSHIFT_CORES_CAPACITY;
-    double expectedSocketsCapacity = SUBSCRIPTION_QUANTITY * OPENSHIFT_SOCKETS_CAPACITY;
-
-    assertTrue(
-        coresIndex >= 0,
-        String.format("Cores metric not found in meta.measurements: %s", metricOrder));
-    assertTrue(
-        socketsIndex >= 0,
-        String.format("Sockets metric not found in meta.measurements: %s", metricOrder));
-
-    assertThat(
+    assertEquals(
+        expectedCoresCapacity,
+        actualCoresCapacity,
         String.format(
-            "Cores capacity at index %d should be %d × %.1f = %.1f",
-            coresIndex, SUBSCRIPTION_QUANTITY, OPENSHIFT_CORES_CAPACITY, expectedCoresCapacity),
-        measurements.get(coresIndex),
-        equalTo(expectedCoresCapacity));
+            "Cores capacity %s should be %d × %.1f = %.1f",
+            actualCoresCapacity, SUBSCRIPTION_QUANTITY, CORES_CAPACITY, expectedCoresCapacity));
 
-    assertThat(
+    assertEquals(
+        expectedSocketsCapacity,
+        actualSocketsCapacity,
         String.format(
-            "Sockets capacity at index %d should be %d × %.1f = %.1f",
-            socketsIndex,
+            "Sockets capacity %s should be %d × %.1f = %.1f",
+            actualSocketsCapacity,
             SUBSCRIPTION_QUANTITY,
-            OPENSHIFT_SOCKETS_CAPACITY,
-            expectedSocketsCapacity),
-        measurements.get(socketsIndex),
-        equalTo(expectedSocketsCapacity));
+            SOCKETS_CAPACITY,
+            expectedSocketsCapacity));
 
     // And: API response should contain exactly one subscription (the one we created)
     assertThat("Subscriptions should not be null", capacity.getSubscriptions(), notNullValue());
@@ -184,6 +173,71 @@ public class OfferingCapacityComponentTest extends BaseContractComponentTest {
         equalTo("Test offering with unlimited usage"));
   }
 
+  @TestPlanName("offering-capacity-TC003")
+  @Test
+  void shouldSynchronizeEntitlementQuantityAttributeOffering() {
+    // Given: An offering with entitlement quantity attribute set to 25
+    String sku = RandomUtils.generateRandom();
+    int entitlementQuantity = 25;
+    Offering offering =
+        Offering.buildRhelOffering(sku, CORES_CAPACITY, SOCKETS_CAPACITY).toBuilder()
+            .entitlementQuantity(String.valueOf(entitlementQuantity))
+            .build();
+    givenSubscriptionIsCreated(sku, offering, Product.RHEL, SUBSCRIPTION_QUANTITY);
+
+    // When: Querying capacity report for the SKU
+    SkuCapacityReportV2 report = service.getSkuCapacityByProductIdForOrg(Product.RHEL, orgId);
+    assertNotNull(report, "SKU capacity should be present in the report for SKU");
+    assertNotNull(report.getData(), "SKU capacity data should be present in the report for SKU");
+    assertNotNull(report.getMeta(), "SKU capacity meta should be present in the report for SKU");
+    Optional<SkuCapacityV2> skuCapacity =
+        report.getData().stream().filter(d -> sku.equals(d.getSku())).findFirst();
+    assertTrue(skuCapacity.isPresent(), "SKU capacity should be present in the report");
+    SkuCapacityV2 capacity = skuCapacity.get();
+    assertNotNull(capacity.getMeasurements(), "Measurements should not be null");
+
+    // Then: Capacity should reflect subscription quantity multiplied by offering metrics
+    double expectedSocketsCapacity = SUBSCRIPTION_QUANTITY * SOCKETS_CAPACITY * entitlementQuantity;
+    Double actualSocketsCapacity = getMetricCapacityFromReport(SOCKETS, capacity, report);
+
+    assertEquals(
+        expectedSocketsCapacity,
+        actualSocketsCapacity,
+        String.format(
+            "Sockets capacity %s should be %d × %.1f = %.1f",
+            actualSocketsCapacity,
+            SUBSCRIPTION_QUANTITY,
+            SOCKETS_CAPACITY,
+            expectedSocketsCapacity));
+  }
+
+  @TestPlanName("offering-capacity-TC004")
+  @Test
+  void shouldSynchronizeEntitlementQuantityAttributeOfferingWithUnlimited() {
+    // Given: An offering with entitlement quantity attribute set to Unlimited
+    String sku = RandomUtils.generateRandom();
+    Offering offering =
+        Offering.buildRhelOffering(sku, CORES_CAPACITY, SOCKETS_CAPACITY).toBuilder()
+            .entitlementQuantity("Unlimited")
+            .build();
+    givenSubscriptionIsCreated(sku, offering, Product.RHEL, SUBSCRIPTION_QUANTITY);
+
+    // When: Querying capacity report for the SKU
+    SkuCapacityReportV2 report = service.getSkuCapacityByProductIdForOrg(Product.RHEL, orgId);
+    assertNotNull(report, "SKU capacity should be present in the report for SKU");
+    assertNotNull(report.getData(), "SKU capacity data should be present in the report for SKU");
+    Optional<SkuCapacityV2> skuCapacity =
+        report.getData().stream().filter(d -> sku.equals(d.getSku())).findFirst();
+    assertTrue(skuCapacity.isPresent(), "SKU capacity should be present in the report");
+    SkuCapacityV2 capacity = skuCapacity.get();
+
+    // Then: Capacity should be infinite
+    assertNotNull(capacity.getHasInfiniteQuantity(), "hasInfiniteQuantity should not be null");
+    assertTrue(
+        capacity.getHasInfiniteQuantity(),
+        "hasInfiniteQuantity flag should be true for unlimited offering");
+  }
+
   /**
    * Helper method to create an offering with subscription for capacity testing.
    *
@@ -232,5 +286,22 @@ public class OfferingCapacityComponentTest extends BaseContractComponentTest {
         is(HttpStatus.SC_OK));
 
     return subscription;
+  }
+
+  private Double getMetricCapacityFromReport(
+      MetricId metric, SkuCapacityV2 capacity, SkuCapacityReportV2 report) {
+    assertNotNull(report);
+    assertNotNull(report.getMeta());
+    List<String> metricOrder = report.getMeta().getMeasurements();
+    assertNotNull(metricOrder);
+    List<Double> measurements = capacity.getMeasurements();
+    assertNotNull(measurements);
+    int index = metricOrder.indexOf(metric.getValue());
+    assertTrue(
+        index >= 0,
+        String.format(
+            "%s metric not found in meta.measurements: %s", metric.getValue(), metricOrder));
+    assertTrue(index < measurements.size());
+    return measurements.get(index);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -143,14 +143,6 @@ public class UpstreamProductData {
     }
   }
 
-  public static String findSku(RESTProductTree skuTree) {
-    List<OperationalProduct> products = skuTree.getProducts();
-    if (products == null || products.isEmpty()) {
-      throw new IllegalArgumentException("SKU data doesn't have any products!");
-    }
-    return products.get(0).getSku();
-  }
-
   public static UpstreamProductData createFromTree(RESTProductTree skuTree) {
     var products = skuTree.getProducts();
 

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -86,7 +86,8 @@ public class UpstreamProductData {
     X_DESCRIPTION,
     /** Role originates from opProd roles field, not an attribute. */
     SPECIAL_PRICING_FLAG,
-    X_ROLE;
+    X_ROLE,
+    ENTITLEMENT_QTY
   }
 
   /** Maps opProd attribute codes to UpstreamProductData.Attrs of the same name. */
@@ -306,6 +307,9 @@ public class UpstreamProductData {
     if (offering.getUsage() != null && offering.getUsage() != Usage.EMPTY) {
       data.attrs.put(Attr.USAGE, offering.getUsage().getValue());
     }
+    if (offering.getEntitlementQuantity() != null) {
+      data.attrs.put(Attr.ENTITLEMENT_QTY, offering.getEntitlementQuantity());
+    }
     return data;
   }
 
@@ -329,6 +333,7 @@ public class UpstreamProductData {
     offering.setLevel1(attrs.get(Attr.LEVEL_1));
     offering.setLevel2(attrs.get(Attr.LEVEL_2));
     offering.setDerivedSku(attrs.get(Attr.DERIVED_SKU));
+    offering.setEntitlementQuantity(attrs.get(Attr.ENTITLEMENT_QTY));
 
     calcCapacityForOffering(offering);
 
@@ -456,14 +461,37 @@ public class UpstreamProductData {
   }
 
   private void calcCapacityForOffering(OfferingEntity offering) {
+    /*
+     * The ENTITLEMENT_QTY attribute defines the per-unit entitlement allowance embedded
+     * within a specific subscription SKU.
+     *
+     * Rather than treating each subscription unit as a 1:1, ENTITLEMENT_QTY acts as a scaling
+     * factor to determine the overall subscription threshold line (total capacity).
+     *
+     * Note that ENTITLEMENT_QTY can contain also "Unlimited" to state that the capacity
+     * is unlimited.
+     */
+    var hasUnlimitedEntitlementQuantity =
+        Optional.ofNullable(attrs.get(Attr.ENTITLEMENT_QTY))
+            .map(UpstreamProductData::hasUnlimitedUsage)
+            .orElse(false);
+    int entitlementQuantity =
+        Optional.ofNullable(nullOrInteger(attrs, Attr.ENTITLEMENT_QTY, sku)).orElse(1);
+
     // If IFL attr is defined, use it...
     Integer cores =
         Optional.ofNullable(attrs.get(Attr.IFL))
             .map(ifl -> Integer.parseInt(ifl) * CONVERSION_RATIO_IFL_TO_CORES)
             // ... but if IFL is not defined, then use the CORES attr.
             .orElseGet(() -> nullOrInteger(attrs, Attr.CORES, sku));
+    if (cores != null) {
+      cores = cores * entitlementQuantity;
+    }
 
     Integer sockets = nullOrInteger(attrs, Attr.SOCKET_LIMIT, sku);
+    if (sockets != null) {
+      sockets = sockets * entitlementQuantity;
+    }
 
     /*
     There are no SKUs today (2021-10-27) that provide both standard capacity and hypervisor capacity
@@ -491,7 +519,8 @@ public class UpstreamProductData {
         Optional.ofNullable(attrs.get(Attr.SOCKET_LIMIT))
             .map(UpstreamProductData::hasUnlimitedUsage)
             .orElse(false);
-    offering.setHasUnlimitedUsage(hasUnlimitedCores || hasUnlimitedSockets);
+    offering.setHasUnlimitedUsage(
+        hasUnlimitedCores || hasUnlimitedSockets || hasUnlimitedEntitlementQuantity);
   }
 
   private static Integer nullOrInteger(Map<Attr, String> attrs, Attr key, String sku) {

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/product/UpstreamProductData.java
@@ -30,6 +30,7 @@ import com.redhat.swatch.common.model.ServiceLevel;
 import com.redhat.swatch.common.model.Usage;
 import com.redhat.swatch.contract.exception.ErrorCode;
 import com.redhat.swatch.contract.exception.ServiceException;
+import com.redhat.swatch.contract.product.umb.ProductAttribute;
 import com.redhat.swatch.contract.product.umb.UmbOperationalProduct;
 import com.redhat.swatch.contract.repository.OfferingEntity;
 import jakarta.ws.rs.core.Response;
@@ -46,6 +47,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -160,7 +162,12 @@ public class UpstreamProductData {
       String role = parent.getRoles().stream().findFirst().orElse(null);
       offer.attrs.put(Attr.X_ROLE, role);
     }
-    offer.mapAttributes(parent);
+    if (parent.getAttributes() != null) {
+      offer.mapAttributes(
+          parent.getAttributes().stream()
+              .filter(attr -> attributeIsAllowed(attr.getValue()))
+              .collect(Collectors.toMap(AttributeValue::getCode, AttributeValue::getValue)));
+    }
 
     // For each child, merge its unconflicting information into the parent.
     children.stream().map(UpstreamProductData::createFromProduct).forEach(offer::merge);
@@ -249,9 +256,13 @@ public class UpstreamProductData {
     if (product.getChildSkus() != null) {
       data.children.addAll(product.getChildSkus());
     }
-    Arrays.stream(product.getAttributes())
-        .filter(attr -> CODE_TO_ENUM.containsKey(attr.getCode()))
-        .forEach(attr -> data.attrs.put(CODE_TO_ENUM.get(attr.getCode()), attr.getValue()));
+    if (product.getAttributes() != null) {
+      data.mapAttributes(
+          Stream.of(product.getAttributes())
+              .filter(attr -> attributeIsAllowed(attr.getValue()))
+              .collect(Collectors.toMap(ProductAttribute::getCode, ProductAttribute::getValue)));
+    }
+
     data.attrs.put(Attr.X_DESCRIPTION, product.getSkuDescription());
     data.attrs.put(Attr.X_ROLE, product.getRole());
     return data;
@@ -543,7 +554,12 @@ public class UpstreamProductData {
 
   private static UpstreamProductData createFromProduct(OperationalProduct product) {
     var mid = new UpstreamProductData(product.getSku());
-    mid.mapAttributes(product);
+    if (product.getAttributes() != null) {
+      mid.mapAttributes(
+          product.getAttributes().stream()
+              .filter(attr -> attributeIsAllowed(attr.getValue()))
+              .collect(Collectors.toMap(AttributeValue::getCode, AttributeValue::getValue)));
+    }
 
     return mid;
   }
@@ -585,14 +601,10 @@ public class UpstreamProductData {
     }
   }
 
-  private void mapAttributes(OperationalProduct opProd) {
-    var prodAttrs = opProd.getAttributes();
-    if (prodAttrs == null || prodAttrs.isEmpty()) {
-      return;
-    }
-    for (AttributeValue sourceAttr : prodAttrs) {
-      Attr destAttr = CODE_TO_ENUM.get(sourceAttr.getCode());
-      String value = sourceAttr.getValue();
+  private void mapAttributes(Map<String, String> attributes) {
+    for (Map.Entry<String, String> source : attributes.entrySet()) {
+      Attr destAttr = CODE_TO_ENUM.get(source.getKey());
+      String value = source.getValue();
       if (destAttr != null && attributeIsAllowed(value)) {
         putIfNoConflict(destAttr, value);
       }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/repository/OfferingEntity.java
@@ -173,6 +173,9 @@ public class OfferingEntity extends ModificationTrackedEntity {
   @Column(name = "special_pricing_flag")
   private String specialPricingFlag;
 
+  @Column(name = "entitlement_quantity", length = 100)
+  private String entitlementQuantity;
+
   public boolean isHasUnlimitedUsage() {
     return hasUnlimitedUsage != null && hasUnlimitedUsage;
   }
@@ -211,7 +214,8 @@ public class OfferingEntity extends ModificationTrackedEntity {
         && Objects.equals(productTags, offering.productTags)
         && Objects.equals(specialPricingFlag, offering.specialPricingFlag)
         && Objects.equals(level1, offering.level1)
-        && Objects.equals(level2, offering.level2);
+        && Objects.equals(level2, offering.level2)
+        && Objects.equals(entitlementQuantity, offering.entitlementQuantity);
   }
 
   @Override
@@ -234,6 +238,7 @@ public class OfferingEntity extends ModificationTrackedEntity {
         productTags,
         specialPricingFlag,
         level1,
-        level2);
+        level2,
+        entitlementQuantity);
   }
 }

--- a/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
+++ b/swatch-contracts/src/main/java/com/redhat/swatch/contract/resource/ContractsResource.java
@@ -427,7 +427,7 @@ public class ContractsResource implements DefaultApi {
                 Response.status(apiExceptionStatus).entity(apiException.getMessage()).build());
         }
       }
-      throw new InternalServerErrorException(e.getMessage());
+      throw new InternalServerErrorException(e);
     }
     if (SyncResult.SKIPPED_NOT_FOUND.equals(result)) {
       throw new NotFoundException(result.description());

--- a/swatch-contracts/src/main/resources/db/202609030810_add_entitlement_quantity_to_offering.xml
+++ b/swatch-contracts/src/main/resources/db/202609030810_add_entitlement_quantity_to_offering.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="202609030810-01" author="jcarvaja">
+    <comment>Add ENTITLEMENT_QTY column to the OFFERING table</comment>
+    <addColumn tableName="offering">
+      <column name="entitlement_quantity" type="VARCHAR(100)"/>
+    </addColumn>
+    <rollback>
+      <dropColumn tableName="offering" columnName="entitlement_quantity"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>
+

--- a/swatch-contracts/src/main/resources/db/changelog.xml
+++ b/swatch-contracts/src/main/resources/db/changelog.xml
@@ -26,4 +26,5 @@
   <include file="db/202511271435_add_index_on_sku_column_in_sku_oid_table.xml"/>
   <include file="db/202604301203_add_last_modified_columns.xml"/>
   <include file="db/202607221600_add_license_id_to_contracts.xml"/>
+  <include file="db/202609030810_add_entitlement_quantity_to_offering.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Jira issue: SWATCH-5480

## Description
Subscriptions like "Red Hat Enterprise Linux for Business Developers"  provide up to 25 physical, virtual, or cloud-based instances per registered user. The value "25" comes from the attribute "Entitlement Qty" from product service. Moreover, other subscriptions like "RH00069: Red Hat Beta Access" can have "Unlimited" to state that the instances are unlimited. 

Today, we don't read the "Entitlement Qty" attribute, so all the sockets/cores capacity uses the 1:1 factor. 

These changes now read the attribute and properly uses the factor from this attribute when set. Also, if the attribute is unlimited, will treat the capacity as unlimited.

### Other findings

Note that we're adding a column in the offering table "entitlement_quantity" to store the attribute value and only run the offering sync when needed. I also found that this column already existed in the past but was dropped as part of https://github.com/RedHatInsights/rhsm-subscriptions/pull/238.

## Testing
Added component tests to reproduce the following scenarios: 
- offering-capacity-TC003: Synchronize entitlement quantity attribute offering
- offering-capacity-TC004: Synchronize entitlement quantity attribute offering with unlimited


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offerings now support entitlement quantities, including numeric values and “Unlimited.”
  * Capacity calculations scale core and socket limits according to the configured entitlement quantity.
  * Offering data preserves entitlement quantity information during synchronization.

* **Database**
  * Added storage for offering entitlement quantities.

* **Bug Fixes**
  * Improved internal error reporting during offering synchronization by preserving the original exception details.

* **Tests**
  * Added coverage for synchronization with limited and unlimited entitlement quantities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->