### PR TITLE
SWATCH-5542 use user_id instead of client_id for service account

### DIFF
--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselPrincipalIds.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/KesselPrincipalIds.java
@@ -81,15 +81,26 @@ public final class KesselPrincipalIds {
   }
 
   private static Optional<String> serviceAccountPrincipalId(Identity identity) {
-    Optional<String> userId = optionalNonBlank(identity.getUserId());
-    if (userId.isPresent()) {
-      return userId;
-    }
+    // Per 3-scale identity schema, user_id is required in service_account object
+    // See: https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/schema.json
     ServiceAccount serviceAccount = identity.getServiceAccount();
     if (serviceAccount == null) {
+      log.error(
+          "ServiceAccount object is null for identity type=ServiceAccount orgId={} - denying access",
+          identity.getOrgId());
       return Optional.empty();
     }
-    return optionalNonBlank(serviceAccount.getClientId());
+
+    Optional<String> userId = optionalNonBlank(serviceAccount.getUserId());
+    if (userId.isEmpty()) {
+      log.error(
+          "ServiceAccount missing REQUIRED user_id field - denying access: type={} orgId={}"
+              + " clientId={}",
+          identity.getType(),
+          identity.getOrgId(),
+          serviceAccount.getClientId());
+    }
+    return userId;
   }
 
   private static Optional<String> userIdFromNestedUser(User user) {

--- a/swatch-common-security/src/main/java/com/redhat/swatch/common/security/ServiceAccount.java
+++ b/swatch-common-security/src/main/java/com/redhat/swatch/common/security/ServiceAccount.java
@@ -35,4 +35,7 @@ public class ServiceAccount {
   private String clientId;
 
   private String username;
+
+  @JsonProperty("user_id")
+  private String userId;
 }

--- a/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPrincipalIdsTest.java
+++ b/swatch-common-security/src/test/java/com/redhat/swatch/common/security/KesselPrincipalIdsTest.java
@@ -47,28 +47,39 @@ class KesselPrincipalIdsTest {
   }
 
   @Test
-  void resolvesServiceAccountFromUserIdWhenPresent() {
+  void resolvesServiceAccountFromServiceAccountUserId() {
+    // Per identity schema, user_id is required in service_account object
     var identity =
         Identity.builder()
             .type("ServiceAccount")
             .orgId("org123")
-            .userId("sa-user-id")
-            .serviceAccount(ServiceAccount.builder().clientId("client-id").build())
+            .serviceAccount(
+                ServiceAccount.builder()
+                    .clientId("b69eaf9e-e6a6-4f9e-805e-02987daddfbd")
+                    .username("service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd")
+                    .userId("60ce65dc-4b5a-4812-8b65-b48178d92b12")
+                    .build())
             .build();
 
-    assertEquals("sa-user-id", KesselPrincipalIds.fromIdentity(identity).orElseThrow());
+    assertEquals(
+        "60ce65dc-4b5a-4812-8b65-b48178d92b12",
+        KesselPrincipalIds.fromIdentity(identity).orElseThrow());
   }
 
   @Test
-  void resolvesServiceAccountFromClientIdWhenUserIdMissing() {
+  void serviceAccountWithoutUserIdReturnsEmpty() {
     var identity =
         Identity.builder()
             .type("ServiceAccount")
             .orgId("org123")
-            .serviceAccount(ServiceAccount.builder().clientId("client-id").build())
+            .serviceAccount(
+                ServiceAccount.builder()
+                    .clientId("client-id")
+                    .username("service-account-client-id")
+                    .build())
             .build();
 
-    assertEquals("client-id", KesselPrincipalIds.fromIdentity(identity).orElseThrow());
+    assertTrue(KesselPrincipalIds.fromIdentity(identity).isEmpty());
   }
 
   @Test

--- a/swatch-contracts/ct/java/tests/ContractsAccessComponentTest.java
+++ b/swatch-contracts/ct/java/tests/ContractsAccessComponentTest.java
@@ -181,9 +181,10 @@ public class ContractsAccessComponentTest extends BaseContractComponentTest {
       AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
     // Given
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     givenServiceAccountAccess(
-        authorizationModel, clientId, requestHeaders, SubscriptionsAccessLevel.GRANTED_ADMIN);
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     // When
     Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);
@@ -199,9 +200,10 @@ public class ContractsAccessComponentTest extends BaseContractComponentTest {
       AuthorizationModel authorizationModel, CustomerFacingEndpoint endpoint) {
     // Given
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     givenServiceAccountAccess(
-        authorizationModel, clientId, requestHeaders, SubscriptionsAccessLevel.DENIED);
+        authorizationModel, userId, requestHeaders, SubscriptionsAccessLevel.DENIED);
 
     // When
     Response response = whenGetCustomerFacingEndpoint(endpoint, requestHeaders);

--- a/swatch-core/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
+++ b/swatch-core/src/main/java/org/candlepin/subscriptions/security/InsightsUserPrincipal.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Represents a user or service account authenticated via the x-rh-identity header.
@@ -31,6 +32,7 @@ import java.util.Optional;
  * <p>This class handles both "User" and "ServiceAccount" identity types from the x-rh-identity
  * header, as they share the same org_id structure and authentication flow.
  */
+@Slf4j
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InsightsUserPrincipal implements RhIdentity.Identity {
 
@@ -80,12 +82,23 @@ public class InsightsUserPrincipal implements RhIdentity.Identity {
     @JsonProperty("client_id")
     private String clientId;
 
+    @JsonProperty("user_id")
+    private String userId;
+
     public String getClientId() {
       return clientId;
     }
 
     public void setClientId(String clientId) {
       this.clientId = clientId;
+    }
+
+    public String getUserId() {
+      return userId;
+    }
+
+    public void setUserId(String userId) {
+      this.userId = userId;
     }
   }
 
@@ -108,24 +121,45 @@ public class InsightsUserPrincipal implements RhIdentity.Identity {
   /**
    * Returns the principal identifier used for Kessel authorization checks ({@code redhat/{id}}).
    *
-   * <p>For users, this returns the user_id. For service accounts, this returns the client_id.
+   * <p>For users, this returns user.user_id or top-level user_id. For service accounts, this
+   * returns service_account.user_id (per <a
+   * href="https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/schema.json">identity
+   * schema</a>), with defensive fallback to top-level user_id.
+   *
+   * <p>Kessel requires user_id, not client_id.
    *
    * <p>Matches insights-rbac and swatch-common-security KesselPrincipalIds logic.
    */
   public Optional<String> getKesselPrincipalId() {
-    // Check top-level user_id first (present in both user and service account identities)
+    // Check ServiceAccount FIRST (before generic fallbacks) to enforce schema contract
+    if (serviceAccount != null) {
+      // Prefer service_account.user_id (correct per schema)
+      if (serviceAccount.getUserId() != null && !serviceAccount.getUserId().isBlank()) {
+        return Optional.of(serviceAccount.getUserId());
+      }
+      // Defensive fallback to top-level user_id (non-standard)
+      if (userId != null && !userId.isBlank()) {
+        log.warn(
+            "ServiceAccount has user_id at top-level instead of service_account.user_id"
+                + " (non-standard): orgId={} clientId={}",
+            getOrgId(),
+            serviceAccount.getClientId());
+        return Optional.of(userId);
+      }
+      // No user_id found - error and deny
+      log.error(
+          "ServiceAccount missing REQUIRED user_id field - denying access: orgId={} clientId={}",
+          getOrgId(),
+          serviceAccount.getClientId());
+      return Optional.empty();
+    }
+    // For Users: check top-level user_id
     if (userId != null && !userId.isBlank()) {
       return Optional.of(userId);
     }
-    // Check nested user.user_id (for User type)
+    // For Users: check nested user.user_id
     if (user != null && user.getUserId() != null && !user.getUserId().isBlank()) {
       return Optional.of(user.getUserId());
-    }
-    // Check service_account.client_id (for ServiceAccount type)
-    if (serviceAccount != null
-        && serviceAccount.getClientId() != null
-        && !serviceAccount.getClientId().isBlank()) {
-      return Optional.of(serviceAccount.getClientId());
     }
     return Optional.empty();
   }

--- a/swatch-core/src/test/java/org/candlepin/subscriptions/security/InsightsUserPrincipalTest.java
+++ b/swatch-core/src/test/java/org/candlepin/subscriptions/security/InsightsUserPrincipalTest.java
@@ -77,4 +77,69 @@ class InsightsUserPrincipalTest {
 
     assertTrue(principal.getKesselPrincipalId().isEmpty());
   }
+
+  @Test
+  void resolvesServiceAccountFromServiceAccountUserId() throws Exception {
+    // Per identity schema, ServiceAccount has user_id in service_account object
+    var principal =
+        mapper.readValue(
+            """
+            {
+              "internal": {"org_id": "11009103"},
+              "type": "ServiceAccount",
+              "service_account": {
+                "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "user_id": "60ce65dc-4b5a-4812-8b65-b48178d92b12"
+              }
+            }
+            """,
+            InsightsUserPrincipal.class);
+
+    assertEquals(
+        "60ce65dc-4b5a-4812-8b65-b48178d92b12", principal.getKesselPrincipalId().orElseThrow());
+  }
+
+  @Test
+  void serviceAccountWithoutUserIdReturnsEmpty() throws Exception {
+    // Kessel requires user_id - if missing, return empty (don't fall back to client_id)
+    var principal =
+        mapper.readValue(
+            """
+            {
+              "internal": {"org_id": "11009103"},
+              "type": "ServiceAccount",
+              "service_account": {
+                "client_id": "client-id",
+                "username": "service-account-client-id"
+              }
+            }
+            """,
+            InsightsUserPrincipal.class);
+
+    assertTrue(principal.getKesselPrincipalId().isEmpty());
+  }
+
+  @Test
+  void serviceAccountWithTopLevelUserIdFallsBack() throws Exception {
+    var principal =
+        mapper.readValue(
+            """
+            {
+              "internal": {"org_id": "11009103"},
+              "type": "ServiceAccount",
+              "user_id": "top-level-fallback-userid",
+              "service_account": {
+                "client_id": "client-id",
+                "username": "service-account-client-id"
+              }
+            }
+            """,
+            InsightsUserPrincipal.class);
+
+    assertEquals(
+        "top-level-fallback-userid",
+        principal.getKesselPrincipalId().orElseThrow(),
+        "ServiceAccount should fall back to top-level user_id with warning");
+  }
 }

--- a/swatch-tally/ct/java/tests/InstancesAccessComponentTest.java
+++ b/swatch-tally/ct/java/tests/InstancesAccessComponentTest.java
@@ -101,10 +101,11 @@ class InstancesAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowInstancesWhenServiceAccountAdminAccessGranted(
       AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     Response response = whenGetInstances(requestHeaders);
 
@@ -117,10 +118,11 @@ class InstancesAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowInstancesWhenServiceAccountReaderAccessGranted(
       AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
 
     Response response = whenGetInstances(requestHeaders);
 
@@ -132,10 +134,11 @@ class InstancesAccessComponentTest extends BaseTallyComponentTest {
   @TestPlanName("rbac-parity-TC007")
   void shouldDenyInstancesWhenServiceAccountAccessDenied(AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     Response response = whenGetInstances(requestHeaders);
 

--- a/swatch-tally/ct/java/tests/OptInRbacAccessComponentTest.java
+++ b/swatch-tally/ct/java/tests/OptInRbacAccessComponentTest.java
@@ -100,10 +100,11 @@ class OptInRbacAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowOptInWhenServiceAccountHasAdminAccess(AuthorizationModel authorizationModel) {
     // Given: ServiceAccount with admin permission
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     // When/Then: All operations succeed
     assertOptInEndpointsSucceed(requestHeaders);
@@ -115,10 +116,11 @@ class OptInRbacAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowOptInWhenServiceAccountHasReaderAccess(AuthorizationModel authorizationModel) {
     // Given: ServiceAccount with reader permission
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
 
     // When/Then: All operations succeed
     assertOptInEndpointsSucceed(requestHeaders);
@@ -130,10 +132,11 @@ class OptInRbacAccessComponentTest extends BaseTallyComponentTest {
   void shouldDenyOptInWhenServiceAccountHasNoAccess(AuthorizationModel authorizationModel) {
     // Given: ServiceAccount with no permissions
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     // When/Then: All operations fail (forbidden)
     assertOptInEndpointsForbidden(requestHeaders);

--- a/swatch-tally/ct/java/tests/TallyReportAccessComponentTest.java
+++ b/swatch-tally/ct/java/tests/TallyReportAccessComponentTest.java
@@ -102,10 +102,11 @@ class TallyReportAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowTallyReportWhenServiceAccountAdminAccessGranted(
       AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     Response response = whenGetTallyReport(requestHeaders);
 
@@ -118,10 +119,11 @@ class TallyReportAccessComponentTest extends BaseTallyComponentTest {
   void shouldAllowTallyReportWhenServiceAccountReaderAccessGranted(
       AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_READER);
 
     Response response = whenGetTallyReport(requestHeaders);
 
@@ -133,10 +135,11 @@ class TallyReportAccessComponentTest extends BaseTallyComponentTest {
   @TestPlanName("rbac-parity-TC007")
   void shouldDenyTallyReportWhenServiceAccountAccessDenied(AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     rbacHelper.givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     Response response = whenGetTallyReport(requestHeaders);
 

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -23,7 +23,6 @@ package com.redhat.swatch.component.tests.utils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
-import java.util.UUID;
 
 public final class SwatchUtils {
   public static final String SERVER_PORT_PROPERTY = "SERVER_PORT";
@@ -101,12 +100,17 @@ public final class SwatchUtils {
   }
 
   /**
-   * Returns headers for a ServiceAccount identity with org and client identifiers (RBAC component
-   * tests). Generates a random UUID for user_id as required by the identity schema.
+   * Returns headers for a ServiceAccount identity with org, client, and user identifiers.
+   *
+   * <p>Per the 3-scale identity schema, ServiceAccount has both client_id and user_id. Kessel v2
+   * authorization uses user_id, so ensure Kessel stubs are configured with the same userId value.
+   *
+   * @param orgId Organization ID
+   * @param clientId Client ID
+   * @param userId User ID (not null identifier used by Kessel for authorization checks)
    */
   public static Map<String, String> securityHeadersWithServiceAccount(
-      String orgId, String clientId) {
-    String userId = UUID.randomUUID().toString();
+      String orgId, String clientId, String userId) {
     String json =
         "{\"identity\":{\"type\":\"ServiceAccount\",\"org_id\":\""
             + orgId

--- a/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
+++ b/swatch-test-framework/src/main/java/com/redhat/swatch/component/tests/utils/SwatchUtils.java
@@ -23,6 +23,7 @@ package com.redhat.swatch.component.tests.utils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.UUID;
 
 public final class SwatchUtils {
   public static final String SERVER_PORT_PROPERTY = "SERVER_PORT";
@@ -101,15 +102,18 @@ public final class SwatchUtils {
 
   /**
    * Returns headers for a ServiceAccount identity with org and client identifiers (RBAC component
-   * tests).
+   * tests). Generates a random UUID for user_id as required by the identity schema.
    */
   public static Map<String, String> securityHeadersWithServiceAccount(
       String orgId, String clientId) {
+    String userId = UUID.randomUUID().toString();
     String json =
         "{\"identity\":{\"type\":\"ServiceAccount\",\"org_id\":\""
             + orgId
             + "\",\"service_account\":{\"client_id\":\""
             + clientId
+            + "\",\"user_id\":\""
+            + userId
             + "\"}}}";
     String rhId = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     return Map.of(ORIGIN_HEADER, ORIGIN_HEADER_VALUE, X_RH_IDENTITY_HEADER, rhId);

--- a/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
+++ b/swatch-utilization/ct/java/tests/OrgPreferencesAccessComponentTest.java
@@ -150,10 +150,11 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
   void shouldAllowGetOrgPreferencesWhenServiceAccountHasAdminAccess(
       AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.GRANTED_ADMIN);
 
     Response response = whenGetOrgPreferences(requestHeaders);
 
@@ -165,10 +166,11 @@ class OrgPreferencesAccessComponentTest extends BaseUtilizationComponentTest {
   @TestPlanName("org-preferences-auth-TC008")
   void shouldDenyBothEndpointsWhenServiceAccountHasNoAccess(AuthorizationModel authorizationModel) {
     String clientId = RandomUtils.generateRandom();
-    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId);
+    String userId = RandomUtils.generateRandom();
+    var requestHeaders = SwatchUtils.securityHeadersWithServiceAccount(orgId, clientId, userId);
     String identityHeader = requestHeaders.get(X_RH_IDENTITY_HEADER);
     givenServiceAccountHasSubscriptionsAccess(
-        authorizationModel, clientId, identityHeader, SubscriptionsAccessLevel.DENIED);
+        authorizationModel, userId, identityHeader, SubscriptionsAccessLevel.DENIED);
 
     Response getResponse = whenGetOrgPreferences(requestHeaders);
     Response postResponse = whenPostOrgPreferences(requestHeaders);


### PR DESCRIPTION
<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5542

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->
After confirming with Kessel team, RBACv1 is using the `client_id`, while for RBACv2 they write `user_id` to Kessel relationships. Hence when we query RBACv2 we need to pass `user_id` and not `client_id`

## Testing
Mostly the component test covers the changes done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Service-account authorization now identifies principals using the nested `service_account.user_id`.
  * In supported flows, a top-level `user_id` may be used when the nested value is unavailable.
  * `client_id` is no longer used as a service-account identity fallback.
  * Service-account data now supports the `user_id` field.
  * Missing or blank user IDs may result in no principal ID and denied access.
* **Tests**
  * Updated coverage for nested, fallback, and missing service-account user IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->