### PR TITLE
SWATCH-5527: cover ACM managed vs self-managed billing in billable-usage

### DIFF
--- a/swatch-billable-usage/COMPONENT_TEST_PLAN.md
+++ b/swatch-billable-usage/COMPONENT_TEST_PLAN.md
@@ -10,6 +10,7 @@ This document defines the **component-level test plan** for `swatch-billable-usa
 
 - Tally summary ingestion and PAYG eligibility filtering
 - Billable usage calculation (contract coverage, billing factor, remittance delta)
+- ACM managed vs self-managed metric split (`vCPUs` / `vCPUs-self-managed`)
 - Contract coverage integration with `swatch-contracts` (mocked in component tests)
 - Remittance persistence and lifecycle (`billable_usage_remittance` table)
 - Kafka message production and consumption (`tally`, `billable-usage`, `billable-usage-hourly-aggregate`, `billable-usage.status`)
@@ -32,6 +33,7 @@ This document defines the **component-level test plan** for `swatch-billable-usa
 - Kafka topics are available and configured for the deployment environment
 - `swatch-contracts` REST API is mockable in component tests
 - Product configuration (`swatch-product-configuration`) is stable for reference products used in tests
+- `rhacm.yaml` defines two counter metrics with billing factor 1.0: `vCPUs` (`awsDimension: acm_vcpu_hours`, `azureDimension: acm_vcpu_hours_mng`) and `vCPUs-self-managed` (`awsDimension`/`azureDimension`: `acm_vcpu_hours_slfmng`); `contractEnabled: true`
 
 **Constraints:**
 
@@ -354,6 +356,154 @@ Java component tests in `ContractCoverageComponentTest` (`swatch-billable-usage/
   - One Kafka BillableUsage with the same smaller `licenseId` and value 1
 - **Expected Result:**  
   - Deterministic overage allocation when start dates tie (lexicographically smaller wins)
+
+---
+
+## ACM Managed vs Self-Managed Dimensions
+
+Java component tests in `AcmMetricSplitComponentTest` (`swatch-billable-usage/ct`); each test uses `@TestPlanName("billable-usage-acm-metric-split-TC00N")`. Product `rhacm` is contract-enabled. Contract API responses are stubbed via Wiremock (`ContractsWiremockService`).
+
+Contract GET does not take a metric id. `ContractsController.getValidContracts()` loads contracts by org, product `rhacm`, billing provider, and billing account. `ContractCoverageService` then sums `contract.metrics[].metric_id` against the provider dimension (`awsDimension` or `azureDimension`). A missing dimension is coverage 0, not `ContractMissingException`.
+
+Tally snapshots must be PAYG-eligible: granularity `HOURLY`, sla `PREMIUM`, usage `PRODUCTION`, specific billing provider, specific billing account (not `_ANY`). Use `PHYSICAL` measurements so `TOTAL` duplicates are not billed. ACM `billingFactor` is unset, so `BillingUnit` defaults to 1.0. Contract metric values are integers (`ContractMetricCapacity` sums `int`).
+
+Do not assert “no Kafka message” when remitted value is 0. `submitBillableUsage` still produces `BillableUsage` unless status is `GRATIS` (same caveat as `billable-usage-contract-coverage-TC009`).
+
+These cases cover billable-usage behavior only. AWS `BatchMeterUsage` and Azure Marketplace submission stay in producer test plans.
+
+**billable-usage-acm-metric-split-TC001 - Map one ACM tally to two independent billable usages (AWS)**
+
+- **Description:** Verify a single hourly ACM tally with both `vCPUs` and `vCPUs-self-managed` measurements produces two billable usages and two remittance rows. Billing factor is 1.0 for both metrics.  
+- **Setup:**  
+  - Product: `rhacm`  
+  - Mock contracts API: contract exists with empty metrics (coverage 0; all usage is billable)  
+  - Tally snapshot `billing_provider=aws` with PHYSICAL measurements: `vCPUs` current_total = 8, `vCPUs-self-managed` current_total = 12  
+- **Action:**  
+  - Publish tally summary to Kafka topic `tally`  
+- **Verification:**  
+  - Two messages on `billable-usage` for org/product `rhacm`  
+  - `vCPUs` usage value = 8, billing factor = 1.0  
+  - `vCPUs-self-managed` usage value = 12, billing factor = 1.0  
+  - Two remittance rows for the shared snapshot/tally ID, keyed by metric id, values 8 and 12  
+  - Both usages `billing_provider=aws`  
+- **Expected Result:**  
+  - Metrics billed independently; values do not combine or overwrite each other  
+
+**billable-usage-acm-metric-split-TC002 - Legacy AWS contract covers managed only**
+
+- **Description:** Verify an existing ACM contract that only lists `acm_vcpu_hours` covers managed usage and treats all self-managed usage as overage. Coverage 0 for a missing dimension is not a contract-missing skip.  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=aws`  
+  - Mock contracts API: one contract with metric `acm_vcpu_hours` = 10 (no `acm_vcpu_hours_slfmng`)  
+  - Tally measurements: `vCPUs` current_total = 15, `vCPUs-self-managed` current_total = 8  
+- **Action:**  
+  - Publish tally summary  
+- **Verification:**  
+  - Managed remittance `remitted_pending_value` = 5 (15 − 10)  
+  - Self-managed remittance `remitted_pending_value` = 8 (coverage 0)  
+  - Two `billable-usage` Kafka messages with values 5 and 8  
+- **Expected Result:**  
+  - Mapping is proven by remittance math: stubbing `acm_vcpu_hours` (not `vCPUs`) is what covers managed usage. Self-managed has no matching contract metric, so coverage is 0 and the amount remits in full. The contracts HTTP query does not include a metric id.  
+
+**billable-usage-acm-metric-split-TC003 - Dual-dimension AWS contract covers each metric independently**
+
+- **Description:** Verify a contract that lists both AWS dimensions applies coverage per metric and does not let unused capacity on one dimension cover the other.  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=aws`  
+  - Mock contracts API: one contract with `acm_vcpu_hours` = 10 and `acm_vcpu_hours_slfmng` = 20  
+  - Tally measurements: `vCPUs` current_total = 12, `vCPUs-self-managed` current_total = 15  
+- **Action:**  
+  - Publish tally summary  
+- **Verification:**  
+  - Managed remittance `remitted_pending_value` = 2 (12 − 10)  
+  - Self-managed account remittance `remittedValue` = 0 (15 ≤ 20)  
+  - One pending remittance row for `vCPUs` with value 2  
+  - No remittance row for `vCPUs-self-managed`  
+  - Do not require Kafka silence for self-managed; a zero-value `BillableUsage` may still be emitted  
+- **Expected Result:**  
+  - Unused self-managed contract capacity does not absorb managed overage  
+
+**billable-usage-acm-metric-split-TC004 - Azure ACM uses azureDimension for contract coverage**
+
+- **Description:** Verify Azure billing provider maps `vCPUs` to `acm_vcpu_hours_mng` and `vCPUs-self-managed` to `acm_vcpu_hours_slfmng`. A listing that only has the managed Azure dimension covers managed usage and bills self-managed as overage.  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=azure`  
+  - Mock contracts API: one contract with metric `acm_vcpu_hours_mng` = 16 (no `acm_vcpu_hours_slfmng`)  
+  - Tally measurements: `vCPUs` current_total = 20, `vCPUs-self-managed` current_total = 9  
+- **Action:**  
+  - Publish tally summary  
+- **Verification:**  
+  - Managed remittance = 4, `billing_provider=azure`  
+  - Self-managed remittance = 9, `billing_provider=azure`  
+- **Expected Result:**  
+  - Mapping is proven by remittance math: if coverage used `acm_vcpu_hours` or `vCPUs`, managed remittance would be 20, not 4. Self-managed has no `acm_vcpu_hours_slfmng` on the contract, so it remits in full.  
+
+**billable-usage-acm-metric-split-TC005 - Remittance ledger does not mix ACM metric ids**
+
+- **Description:** Verify month-to-date remittance already recorded for `vCPUs` is not subtracted from a later `vCPUs-self-managed` tally in the same org/account/month.  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=aws`  
+  - Mock contracts API: contract with empty metrics (coverage 0)  
+  - Same org, billing account, and month  
+  - First tally: `vCPUs` current_total = 10 (creates remittance 10)  
+- **Action:**  
+  - Publish second tally with only `vCPUs-self-managed` current_total = 6  
+- **Verification:**  
+  - Self-managed remittance `remitted_pending_value` = 6  
+  - Managed remittance row unchanged at 10  
+  - Account remittance API returns 10 for `vCPUs` and 6 for `vCPUs-self-managed`  
+- **Expected Result:**  
+  - `totalRemittedFilter` keys on metric id; the two ACM dimensions keep separate running totals  
+
+**billable-usage-acm-metric-split-TC006 - Hourly aggregation emits one aggregate per ACM metric**
+
+- **Description:** Verify Kafka Streams hourly aggregation uses `metricId` on `BillableUsageAggregateKey`, so managed and self-managed ACM usage do not share an hourly rollup.  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=aws`  
+  - Mock contracts API: contract with empty metrics  
+  - Same org, billing account, and clock hour: one `vCPUs` tally (current_total 8) and one `vCPUs-self-managed` tally (current_total 12)  
+- **Action:**  
+  - Publish both tallies  
+  - Wait for both `billable-usage` messages (same as `billable-usage-aggregation-TC001`)  
+  - Flush aggregation: `POST /internal/rpc/topics/flush`  
+- **Verification:**  
+  - Two messages on `billable-usage-hourly-aggregate`  
+  - Aggregate key `metricId` = `vCPUs`, `totalValue` = 8  
+  - Aggregate key `metricId` = `vCPUs-self-managed`, `totalValue` = 12  
+- **Expected Result:**  
+  - Producers receive two ACM aggregates for the same hour, one per marketplace dimension  
+
+**billable-usage-acm-metric-split-TC007 - Skip both ACM metrics when no contract exists**
+
+- **Description:** Verify `rhacm` remains contract-enabled: missing contract skips processing for both measurements, same as ROSA.  
+- **Setup:**  
+  - Product: `rhacm`  
+  - Mock contracts API: empty contract list  
+  - Tally with both `vCPUs` = 8 and `vCPUs-self-managed` = 12  
+- **Action:**  
+  - Publish tally summary  
+- **Verification:**  
+  - Account remittance API returns `remittedValue` = 0 for both metric ids  
+  - No remittance rows: `getRemittancesByTally` returns HTTP 400 (`Tally id not found in billable usage remittance`)  
+  - No `billable-usage` Kafka messages  
+- **Expected Result:**  
+  - Self-managed does not bypass the contract-enabled gate  
+
+**billable-usage-acm-metric-split-TC008 - Azure ACM PAYG remits both dimensions**
+
+- **Description:** Verify Azure ACM usage with a contract record but no metric coverage remits both dimensions with `billing_provider=azure`. This is the new Azure path (ACM previously had no `azureDimension`).  
+- **Setup:**  
+  - Product: `rhacm`, `billing_provider=azure`  
+  - Mock contracts API: contract exists with empty metrics  
+  - Tally measurements: `vCPUs` = 16, `vCPUs-self-managed` = 20  
+- **Action:**  
+  - Publish tally summary  
+- **Verification:**  
+  - Two `billable-usage` messages with `billing_provider=azure`  
+  - Values 16 and 20 (billing factor 1.0)  
+  - Two pending remittance rows  
+- **Expected Result:**  
+  - Azure ACM aggregates are eligible for `swatch-producer-azure`; marketplace accept/reject stays out of this plan  
 
 ---
 

--- a/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageSwatchService.java
@@ -52,6 +52,13 @@ public class BillableUsageSwatchService extends SwatchService {
         .as(new TypeRef<List<TallyRemittance>>() {});
   }
 
+  public void getRemittancesByTallyExpectBadRequest(String tallyId) {
+    given()
+        .get(REMITTANCE_ENDPOINT_BY_TALLY_ID, tallyId)
+        .then()
+        .statusCode(HttpStatus.SC_BAD_REQUEST);
+  }
+
   /**
    * Get monthly remittances for an account (product, org, metric, billing provider, billing
    * account). Use to verify remittances per accumulation period (e.g. last month vs current month).

--- a/swatch-billable-usage/ct/java/api/BillableUsageTestHelper.java
+++ b/swatch-billable-usage/ct/java/api/BillableUsageTestHelper.java
@@ -131,6 +131,58 @@ public final class BillableUsageTestHelper {
     return tallySummary;
   }
 
+  public static TallyMeasurement createPhysicalMeasurement(String metricId, double currentTotal) {
+    var measurement = new TallyMeasurement();
+    measurement.setHardwareMeasurementType("PHYSICAL");
+    measurement.setMetricId(metricId);
+    measurement.setValue(currentTotal);
+    measurement.setCurrentTotal(currentTotal);
+    return measurement;
+  }
+
+  /**
+   * Create a tally summary with multiple PHYSICAL measurements on one snapshot. Use for products
+   * with more than one billable metric (for example ACM managed and self-managed).
+   */
+  public static TallySummary createTallySummaryWithMeasurements(
+      String orgId,
+      String productId,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      TallyMeasurement... measurements) {
+    return createTallySummaryWithMeasurements(
+        orgId,
+        productId,
+        billingProvider,
+        billingAccountId,
+        OffsetDateTime.now().minusHours(1).withOffsetSameInstant(ZoneOffset.UTC),
+        measurements);
+  }
+
+  public static TallySummary createTallySummaryWithMeasurements(
+      String orgId,
+      String productId,
+      BillingProvider billingProvider,
+      String billingAccountId,
+      OffsetDateTime snapshotDate,
+      TallyMeasurement... measurements) {
+    var snapshot = new TallySnapshot();
+    snapshot.setId(UUID.randomUUID());
+    snapshot.setProductId(productId);
+    snapshot.setBillingProvider(billingProvider.toTallyApiModel());
+    snapshot.setBillingAccountId(billingAccountId);
+    snapshot.setSnapshotDate(snapshotDate);
+    snapshot.setSla(TallySnapshot.Sla.PREMIUM);
+    snapshot.setUsage(TallySnapshot.Usage.PRODUCTION);
+    snapshot.setGranularity(TallySnapshot.Granularity.HOURLY);
+    snapshot.setTallyMeasurements(List.of(measurements));
+
+    var tallySummary = new TallySummary();
+    tallySummary.setOrgId(orgId);
+    tallySummary.setTallySnapshots(List.of(snapshot));
+    return tallySummary;
+  }
+
   public static TallySummary createTallySummaryWithGranularity(
       String orgId,
       String productId,

--- a/swatch-billable-usage/ct/java/domain/Product.java
+++ b/swatch-billable-usage/ct/java/domain/Product.java
@@ -35,7 +35,8 @@ import lombok.Getter;
 public enum Product {
   ROSA("rosa", MetricIdUtils.getCores(), MetricIdUtils.getInstanceHours()),
   RHEL_PAYG_ADDON("rhel-for-x86-els-payg-addon", MetricIdUtils.getVCpus()),
-  ANSIBLE_AAP_MANAGED("ansible-aap-managed", MetricIdUtils.getManagedNodes());
+  ANSIBLE_AAP_MANAGED("ansible-aap-managed", MetricIdUtils.getManagedNodes()),
+  RHACM("rhacm", MetricIdUtils.getVCpus(), MetricIdUtils.getVCpusSelfManaged());
 
   private final ProductId id;
   private final Map<MetricId, Metric> metrics;

--- a/swatch-billable-usage/ct/java/tests/AcmMetricSplitComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/AcmMetricSplitComponentTest.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.BillableUsageTestHelper.createPhysicalMeasurement;
+import static api.BillableUsageTestHelper.createTallySummary;
+import static api.BillableUsageTestHelper.createTallySummaryWithMeasurements;
+import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
+import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import api.MessageValidators;
+import com.redhat.swatch.billable.usage.openapi.model.MonthlyRemittance;
+import com.redhat.swatch.billable.usage.openapi.model.TallyRemittance;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilitySettings;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.configuration.util.MetricIdUtils;
+import domain.BillingProvider;
+import domain.Product;
+import domain.RemittanceStatus;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.candlepin.subscriptions.billable.usage.BillableUsage;
+import org.candlepin.subscriptions.billable.usage.BillableUsageAggregate;
+import org.candlepin.subscriptions.billable.usage.TallySummary;
+import org.junit.jupiter.api.Test;
+
+public class AcmMetricSplitComponentTest extends BaseBillableUsageComponentTest {
+
+  private static final Product RHACM = Product.RHACM;
+  private static final MetricId VCPUS_SELF_MANAGED = MetricIdUtils.getVCpusSelfManaged();
+  private static final double ACM_BILLING_FACTOR = 1.0;
+  private static final String ACM_VCPU_HOURS = RHACM.getMetric(VCPUS).getAwsDimension();
+  private static final String ACM_VCPU_HOURS_SLFMNG =
+      RHACM.getMetric(VCPUS_SELF_MANAGED).getAwsDimension();
+  private static final String ACM_VCPU_HOURS_MNG = RHACM.getMetric(VCPUS).getAzureDimension();
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC001")
+  void shouldMapAcmTallyToTwoIndependentAwsUsages() {
+    givenAcmContractWithEmptyMetrics();
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AWS, 8.0, 12.0);
+
+    List<BillableUsage> usages = thenTwoAcmUsagesReceived();
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS.toString(), 8.0, BillableUsage.BillingProvider.AWS);
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS_SELF_MANAGED.toString(), 12.0, BillableUsage.BillingProvider.AWS);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary),
+        Map.of(VCPUS.toString(), 8.0, VCPUS_SELF_MANAGED.toString(), 12.0),
+        BillingProvider.AWS);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC002")
+  void shouldCoverManagedOnlyForLegacyAwsContract() {
+    givenLegacyAwsAcmContract(10.0);
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AWS, 15.0, 8.0);
+
+    List<BillableUsage> usages = thenTwoAcmUsagesReceived();
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS.toString(), 5.0, BillableUsage.BillingProvider.AWS);
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS_SELF_MANAGED.toString(), 8.0, BillableUsage.BillingProvider.AWS);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary),
+        Map.of(VCPUS.toString(), 5.0, VCPUS_SELF_MANAGED.toString(), 8.0),
+        BillingProvider.AWS);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC003")
+  void shouldApplyAwsCoveragePerAcmDimension() {
+    givenDualDimensionAwsAcmContract(10.0, 20.0);
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AWS, 12.0, 15.0);
+
+    // Wait for both measurements to finish. Do not assert the self-managed
+    // Kafka value: a zero-value BillableUsage may still be emitted.
+    List<BillableUsage> usages = thenTwoAcmUsagesReceived();
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS.toString(), 2.0, BillableUsage.BillingProvider.AWS);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary), Map.of(VCPUS.toString(), 2.0), BillingProvider.AWS);
+    thenAccountRemittanceEquals(VCPUS_SELF_MANAGED.toString(), BillingProvider.AWS, 0.0);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC004")
+  void shouldUseAzureDimensionForAcmCoverage() {
+    givenAzureManagedOnlyAcmContract(16.0);
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AZURE, 20.0, 9.0);
+
+    List<BillableUsage> usages = thenTwoAcmUsagesReceived();
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS.toString(), 4.0, BillableUsage.BillingProvider.AZURE);
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS_SELF_MANAGED.toString(), 9.0, BillableUsage.BillingProvider.AZURE);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary),
+        Map.of(VCPUS.toString(), 4.0, VCPUS_SELF_MANAGED.toString(), 9.0),
+        BillingProvider.AZURE);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC005")
+  void shouldKeepAcmRemittanceLedgersSeparate() {
+    givenAcmContractWithEmptyMetrics();
+    TallySummary managedTally = givenAcmManagedRemittance(10.0);
+
+    TallySummary selfManagedTally =
+        whenAcmSingleMetricTallyIsPublished(
+            VCPUS_SELF_MANAGED.toString(), 6.0, BillingProvider.AWS);
+
+    thenTallyRemittancesMatch(
+        tallyId(managedTally), Map.of(VCPUS.toString(), 10.0), BillingProvider.AWS);
+    thenTallyRemittancesMatch(
+        tallyId(selfManagedTally), Map.of(VCPUS_SELF_MANAGED.toString(), 6.0), BillingProvider.AWS);
+    thenAccountRemittanceEquals(VCPUS.toString(), BillingProvider.AWS, 10.0);
+    thenAccountRemittanceEquals(VCPUS_SELF_MANAGED.toString(), BillingProvider.AWS, 6.0);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC006")
+  void shouldEmitHourlyAggregatePerAcmMetric() {
+    givenAcmContractWithEmptyMetrics();
+    OffsetDateTime snapshotDate =
+        OffsetDateTime.now().minusHours(1).withOffsetSameInstant(ZoneOffset.UTC);
+
+    List<BillableUsageAggregate> aggregates =
+        whenAcmHourlyAggregatesAreFlushed(snapshotDate, 8.0, 12.0);
+
+    thenHourlyAggregatePerAcmMetric(aggregates, 8.0, 12.0);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC007")
+  void shouldSkipBothAcmMetricsWhenNoContract() {
+    givenNoAcmContract();
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AWS, 8.0, 12.0);
+
+    thenNoBillableUsageKafkaMessage();
+    thenNoTallyRemittanceRows(tallyId(tallySummary));
+    thenAccountRemittanceEquals(VCPUS.toString(), BillingProvider.AWS, 0.0);
+    thenAccountRemittanceEquals(VCPUS_SELF_MANAGED.toString(), BillingProvider.AWS, 0.0);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-acm-metric-split-TC008")
+  void shouldRemitBothAcmDimensionsForAzurePayg() {
+    givenAcmContractWithEmptyMetrics();
+
+    TallySummary tallySummary =
+        whenAcmTallyWithBothMetricsIsPublished(BillingProvider.AZURE, 16.0, 20.0);
+
+    List<BillableUsage> usages = thenTwoAcmUsagesReceived();
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS.toString(), 16.0, BillableUsage.BillingProvider.AZURE);
+    thenUsageHasValueFactorAndProvider(
+        usages, VCPUS_SELF_MANAGED.toString(), 20.0, BillableUsage.BillingProvider.AZURE);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary),
+        Map.of(VCPUS.toString(), 16.0, VCPUS_SELF_MANAGED.toString(), 20.0),
+        BillingProvider.AZURE);
+  }
+
+  private static String tallyId(TallySummary tallySummary) {
+    return tallySummary.getTallySnapshots().getFirst().getId().toString();
+  }
+
+  private void givenAcmContractWithEmptyMetrics() {
+    contractsWiremock.setupNoContractCoverage(orgId, RHACM.getName());
+  }
+
+  private void givenLegacyAwsAcmContract(double managedCoverage) {
+    contractsWiremock.setupContractCoverage(
+        orgId, RHACM.getName(), ACM_VCPU_HOURS, managedCoverage);
+  }
+
+  private void givenDualDimensionAwsAcmContract(
+      double managedCoverage, double selfManagedCoverage) {
+    contractsWiremock.setupMultiMetricContractCoverage(
+        orgId,
+        RHACM.getName(),
+        Map.of(ACM_VCPU_HOURS, managedCoverage, ACM_VCPU_HOURS_SLFMNG, selfManagedCoverage));
+  }
+
+  private void givenAzureManagedOnlyAcmContract(double managedCoverage) {
+    contractsWiremock.setupContractCoverage(
+        orgId, RHACM.getName(), ACM_VCPU_HOURS_MNG, managedCoverage);
+  }
+
+  private void givenNoAcmContract() {
+    contractsWiremock.setupContractNotFound(orgId, RHACM.getName());
+  }
+
+  private TallySummary givenAcmManagedRemittance(double currentTotal) {
+    TallySummary tallySummary =
+        whenAcmSingleMetricTallyIsPublished(VCPUS.toString(), currentTotal, BillingProvider.AWS);
+    thenTallyRemittancesMatch(
+        tallyId(tallySummary), Map.of(VCPUS.toString(), currentTotal), BillingProvider.AWS);
+    return tallySummary;
+  }
+
+  private TallySummary whenAcmTallyWithBothMetricsIsPublished(
+      BillingProvider billingProvider, double managedTotal, double selfManagedTotal) {
+    TallySummary tallySummary =
+        createTallySummaryWithMeasurements(
+            orgId,
+            RHACM.getName(),
+            billingProvider,
+            billingAccountId,
+            createPhysicalMeasurement(VCPUS.toString(), managedTotal),
+            createPhysicalMeasurement(VCPUS_SELF_MANAGED.toString(), selfManagedTotal));
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+    return tallySummary;
+  }
+
+  private TallySummary whenAcmSingleMetricTallyIsPublished(
+      String metricId, double currentTotal, BillingProvider provider) {
+    TallySummary tallySummary =
+        createTallySummary(
+            orgId, RHACM.getName(), metricId, currentTotal, provider, billingAccountId);
+    kafkaBridge.produceKafkaMessage(TALLY, tallySummary);
+    return tallySummary;
+  }
+
+  private List<BillableUsageAggregate> whenAcmHourlyAggregatesAreFlushed(
+      OffsetDateTime snapshotDate, double managedTotal, double selfManagedTotal) {
+    kafkaBridge.produceKafkaMessage(
+        TALLY,
+        createTallySummary(
+            orgId,
+            RHACM.getName(),
+            VCPUS.toString(),
+            managedTotal,
+            BillingProvider.AWS,
+            billingAccountId,
+            snapshotDate));
+    kafkaBridge.produceKafkaMessage(
+        TALLY,
+        createTallySummary(
+            orgId,
+            RHACM.getName(),
+            VCPUS_SELF_MANAGED.toString(),
+            selfManagedTotal,
+            BillingProvider.AWS,
+            billingAccountId,
+            snapshotDate));
+    kafkaBridge.waitForKafkaMessage(
+        BILLABLE_USAGE, MessageValidators.billableUsageMatches(orgId, RHACM.getName()), 2);
+    return whenHourlyAggregatesAreReceived(orgId, 2);
+  }
+
+  private List<BillableUsage> thenTwoAcmUsagesReceived() {
+    List<BillableUsage> usages =
+        kafkaBridge.waitForKafkaMessage(
+            BILLABLE_USAGE, MessageValidators.billableUsageMatches(orgId, RHACM.getName()), 2);
+    assertEquals(2, usages.size(), "Expected two billable-usage messages for rhacm");
+    return usages;
+  }
+
+  private void thenUsageHasValueFactorAndProvider(
+      List<BillableUsage> usages,
+      String metricId,
+      double expectedValue,
+      BillableUsage.BillingProvider provider) {
+    BillableUsage usage =
+        usages.stream().filter(u -> metricId.equals(u.getMetricId())).findFirst().orElse(null);
+    assertNotNull(usage, "Expected billable usage for metric " + metricId);
+    assertEquals(
+        expectedValue, usage.getValue(), 0.001, "Billable usage value for metric " + metricId);
+    assertEquals(
+        ACM_BILLING_FACTOR,
+        usage.getBillingFactor(),
+        0.001,
+        "Billing factor for metric " + metricId);
+    assertEquals(provider, usage.getBillingProvider(), "Billing provider for metric " + metricId);
+  }
+
+  private void thenTallyRemittancesMatch(
+      String tallyId, Map<String, Double> expectedByMetric, BillingProvider billingProvider) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<TallyRemittance> remittances = service.getRemittancesByTally(tallyId);
+          assertNotNull(remittances, "Remittances should exist for tally");
+          Map<String, Double> actual =
+              remittances.stream()
+                  .collect(
+                      Collectors.toMap(
+                          TallyRemittance::getMetricId, TallyRemittance::getRemittedPendingValue));
+          assertEquals(expectedByMetric, actual, "Tally remittances mismatch");
+          String expectedProvider = billingProvider.toTallyApiModel().value();
+          for (TallyRemittance remittance : remittances) {
+            assertEquals(
+                RemittanceStatus.PENDING.name(),
+                remittance.getStatus(),
+                "Remittance status for metric " + remittance.getMetricId());
+            assertEquals(
+                expectedProvider,
+                remittance.getBillingProvider(),
+                "Remittance billing provider for metric " + remittance.getMetricId());
+          }
+        });
+  }
+
+  private void thenAccountRemittanceEquals(
+      String metricId, BillingProvider billingProvider, double expectedRemittedValue) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<MonthlyRemittance> remittances =
+              service.getRemittances(
+                  RHACM.getName(),
+                  orgId,
+                  metricId,
+                  billingProvider.toTallyApiModel().value(),
+                  billingAccountId);
+          assertFalse(remittances.isEmpty(), "Expected account remittance");
+          assertEquals(
+              expectedRemittedValue,
+              remittances.get(0).getRemittedValue(),
+              0.001,
+              "Account remittance value mismatch");
+        });
+  }
+
+  private void thenNoBillableUsageKafkaMessage() {
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                0,
+                kafkaBridge
+                    .waitForKafkaMessage(
+                        BILLABLE_USAGE,
+                        MessageValidators.billableUsageMatches(orgId, RHACM.getName()),
+                        0,
+                        AwaitilitySettings.using(Duration.ofSeconds(1), Duration.ofSeconds(2)))
+                    .size(),
+                "Expected no billable-usage Kafka message for rhacm"),
+        AwaitilitySettings.usingTimeout(Duration.ofSeconds(15)));
+  }
+
+  private void thenNoTallyRemittanceRows(String tallyId) {
+    service.getRemittancesByTallyExpectBadRequest(tallyId);
+  }
+
+  private void thenHourlyAggregatePerAcmMetric(
+      List<BillableUsageAggregate> aggregates, double expectedManaged, double expectedSelfManaged) {
+    assertEquals(2, aggregates.size(), "Expected two hourly aggregates (one per ACM metric)");
+    thenAggregateHasMetricValue(aggregates, VCPUS.toString(), expectedManaged);
+    thenAggregateHasMetricValue(aggregates, VCPUS_SELF_MANAGED.toString(), expectedSelfManaged);
+  }
+
+  private void thenAggregateHasMetricValue(
+      List<BillableUsageAggregate> aggregates, String metricId, double expectedValue) {
+    BillableUsageAggregate found =
+        aggregates.stream()
+            .filter(
+                a ->
+                    a.getAggregateKey() != null
+                        && metricId.equals(a.getAggregateKey().getMetricId()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(found, "Expected hourly aggregate for metric " + metricId);
+    assertEquals(
+        expectedValue,
+        found.getTotalValue().doubleValue(),
+        0.001,
+        "Hourly aggregate totalValue for metric " + metricId);
+  }
+}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5082

## Description
ACM (rhacm) now meters managed and self-managed usage as two independent metrics:
- `vCPUs` → AWS `acm_vcpu_hours`, Azure `acm_vcpu_hours_mng`
- `vCPUs-self-managed` → `acm_vcpu_hours_slfmng` on both clouds
Product config already defines both metrics (`contractEnabled: true`, billing factor 1.0). This PR adds `swatch-billable-usage` component tests so contract coverage, remittance ledgers, and hourly aggregation stay per-metric, including the new Azure path.
Adds `AcmMetricSplitComponentTest` (`billable-usage-acm-metric-split-TC001`–`TC008`), `Product.RHACM`, multi-measurement tally helpers, and the matching `COMPONENT_TEST_PLAN.md` section.

## Testing
### Setup
1. `podman compose up -d kafka kafka-bridge kafka-setup wiremock db`
2. Enable the Podman socket and set `DOCKER_HOST` (see `CONTRIBUTING.md`)
3. Install service SNAPSHOT deps once: `./mvnw install -pl swatch-billable-usage -am -DskipTests`
### Steps
1. Run:
```
./mvnw install -Pcomponent-tests -pl swatch-billable-usage/ct -am
-Dtest=AcmMetricSplitComponentTest
-Dsurefire.failIfNoSpecifiedTests=false
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added billing support for Red Hat Advanced Cluster Management usage, splitting managed and self-managed vCPU metrics.
  - Added coverage for AWS and Azure billing providers, including provider-specific dimensions and PAYG remittances.

- **Tests**
  - Added component tests covering independent metric billing, hourly aggregation, remittance tracking, contract requirements, missing dimensions, and unsupported-contract behavior.
  - Expanded test utilities for creating physical measurements and tally summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->