### PR TITLE
fix(ct): fix debug when running Quarkus services via intellij

### DIFF
--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/logging/ServiceLoggingHandler.java
@@ -47,7 +47,7 @@ public abstract class ServiceLoggingHandler extends LoggingHandler {
 
   @Override
   protected void onLine(String line) {
-    if (!testActive) {
+    if (!testActive && !service.isDebug()) {
       return;
     }
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/resources/quarkus/LocalQuarkusManagedResource.java
@@ -94,6 +94,8 @@ public class LocalQuarkusManagedResource extends DevProcessManagedResource {
         .map(e -> "-D" + e.getKey() + "=" + e.getValue())
         .forEach(command::add);
 
+    command.add("-Dquarkus.console.enabled=false");
+
     if (context.isDebug()) {
       assignedDebugPort = SocketUtils.findAvailablePort(context.getOwner());
       command.add("-Ddebug=" + assignedDebugPort);
@@ -105,7 +107,6 @@ public class LocalQuarkusManagedResource extends DevProcessManagedResource {
     assignedHttpPort = getOrAssignPortByProperty(SERVER_PORT_PROPERTY);
     propertiesToOverwrite.put(SERVER_PORT_PROPERTY, "" + assignedHttpPort);
     this.assignedCustomPorts = assignCustomPorts();
-    propertiesToOverwrite.put("quarkus.console.enabled", "false");
   }
 
   protected Map<Integer, Integer> assignCustomPorts() {


### PR DESCRIPTION
## Description
These changes fix the debug execution of component tests running from IntelliJ. 

Changes:
**- ServiceLoggingHandler — log service output in debug mode before tests run**
When log.enabled.on-test-started is true (the default), onLine() only forwards logs while a test method is running (testActive == true). That is fine for normal CT runs, but not when debugging from IntelliJ:

The test JVM starts in debug mode (suspend=y).
Quarkus services start at suite scope, before any @Test runs.
With the old guard, Quarkus startup logs were captured internally but not printed to the IntelliJ console — it looked like output was still buffered.
The condition is now if (!testActive && !service.isDebug()), so in debug mode service logs are always mirrored to the IDE console, including during startup and while waiting on breakpoints.

**- LocalQuarkusManagedResource — move quarkus.console.enabled=false to configureCommand()**

#6521 introduced quarkus.console.enabled=false to work around Quarkus 3.38+ buffering dev-mode output through the Aesh console on Linux (logs never reached out.log, breaking readiness detection). It was added via propertiesToOverwrite inside assignPorts(), which is the wrong place: that map is for runtime/service configuration (ports, etc.), not for how the quarkus:dev process is launched.

The property is now passed explicitly in configureCommand() as -Dquarkus.console.enabled=false, alongside the other Maven dev-mode arguments. Adding it after the merged -D properties from the map guarantees it wins on the command line if a service or test override sets quarkus.console.enabled elsewhere.

## Testing
Regression testing only.
and running tests in debug mode from intellij.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug-mode service logs are now processed even when no test is active.
  * Non-debug services continue to suppress logs when no test is active.
  * Quarkus dev-mode startup continues to run with the console disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->