### PR TITLE
SWATCH-5565: Expose licenseId on monthly account remittances API

### DIFF
--- a/swatch-billable-usage/COMPONENT_TEST_PLAN.md
+++ b/swatch-billable-usage/COMPONENT_TEST_PLAN.md
@@ -357,6 +357,23 @@ Java component tests in `ContractCoverageComponentTest` (`swatch-billable-usage/
 - **Expected Result:**  
   - Deterministic overage allocation when start dates tie (lexicographically smaller wins)
 
+**billable-usage-contract-coverage-TC015 - Monthly account remittance splits by licenseId**
+
+- **Description:** Verify aggregated `accountRemittances` returns one row per `licenseId` while the monthly total across rows is unchanged.  
+- **Setup:**  
+  - Two ROSA contracts with different `licenseId`s and combined coverage = 4 Instance-hours  
+  - First tally `current_total` = 5 (overage 1 on newest license)  
+  - Contracts restubbed so the other license becomes newest  
+  - Second tally `current_total` = 6 (additional overage 1 on the other license)
+- **Action:**  
+  - Publish both tally summaries in the same accumulation period
+- **Verification:**  
+  - Monthly `accountRemittances` returns two rows (one per `licenseId`)  
+  - Each row has `remittedValue` = 1 for its license  
+  - Sum of monthly `remittedValue` = 2
+- **Expected Result:**  
+  - Per-license monthly attribution without changing the total remitted amount
+
 ---
 
 ## ACM Managed vs Self-Managed Dimensions

--- a/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/ContractAdjustmentComponentTest.java
@@ -244,10 +244,9 @@ public class ContractAdjustmentComponentTest extends BaseBillableUsageComponentT
                       metric.metricId().toString(),
                       BillingProvider.AWS.toTallyApiModel().value(),
                       billingAccountId);
-              assertEquals(1, remittances.size(), "Expected one monthly remittance row per metric");
               assertEquals(
                   expectedRemittedValue,
-                  remittances.get(0).getRemittedValue(),
+                  remittances.stream().mapToDouble(MonthlyRemittance::getRemittedValue).sum(),
                   0.001,
                   "Account remittance mismatch for metric " + metric.metricId());
             });

--- a/swatch-billable-usage/ct/java/tests/ContractCoverageComponentTest.java
+++ b/swatch-billable-usage/ct/java/tests/ContractCoverageComponentTest.java
@@ -24,7 +24,6 @@ import static api.BillableUsageTestHelper.createTallySummary;
 import static com.redhat.swatch.component.tests.utils.Topics.BILLABLE_USAGE;
 import static com.redhat.swatch.component.tests.utils.Topics.TALLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -44,6 +43,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.candlepin.subscriptions.billable.usage.BillableUsage;
 import org.candlepin.subscriptions.billable.usage.TallySummary;
 import org.junit.jupiter.api.BeforeAll;
@@ -222,6 +222,7 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
             INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
     String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 1.0, newerLicense);
     thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, newerLicense);
     thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, newerLicense);
   }
@@ -251,6 +252,7 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
             INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
     String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 1.0, licensedId);
     thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, licensedId);
     thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, licensedId);
   }
@@ -280,6 +282,8 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     TallySummary tallySummary = whenAnsibleTallyIsPublished(3.0, ANSIBLE_GRATIS_SNAPSHOT_DATE);
     String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
+    thenAccountRemittanceEquals(
+        ANSIBLE_AAP_MANAGED.getName(), MANAGED_NODES.toString(), 1.0, newestLicense);
     thenTallyRemittanceStatusLicenseAndValueEquals(
         tallyId, RemittanceStatus.PENDING, newestLicense, 1.0);
     thenBillableUsageKafkaMessageWithLicense(ANSIBLE_AAP_MANAGED.getName(), 1.0, newestLicense);
@@ -309,6 +313,8 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
     TallySummary tallySummary = whenAnsibleTallyIsPublished(3.0, snapshotDate);
     String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
+    thenAccountRemittanceEquals(
+        ANSIBLE_AAP_MANAGED.getName(), MANAGED_NODES.toString(), 1.0, newestLicense);
     thenTallyRemittanceStatusLicenseAndValueEquals(
         tallyId, RemittanceStatus.GRATIS, newestLicense, 1.0);
     thenNoBillableUsageKafkaMessage(ANSIBLE_AAP_MANAGED.getName());
@@ -318,23 +324,62 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
   @TestPlanName("billable-usage-contract-coverage-TC014")
   void shouldSelectLexicographicallySmallerLicenseOnTie() {
     String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
-    String smallerLicense = "arn:aws:license-manager:1:license:a";
-    String largerLicense = "arn:aws:license-manager:1:license:z";
+    String lexicographicallySmallerLicenseId = "arn:aws:license-manager:1:license:a";
+    String lexicographicallyLargerLicenseId = "arn:aws:license-manager:1:license:z";
     OffsetDateTime sameStart = OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1);
     OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
     givenContracts(
         ROSA.getName(),
         List.of(
-            new ContractStub(sameStart, end, Map.of(awsDimension, 2.0), largerLicense),
-            new ContractStub(sameStart, end, Map.of(awsDimension, 2.0), smallerLicense)));
+            new ContractStub(
+                sameStart, end, Map.of(awsDimension, 2.0), lexicographicallyLargerLicenseId),
+            new ContractStub(
+                sameStart, end, Map.of(awsDimension, 2.0), lexicographicallySmallerLicenseId)));
 
     TallySummary tallySummary =
         whenRosaTallyIsPublished(
             INSTANCE_HOURS.toString(), 5.0, OffsetDateTime.now(ZoneOffset.UTC));
     String tallyId = tallySummary.getTallySnapshots().getFirst().getId().toString();
 
-    thenTallyRemittancePendingValueAndLicenseEquals(tallyId, 1.0, smallerLicense);
-    thenBillableUsageKafkaMessageWithLicense(ROSA.getName(), 1.0, smallerLicense);
+    thenAccountRemittanceEquals(
+        ROSA.getName(), INSTANCE_HOURS.toString(), 1.0, lexicographicallySmallerLicenseId);
+    thenTallyRemittancePendingValueAndLicenseEquals(
+        tallyId, 1.0, lexicographicallySmallerLicenseId);
+    thenBillableUsageKafkaMessageWithLicense(
+        ROSA.getName(), 1.0, lexicographicallySmallerLicenseId);
+  }
+
+  @Test
+  @TestPlanName("billable-usage-contract-coverage-TC015")
+  void shouldExposeSeparateMonthlyAccountRemittanceRowsPerLicenseId() {
+    String awsDimension = ROSA.getMetric(INSTANCE_HOURS).getAwsDimension();
+    String licenseA = "arn:aws:license-manager:1:license:a";
+    String licenseB = "arn:aws:license-manager:1:license:b";
+    OffsetDateTime end = OffsetDateTime.now(ZoneOffset.UTC).plusYears(1);
+    OffsetDateTime firstSnapshot = OffsetDateTime.now(ZoneOffset.UTC);
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(
+                firstSnapshot.minusMonths(2), end, Map.of(awsDimension, 2.0), licenseA),
+            new ContractStub(
+                firstSnapshot.minusMonths(1), end, Map.of(awsDimension, 2.0), licenseB)));
+
+    whenRosaTallyIsPublished(INSTANCE_HOURS.toString(), 5.0, firstSnapshot);
+
+    givenContracts(
+        ROSA.getName(),
+        List.of(
+            new ContractStub(firstSnapshot.minusDays(5), end, Map.of(awsDimension, 2.0), licenseA),
+            new ContractStub(
+                firstSnapshot.minusMonths(1), end, Map.of(awsDimension, 2.0), licenseB)));
+
+    whenRosaTallyIsPublished(INSTANCE_HOURS.toString(), 6.0, firstSnapshot.plusHours(1));
+
+    thenAccountRemittanceRowCount(ROSA.getName(), INSTANCE_HOURS.toString(), 2);
+    thenAccountRemittanceSumEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 2.0);
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 1.0, licenseB);
+    thenAccountRemittanceEquals(ROSA.getName(), INSTANCE_HOURS.toString(), 1.0, licenseA);
   }
 
   private void givenNoContractExistsForRosa() {
@@ -403,6 +448,11 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
 
   private void thenAccountRemittanceEquals(
       String productId, String metricId, double expectedRemittedValue) {
+    thenAccountRemittanceEquals(productId, metricId, expectedRemittedValue, null);
+  }
+
+  private void thenAccountRemittanceSumEquals(
+      String productId, String metricId, double expectedRemittedTotal) {
     AwaitilityUtils.untilAsserted(
         () -> {
           List<MonthlyRemittance> remittances =
@@ -412,12 +462,58 @@ public class ContractCoverageComponentTest extends BaseBillableUsageComponentTes
                   metricId,
                   BillingProvider.AWS.toTallyApiModel().value(),
                   billingAccountId);
-          assertFalse(remittances.isEmpty(), "Expected account remittance response");
+          assertEquals(
+              expectedRemittedTotal,
+              remittances.stream().mapToDouble(MonthlyRemittance::getRemittedValue).sum(),
+              0.001,
+              "Account remittance total mismatch");
+        });
+  }
+
+  private void thenAccountRemittanceRowCount(
+      String productId, String metricId, int expectedRowCount) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<MonthlyRemittance> remittances =
+              service.getRemittances(
+                  productId,
+                  orgId,
+                  metricId,
+                  BillingProvider.AWS.toTallyApiModel().value(),
+                  billingAccountId);
+          assertEquals(
+              expectedRowCount,
+              remittances.size(),
+              "Unexpected monthly account remittance row count");
+        });
+  }
+
+  private void thenAccountRemittanceEquals(
+      String productId, String metricId, double expectedRemittedValue, String expectedLicenseId) {
+    AwaitilityUtils.untilAsserted(
+        () -> {
+          List<MonthlyRemittance> remittances =
+              service.getRemittances(
+                  productId,
+                  orgId,
+                  metricId,
+                  BillingProvider.AWS.toTallyApiModel().value(),
+                  billingAccountId);
+          MonthlyRemittance remittance =
+              remittances.stream()
+                  .filter(row -> Objects.equals(expectedLicenseId, row.getLicenseId()))
+                  .findFirst()
+                  .orElseThrow(
+                      () -> new AssertionError("Expected account remittance for licenseId"));
           assertEquals(
               expectedRemittedValue,
-              remittances.get(0).getRemittedValue(),
+              remittance.getRemittedValue(),
               0.001,
               "Account remittance value mismatch");
+          assertEquals(
+              expectedLicenseId,
+              remittance.getLicenseId(),
+              "Account remittance licenseId mismatch");
         });
   }
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageController.java
@@ -153,7 +153,8 @@ public class InternalBillableUsageController {
               .remittanceErrorCode(
                   ofNullable(entity.getErrorCode())
                       .map(RemittanceErrorCode::getValue)
-                      .orElse("null"));
+                      .orElse("null"))
+              .licenseId(entity.getLicenseId());
       remittances.add(accountRemittance);
     }
     log.debug("Found {} remittances for this account", remittances.size());

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepository.java
@@ -67,7 +67,8 @@ public class BillableUsageRemittanceRepository
           root.get(BillableUsageRemittanceEntity_.ORG_ID),
           root.get(BillableUsageRemittanceEntity_.PRODUCT_ID),
           root.get(BillableUsageRemittanceEntity_.STATUS),
-          root.get(BillableUsageRemittanceEntity_.ERROR_CODE));
+          root.get(BillableUsageRemittanceEntity_.ERROR_CODE),
+          root.get(BillableUsageRemittanceEntity_.LICENSE_ID));
     }
     query.select(
         criteriaBuilder.construct(
@@ -83,7 +84,8 @@ public class BillableUsageRemittanceRepository
             root.get(BillableUsageRemittanceEntity_.BILLING_ACCOUNT_ID),
             root.get(BillableUsageRemittanceEntity_.METRIC_ID),
             root.get(BillableUsageRemittanceEntity_.STATUS),
-            root.get(BillableUsageRemittanceEntity_.ERROR_CODE)));
+            root.get(BillableUsageRemittanceEntity_.ERROR_CODE),
+            root.get(BillableUsageRemittanceEntity_.LICENSE_ID)));
     return entityManager.createQuery(query).getResultList();
   }
 

--- a/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
+++ b/swatch-billable-usage/src/main/java/com/redhat/swatch/billable/usage/data/RemittanceSummaryProjection.java
@@ -43,4 +43,5 @@ public class RemittanceSummaryProjection {
   private String metricId;
   private RemittanceStatus status;
   private RemittanceErrorCode errorCode;
+  private String licenseId;
 }

--- a/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
+++ b/swatch-billable-usage/src/main/resources/META-INF/openapi.yaml
@@ -247,6 +247,9 @@ components:
           type: string
         remittanceErrorCode:
           type: string
+        licenseId:
+          type: string
+          nullable: true
     TallyRemittances:
       type: array
       items:

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageControllerTest.java
@@ -207,6 +207,64 @@ class InternalBillableUsageControllerTest {
   }
 
   @Test
+  @Transactional
+  void testFilterByOrgIdAndProductGroupsRemittancesByLicenseId() {
+    remittanceRepo.deleteAll();
+    var licenseZRemittance = remittanceWithLicense("org123", "license-z", 3.0);
+    var licenseARemittance = remittanceWithLicense("org123", "license-a", 5.0);
+    var sameLicenseRemittance = remittanceWithLicense("org123", "license-a", 2.0);
+    sameLicenseRemittance.setRemittancePendingDate(clock.startOfCurrentMonth().plusDays(1));
+    licenseARemittance.setRemittancePendingDate(clock.startOfCurrentMonth().plusDays(2));
+    remittanceRepo.persist(List.of(licenseZRemittance, licenseARemittance, sameLicenseRemittance));
+    remittanceRepo.flush();
+
+    var response =
+        controller.getRemittances(
+            BillableUsageRemittanceFilter.builder().orgId("org123").productId("product1").build());
+
+    assertEquals(2, response.size());
+    assertEquals(
+        10.0, response.stream().mapToDouble(MonthlyRemittance::getRemittedValue).sum(), 0.001);
+    assertEquals(
+        7.0,
+        response.stream()
+            .filter(remittance -> "license-a".equals(remittance.getLicenseId()))
+            .mapToDouble(MonthlyRemittance::getRemittedValue)
+            .sum(),
+        0.001);
+    assertEquals(
+        3.0,
+        response.stream()
+            .filter(remittance -> "license-z".equals(remittance.getLicenseId()))
+            .mapToDouble(MonthlyRemittance::getRemittedValue)
+            .sum(),
+        0.001);
+  }
+
+  @Test
+  @Transactional
+  void testFilterByOrgIdAndProductKeepsUnlicensedRemittanceNull() {
+    remittanceRepo.deleteAll();
+    remittanceRepo.persist(
+        remittance(
+            "org123",
+            "product1",
+            BillableUsage.BillingProvider.AWS,
+            3.0,
+            clock.startOfCurrentMonth(),
+            RemittanceStatus.PENDING));
+    remittanceRepo.flush();
+
+    var response =
+        controller.getRemittances(
+            BillableUsageRemittanceFilter.builder().orgId("org123").productId("product1").build());
+
+    assertEquals(1, response.size());
+    assertEquals(3.0, response.get(0).getRemittedValue());
+    assertNull(response.get(0).getLicenseId());
+  }
+
+  @Test
   void testAccountAndOrgIdShouldReturnEmpty() {
     var response =
         controller.getRemittances(
@@ -425,5 +483,19 @@ class InternalBillableUsageControllerTest {
         .remittedPendingValue(value)
         .status(remittanceStatus)
         .build();
+  }
+
+  private BillableUsageRemittanceEntity remittanceWithLicense(
+      String orgId, String licenseId, Double value) {
+    var remittance =
+        remittance(
+            orgId,
+            "product1",
+            BillableUsage.BillingProvider.AWS,
+            value,
+            clock.startOfCurrentMonth(),
+            RemittanceStatus.PENDING);
+    remittance.setLicenseId(licenseId);
+    return remittance;
   }
 }

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/admin/api/InternalBillableUsageResourceTest.java
@@ -60,6 +60,9 @@ class InternalBillableUsageResourceTest {
 
   private static final String ORG_ID = "org123";
   private static final String PRODUCT_ID = "rosa";
+  private static final String LICENSE_ID =
+      "arn:aws:license-manager:us-east-1:123456789012:license:swatch-test-license";
+  private static final String TALLY_ID = "c204074d-626f-4272-aa05-b6d69d6de16a";
 
   @InjectMock ApplicationConfiguration configuration;
   @InjectSpy BillableUsageRemittanceRepository remittanceRepository;
@@ -125,24 +128,26 @@ class InternalBillableUsageResourceTest {
     assertEquals(ORG_ID, remittances[0].getOrgId());
     assertEquals(RemittanceStatus.FAILED.getValue(), remittances[0].getRemittanceStatus());
     assertEquals(RemittanceErrorCode.UNKNOWN.getValue(), remittances[0].getRemittanceErrorCode());
+    assertEquals(LICENSE_ID, remittances[0].getLicenseId());
   }
 
   @Test
   void testGetRemittancesReturnsBadRequestWhenWrongTallyId() {
-    String tallyId = "e404074d-626f-4272-aa05-b6d69d6de16c";
+    String nonexistentTallyId = "e404074d-626f-4272-aa05-b6d69d6de16c";
     given()
-        .get("/api/swatch-billable-usage/internal/remittance/accountRemittances/" + tallyId)
+        .get(
+            "/api/swatch-billable-usage/internal/remittance/accountRemittances/"
+                + nonexistentTallyId)
         .then()
         .statusCode(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test
   void testGetRemittancesByTallyId() {
-    String tallyId = "c204074d-626f-4272-aa05-b6d69d6de16a";
-    givenRemittanceForTallyId(tallyId);
+    givenRemittanceForTallyId(TALLY_ID);
     TallyRemittance[] remittances =
         given()
-            .get("/api/swatch-billable-usage/internal/remittance/accountRemittances/" + tallyId)
+            .get("/api/swatch-billable-usage/internal/remittance/accountRemittances/" + TALLY_ID)
             .as(TallyRemittance[].class);
     assertEquals(1, remittances.length);
     assertEquals(ORG_ID, remittances[0].getOrgId());
@@ -228,7 +233,8 @@ class InternalBillableUsageResourceTest {
             .remittedPendingValue(2.0)
             .status(RemittanceStatus.FAILED)
             .errorCode(RemittanceErrorCode.UNKNOWN)
-            .tallyId(UUID.fromString("c204074d-626f-4272-aa05-b6d69d6de16a"))
+            .licenseId(LICENSE_ID)
+            .tallyId(UUID.fromString(TALLY_ID))
             .build();
     remittanceRepository.persist(entity);
     return entity;

--- a/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepositoryTest.java
+++ b/swatch-billable-usage/src/test/java/com/redhat/swatch/billable/usage/data/BillableUsageRemittanceRepositoryTest.java
@@ -139,6 +139,13 @@ class BillableUsageRemittanceRepositoryTest {
         .build();
   }
 
+  private BillableUsageRemittanceEntity remittanceWithLicense(
+      String orgId, String licenseId, Double value, OffsetDateTime remittanceDate) {
+    var remittance = remittance(orgId, "product1", BILLING_PROVIDER_AWS, value, remittanceDate);
+    remittance.setLicenseId(licenseId);
+    return remittance;
+  }
+
   @Test
   void testFindByProductId() {
     BillableUsageRemittanceEntity remittance1 =
@@ -354,6 +361,46 @@ class BillableUsageRemittanceRepositoryTest {
     List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter1);
     assertEquals(2, results.size());
     assertTrue(results.containsAll(List.of(expectedSummary1, expectedSummary2)));
+  }
+
+  @Test
+  void getMonthlySummaryGroupsByLicenseIdWhilePreservingMonthlyTotal() {
+    OffsetDateTime remittanceDate = truncateDate(clock.startOfCurrentMonth());
+    BillableUsageRemittanceEntity licenseARowOne =
+        remittanceWithLicense("org123", "license-a", 3.0, remittanceDate);
+    BillableUsageRemittanceEntity licenseARowTwo =
+        remittanceWithLicense("org123", "license-a", 2.0, remittanceDate.plusDays(1));
+    BillableUsageRemittanceEntity licenseBRow =
+        remittanceWithLicense("org123", "license-b", 5.0, remittanceDate.plusDays(2));
+
+    repository.persist(List.of(licenseARowOne, licenseARowTwo, licenseBRow));
+
+    BillableUsageRemittanceFilter filter =
+        BillableUsageRemittanceFilter.builder().orgId("org123").productId("product1").build();
+
+    List<RemittanceSummaryProjection> results = repository.getRemittanceSummaries(filter);
+
+    assertEquals(2, results.size());
+    assertEquals(
+        10.0,
+        results.stream()
+            .mapToDouble(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+            .sum(),
+        0.001);
+    assertEquals(
+        5.0,
+        results.stream()
+            .filter(summary -> "license-a".equals(summary.getLicenseId()))
+            .mapToDouble(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+            .sum(),
+        0.001);
+    assertEquals(
+        5.0,
+        results.stream()
+            .filter(summary -> "license-b".equals(summary.getLicenseId()))
+            .mapToDouble(RemittanceSummaryProjection::getTotalRemittedPendingValue)
+            .sum(),
+        0.001);
   }
 
   @Test


### PR DESCRIPTION
Group monthly account remittance summaries by licenseId so IQE can validate per-license overage attribution while monthly totals stay unchanged.


<!-- Replace XXXX with the issue number. Issue will be auto-linked -->
Jira issue: SWATCH-5565

## Description
<!-- Provide a description of this PR.  Try to provide answers to "what", "how",
and "why" -->

## Testing
<!--
When possible, please use commands a developer can directly paste or modify
-->
Unit:
  ```bash
  ./mvnw test -pl swatch-billable-usage -am
  ```
Component:
  ```bash
  ./mvnw clean install -Pcomponent-tests -pl swatch-billable-usage/ct -am
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly remittance results now include an optional license ID.
  * Remittance data is grouped and reported separately for each license, while aggregate totals remain unchanged.
  * Unlicensed remittances continue to be supported with no license ID.

* **Tests**
  * Added coverage for multiple licenses, repeated tally publications, per-license attribution, row counts, and preserved monthly totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->