### PR TITLE
SWATCH-5336: Add IT partner gateway kafka consumer component tests.

### DIFF
--- a/swatch-contracts/COMPONENT_TEST_PLAN.md
+++ b/swatch-contracts/COMPONENT_TEST_PLAN.md
@@ -2088,8 +2088,7 @@ This section verifies the automatic contract termination behavior when contracts
 - **Verification**: Poll internal contracts API until 1 contract appears for the org
 - **Expected Result**:
   - Contract created with correct `org_id`, `sku`, and `billing_provider`
-  - Optional fields with null values stored as null (not rejected)
-  - No `NullPointerException` or validation errors logged
+  - `billing_provider_id` contains `null` literal for the absent `sellerAccountId` field (e.g. `{vendorProductCode};{awsCustomerId};null`), proving null was handled via string formatting rather than rejected or NPE-d
 
 **partner-gateway-kafka-TC014 - Invalid/unknown source value in Kafka message**
 - **Description**: Verify that a Kafka message with an invalid or unknown `source` value (e.g., `"GCP"`) is handled gracefully — no contract persisted, service stays healthy.
@@ -2118,6 +2117,17 @@ This section verifies the automatic contract termination behavior when contracts
 - **Action**: Publish a valid `PartnerEntitlementContract` JSON message to the `VirtualTopic.services.partner-entitlement-gateway` UMB channel
 - **Verification**: Poll contracts after 3 second delay via internal API
 - **Expected Result**: Zero contracts created for the test org
+
+**partner-gateway-umb-TC004 - Cross-consumer duplicate message is idempotent**
+- **Description**: Verify that receiving the same partner entitlement message via both the Kafka consumer and the UMB consumer (both enabled) results in exactly one contract — the second delivery is treated as an idempotent update regardless of channel.
+- **Setup**:
+  - Ensure `UMB_ENABLED=true`
+  - Unleash toggle enabled; `config` variant set with `{"kafka_consumer_enabled":true,"umb_consumer_enabled":true}`; stubs in place and offering synced
+- **Action**:
+  1. Produce the contract message via Kafka Bridge; wait until 1 contract appears
+  2. Publish the same contract message via UMB
+- **Verification**: Poll internal contracts API
+- **Expected Result**: Still exactly 1 contract for the org
 
 **partner-gateway-umb-TC003 - Process UMB message when Kafka consumer disabled via config variant**
 - **Description**: Verify that disabling the Kafka consumer via variant (`kafka_consumer_enabled=false`) does not prevent the UMB consumer from working.

--- a/swatch-contracts/ct/java/api/ContractsUnleashService.java
+++ b/swatch-contracts/ct/java/api/ContractsUnleashService.java
@@ -68,6 +68,34 @@ public class ContractsUnleashService extends UnleashService {
     clearVariants(IT_SUBSCRIPTION_SERVICE);
   }
 
+  public void enablePartnerGatewayContractsKafkaOnly() {
+    enableFlag(PARTNER_GATEWAY_CONTRACTS);
+    setVariant(
+        PARTNER_GATEWAY_CONTRACTS,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":false}");
+  }
+
+  public void enablePartnerGatewayContractsUmbOnly() {
+    enableFlag(PARTNER_GATEWAY_CONTRACTS);
+    setVariant(
+        PARTNER_GATEWAY_CONTRACTS,
+        "config",
+        "{\"kafka_consumer_enabled\":false,\"umb_consumer_enabled\":true}");
+  }
+
+  public void enablePartnerGatewayContractsBothConsumers() {
+    enableFlag(PARTNER_GATEWAY_CONTRACTS);
+    setVariant(
+        PARTNER_GATEWAY_CONTRACTS,
+        "config",
+        "{\"kafka_consumer_enabled\":true,\"umb_consumer_enabled\":true}");
+  }
+
+  public void clearPartnerGatewayContractsVariants() {
+    clearVariants(PARTNER_GATEWAY_CONTRACTS);
+  }
+
   public void disablePartnerGatewayContracts() {
     disableFlag(PARTNER_GATEWAY_CONTRACTS);
   }

--- a/swatch-contracts/ct/java/api/PartnerApiStubs.java
+++ b/swatch-contracts/ct/java/api/PartnerApiStubs.java
@@ -188,6 +188,38 @@ public class PartnerApiStubs {
     registerPartnerSubscriptionsMapping(expectedQuery, responseBody);
   }
 
+  public void stubPartnerSubscriptionsServerError(Contract contract) {
+    var expectedQuery = buildPartnerSubscriptionsQueryByContract(contract);
+    registerPartnerSubscriptionsErrorMapping(expectedQuery, 503);
+  }
+
+  private void registerPartnerSubscriptionsErrorMapping(
+      Map<String, Object> expectedQuery, int httpStatus) {
+    wiremockService
+        .given()
+        .contentType(ContentType.JSON)
+        .body(
+            Map.of(
+                "request",
+                Map.of(
+                    "method",
+                    "POST",
+                    "urlPathPattern",
+                    "/mock/partnerApi/v1/partnerSubscriptions",
+                    "bodyPatterns",
+                    List.of(Map.of("equalToJson", JsonUtils.toJson(expectedQuery)))),
+                "response",
+                Map.of("status", httpStatus, "headers", Map.of("Content-Type", "application/json")),
+                "priority",
+                9,
+                "metadata",
+                wiremockService.getMetadataTags()))
+        .when()
+        .post("/__admin/mappings")
+        .then()
+        .statusCode(201);
+  }
+
   /** Build a raw entitlement body with null purchase for testing malformed data. */
   public static Map<String, Object> buildEntitlementWithNullPurchase(
       String orgId, String sourcePartner) {

--- a/swatch-contracts/ct/java/api/PartnerContractKafkaSender.java
+++ b/swatch-contracts/ct/java/api/PartnerContractKafkaSender.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package api;
+
+import static com.redhat.swatch.component.tests.utils.Topics.PARTNER_ENTITLEMENT_GATEWAY;
+
+import com.redhat.swatch.component.tests.api.KafkaBridgeService;
+import com.redhat.swatch.contract.test.model.Dimension;
+import com.redhat.swatch.contract.test.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.test.model.PartnerEntitlementContractCloudIdentifiers;
+import domain.BillingProvider;
+import domain.Contract;
+import java.util.List;
+
+/**
+ * Builder for creating and sending PartnerEntitlementContract messages via the IT Partner Gateway
+ * Kafka topic. Mirrors the structure of PartnerContractArtemisSender for UMB.
+ */
+public class PartnerContractKafkaSender {
+
+  private final KafkaBridgeService kafkaBridge;
+
+  public PartnerContractKafkaSender(KafkaBridgeService kafkaBridge) {
+    this.kafkaBridge = kafkaBridge;
+  }
+
+  public PartnerEntitlementContract buildMessage(Contract contract) {
+    PartnerEntitlementContract message = new PartnerEntitlementContract();
+
+    if (contract.getBillingProvider() == BillingProvider.AWS) {
+      message.setRedHatSubscriptionNumber(contract.getSubscriptionNumber());
+    }
+    message.setAction("contract-updated");
+
+    var cloudIdentifiers = new PartnerEntitlementContractCloudIdentifiers();
+    if (contract.getBillingProvider() == BillingProvider.AWS) {
+      cloudIdentifiers.setAwsCustomerId(contract.getCustomerId());
+      cloudIdentifiers.setAwsCustomerAccountId(contract.getBillingAccountId());
+      cloudIdentifiers.setProductCode(contract.getProductCode());
+    } else if (contract.getBillingProvider() == BillingProvider.AZURE) {
+      cloudIdentifiers.setPartner("azure_marketplace");
+      cloudIdentifiers.setAzureResourceId(contract.getResourceId());
+      cloudIdentifiers.setAzureTenantId(contract.getClientId());
+      cloudIdentifiers.setAzureOfferId(contract.getProductCode());
+      cloudIdentifiers.setPlanId(contract.getPlanId());
+    }
+    message.setCloudIdentifiers(cloudIdentifiers);
+
+    List<Dimension> dimensions =
+        contract.getContractMetrics().entrySet().stream()
+            .map(
+                entry -> {
+                  Dimension dim = new Dimension();
+                  dim.setDimensionName(entry.getKey());
+                  dim.setDimensionValue(String.valueOf(entry.getValue().intValue()));
+                  dim.setExpirationDate(contract.getEndDate());
+                  return dim;
+                })
+            .toList();
+
+    if (!dimensions.isEmpty()) {
+      message.setCurrentDimensions(dimensions);
+    }
+
+    return message;
+  }
+
+  public void send(Contract contract) {
+    kafkaBridge.produceKafkaMessage(PARTNER_ENTITLEMENT_GATEWAY, buildMessage(contract));
+  }
+
+  public void sendRaw(Object rawMessage) {
+    kafkaBridge.produceKafkaMessage(PARTNER_ENTITLEMENT_GATEWAY, rawMessage);
+  }
+}

--- a/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
+++ b/swatch-contracts/ct/java/tests/BaseContractComponentTest.java
@@ -24,6 +24,7 @@ import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import api.ContractsSwatchService;
 import api.ContractsUnleashService;
@@ -36,6 +37,7 @@ import com.redhat.swatch.component.tests.api.Unleash;
 import com.redhat.swatch.component.tests.api.Wiremock;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
 import com.redhat.swatch.component.tests.utils.RandomUtils;
+import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.configuration.util.MetricIdUtils;
 import com.redhat.swatch.contract.test.model.CapacityReportByMetricId;
@@ -53,6 +55,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.candlepin.clock.ApplicationClock;
 import org.junit.jupiter.api.AfterEach;
@@ -304,5 +307,75 @@ public class BaseContractComponentTest {
         .logs()
         .assertContains(
             "Subscription deleted org_id=" + orgId, "delete_reason=" + deleteReason.name());
+  }
+
+  protected void verifyCommonContractFields(
+      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
+    assertEquals(expected.getSubscriptionNumber(), actual.getSubscriptionNumber());
+    assertEquals(expected.getOffering().getSku(), actual.getSku());
+    assertEquals(orgId, actual.getOrgId());
+    assertNotNull(actual.getUuid());
+    assertNotNull(actual.getStartDate());
+    assertNotNull(actual.getEndDate());
+    assertNotNull(actual.getMetrics());
+  }
+
+  protected void verifyAwsBillingProviderId(
+      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
+    assertEquals("aws", actual.getBillingProvider());
+    String expectedId =
+        expected.getProductCode()
+            + ";"
+            + expected.getCustomerId()
+            + ";"
+            + expected.getSellerAccountId();
+    assertEquals(
+        expectedId,
+        actual.getBillingProviderId(),
+        "billing_provider_id should follow AWS format:"
+            + " {vendorProductCode};{awsCustomerId};{sellerAccountId}");
+  }
+
+  protected void verifyAzureBillingProviderId(
+      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
+    assertEquals("azure", actual.getBillingProvider());
+    String expectedId =
+        expected.getResourceId()
+            + ";"
+            + expected.getPlanId()
+            + ";"
+            + expected.getProductCode()
+            + ";"
+            + expected.getCustomerId()
+            + ";"
+            + expected.getClientId();
+    assertEquals(
+        expectedId,
+        actual.getBillingProviderId(),
+        "billing_provider_id should follow Azure format:"
+            + " {azureResourceId};{planId};{vendorProductCode};{customer};{clientId}");
+  }
+
+  protected void verifyMetric(
+      com.redhat.swatch.contract.test.model.Contract contract,
+      Metric metric,
+      double expectedMetricValue) {
+    String dimension =
+        BillingProvider.AZURE.toApiModel().equals(contract.getBillingProvider())
+            ? metric.getAzureDimension()
+            : metric.getAwsDimension();
+
+    var contractMetric =
+        contract.getMetrics().stream()
+            .filter(m -> m.getMetricId().equals(dimension))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError(metric.getId() + " metric not found in contract"));
+    double expectedValue =
+        expectedMetricValue * Optional.ofNullable(metric.getBillingFactor()).orElse(1.0);
+    assertEquals(
+        (int) expectedValue,
+        contractMetric.getValue().intValue(),
+        metric.getId() + " value should be " + expectedValue);
   }
 }

--- a/swatch-contracts/ct/java/tests/ContractCreationComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractCreationComponentTest.java
@@ -32,7 +32,6 @@ import api.ContractsArtemisService;
 import com.redhat.swatch.component.tests.api.Artemis;
 import com.redhat.swatch.component.tests.api.TestPlanName;
 import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
-import com.redhat.swatch.configuration.registry.Metric;
 import com.redhat.swatch.configuration.registry.MetricId;
 import com.redhat.swatch.contract.test.model.ContractRequest;
 import domain.BillingProvider;
@@ -40,7 +39,6 @@ import domain.Contract;
 import domain.Offering;
 import io.restassured.response.Response;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -436,83 +434,5 @@ public class ContractCreationComponentTest extends BaseContractComponentTest {
     AwaitilityUtils.until(() -> service.getContracts(contract).size(), is(1));
 
     return contract;
-  }
-
-  private void verifyCommonContractFields(
-      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
-    assertNotNull(actual.getUuid());
-    assertEquals(expected.getSubscriptionNumber(), actual.getSubscriptionNumber());
-    assertEquals(expected.getOffering().getSku(), actual.getSku());
-    assertNotNull(actual.getStartDate());
-    assertNotNull(actual.getEndDate());
-    assertEquals(orgId, actual.getOrgId());
-    assertNotNull(actual.getMetrics());
-  }
-
-  /**
-   * Verifies AWS billing_provider_id follows the format:
-   * {vendorProductCode};{awsCustomerId};{sellerAccountId}
-   */
-  private void verifyAwsBillingProviderId(
-      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
-    assertEquals("aws", actual.getBillingProvider());
-    String expectedId =
-        expected.getProductCode()
-            + ";"
-            + expected.getCustomerId()
-            + ";"
-            + expected.getSellerAccountId();
-    assertEquals(
-        expectedId,
-        actual.getBillingProviderId(),
-        "billing_provider_id should follow AWS format: {vendorProductCode};{awsCustomerId};{sellerAccountId}");
-  }
-
-  /**
-   * Verifies Azure billing_provider_id follows the format:
-   * {azureResourceId};{planId};{vendorProductCode};{customer};{clientId}
-   */
-  private void verifyAzureBillingProviderId(
-      Contract expected, com.redhat.swatch.contract.test.model.Contract actual) {
-    assertEquals("azure", actual.getBillingProvider());
-    String expectedId =
-        expected.getResourceId()
-            + ";"
-            + expected.getPlanId()
-            + ";"
-            + expected.getProductCode()
-            + ";"
-            + expected.getCustomerId()
-            + ";"
-            + expected.getClientId();
-    assertEquals(
-        expectedId,
-        actual.getBillingProviderId(),
-        "billing_provider_id should follow Azure format: {azureResourceId};{planId};{vendorProductCode};{customer};{clientId}");
-  }
-
-  /** Verifies a specific metric exists in the contract with the expected value. */
-  private void verifyMetric(
-      com.redhat.swatch.contract.test.model.Contract contract,
-      Metric metricId,
-      double expectedMetricValue) {
-    String dimension =
-        BillingProvider.AZURE.toApiModel().equals(contract.getBillingProvider())
-            ? metricId.getAzureDimension()
-            : metricId.getAwsDimension();
-
-    var metric =
-        contract.getMetrics().stream()
-            .filter(m -> m.getMetricId().equals(dimension))
-            .findFirst()
-            .orElseThrow(
-                () -> new AssertionError(metricId.getId() + " metric not found in contract"));
-    // Note: metric values get converted by billing factor
-    double expectedValue =
-        expectedMetricValue * Optional.ofNullable(metricId.getBillingFactor()).orElse(1.0);
-    assertEquals(
-        (int) expectedValue,
-        metric.getValue().intValue(),
-        metricId.getId() + " value should be " + expectedValue);
   }
 }

--- a/swatch-contracts/ct/java/tests/PartnerGatewayKafkaComponentTest.java
+++ b/swatch-contracts/ct/java/tests/PartnerGatewayKafkaComponentTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
+import static domain.Contract.buildRosaContract;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import api.PartnerContractKafkaSender;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.configuration.registry.MetricId;
+import com.redhat.swatch.contract.test.model.PartnerEntitlementContract;
+import com.redhat.swatch.contract.test.model.PartnerEntitlementContractCloudIdentifiers;
+import domain.BillingProvider;
+import domain.Contract;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class PartnerGatewayKafkaComponentTest extends BaseContractComponentTest {
+
+  private static final double DEFAULT_CAPACITY = 10.0;
+  private static final double INSTANCE_HOURS_CAPACITY = 18.0;
+
+  @BeforeAll
+  static void enablePartnerGatewayContractsFeatureFlag() {
+    unleash.enablePartnerGatewayContracts();
+  }
+
+  @AfterAll
+  static void disablePartnerGatewayContractsFeatureFlag() {
+    unleash.disablePartnerGatewayContracts();
+  }
+
+  @AfterEach
+  void restorePartnerGatewayContractsFlag() {
+    unleash.enablePartnerGatewayContracts();
+    unleash.clearPartnerGatewayContractsVariants();
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC001")
+  @Test
+  void shouldProcessValidAwsContractViaKafka() {
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    verifyAwsBillingProviderId(contract, actual);
+    assertEquals(
+        contract.getBillingAccountId(),
+        actual.getBillingAccountId(),
+        "billing_account_id should match awsCustomerAccountId");
+    assertEquals(1, actual.getMetrics().size(), "Should have exactly 1 metric (Cores)");
+    verifyMetric(actual, contract.getProduct().getMetric(CORES), DEFAULT_CAPACITY);
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC002")
+  @Test
+  void shouldProcessValidAzureContractViaKafka() {
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AZURE, Map.of(CORES, DEFAULT_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    verifyAzureBillingProviderId(contract, actual);
+    assertEquals(
+        contract.getBillingAccountId(),
+        actual.getBillingAccountId(),
+        "billing_account_id should match azureTenantId");
+    assertEquals(1, actual.getMetrics().size(), "Should have exactly 1 metric (Cores)");
+    verifyMetric(actual, contract.getProduct().getMetric(CORES), DEFAULT_CAPACITY);
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC003")
+  @Test
+  void shouldProcessPurePaygAwsContractViaKafka() {
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AWS, Map.of(SOCKETS, DEFAULT_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    verifyAwsBillingProviderId(contract, actual);
+    assertEquals(0, actual.getMetrics().size(), "Pure PAYG contract should have 0 metrics");
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC004")
+  @Test
+  void shouldProcessContractWithMultipleValidMetricsViaKafka() {
+    Contract contract =
+        givenContractCreatedViaKafka(
+            BillingProvider.AWS,
+            Map.of(CORES, DEFAULT_CAPACITY, INSTANCE_HOURS, INSTANCE_HOURS_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    verifyAwsBillingProviderId(contract, actual);
+    assertEquals(2, actual.getMetrics().size(), "Should have 2 metrics (Cores and Instance-hours)");
+    verifyMetric(actual, contract.getProduct().getMetric(CORES), DEFAULT_CAPACITY);
+    verifyMetric(actual, contract.getProduct().getMetric(INSTANCE_HOURS), INSTANCE_HOURS_CAPACITY);
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC005")
+  @Test
+  void shouldHandleMalformedJsonInKafkaMessage() {
+    kafkaSender().sendRaw("not-a-json-object");
+
+    service.logs().assertContains("Unable to read IT Partner Kafka message from JSON");
+    assertTrue(service.isRunning(), "Service health checks should all be UP");
+
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC006")
+  @Test
+  void shouldNotPersistContractWhenSearchApiReturnsNoSubscription() {
+    Contract contract =
+        buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubSearchApiNotFound(contract.getSubscriptionNumber());
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    kafkaSender().send(contract);
+
+    thenNoContractCreated();
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC007")
+  @Test
+  void shouldNotPersistContractWhenPartnerApiIsUnavailable() {
+    Contract contract =
+        buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptionsServerError(contract);
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    kafkaSender().send(contract);
+
+    thenNoContractCreated();
+    assertTrue(service.isRunning(), "Service health checks should all be UP");
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC008")
+  @Test
+  void shouldHandleDuplicateKafkaMessages() {
+    Contract contract =
+        buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    kafkaSender().send(contract);
+    AwaitilityUtils.until(() -> service.getContracts(contract).size(), is(1));
+
+    kafkaSender().send(contract);
+
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                1,
+                service.getContractsByOrgId(orgId).size(),
+                "Duplicate message should not create a second contract"));
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC009")
+  @Test
+  void shouldIgnoreKafkaMessageWhenKafkaConsumerDisabledViaVariant() {
+    unleash.enablePartnerGatewayContractsUmbOnly();
+
+    Contract contract =
+        buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+    service.syncOffering(contract.getOffering().getSku());
+
+    kafkaSender().send(contract);
+
+    service
+        .logs()
+        .assertContains("IT Partner Kafka consumer for contracts is disabled by feature flag.");
+    thenNoContractCreated();
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC010")
+  @Test
+  void shouldProcessKafkaMessageWhenUmbConsumerDisabledViaVariant() {
+    unleash.enablePartnerGatewayContractsKafkaOnly();
+
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    assertEquals("aws", actual.getBillingProvider());
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC011")
+  @Test
+  void shouldProcessKafkaMessageWhenBothConsumersEnabledViaVariant() {
+    unleash.enablePartnerGatewayContractsBothConsumers();
+
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+
+    var actual = service.getContracts(contract).get(0);
+    verifyCommonContractFields(contract, actual);
+    assertEquals("aws", actual.getBillingProvider());
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC012")
+  @Test
+  void shouldRejectKafkaMessageWithMissingRequiredFields() {
+    PartnerEntitlementContract emptyMessage = new PartnerEntitlementContract();
+    emptyMessage.setAction("contract-updated");
+
+    kafkaSender().sendRaw(emptyMessage);
+
+    service.logs().assertContains("Can't process the partner contract");
+    thenNoContractCreated();
+
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC013")
+  @Test
+  void shouldProcessKafkaMessageWithNullOptionalFields() {
+    Contract contract =
+        buildRosaContract(orgId, BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY)).toBuilder()
+            .sellerAccountId(null)
+            .build();
+
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    kafkaSender().send(contract);
+
+    AwaitilityUtils.until(() -> service.getContractsByOrgId(orgId).size(), is(1));
+    var actual = service.getContractsByOrgId(orgId).get(0);
+    assertNotNull(actual.getUuid(), "Contract should be created");
+    assertEquals(orgId, actual.getOrgId());
+    verifyAwsBillingProviderId(contract, actual);
+  }
+
+  @TestPlanName("partner-gateway-kafka-TC014")
+  @Test
+  void shouldHandleUnknownSourceValueInKafkaMessage() {
+    PartnerEntitlementContract message = new PartnerEntitlementContract();
+    message.setAction("contract-updated");
+    var cloudIdentifiers = new PartnerEntitlementContractCloudIdentifiers();
+    cloudIdentifiers.setPartner("gcp");
+    message.setCloudIdentifiers(cloudIdentifiers);
+
+    kafkaSender().sendRaw(message);
+
+    service.logs().assertContains("Can't process the partner contract");
+    thenNoContractCreated();
+    assertTrue(service.isRunning(), "Service health checks should all be UP");
+
+    thenKafkaConsumerAcceptsSubsequentMessages();
+  }
+
+  private Contract givenContractCreatedViaKafka(
+      BillingProvider provider, Map<MetricId, Double> metrics) {
+    Contract contract = buildRosaContract(orgId, provider, metrics);
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    kafkaSender().send(contract);
+
+    AwaitilityUtils.until(() -> service.getContracts(contract).size(), is(1));
+    return contract;
+  }
+
+  private void thenNoContractCreated() {
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                0, service.getContractsByOrgId(orgId).size(), "No contract should be created"));
+  }
+
+  private void thenKafkaConsumerAcceptsSubsequentMessages() {
+    Contract contract =
+        givenContractCreatedViaKafka(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    assertNotNull(
+        service.getContracts(contract).get(0).getUuid(),
+        "Consumer should accept subsequent valid messages");
+  }
+
+  private PartnerContractKafkaSender kafkaSender() {
+    return new PartnerContractKafkaSender(kafkaBridge);
+  }
+}

--- a/swatch-contracts/ct/java/tests/PartnerGatewayUmbComponentTest.java
+++ b/swatch-contracts/ct/java/tests/PartnerGatewayUmbComponentTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package tests;
+
+import static api.PartnerApiStubs.PartnerSubscriptionsStubRequest.forContract;
+import static domain.Contract.buildRosaContract;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import api.ContractsArtemisService;
+import api.PartnerContractKafkaSender;
+import com.redhat.swatch.component.tests.api.Artemis;
+import com.redhat.swatch.component.tests.api.TestPlanName;
+import com.redhat.swatch.component.tests.utils.AwaitilityUtils;
+import com.redhat.swatch.configuration.registry.MetricId;
+import domain.BillingProvider;
+import domain.Contract;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class PartnerGatewayUmbComponentTest extends BaseContractComponentTest {
+
+  private static final double DEFAULT_CAPACITY = 10.0;
+
+  @Artemis static ContractsArtemisService artemis = new ContractsArtemisService();
+
+  @BeforeAll
+  static void enablePartnerGatewayContractsFeatureFlag() {
+    unleash.enablePartnerGatewayContracts();
+  }
+
+  @AfterAll
+  static void disablePartnerGatewayContractsFeatureFlag() {
+    unleash.disablePartnerGatewayContracts();
+  }
+
+  @AfterEach
+  void restorePartnerGatewayContractsFlag() {
+    unleash.enablePartnerGatewayContracts();
+    unleash.clearPartnerGatewayContractsVariants();
+  }
+
+  @TestPlanName("partner-gateway-umb-TC001")
+  @Test
+  void shouldIgnoreUmbMessageWhenFeatureFlagDisabled() {
+    unleash.disablePartnerGatewayContracts();
+
+    Contract contract = givenContractSetup(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    artemis.forContracts().sendAsText(contract);
+
+    service
+        .logs()
+        .assertContains("IT Partner UMB consumer for contracts is disabled by feature flag.");
+    thenNoContractCreated();
+  }
+
+  @TestPlanName("partner-gateway-umb-TC002")
+  @Test
+  void shouldIgnoreUmbMessageWhenUmbConsumerDisabledViaVariant() {
+    unleash.enablePartnerGatewayContractsKafkaOnly();
+
+    Contract contract = givenContractSetup(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    artemis.forContracts().sendAsText(contract);
+
+    service
+        .logs()
+        .assertContains("IT Partner UMB consumer for contracts is disabled by feature flag.");
+    thenNoContractCreated();
+  }
+
+  @TestPlanName("partner-gateway-umb-TC003")
+  @Test
+  void shouldProcessUmbMessageWhenKafkaConsumerDisabledViaVariant() {
+    unleash.enablePartnerGatewayContractsUmbOnly();
+
+    Contract contract = givenContractSetup(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+    artemis.forContracts().sendAsText(contract);
+
+    AwaitilityUtils.until(() -> service.getContracts(contract).size(), is(1));
+    var actual = service.getContracts(contract).get(0);
+    assertNotNull(actual.getUuid());
+    assertEquals(orgId, actual.getOrgId());
+    assertEquals("aws", actual.getBillingProvider());
+    assertEquals(contract.getOffering().getSku(), actual.getSku());
+  }
+
+  @TestPlanName("partner-gateway-umb-TC004")
+  @Test
+  void shouldProcessCrossConsumerDuplicateAsIdempotent() {
+    unleash.enablePartnerGatewayContractsBothConsumers();
+
+    Contract contract = givenContractSetup(BillingProvider.AWS, Map.of(CORES, DEFAULT_CAPACITY));
+
+    new PartnerContractKafkaSender(kafkaBridge).send(contract);
+    AwaitilityUtils.until(() -> service.getContractsByOrgId(orgId).size(), is(1));
+
+    artemis.forContracts().sendAsText(contract);
+
+    service
+        .logs()
+        .assertContains(
+            "IT Partner message consumed: source=umb",
+            "redHatSubscriptionNumber=" + contract.getSubscriptionNumber());
+
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                1,
+                service.getContractsByOrgId(orgId).size(),
+                "Cross-consumer duplicate should not create a second contract"));
+  }
+
+  private Contract givenContractSetup(BillingProvider provider, Map<MetricId, Double> metrics) {
+    Contract contract = buildRosaContract(orgId, provider, metrics);
+    wiremock.forProductAPI().stubOfferingData(contract.getOffering());
+    wiremock.forPartnerAPI().stubPartnerSubscriptions(forContract(contract));
+    wiremock.forSearchApi().stubGetSubscriptionBySubscriptionNumber(contract);
+
+    Response sync = service.syncOffering(contract.getOffering().getSku());
+    assertThat("Sync offering should succeed", sync.statusCode(), is(HttpStatus.SC_OK));
+
+    return contract;
+  }
+
+  private void thenNoContractCreated() {
+    AwaitilityUtils.untilAsserted(
+        () ->
+            assertEquals(
+                0, service.getContractsByOrgId(orgId).size(), "No contract should be created"));
+  }
+}

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/Topics.java
@@ -38,6 +38,8 @@ public final class Topics {
       "platform.rhsm-subscriptions.subscription-sync-task";
   public static final String CAPACITY_RECONCILE = SUFFIX + "capacity-reconcile";
   public static final String IT_SUBSCRIPTION_SYNC = "subscription.subscriptions.private";
+  public static final String PARTNER_ENTITLEMENT_GATEWAY =
+      "partner-integration.entitlement-gateway.partner-entitlement.protected";
   public static final String EXPORT_REQUESTS = "platform.export.requests";
 
   private Topics() {}


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5336

## Description
Implemented the test plan for it partner gateway consumers

## Testing
podman compose up -d 
./mvnw clean install -Pcomponent-tests -pl swatch-contracts/ct -am

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing partner contracts through Kafka and UMB.
  - Added support for AWS, Azure, and PAYG contract data, including optional fields and multiple metrics.
  - Added configuration options to run either consumer independently or both together.

- **Bug Fixes**
  - Prevented duplicate contract creation when identical deliveries arrive through multiple channels.
  - Improved resilience when partner services are unavailable or messages are malformed.
  - Confirmed processing continues after invalid messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->