### PR TITLE
fix(ci): pin kessel-kafka-connect to latest in ephemeral deployments

### DIFF
--- a/.tekton/bonfire-integration-tests-pipelinerun.yaml
+++ b/.tekton/bonfire-integration-tests-pipelinerun.yaml
@@ -60,6 +60,7 @@ spec:
         -p host-inventory/REPLICAS_WORKSPACES=0
         -p host-inventory/REPLICAS_WORKSPACES_BULK=0
         -p host-inventory/REPLICAS_HOST_APP_DATA=0
+        --set-image-tag quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect=latest
     - name: DEPLOY_OPTIONAL_DEPS_METHOD
       value: "none"
     - name: DEPLOY_FRONTENDS


### PR DESCRIPTION
## Description
The konflux integration tests are failing with:

```
ERROR: deploy failed: Found resource status errors:
* ErrImagePull error for pod/kessel-kafka-connect-connect-0 (container 'kessel-kafka-connect-connect'): unable to pull image or OCI artifact: pull image err: initializing source docker://quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect:a3ab287: reading manifest a3ab287 in quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect: manifest unknown; artifact err: image reference: get manifest from ref: create image source: reading manifest a3ab287 in quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect: manifest unknown
```

This can happen if the kessel team pushes a new commit that failed to be released. 

Let's use the kessel-kafka-connect to `latest` which always contains the latest up to date release.

## Testing
Pipeline is passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration test deployments to use the latest Kafka Connect container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->