### PR TITLE
SWATCH-5521 Fix 403 errors for stage Kessel integration

### DIFF
--- a/src/main/java/org/candlepin/subscriptions/security/KesselConfiguration.java
+++ b/src/main/java/org/candlepin/subscriptions/security/KesselConfiguration.java
@@ -70,7 +70,7 @@ public class KesselConfiguration {
   }
 
   private OAuth2AuthRequest initializeRbacAuth(KesselProperties props) {
-    var issuerUrl = props.getAuthDiscoveryIssuerUrl();
+    var issuerUrl = props.getAuthOidcIssuer();
     var clientId = props.getAuthClientId();
     var clientSecret = props.getAuthClientSecret();
     if (issuerUrl == null

--- a/src/main/resources/application-api.yaml
+++ b/src/main/resources/application-api.yaml
@@ -3,8 +3,6 @@
 RHSM_RBAC_URL: ${clowder.endpoints.rbac-service.url:http://localhost:8819}
 RHSM_CONTRACTS_URL: ${clowder.endpoints.swatch-contracts-service.url:http://localhost:8011}
 KESSEL_ENDPOINT: ${clowder.endpoints.kessel-inventory-api.hostname:localhost}:9000
-KESSEL_INSECURE: false
-KESSEL_TIMEOUT_MS: 5000
 
 rhsm-subscriptions:
   pretty-print-json: ${PRETTY_PRINT_JSON:false}
@@ -17,10 +15,10 @@ rhsm-subscriptions:
     max-connections: ${RHSM_RBAC_MAX_CONNECTIONS:100}
   kessel:
     endpoint: ${KESSEL_ENDPOINT}
-    insecure: ${KESSEL_INSECURE}
-    timeout-ms: ${KESSEL_TIMEOUT_MS}
+    insecure: ${KESSEL_INSECURE:true}
+    timeout-ms: ${KESSEL_TIMEOUT_MS:5000}
     rbac-base-endpoint: ${RBAC_BASE_ENDPOINT:${RHSM_RBAC_URL}}
-    auth-discovery-issuer-url: ${AUTH_DISCOVERY_ISSUER_URL:}
+    auth-oidc-issuer: ${KESSEL_AUTH_OIDC_ISSUER:}
     auth-client-id: ${KESSEL_AUTH_CLIENT_ID:}
     auth-client-secret: ${KESSEL_AUTH_CLIENT_SECRET:}
   contracts:

--- a/swatch-api/deploy/clowdapp.yaml
+++ b/swatch-api/deploy/clowdapp.yaml
@@ -87,10 +87,8 @@ parameters:
   - name: KESSEL_INSECURE
     value: 'true'
   - name: KESSEL_AUTH_ENABLED
-    value: 'false'
 #    Environment provides this
   - name: KESSEL_AUTH_OIDC_ISSUER
-  - name: AUTH_DISCOVERY_ISSUER_URL
   - name: RBAC_BASE_ENDPOINT
 
 objects:

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselAuthorizationService.java
@@ -83,7 +83,7 @@ public class KesselAuthorizationService {
   }
 
   private void initializeRbacAuth() throws Exception {
-    var issuerUrl = properties.authDiscoveryIssuerUrl().filter(s -> !s.isBlank());
+    var issuerUrl = properties.authOidcIssuer().filter(s -> !s.isBlank());
     var clientId = properties.authClientId().filter(s -> !s.isBlank());
     var clientSecret = properties.authClientSecret().filter(s -> !s.isBlank());
     if (issuerUrl.isEmpty() || clientId.isEmpty() || clientSecret.isEmpty()) {

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselProperties.java
@@ -42,7 +42,7 @@ public interface KesselProperties {
   @WithDefault("http://localhost:8080")
   String rbacBaseEndpoint();
 
-  Optional<String> authDiscoveryIssuerUrl();
+  Optional<String> authOidcIssuer();
 
   Optional<String> authClientId();
 

--- a/swatch-common-security/src/main/resources/application.properties
+++ b/swatch-common-security/src/main/resources/application.properties
@@ -36,14 +36,11 @@ KESSEL_ENDPOINT=${clowder.endpoints.kessel-inventory-api.url:http://localhost:90
 %dev.KESSEL_ENDPOINT=localhost:8006
 %test.KESSEL_ENDPOINT=localhost:9000
 %component-tests.KESSEL_ENDPOINT=wiremock-service:8000
-KESSEL_INSECURE=true
-%prod.KESSEL_INSECURE=false
-KESSEL_TIMEOUT_MS=5000
 
 swatch.kessel.endpoint=${KESSEL_ENDPOINT}
-swatch.kessel.insecure=${KESSEL_INSECURE}
-swatch.kessel.timeout-ms=${KESSEL_TIMEOUT_MS}
+swatch.kessel.insecure=${KESSEL_INSECURE:true}
+swatch.kessel.timeout-ms=${KESSEL_TIMEOUT_MS:5000}
 swatch.kessel.rbac-base-endpoint=${RBAC_BASE_ENDPOINT:${RBAC_ENDPOINT}}
-swatch.kessel.auth-discovery-issuer-url=${AUTH_DISCOVERY_ISSUER_URL:}
+swatch.kessel.auth-oidc-issuer=${KESSEL_AUTH_OIDC_ISSUER:}
 swatch.kessel.auth-client-id=${KESSEL_AUTH_CLIENT_ID:}
 swatch.kessel.auth-client-secret=${KESSEL_AUTH_CLIENT_SECRET:}

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPropertiesTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPropertiesTest.java
@@ -85,7 +85,7 @@ class KesselPropertiesTest {
       }
 
       @Override
-      public Optional<String> authDiscoveryIssuerUrl() {
+      public Optional<String> authOidcIssuer() {
         return Optional.empty();
       }
 

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServerTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/MockKesselServerTest.java
@@ -69,7 +69,7 @@ class MockKesselServerTest {
           }
 
           @Override
-          public Optional<String> authDiscoveryIssuerUrl() {
+          public Optional<String> authOidcIssuer() {
             return Optional.empty();
           }
 

--- a/swatch-contracts/deploy/clowdapp.yaml
+++ b/swatch-contracts/deploy/clowdapp.yaml
@@ -179,10 +179,8 @@ parameters:
   - name: KESSEL_INSECURE
     value: 'true'
   - name: KESSEL_AUTH_ENABLED
-    value: 'false'
 #    Environment provides this
   - name: KESSEL_AUTH_OIDC_ISSUER
-  - name: AUTH_DISCOVERY_ISSUER_URL
   - name: RBAC_BASE_ENDPOINT
 
 # Shared FloorPlan specification for all environments (sandbox, dev, preprod, prod)

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselProperties.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/rbac/KesselProperties.java
@@ -31,7 +31,7 @@ public class KesselProperties implements KesselConfig {
   private boolean insecure = true;
   private long timeoutMs = 5000;
   private String rbacBaseEndpoint = "http://localhost:8080";
-  private String authDiscoveryIssuerUrl;
+  private String authOidcIssuer;
   private String authClientId;
   private String authClientSecret;
 

--- a/swatch-tally/deploy/clowdapp.yaml
+++ b/swatch-tally/deploy/clowdapp.yaml
@@ -274,10 +274,8 @@ parameters:
   - name: KESSEL_INSECURE
     value: 'true'
   - name: KESSEL_AUTH_ENABLED
-    value: 'false'
 #    Environment provides this
   - name: KESSEL_AUTH_OIDC_ISSUER
-  - name: AUTH_DISCOVERY_ISSUER_URL
   - name: RBAC_BASE_ENDPOINT
 
 # Shared FloorPlan specification for all environments (sandbox, dev, preprod, prod)

--- a/swatch-utilization/deploy/clowdapp.yaml
+++ b/swatch-utilization/deploy/clowdapp.yaml
@@ -113,10 +113,8 @@ parameters:
   - name: KESSEL_INSECURE
     value: 'true'
   - name: KESSEL_AUTH_ENABLED
-    value: 'false'
 #    Environment provides this
   - name: KESSEL_AUTH_OIDC_ISSUER
-  - name: AUTH_DISCOVERY_ISSUER_URL
   - name: RBAC_BASE_ENDPOINT
 
 # Shared FloorPlan specification for all environments (sandbox, dev, preprod, prod)


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5521

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

The stage is having error `Failed to fetch default workspace` when trying to authenticate using Kessel service. This is causing UI to fail with 403 errors.

This PR Fixes:

- Some of the default property values for stage and prod should come from app-interface and we shouldn't override them.
- Removed some unknown properties and replaced with what is needed from the config. This should fix the issue that we are seeing for both contracts and tally.

Following the property values we see in app-interface 
https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/products/insights/environments/production.yml?ref_type=heads

https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/products/insights/environments/stage.yml

### Testing & Verification
<!-- Enter the steps needed to verify the test passed -->
1. This is to fix stage Kessel integration so it has to be trial and error. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Renamed the OIDC issuer setting to `KESSEL_AUTH_OIDC_ISSUER`.
  - Kessel connections now default to insecure mode unless explicitly configured otherwise.
  - Deployment templates no longer provide a default for authentication enablement; this value must be supplied by the deployment environment.
  - Removed the obsolete OIDC discovery issuer setting from deployment configuration.
- **Compatibility**
  - Authentication continues to use OIDC discovery and existing client credentials when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->