### PR TITLE
feat(tekton): Ibutsu S3 uploads for ephemeral Konflux IQE tests

### DIFF
--- a/.tekton/bonfire-integration-tests-pipeline.yaml
+++ b/.tekton/bonfire-integration-tests-pipeline.yaml
@@ -129,16 +129,6 @@ spec:
       description: IQE log level
       default: "debug"
 
-    # Data Router configuration
-    - name: DATAROUTER_CREDENTIALS_NAME
-      type: string
-      description: Secret name for Data Router credentials
-      default: "smqe-datarouter-credentials"
-    - name: DATAROUTER_URL
-      type: string
-      default: "https://datarouter.ccitredhat.com"
-      description: Data Router public URL
-
     # Project configuration
     - name: GITHUB_TOKEN_SECRET
       type: string
@@ -641,15 +631,21 @@ spec:
           value: "$(tasks.extract-metadata.results.IQE_IMAGE_TAG)"
         - name: IQE_PARALLEL_ENABLED
           value: "$(params.IQE_PARALLEL_ENABLED)"
+        - name: IQE_RP_ARGS
+          value: "$(params.IQE_RP_ARGS)"
+        - name: PROJECT_REPO
+          value: "$(params.PROJECT_REPO)"
+        - name: GIT_REVISION
+          value: "$(tasks.extract-metadata.results.GIT_REVISION)"
       taskRef:
         resolver: git
         params:
           - name: url
-            value: "$(params.BONFIRE_REPO)"
+            value: "https://github.com/$(params.PROJECT_REPO).git"
           - name: revision
-            value: "$(params.BONFIRE_REVISION)"
+            value: "$(tasks.extract-metadata.results.GIT_REVISION)"
           - name: pathInRepo
-            value: tasks/run-iqe-cji.yaml
+            value: .tekton/tasks/run-iqe-cji.yaml
 
     - name: collect-logs
       onError: continue
@@ -709,161 +705,6 @@ spec:
 
               echo "Artifacts collected:"
               ls -la "$ARTIFACTS_DIR"
-
-    - name: send-to-datarouter
-      onError: continue
-      runAfter:
-        - collect-logs
-      when:
-        - input: "$(tasks.verify-snapshot-completeness.results.SKIP_TESTS)"
-          operator: in
-          values: [ "false" ]
-        - input: "$(tasks.deploy-application.results.DEPLOY_SUCCEEDED)"
-          operator: in
-          values: ["true"]
-      workspaces:
-        - name: artifacts
-          workspace: artifacts
-      params:
-        - name: DATAROUTER_CREDENTIALS_NAME
-          value: "$(params.DATAROUTER_CREDENTIALS_NAME)"
-        - name: DATAROUTER_URL
-          value: "$(params.DATAROUTER_URL)"
-        - name: PIPELINE_NAME
-          value: "$(context.pipelineRun.name)"
-        - name: GIT_REVISION
-          value: "$(tasks.extract-metadata.results.GIT_REVISION)"
-      taskSpec:
-        params:
-          - name: DATAROUTER_CREDENTIALS_NAME
-          - name: DATAROUTER_URL
-          - name: PIPELINE_NAME
-          - name: GIT_REVISION
-        workspaces:
-          - name: artifacts
-        steps:
-          - name: send
-            image: quay.io/dno/droute:latest
-            imagePullPolicy: Always
-            env:
-              - name: DATAROUTER_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    name: $(params.DATAROUTER_CREDENTIALS_NAME)
-                    key: username
-              - name: DATAROUTER_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: $(params.DATAROUTER_CREDENTIALS_NAME)
-                    key: password
-              - name: PIPELINE_NAME
-                value: "$(params.PIPELINE_NAME)"
-              - name: EVENT_TYPE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['pac.test.appstudio.openshift.io/event-type']
-              - name: GROUP_TEST_INFO
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.annotations['test.appstudio.openshift.io/group-test-info']
-              - name: GIT_REVISION
-                value: "$(params.GIT_REVISION)"
-              - name: INTEGRATION_TEST_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['test.appstudio.openshift.io/scenario']
-            script: |
-              #!/bin/bash
-              set -euo pipefail
-
-              ARTIFACTS_DIR="$(workspaces.artifacts.path)"
-              METADATA_FILE="/tmp/datarouter.json"
-
-              echo "Generating Data Router metadata for event type: ${EVENT_TYPE}"
-
-              PR_NUMBER=""
-              if [ -n "${GROUP_TEST_INFO:-}" ]; then
-                PR_NUMBER=$(echo "${GROUP_TEST_INFO}" | jq -r '.[0].pullRequestNumber // empty' 2>/dev/null || echo "")
-                [ -n "$PR_NUMBER" ] && echo "PR number: $PR_NUMBER"
-              fi
-
-              cat > "$METADATA_FILE" << EOF
-              {
-                "targets": {
-                  "reportportal": {
-                    "config": {
-                      "hostname": "reportportal-smqe.apps.dno.ocp-hub.prod.psi.redhat.com",
-                      "project": "SUBSCRIPTION_WATCH"
-                    },
-                    "processing": {
-                      "property_filter": ["component", "test-plan", "tag"],
-                      "apply_tfa": false,
-                      "apply_llm_analysis": false,
-                      "disable_testitem_updater": false,
-                      "launch": {
-                        "name": "rhsm-subscriptions iqe tests",
-                        "description": "Integration tests ran in Ephemeral through Konflux pipeline.",
-                        "attributes": [
-                          {"key": "tool", "value": "data-router"},
-                          {"key": "environment", "value": "ephemeral"},
-                          {"key": "event_type", "value": "${EVENT_TYPE}"},
-                          {"key": "pipeline_name", "value": "${PIPELINE_NAME}"},
-                          {"key": "git_revision", "value": "${GIT_REVISION}"},
-                          {"key": "integration_test_name", "value": "${INTEGRATION_TEST_NAME}"}
-                        ]
-                      },
-                      "tfa": {
-                        "add_attributes": false,
-                        "auto_finalize_defect_type": false,
-                        "auto_finalization_threshold": 0.55
-                      },
-                      "testcase_concat_char": " "
-                    }
-                  }
-                }
-              }
-              EOF
-
-              if [ -n "$PR_NUMBER" ]; then
-                jq --arg pr "$PR_NUMBER" \
-                  '.targets.reportportal.processing.launch.attributes += [{"key": "pull_request", "value": $pr}]' \
-                  "$METADATA_FILE" > "${METADATA_FILE}.tmp" && mv "${METADATA_FILE}.tmp" "$METADATA_FILE"
-              fi
-
-              echo "Metadata:"
-              jq . "$METADATA_FILE" || cat "$METADATA_FILE"
-
-              MAX_RETRIES=3
-              RETRY_DELAY=45
-              attempt=1
-              while [ $attempt -le $MAX_RETRIES ]; do
-                echo "=== Attempt $attempt of $MAX_RETRIES ==="
-                set +e
-                OUTPUT=$(/droute send \
-                  --url=$(params.DATAROUTER_URL) \
-                  --username=$DATAROUTER_USERNAME \
-                  --password=$DATAROUTER_PASSWORD \
-                  --metadata=$METADATA_FILE \
-                  --results="$ARTIFACTS_DIR/junit-rhsm_subscriptions-sequential.xml" 2>&1)
-                EXIT_CODE=$?
-                set -e
-                echo "Exit code: $EXIT_CODE"
-                echo "Output: $OUTPUT"
-
-                if [ $EXIT_CODE -eq 0 ]; then
-                  echo "Data Router send succeeded"
-                  break
-                fi
-
-                if echo "$OUTPUT" | grep -qi -E "5[0-9][0-9] " && [ $attempt -lt $MAX_RETRIES ]; then
-                  echo "Retrying in $RETRY_DELAY seconds..."
-                  sleep $RETRY_DELAY
-                  attempt=$((attempt + 1))
-                else
-                  echo "Data Router send failed."
-                  break
-                fi
-              done
 
     - name: post-pr-comment
       onError: continue

--- a/.tekton/resources/iqe-cji-ibutsu-s3.yaml
+++ b/.tekton/resources/iqe-cji-ibutsu-s3.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: iqe-cji-ibutsu-s3
+
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: ${NAME}
+  spec:
+    appName: ${APP_NAME}
+    testing:
+      iqe:
+        debug: ${{DEBUG}}
+        imageTag: ${IMAGE_TAG}
+        ui:
+          selenium:
+            deploy: ${{DEPLOY_SELENIUM}}
+          playwright:
+            deploy: ${{DEPLOY_PLAYWRIGHT}}
+        env:
+          - name: IQE_MARKER_EXPRESSION
+            value: ${MARKER}
+          - name: IQE_FILTER_EXPRESSION
+            value: ${FILTER}
+          - name: IQE_PLUGINS
+            value: ${PLUGINS}
+          - name: ENV_FOR_DYNACONF
+            value: ${ENV_NAME}
+          - name: IQE_REQUIREMENTS
+            value: ${REQUIREMENTS}
+          - name: IQE_REQUIREMENTS_PRIORITY
+            value: ${REQUIREMENTS_PRIORITY}
+          - name: IQE_TEST_IMPORTANCE
+            value: ${TEST_IMPORTANCE}
+          - name: IQE_PARALLEL_ENABLED
+            value: ${PARALLEL_ENABLED}
+          - name: IQE_PARALLEL_WORKER_COUNT
+            value: ${PARALLEL_WORKER_COUNT}
+          - name: IQE_RP_ARGS
+            value: ${RP_ARGS}
+          - name: IQE_IBUTSU_SOURCE
+            value: ${IBUTSU_SOURCE}
+          - name: IQE_ENABLE_MINIO
+            value: "true"
+          - name: IBUTSU_MODE
+            value: "s3"
+          - name: IBUTSU_PROJECT
+            valueFrom:
+              configMapKeyRef:
+                name: ${IBUTSU_CONFIGMAP}
+                key: IBUTSU_PROJECT
+                optional: true
+          - name: IBUTSU_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${IBUTSU_SECRET}
+                key: IBUTSU_TOKEN
+                optional: true
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${IBUTSU_AWS_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${IBUTSU_AWS_SECRET}
+                key: aws_secret_access_key
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${IBUTSU_AWS_SECRET}
+                key: aws_region
+          - name: AWS_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: ${IBUTSU_AWS_SECRET}
+                key: bucket
+
+parameters:
+- name: NAME
+  required: true
+- name: APP_NAME
+  required: true
+- name: DEBUG
+  value: "false"
+- name: IMAGE_TAG
+  value: ""
+- name: MARKER
+  value: ""
+- name: FILTER
+  value: ""
+- name: ENV_NAME
+  value: "clowder_smoke"
+  required: true
+- name: REQUIREMENTS
+  value: ""
+- name: REQUIREMENTS_PRIORITY
+  value: ""
+- name: TEST_IMPORTANCE
+  value: ""
+- name: PLUGINS
+  value: ""
+- name: DEPLOY_SELENIUM
+  value: "false"
+- name: DEPLOY_PLAYWRIGHT
+  value: "false"
+- name: PARALLEL_ENABLED
+  value: "true"
+- name: PARALLEL_WORKER_COUNT
+  value: "2"
+- name: RP_ARGS
+  value: ""
+- name: IBUTSU_SOURCE
+  value: ""
+- name: IBUTSU_CONFIGMAP
+  value: "ibutsu-config"
+- name: IBUTSU_SECRET
+  value: "iqe-ibutsu-token"
+- name: IBUTSU_AWS_SECRET
+  value: "ibutsu-aws-credentials"

--- a/.tekton/tasks/run-iqe-cji.yaml
+++ b/.tekton/tasks/run-iqe-cji.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: run-iqe-cji
+spec:
+  description: Deploy IQE CJI with ibutsu-aws-credentials mounted and Ibutsu S3 uploads enabled.
+  params:
+    - name: BONFIRE_IMAGE
+      type: string
+    - name: EPHEMERAL_ENV_PROVIDER_SECRET
+      type: string
+      default: ephemeral-env-provider
+    - name: NS
+      type: string
+    - name: NS_REQUESTER
+      type: string
+    - name: COMPONENT_NAME
+      type: string
+    - name: BONFIRE_COMPONENT_NAME
+      type: string
+      default: ""
+    - name: IQE_CJI_CLOWDAPP_NAME
+      type: string
+      default: ""
+    - name: IQE_PLUGINS
+      type: string
+    - name: IQE_MARKER_EXPRESSION
+      type: string
+      default: ""
+    - name: IQE_FILTER_EXPRESSION
+      type: string
+      default: ""
+    - name: IQE_REQUIREMENTS
+      type: string
+      default: ""
+    - name: IQE_REQUIREMENTS_PRIORITY
+      type: string
+      default: ""
+    - name: IQE_TEST_IMPORTANCE
+      type: string
+      default: ""
+    - name: IQE_CJI_TIMEOUT
+      type: string
+      default: 30m
+    - name: IQE_ENV
+      type: string
+      default: "clowder_smoke"
+    - name: IQE_SELENIUM
+      type: string
+      default: "false"
+    - name: IQE_PLAYWRIGHT
+      type: string
+      default: "false"
+    - name: IQE_PARALLEL_ENABLED
+      type: string
+      default: "false"
+    - name: IQE_RP_ARGS
+      type: string
+      default: ""
+    - name: IQE_IMAGE_TAG
+      type: string
+      default: ""
+    - name: PROJECT_REPO
+      type: string
+      default: "RedHatInsights/rhsm-subscriptions"
+    - name: GIT_REVISION
+      type: string
+      description: Git revision used to fetch the CJI template from the project repo
+    - name: IQE_CJI_TEMPLATE
+      type: string
+      default: ".tekton/resources/iqe-cji-ibutsu-s3.yaml"
+  steps:
+    - name: deploy-iqe-cji
+      image: "$(params.BONFIRE_IMAGE)"
+      env:
+        - name: OC_LOGIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
+              key: token
+        - name: OC_LOGIN_SERVER
+          valueFrom:
+            secretKeyRef:
+              name: $(params.EPHEMERAL_ENV_PROVIDER_SECRET)
+              key: url
+        - name: COMPONENT_NAME
+          value: $(params.COMPONENT_NAME)
+        - name: BONFIRE_COMPONENT_NAME
+          value: $(params.BONFIRE_COMPONENT_NAME)
+        - name: IQE_CJI_CLOWDAPP_NAME
+          value: $(params.IQE_CJI_CLOWDAPP_NAME)
+        - name: IQE_PLUGINS
+          value: $(params.IQE_PLUGINS)
+        - name: IQE_MARKER_EXPRESSION
+          value: $(params.IQE_MARKER_EXPRESSION)
+        - name: IQE_FILTER_EXPRESSION
+          value: $(params.IQE_FILTER_EXPRESSION)
+        - name: IQE_REQUIREMENTS
+          value: $(params.IQE_REQUIREMENTS)
+        - name: IQE_REQUIREMENTS_PRIORITY
+          value: $(params.IQE_REQUIREMENTS_PRIORITY)
+        - name: IQE_TEST_IMPORTANCE
+          value: $(params.IQE_TEST_IMPORTANCE)
+        - name: IQE_CJI_TIMEOUT
+          value: $(params.IQE_CJI_TIMEOUT)
+        - name: IQE_ENV
+          value: $(params.IQE_ENV)
+        - name: IQE_SELENIUM
+          value: $(params.IQE_SELENIUM)
+        - name: IQE_PLAYWRIGHT
+          value: $(params.IQE_PLAYWRIGHT)
+        - name: IQE_PARALLEL_ENABLED
+          value: $(params.IQE_PARALLEL_ENABLED)
+        - name: IQE_RP_ARGS
+          value: $(params.IQE_RP_ARGS)
+        - name: IQE_IMAGE_TAG
+          value: $(params.IQE_IMAGE_TAG)
+        - name: PROJECT_REPO
+          value: $(params.PROJECT_REPO)
+        - name: GIT_REVISION
+          value: $(params.GIT_REVISION)
+        - name: IQE_CJI_TEMPLATE_PATH
+          value: $(params.IQE_CJI_TEMPLATE)
+        - name: BONFIRE_BOT
+          value: "true"
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        login.sh
+
+        template_url="https://raw.githubusercontent.com/${PROJECT_REPO}/${GIT_REVISION}/${IQE_CJI_TEMPLATE_PATH}"
+        export IQE_CJI_TEMPLATE="/tmp/iqe-cji-template.yaml"
+        echo "Fetching CJI template from ${template_url}"
+        curl -fsSL "${template_url}" -o "${IQE_CJI_TEMPLATE}"
+
+        deploy-iqe-cji.sh "$(params.NS)" "$(params.NS_REQUESTER)"


### PR DESCRIPTION
## Summary

- Add custom CJI template (`.tekton/resources/iqe-cji-ibutsu-s3.yaml`) that mounts `ibutsu-aws-credentials` and sets `IBUTSU_MODE=s3`.
- Replace bonfire-tekton `run-iqe-cji` with a local task that fetches the template from this repo and calls `deploy-iqe-cji.sh`.
- Remove the Data Router step; test results are published via Ibutsu S3 instead.

## Why this is needed

Ephemeral Konflux IQE runs cannot upload to Ibutsu S3 today because:

1. Bonfire's default CJI template only mounts `ibutsu-config` / `iqe-ibutsu-token` — not `ibutsu-aws-credentials` (required for `AWS_*` env vars).
2. `deploy-iqe-cji.sh` did not support `--template-file`, forcing inline bonfire calls in Tekton tasks.

Depends on https://github.com/RedHatInsights/cicd-tools/pull/209 — after merge, bump `BONFIRE_IMAGE` in the pipelinerun to the new cicd-tools image tag.

## Test plan

- [ ] Run Konflux integration test on a PR and confirm IQE pod has `IBUTSU_MODE=s3` and AWS env vars from `ibutsu-aws-credentials`.
- [ ] Verify Ibutsu results appear in S3 after the run.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running IQE tests through a configurable ClowdJobInvocation.
  * Added S3-backed Ibutsu reporting with configurable test filters, plugins, parallelism, and reporting options.
  * IQE test jobs can now retrieve templates from the project repository at a specified revision.

* **Changes**
  * Integration test pipelines no longer upload results or metadata to Data Router.
  * Expanded configuration options for deployment details, credentials, test execution, and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->