### PR TITLE
Align over-usage threshold log format with custom threshold logs

### DIFF
--- a/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
+++ b/swatch-utilization/src/main/java/com/redhat/swatch/utilization/service/OverThresholdUtilizationHandlerService.java
@@ -49,31 +49,30 @@ public class OverThresholdUtilizationHandlerService extends BaseThresholdUtiliza
     }
 
     double overagePercent = utilizationPercent - FULL_CAPACITY_PERCENT;
+    double utilizationThresholdPercent = FULL_CAPACITY_PERCENT + overUsageThreshold;
 
     if (overagePercent > overUsageThreshold) {
       log.info(
-          "Over-usage detected: orgId={} productId={} metricId={} sla={} usage={} utilizationPercent={}% overagePercent={}% threshold={}%",
+          "Over-usage threshold exceeded: orgId={} productId={} metricId={} sla={} usage={} utilizationPercent={}% threshold={}%",
           payload.getOrgId(),
           payload.getProductId(),
           measurement.getMetricId(),
           payload.getSla(),
           payload.getUsage(),
           String.format(PERCENT_FORMAT, utilizationPercent),
-          String.format(PERCENT_FORMAT, overagePercent),
-          String.format(PERCENT_FORMAT, overUsageThreshold));
+          String.format(PERCENT_FORMAT, utilizationThresholdPercent));
       return Optional.of(buildEvent(utilizationPercent));
     }
 
     log.debug(
-        "Usage within threshold: orgId={} productId={} metricId={} sla={} usage={} utilizationPercent={}% overagePercent={}% threshold={}%",
+        "Over-usage threshold not exceeded: orgId={} productId={} metricId={} sla={} usage={} utilizationPercent={}% threshold={}%",
         payload.getOrgId(),
         payload.getProductId(),
         measurement.getMetricId(),
         payload.getSla(),
         payload.getUsage(),
         String.format(PERCENT_FORMAT, utilizationPercent),
-        String.format(PERCENT_FORMAT, overagePercent),
-        String.format(PERCENT_FORMAT, overUsageThreshold));
+        String.format(PERCENT_FORMAT, utilizationThresholdPercent));
     return Optional.empty();
   }
 


### PR DESCRIPTION
## Summary

Aligns `OverThresholdUtilizationHandlerService` INFO/DEBUG logs with the shape used by `CustomThresholdUtilizationHandlerService`.

**Before**
```
Over-usage detected: ... utilizationPercent=336.82% overagePercent=236.82% threshold=5.00%
```

**After**
```
Over-usage threshold exceeded: ... utilizationPercent=336.82% threshold=105.00%
```

## Why

- Custom threshold logs compare `utilizationPercent` to an absolute utilization `threshold` (e.g. 80%).
- Over-usage logs previously mixed absolute utilization with a margin above 100% (`threshold=5%`), which is hard to read next to `utilizationPercent=336%`.
- `threshold` in the over-usage log is now logged as `100 + overUsageThreshold` so both handlers use the same field names and the same scale.
- `overagePercent` is removed from the log line. Detection logic is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated threshold-related log messages to report the complete utilization threshold percentage, improving clarity when reviewing utilization events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->