### PR TITLE
SWATCH-5084: Fix IT Kafka Managed grafana dashboards to use 1m interval

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": 1122808,
+      "id": 1123305,
       "links": [],
       "panels": [
         {
@@ -8605,7 +8605,7 @@ data:
             "y": 37
           },
           "id": 5003,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -8744,7 +8744,7 @@ data:
             "y": 37
           },
           "id": 5004,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -8883,7 +8883,7 @@ data:
             "y": 45
           },
           "id": 5049,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -9022,7 +9022,7 @@ data:
             "y": 45
           },
           "id": 5050,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -9161,7 +9161,7 @@ data:
             "y": 53
           },
           "id": 9057,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -9300,7 +9300,7 @@ data:
             "y": 53
           },
           "id": 9058,
-          "interval": "1d",
+          "interval": "1m",
           "options": {
             "legend": {
               "calcs": [],
@@ -13083,8 +13083,8 @@ data:
         "list": [
           {
             "current": {
-              "text": "crcs02ue1-prometheus",
-              "value": "PDD8BE47D10408F45"
+              "text": "crcp01ue1-prometheus",
+              "value": "PC1EAC84DCBBF0697"
             },
             "includeAll": false,
             "name": "datasource",
@@ -13096,8 +13096,8 @@ data:
           },
           {
             "current": {
-              "text": "AWS insights-stage",
-              "value": "PB2EEA3F591968575"
+              "text": "AWS insights-prod",
+              "value": "PD4288CE6A02EB473"
             },
             "includeAll": false,
             "name": "rdsdatasource",
@@ -13109,8 +13109,8 @@ data:
           },
           {
             "current": {
-              "text": "appsres11ue1-prometheus",
-              "value": "PC52EF5F0B75AF530"
+              "text": "appsrep11ue1-prometheus",
+              "value": "P677746A44F299DAF"
             },
             "name": "aws_kafka_datasource",
             "options": [],


### PR DESCRIPTION
Jira issue: SWATCH-5084

## Description
Before these changes, the IT Kafka Managed panels were using 1 day interval, which implies not seeing the metrics until the day passed.

With these changes, we'll use the 1 minute interval as the rest of the panels. 

## Testing
1. Log in with oc
2. Run oc extract -f .rhcicd/grafana/grafana-dashboard-subscription-watch.configmap.yaml --confirm
3. Create a new empty dashboard on your folder in Gragana
4. Import generated subscription-watch.json
5. Verify panels:
<img width="810" height="603" alt="Screenshot 2026-09-03 at 12 44 11" src="https://github.com/user-attachments/assets/70230f42-33ae-4493-a8b6-3bd6f9f7dde9" />
